### PR TITLE
✈️ refactor: Move Media Attachment Handling back to LibreChat

### DIFF
--- a/src/llm/google/utils/common.ts
+++ b/src/llm/google/utils/common.ts
@@ -316,20 +316,6 @@ function _convertLangChainContentToPart(
         mimeType,
       },
     };
-  } else if (
-    content.type === 'document' ||
-    content.type === 'audio' ||
-    content.type === 'video'
-  ) {
-    if (!isMultimodalModel) {
-      throw new Error(`This model does not support ${content.type}s`);
-    }
-    return {
-      inlineData: {
-        data: content.data,
-        mimeType: content.mimeType,
-      },
-    };
   } else if (content.type === 'media') {
     return messageContentMedia(content);
   } else if (content.type === 'tool_use') {


### PR DESCRIPTION
This pull request reverts the change to the `_convertLangChainContentToPart` function in `src/llm/google/utils/common.ts` by removing the conditional block that handled `document`, `audio`, and `video` content types. This change was originally introduced due to incorrect formatting of Gemini and VertexAI API payloads while implementing multimodal uploads in [LibreChat PR #9088](https://github.com/danny-avila/LibreChat/pull/9088). The payload transformation will now properly be handled by messageMediaContent() due to the correct `type: 'media'` being used in the payload.

> Note: This is a sibling PR to [PR #10586](https://github.com/danny-avila/LibreChat/pull/10586) in the LibreChat repository and depends on the changes in that PR in order to retain functionality