### PR TITLE
🚚 refactor: move `addBedrockCacheControl` logic and tests over from LC

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -39,6 +39,7 @@ import {
 import {
   formatAnthropicArtifactContent,
   convertMessagesToContent,
+  addBedrockCacheControl,
   modifyDeltaProperties,
   formatArtifactPayload,
   formatContentStrings,
@@ -661,6 +662,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           anthropicBeta.includes('prompt-caching')
         ) {
           finalMessages = addCacheControl<BaseMessage>(finalMessages);
+        }
+      } else if (agentContext.provider === Providers.BEDROCK) {
+        const bedrockOptions = agentContext.clientOptions as
+          | t.BedrockAnthropicClientOptions
+          | undefined;
+        if (bedrockOptions?.promptCache === true) {
+          finalMessages = addBedrockCacheControl<BaseMessage>(finalMessages);
         }
       }
 

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -1,6 +1,8 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import type { AnthropicMessages } from '@/types/messages';
-import { addCacheControl } from './cache';
+import { addCacheControl, addBedrockCacheControl } from './cache';
+import { MessageContentComplex } from '@langchain/core/messages';
+import { ContentTypes } from '@/common/enum';
 
 describe('addCacheControl', () => {
   test('should add cache control to the last two user messages with array content', () => {
@@ -258,5 +260,189 @@ describe('addCacheControl', () => {
       text: 'Correct!',
       cache_control: { type: 'ephemeral' },
     });
+  });
+});
+
+type TestMsg = {
+  role?: 'user' | 'assistant' | 'system';
+  content?: string | MessageContentComplex[];
+};
+
+describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
+  it('returns input when not enough messages', () => {
+    const empty: TestMsg[] = [];
+    expect(addBedrockCacheControl(empty)).toEqual(empty);
+    const single: TestMsg[] = [{ role: 'user', content: 'only' }];
+    expect(addBedrockCacheControl(single)).toEqual(single);
+  });
+
+  it('wraps string content and appends separate cachePoint block', () => {
+    const messages: TestMsg[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: [{ type: ContentTypes.TEXT, text: 'Hi' }] },
+    ];
+    const result = addBedrockCacheControl(messages);
+    const last = result[1].content as MessageContentComplex[];
+    expect(Array.isArray(last)).toBe(true);
+    expect(last[0]).toEqual({ type: ContentTypes.TEXT, text: 'Hi' });
+    expect(last[1]).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  it('inserts cachePoint after the last text when multiple text blocks exist', () => {
+    const messages: TestMsg[] = [
+      {
+        role: 'user',
+        content: [
+          { type: ContentTypes.TEXT, text: 'Intro' },
+          { type: ContentTypes.TEXT, text: 'Details' },
+          {
+            type: ContentTypes.IMAGE_FILE,
+            image_file: { file_id: 'file_123' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, text: 'Reply A' },
+          { type: ContentTypes.TEXT, text: 'Reply B' },
+        ],
+      },
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    const first = result[0].content as MessageContentComplex[];
+    const second = result[1].content as MessageContentComplex[];
+
+    expect(first[0]).toEqual({ type: ContentTypes.TEXT, text: 'Intro' });
+    expect(first[1]).toEqual({ type: ContentTypes.TEXT, text: 'Details' });
+    expect(first[2]).toEqual({ cachePoint: { type: 'default' } });
+
+    const img = first[3] as MessageContentComplex;
+    expect(img.type).toBe(ContentTypes.IMAGE_FILE);
+    if (img.type === ContentTypes.IMAGE_FILE) {
+      expect('image_file' in img).toBe(true);
+    }
+
+    expect(second[0]).toEqual({ type: ContentTypes.TEXT, text: 'Reply A' });
+    expect(second[1]).toEqual({ type: ContentTypes.TEXT, text: 'Reply B' });
+    expect(second[2]).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  it('appends cachePoint when content is an empty array', () => {
+    const messages: TestMsg[] = [
+      { role: 'user', content: [] },
+      { role: 'assistant', content: [] },
+      { role: 'user', content: 'ignored because only last two are modified' },
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    const first = result[0].content as MessageContentComplex[];
+    const second = result[1].content as MessageContentComplex[];
+
+    expect(Array.isArray(first)).toBe(true);
+    expect(first.length).toBe(0);
+
+    expect(Array.isArray(second)).toBe(true);
+    expect(second.length).toBe(1);
+    expect(second[0]).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  /** (I don't think this will ever occur in actual use, but its the only branch left uncovered so I'm covering it */
+  it('skips messages with non-string, non-array content and still modifies the previous to reach two edits', () => {
+    const messages: TestMsg[] = [
+      {
+        role: 'user',
+        content: [{ type: ContentTypes.TEXT, text: 'Will be modified' }],
+      },
+      { role: 'assistant', content: undefined },
+      {
+        role: 'user',
+        content: [{ type: ContentTypes.TEXT, text: 'Also modified' }],
+      },
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    const last = result[2].content as MessageContentComplex[];
+    expect(last[0]).toEqual({ type: ContentTypes.TEXT, text: 'Also modified' });
+    expect(last[1]).toEqual({ cachePoint: { type: 'default' } });
+
+    expect(result[1].content).toBeUndefined();
+
+    const first = result[0].content as MessageContentComplex[];
+    expect(first[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Will be modified',
+    });
+    expect(first[1]).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  it('works with the example from the langchain pr', () => {
+    const messages: TestMsg[] = [
+      {
+        role: 'system',
+        content: [
+          { type: ContentTypes.TEXT, text: 'You\'re an advanced AI assistant.' },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: ContentTypes.TEXT, text: 'What is the capital of France?' },
+        ],
+      },
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    let system = result[0].content as MessageContentComplex[];
+    let user = result[1].content as MessageContentComplex[];
+
+    expect(system[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'You\'re an advanced AI assistant.',
+    });
+    expect(system[1]).toEqual({ cachePoint: { type: 'default' } });
+    expect(user[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'What is the capital of France?',
+    });
+    expect(user[1]).toEqual({ cachePoint: { type: 'default' } });
+
+    result.push({
+      role: 'assistant',
+      content: [
+        {
+          type: ContentTypes.TEXT,
+          text: 'Sure! The capital of France is Paris.',
+        },
+      ],
+    });
+
+    const result2 = addBedrockCacheControl(result);
+
+    system = result2[0].content as MessageContentComplex[];
+    user = result2[1].content as MessageContentComplex[];
+    const assistant = result2[2].content as MessageContentComplex[];
+
+    expect(system[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'You\'re an advanced AI assistant.',
+    });
+    expect(system[1]).toEqual({ cachePoint: { type: 'default' } });
+    expect(user[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'What is the capital of France?',
+    });
+    expect(user[1]).toEqual({ cachePoint: { type: 'default' } });
+
+    expect(assistant[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Sure! The capital of France is Paris.',
+    });
+    expect(assistant[1]).toEqual({ cachePoint: { type: 'default' } });
   });
 });

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -1,6 +1,11 @@
+import { BaseMessage, MessageContentComplex } from '@langchain/core/messages';
 import type { AnthropicMessage } from '@/types/messages';
 import type Anthropic from '@anthropic-ai/sdk';
-import { BaseMessage } from '@langchain/core/messages';
+import { ContentTypes } from '@/common/enum';
+
+type MessageWithContent = {
+  content?: string | MessageContentComplex[];
+};
 
 /**
  * Anthropic API: Adds cache control to the appropriate user messages in the payload.
@@ -49,6 +54,65 @@ export function addCacheControl<T extends AnthropicMessage | BaseMessage>(
           break;
         }
       }
+    }
+  }
+
+  return updatedMessages;
+}
+
+/**
+ * Adds Bedrock Converse API cache points to the last two messages.
+ * Inserts `{ cachePoint: { type: 'default' } }` as a separate content block
+ * immediately after the last text block in each targeted message.
+ * @param messages - The array of message objects.
+ * @returns - The updated array of message objects with cache points added.
+ */
+export function addBedrockCacheControl<
+  T extends Partial<BaseMessage> & MessageWithContent,
+>(messages: T[]): T[] {
+  if (!Array.isArray(messages) || messages.length < 2) {
+    return messages;
+  }
+
+  const updatedMessages: T[] = messages.slice();
+  let messagesModified = 0;
+
+  for (
+    let i = updatedMessages.length - 1;
+    i >= 0 && messagesModified < 2;
+    i--
+  ) {
+    const message = updatedMessages[i];
+    const content = message.content;
+
+    if (typeof content === 'string') {
+      message.content = [
+        { type: ContentTypes.TEXT, text: content },
+        { cachePoint: { type: 'default' } },
+      ] as MessageContentComplex[];
+      messagesModified++;
+      continue;
+    }
+
+    if (Array.isArray(content)) {
+      let inserted = false;
+      for (let j = content.length - 1; j >= 0; j--) {
+        const block = content[j] as MessageContentComplex;
+        const type = (block as { type?: string }).type;
+        if (type === ContentTypes.TEXT || type === 'text') {
+          content.splice(j + 1, 0, {
+            cachePoint: { type: 'default' },
+          } as MessageContentComplex);
+          inserted = true;
+          break;
+        }
+      }
+      if (!inserted) {
+        content.push({
+          cachePoint: { type: 'default' },
+        } as MessageContentComplex);
+      }
+      messagesModified++;
     }
   }
 

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -66,8 +66,10 @@ export type VertexAIClientOptions = ChatVertexAIInput & {
 export type BedrockAnthropicInput = ChatBedrockConverseInput & {
   additionalModelRequestFields?: ChatBedrockConverseInput['additionalModelRequestFields'] &
     AnthropicReasoning;
+  promptCache?: boolean;
 };
 export type BedrockConverseClientOptions = ChatBedrockConverseInput;
+export type BedrockAnthropicClientOptions = BedrockAnthropicInput;
 export type GoogleClientOptions = GoogleGenerativeAIChatInput & {
   customHeaders?: RequestOptions['customHeaders'];
   thinkingConfig?: GeminiGenerationConfig['thinkingConfig'];


### PR DESCRIPTION
Sibling PR to [#8271](https://github.com/danny-avila/LibreChat/pull/8271)

Since 0e19057e03508299d560e7304933bd495aa4965f, addCacheControl logic has been moved into agents from [api/server/controllers/agents/client.js](https://github.com/danny-avila/LibreChat/blob/main/api/server/controllers/agents/client.js). This PR migrates the addBedrockCacheControl logic to sit alongside addCacheControl to maintain architectural consistency. 

Still requires testing to confirm proper implementation.

