### PR TITLE
fix wrong crawl format ('html' to 'rawHtml')

### DIFF
--- a/src/tools/search/firecrawl.ts
+++ b/src/tools/search/firecrawl.ts
@@ -23,7 +23,7 @@ export class FirecrawlScraper {
       'https://api.firecrawl.dev';
     this.apiUrl = `${baseUrl.replace(/\/+$/, '')}/v1/scrape`;
 
-    this.defaultFormats = config.formats ?? ['markdown', 'html'];
+    this.defaultFormats = config.formats ?? ['markdown', 'rawHtml'];
     this.timeout = config.timeout ?? 7500;
 
     this.logger = config.logger || createDefaultLogger();


### PR DESCRIPTION
it fixes the bug that prevents some users from using local firecrawl-simple instances. as found out [here](https://discord.com/channels/1086345563026489514/1389590707949273148/1391439767597613229), it is because librechat sends “html” as format, which was removed by firecrawl-simple in december 2024.