### PR TITLE
🏗️ fix: Resolve Build Errors with 3.0.0-rc11

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -299,7 +299,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       agentContext.currentTokenType === 'think_and_text'
     ) {
       keyList.push('reasoning');
-    } else if (this.tokenTypeSwitch === 'content') {
+    } else if (agentContext.tokenTypeSwitch === 'content') {
       keyList.push('post-reasoning');
     }
 


### PR DESCRIPTION
Resolve errors that came up during build for 3.0.0-rc11 so that Publish Package workflow can run.

```
./src/index.ts → dist/esm, dist/cjs...
(!) [plugin typescript] src/graphs/Graph.ts (302:21): @rollup/plugin-typescript TS2339: Property 'tokenTypeSwitch' does not exist on type 'StandardGraph'.
/home/runner/work/agents/agents/src/graphs/Graph.ts:302:21

302     } else if (this.tokenTypeSwitch === 'content') {
                        ~~~~~~~~~~~~~~~

created dist/esm, dist/cjs in 7.4s
Error: src/graphs/Graph.ts(302,21): error TS2339: Property 'tokenTypeSwitch' does not exist on type 'StandardGraph'.
Error: Process completed with exit code 2.
```