### PR TITLE
feat: enhance formatAgentMessages for Anthropic native PDF support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14038,6 +14038,7 @@
       "resolved": "https://registry.npmjs.org/rollup-plugin-cleandir/-/rollup-plugin-cleandir-2.0.0.tgz",
       "integrity": "sha512-cTL/WbBJqHQkYBplhtiQ/yc0IqTuRR7EGw/S+XtQdaFhtv6+Xq/j8dxkk5lzTcxd0hCahUebZFYhLBRzSsgynw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@mstssk/cleandir": "^1.2.0"
       },


### PR DESCRIPTION
- Add document detection for PDF content blocks with multiple patterns
- Preserve array structure for messages containing documents
- Support base64 PDF data with proper media type handling
- Maintain clean implementation without debug overhead
- Enable Anthropic Claude's native visual PDF analysis capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)