### PR TITLE
feat: Make Langfuse environment configurable

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -11,7 +11,7 @@ if (
     publicKey: process.env.LANGFUSE_PUBLIC_KEY,
     secretKey: process.env.LANGFUSE_SECRET_KEY,
     baseUrl: process.env.LANGFUSE_BASE_URL,
-    environment: process.env.NODE_ENV ?? 'development',
+    environment: process.env.LANGFUSE_TRACING_ENVIRONMENT ?? process.env.NODE_ENV ?? 'development',
   });
 
   const sdk = new NodeSDK({


### PR DESCRIPTION
Make [Langfuse environment](https://langfuse.com/docs/observability/features/environments) configurable with default Langfuse env var - `LANGFUSE_TRACING_ENVIRONMENT`