### PR TITLE
⚙️ fix: filter out content items with metadata property

### DIFF
--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -85,6 +85,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             { ...call, args, type: 'tool_call', stepId, turn },
             config
           );
+
+          // Filter out content items with metadata property.
+          // This property is used to pass UI Resources from the tool response to the frontend.
+          // But it should not be sent to the LLM since it's not part of the tool response schema.
+          if (
+            isBaseMessage(output) &&
+            output.content &&
+            Array.isArray(output.content)
+          ) {
+            output.content = output.content.filter(
+              (item: t.MessageContentComplex) =>
+                typeof item === 'string' || !('metadata' in item)
+            );
+          }
+
           if (
             (isBaseMessage(output) && output._getType() === 'tool') ||
             isCommand(output)


### PR DESCRIPTION
Follow-up to these 2 LibreChat PRs regarding the MCP UI integration:
- https://github.com/danny-avila/LibreChat/pull/9299
- https://github.com/danny-avila/LibreChat/pull/9418

When we add UI Resources to the formatted tool call content [here](https://github.com/mcp-ui-dev/LibreChat/blob/633e985e81ec819a7c4a285040210764c75285c8/packages/api/src/mcp/parsers.ts#L185-L194), the goal is to parse it back in the frontend [here](https://github.com/mcp-ui-dev/LibreChat/blob/633e985e81ec819a7c4a285040210764c75285c8/client/src/components/Chat/Messages/Content/ToolCallInfo.tsx#L57-L71).

But this added content is also being sent to the LLM, as we can see in the logs here at the place we do our change here:

```
backend      |  toolnode output before change: ToolMessage {
backend      |   "content": [
backend      |     {
backend      |       "type": "text",
backend      |       "text": "Resource Text: {\"location\":\"Paris\",\"temperature\":77,\"unit\":\"°F\",\"condition\":\"Overcast\",\"humidity\":55,\"windSpeed\":15,\"windUnit\":\"mph\",\"description\":\"Current weather in Paris\"}\nResource URI: http://mcp-aharvard/weather-data\nResource MIME Type: application/json"
backend      |     },
backend      |     {
backend      |       "type": "text",
backend      |       "metadata": {
backend      |         "type": "ui_resources",
backend      |         "data": "[Array]"
backend      |       },
backend      |       "text": ""
backend      |     }
backend      |   ],
backend      |   "name": "get-weather_mcp_mcp-aharvard",
backend      |   "additional_kwargs": {},
backend      |   "response_metadata": {},
backend      |   "tool_call_id": "call_hye2sm6DuNXWa1YW6DwDiIVD"
backend      | }
```

After our change we get:

```
backend      |  toolnode output after change: ToolMessage {
backend      |   "content": [
backend      |     {
backend      |       "type": "text",
backend      |       "text": "Resource Text: {\"location\":\"Paris\",\"temperature\":77,\"unit\":\"°F\",\"condition\":\"Overcast\",\"humidity\":55,\"windSpeed\":15,\"windUnit\":\"mph\",\"description\":\"Current weather in Paris\"}\nResource URI: http://mcp-aharvard/weather-data\nResource MIME Type: application/json"
backend      |     }
backend      |   ],
backend      |   "name": "get-weather_mcp_mcp-aharvard",
backend      |   "additional_kwargs": {},
backend      |   "response_metadata": {},
backend      |   "tool_call_id": "call_PMi8ZfmNEoGWi3jbQMSSwDrg"
backend      | }
```

We are lucky since most LLM providers accept this extra `metadata` property. 

But this is just luck and we can't count on it. Any of them could decide any day to be stricter and only accept properties in their official signatures/documentations.

This PR makes sure that we don't rely on luck but rather on sound engineering principles.