### PR TITLE
feat: extend FirecrawlScraper configuration options

### DIFF
--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -346,7 +346,7 @@ export const createSearchTool = (
     safeSearch = 1,
     firecrawlApiKey,
     firecrawlApiUrl,
-    firecrawlFormats = ['markdown', 'html'],
+    firecrawlOptions,
     scraperTimeout,
     jinaApiKey,
     cohereApiKey,
@@ -385,10 +385,11 @@ export const createSearchTool = (
   });
 
   const firecrawlScraper = createFirecrawlScraper({
+    ...firecrawlOptions,
     apiKey: firecrawlApiKey ?? process.env.FIRECRAWL_API_KEY,
     apiUrl: firecrawlApiUrl,
-    timeout: scraperTimeout,
-    formats: firecrawlFormats,
+    timeout: scraperTimeout ?? firecrawlOptions?.timeout,
+    formats: firecrawlOptions?.formats ?? ['markdown', 'rawHtml'],
   });
 
   const selectedReranker = createReranker({

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -94,7 +94,7 @@ export interface ProcessSourcesConfig {
 export interface FirecrawlConfig {
   firecrawlApiKey?: string;
   firecrawlApiUrl?: string;
-  firecrawlFormats?: string[];
+  firecrawlOptions?: FirecrawlScraperConfig;
 }
 
 export interface ScraperContentResult {
@@ -170,15 +170,10 @@ export type UsedReferences = {
 }[];
 
 /** Firecrawl */
-
-export interface FirecrawlScrapeOptions {
-  formats?: string[];
-  includeTags?: string[];
-  excludeTags?: string[];
-  headers?: Record<string, string>;
-  waitFor?: number;
-  timeout?: number;
-}
+export type FirecrawlScrapeOptions = Omit<
+  FirecrawlScraperConfig,
+  'apiKey' | 'apiUrl' | 'logger'
+>;
 
 export interface ScrapeMetadata {
   // Core source information
@@ -261,6 +256,21 @@ export interface FirecrawlScraperConfig {
   formats?: string[];
   timeout?: number;
   logger?: Logger;
+  includeTags?: string[];
+  excludeTags?: string[];
+  waitFor?: number;
+  maxAge?: number;
+  mobile?: boolean;
+  skipTlsVerification?: boolean;
+  blockAds?: boolean;
+  removeBase64Images?: boolean;
+  parsePDF?: boolean;
+  storeInCache?: boolean;
+  zeroDataRetention?: boolean;
+  headers?: Record<string, string>;
+  location?: { country?: string; languages?: string[] };
+  onlyMainContent?: boolean;
+  changeTrackingOptions?: object;
 }
 
 export type GetSourcesParams = {


### PR DESCRIPTION
Sibling PR to #8495 in LC

This pull request enhances the `FirecrawlScraper` functionality by introducing new configuration options and refactoring its usage across the codebase. The changes improve flexibility in scraping operations and streamline how configuration parameters are passed and handled.

### Enhancements to `FirecrawlScraper`:

* Added new configuration options to the `FirecrawlScraper` class, including `includeTags`, `excludeTags`, `waitFor`, `maxAge`, `mobile`, `skipTlsVerification`, `blockAds`, `removeBase64Images`, `parsePDF`, `storeInCache`, `zeroDataRetention`, `headers`, `location`, `onlyMainContent`, and `changeTrackingOptions`. These options provide more granular control over scraping behavior. (`src/tools/search/firecrawl.ts`, [[1]](diffhunk://#diff-2ca89e57e548aed65eb2e79759d23399773a5ff1c84f9230fb5d1d502800023eR16-R30) [[2]](diffhunk://#diff-2ca89e57e548aed65eb2e79759d23399773a5ff1c84f9230fb5d1d502800023eL26-R61)
* Refactored the payload construction for API requests by introducing the `omitUndefined` helper function to remove undefined values, ensuring cleaner and more accurate request payloads. 

* Updated `createSearchTool` to pass the new `firecrawlOptions` object directly. `src/tools/search/tool.ts`, [[1]](diffhunk://#diff-f4c138911e3684335208a3c42c4559c2c0c30f27387013102c46802f02739115L349-R349) [[2]](diffhunk://#diff-f4c138911e3684335208a3c42c4559c2c0c30f27387013102c46802f02739115R388-R392)

### Default format adjustment:

* Changed the default formats for `FirecrawlScraper` from `['markdown', 'html']` to `['markdown', 'rawHtml']` in reference to PR #6 by @XHyperDEVX. (`src/tools/search/firecrawl.ts`, [[1]](diffhunk://#diff-2ca89e57e548aed65eb2e79759d23399773a5ff1c84f9230fb5d1d502800023eL26-R61) `src/tools/search/tool.ts`, [[2]](diffhunk://#diff-f4c138911e3684335208a3c42c4559c2c0c30f27387013102c46802f02739115R388-R392)