### PR TITLE
Improve <think>/<thinking> tag identification in streaming responses

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -141,6 +141,11 @@ export class AgentContext {
   /** Current token type being processed */
   currentTokenType: ContentTypes.TEXT | ContentTypes.THINK | 'think_and_text' =
     ContentTypes.TEXT;
+  /** State machine for detecting fragmented thinking tags */
+  thinkingState: 'normal' | 'buffering_open' | 'thinking' | 'buffering_close' =
+    'normal';
+  /** Buffer for accumulating potential thinking tags */
+  tagBuffer: string = '';
   /** Whether tools should end the workflow */
   toolEnd: boolean = false;
   /** Cached system runnable (created lazily) */

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -141,7 +141,14 @@ export class AgentContext {
   /** Current token type being processed */
   currentTokenType: ContentTypes.TEXT | ContentTypes.THINK | 'think_and_text' =
     ContentTypes.TEXT;
-  /** State machine for detecting fragmented thinking tags */
+  /**
+   * State machine for detecting fragmented thinking tags in streaming content.
+   * States:
+   * - 'normal': Processing regular text, looking for opening tags
+   * - 'buffering_open': Accumulating potential opening tag (<think> or <thinking>)
+   * - 'thinking': Inside thinking block, processing thinking content
+   * - 'buffering_close': Accumulating potential closing tag (</think> or </thinking>)
+   */
   thinkingState: 'normal' | 'buffering_open' | 'thinking' | 'buffering_close' =
     'normal';
   /** Buffer for accumulating potential thinking tags */

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -146,6 +146,8 @@ export class AgentContext {
     'normal';
   /** Buffer for accumulating potential thinking tags */
   tagBuffer: string = '';
+  /** Current step ID for flushing buffer at stream end */
+  currentStepId?: string;
   /** Whether tools should end the workflow */
   toolEnd: boolean = false;
   /** Cached system runnable (created lazily) */

--- a/src/specs/fragmented-thinking.test.ts
+++ b/src/specs/fragmented-thinking.test.ts
@@ -1,0 +1,170 @@
+// src/specs/fragmented-thinking.test.ts
+// Tests for fragmented <thinking> tag handling in streamed content
+// This tests the state machine that detects thinking tags split across chunks
+
+import { HumanMessage, MessageContentText } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
+import { GraphEvents, Providers } from '@/common';
+import { getLLMConfig } from '@/utils/llmConfig';
+import { Run } from '@/run';
+
+describe('Fragmented Thinking Tags Tests', () => {
+  jest.setTimeout(30000);
+  let run: Run<t.IState>;
+  let contentParts: t.MessageContentComplex[];
+  let aggregateContent: t.ContentAggregator;
+  let runSteps: Set<string>;
+
+  const config: Partial<RunnableConfig> & {
+    version: 'v1' | 'v2';
+    run_id?: string;
+    streamMode: string;
+  } = {
+    configurable: {
+      thread_id: 'fragmented-thinking-test',
+    },
+    streamMode: 'values',
+    version: 'v2' as const,
+    callbacks: [
+      {
+        async handleCustomEvent(event, data): Promise<void> {
+          if (event !== GraphEvents.ON_MESSAGE_DELTA) {
+            return;
+          }
+          const messageDeltaData = data as t.MessageDeltaEvent;
+
+          // Wait until we see the run step
+          const maxAttempts = 50;
+          let attempts = 0;
+          while (!runSteps.has(messageDeltaData.id) && attempts < maxAttempts) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            attempts++;
+          }
+
+          aggregateContent({ event, data: messageDeltaData });
+        },
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    const { contentParts: parts, aggregateContent: ac } =
+      createContentAggregator();
+    aggregateContent = ac;
+    runSteps = new Set();
+    contentParts = parts as t.MessageContentComplex[];
+  });
+
+  afterEach(() => {
+    runSteps.clear();
+  });
+
+  const onReasoningDeltaSpy = jest.fn();
+
+  afterAll(() => {
+    onReasoningDeltaSpy.mockReset();
+  });
+
+  const setupCustomHandlers = (): Record<
+    string | GraphEvents,
+    t.EventHandler
+  > => ({
+    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP_COMPLETED,
+        data: t.StreamEventData
+      ): void => {
+        aggregateContent({
+          event,
+          data: data as unknown as { result: t.ToolEndEvent },
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP,
+        data: t.StreamEventData
+      ): void => {
+        const runStepData = data as t.RunStep;
+        runSteps.add(runStepData.id);
+        aggregateContent({ event, data: runStepData });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP_DELTA,
+        data: t.StreamEventData
+      ): void => {
+        aggregateContent({ event, data: data as t.RunStepDeltaEvent });
+      },
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: t.StreamEventData
+      ): void => {
+        onReasoningDeltaSpy(event, data);
+        aggregateContent({ event, data: data as t.ReasoningDeltaEvent });
+      },
+    },
+  });
+
+  // Test with a complete thinking block that will be split by whitespace
+  // The fake model splits on whitespace by default, so this simulates
+  // receiving "<thinking>" and "</thinking>" as separate chunks
+  const thinkingResponse =
+    '<thinking> Let me think about this. </thinking> The answer is 42.';
+
+  test('should handle thinking tags in streamed content', async () => {
+    const llmConfig = getLLMConfig(Providers.BEDROCK);
+    const customHandlers = setupCustomHandlers();
+
+    run = await Run.create<t.IState>({
+      runId: 'fragmented-thinking-test-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        instructions: 'You are a helpful assistant.',
+      },
+      returnContent: true,
+      customHandlers,
+    });
+
+    // Pass the full response - the fake model will split it on whitespace
+    run.Graph?.overrideTestModel([thinkingResponse], 2);
+
+    const inputs = {
+      messages: [new HumanMessage('What is the meaning of life?')],
+    };
+
+    await run.processStream(inputs, config);
+
+    expect(contentParts).toBeDefined();
+    expect(contentParts.length).toBe(2);
+
+    // Find the thinking and text parts (order may vary based on event handling)
+    const thinkingPart = contentParts.find(
+      (p) => (p as t.ReasoningContentText).think !== undefined
+    ) as t.ReasoningContentText;
+    const textPart = contentParts.find(
+      (p) => (p as MessageContentText).text !== undefined
+    ) as MessageContentText;
+
+    // Thinking content should not contain the tags
+    expect(thinkingPart).toBeDefined();
+    expect(thinkingPart.think).toContain('Let me think about this.');
+    expect(thinkingPart.think).not.toContain('<thinking>');
+    expect(thinkingPart.think).not.toContain('</thinking>');
+
+    // Text content should be the response after thinking
+    expect(textPart).toBeDefined();
+    expect(textPart.text).toContain('The answer is 42.');
+    expect(textPart.text).not.toContain('<thinking>');
+
+    // Verify reasoning delta was called
+    expect(onReasoningDeltaSpy).toHaveBeenCalled();
+  });
+});

--- a/src/specs/reasoning.test.ts
+++ b/src/specs/reasoning.test.ts
@@ -174,7 +174,8 @@ describe(`${capitalizeFirstLetter(provider)} Streaming Tests`, () => {
     await run.processStream(inputs, config);
     expect(contentParts).toBeDefined();
     expect(contentParts.length).toBe(2);
-    const reasoningContent = reasoningText.match(/<think>(.*)<\/think>/s)?.[0];
+    // Tags are stripped from thinking content by the state machine
+    const reasoningContent = reasoningText.match(/<think>(.*)<\/think>/s)?.[1];
     const content = reasoningText.split(/<\/think>/)[1];
     expect((contentParts[0] as t.ReasoningContentText).think).toBe(
       reasoningContent

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -19,57 +19,6 @@ import {
 } from '@/tools/handlers';
 import { getMessageId } from '@/messages';
 
-/**
- * Parses content to extract thinking sections enclosed in <think> tags using string operations
- * @param content The content to parse
- * @returns An object with separated text and thinking content
- */
-function parseThinkingContent(content: string): {
-  text: string;
-  thinking: string;
-} {
-  // If no think tags, return the original content as text
-  if (!content.includes('<think>')) {
-    return { text: content, thinking: '' };
-  }
-
-  let textResult = '';
-  const thinkingResult: string[] = [];
-  let position = 0;
-
-  while (position < content.length) {
-    const thinkStart = content.indexOf('<think>', position);
-
-    if (thinkStart === -1) {
-      // No more think tags, add the rest and break
-      textResult += content.slice(position);
-      break;
-    }
-
-    // Add text before the think tag
-    textResult += content.slice(position, thinkStart);
-
-    const thinkEnd = content.indexOf('</think>', thinkStart);
-    if (thinkEnd === -1) {
-      // Malformed input, no closing tag
-      textResult += content.slice(thinkStart);
-      break;
-    }
-
-    // Add the thinking content
-    const thinkContent = content.slice(thinkStart + 7, thinkEnd);
-    thinkingResult.push(thinkContent);
-
-    // Move position to after the think tag
-    position = thinkEnd + 8; // 8 is the length of '</think>'
-  }
-
-  return {
-    text: textResult.trim(),
-    thinking: thinkingResult.join('\n').trim(),
-  };
-}
-
 function getNonEmptyValue(possibleValues: string[]): string | undefined {
   for (const value of possibleValues) {
     if (value && value.trim() !== '') {
@@ -271,62 +220,183 @@ hasToolCallChunks: ${hasToolCallChunks}
     ) {
       return;
     } else if (typeof content === 'string') {
-      if (agentContext.currentTokenType === ContentTypes.TEXT) {
-        await graph.dispatchMessageDelta(stepId, {
-          content: [
-            {
-              type: ContentTypes.TEXT,
-              text: content,
-            },
-          ],
-        });
-      } else if (agentContext.currentTokenType === 'think_and_text') {
-        const { text, thinking } = parseThinkingContent(content);
-        if (thinking) {
-          await graph.dispatchReasoningDelta(stepId, {
-            content: [
-              {
-                type: ContentTypes.THINK,
-                think: thinking,
-              },
-            ],
-          });
-        }
-        if (text) {
-          agentContext.currentTokenType = ContentTypes.TEXT;
-          agentContext.tokenTypeSwitch = 'content';
-          const newStepKey = graph.getStepKey(metadata);
-          const message_id = getMessageId(newStepKey, graph) ?? '';
-          await graph.dispatchRunStep(
-            newStepKey,
-            {
-              type: StepTypes.MESSAGE_CREATION,
-              message_creation: {
-                message_id,
-              },
-            },
-            metadata
-          );
+      // State machine for detecting <thinking>/<think> tags in streamed fragments
+      // States: 'normal', 'buffering_open', 'thinking', 'buffering_close'
+      if (!agentContext.thinkingState) {
+        agentContext.thinkingState = 'normal';
+        agentContext.tagBuffer = '';
+      }
 
-          const newStepId = graph.getStepIdByKey(newStepKey);
-          await graph.dispatchMessageDelta(newStepId, {
-            content: [
-              {
-                type: ContentTypes.TEXT,
-                text: text,
-              },
-            ],
-          });
+      let remaining = content;
+
+      while (remaining.length > 0) {
+        if (agentContext.thinkingState === 'normal') {
+          // Look for '<' to start buffering potential opening tag
+          const ltPos = remaining.indexOf('<');
+          if (ltPos === -1) {
+            // No '<', yield all as TEXT
+            await graph.dispatchMessageDelta(stepId, {
+              content: [{ type: ContentTypes.TEXT, text: remaining }],
+            });
+            remaining = '';
+          } else if (ltPos > 0) {
+            // Yield text before '<'
+            await graph.dispatchMessageDelta(stepId, {
+              content: [
+                { type: ContentTypes.TEXT, text: remaining.slice(0, ltPos) },
+              ],
+            });
+            remaining = remaining.slice(ltPos);
+          } else {
+            // Starts with '<', start buffering
+            agentContext.thinkingState = 'buffering_open';
+            agentContext.tagBuffer = remaining;
+            remaining = '';
+
+            // Check immediately if we have enough to decide
+            const bufLower = agentContext.tagBuffer.toLowerCase();
+            if (bufLower.startsWith('<thinking>')) {
+              agentContext.thinkingState = 'thinking';
+              agentContext.currentTokenType = ContentTypes.THINK;
+              remaining = agentContext.tagBuffer.slice(10);
+              agentContext.tagBuffer = '';
+            } else if (bufLower.startsWith('<think>')) {
+              agentContext.thinkingState = 'thinking';
+              agentContext.currentTokenType = ContentTypes.THINK;
+              remaining = agentContext.tagBuffer.slice(7);
+              agentContext.tagBuffer = '';
+            } else if (
+              !(
+                '<thinking>'.startsWith(bufLower) ||
+                '<think>'.startsWith(bufLower)
+              )
+            ) {
+              // Definitely not a thinking tag
+              await graph.dispatchMessageDelta(stepId, {
+                content: [
+                  { type: ContentTypes.TEXT, text: agentContext.tagBuffer },
+                ],
+              });
+              agentContext.tagBuffer = '';
+              agentContext.thinkingState = 'normal';
+            }
+            // else: partial match, keep buffering
+          }
+        } else if (agentContext.thinkingState === 'buffering_open') {
+          // Accumulating potential <thinking> tag
+          agentContext.tagBuffer += remaining;
+          remaining = '';
+
+          const bufLower = agentContext.tagBuffer.toLowerCase();
+          if (bufLower.startsWith('<thinking>')) {
+            agentContext.thinkingState = 'thinking';
+            agentContext.currentTokenType = ContentTypes.THINK;
+            remaining = agentContext.tagBuffer.slice(10);
+            agentContext.tagBuffer = '';
+          } else if (bufLower.startsWith('<think>')) {
+            agentContext.thinkingState = 'thinking';
+            agentContext.currentTokenType = ContentTypes.THINK;
+            remaining = agentContext.tagBuffer.slice(7);
+            agentContext.tagBuffer = '';
+          } else if (
+            '<thinking>'.startsWith(bufLower) ||
+            '<think>'.startsWith(bufLower)
+          ) {
+            // Still could be a tag, keep buffering
+          } else {
+            // Not a thinking tag, yield buffer and return to normal
+            await graph.dispatchMessageDelta(stepId, {
+              content: [
+                { type: ContentTypes.TEXT, text: agentContext.tagBuffer },
+              ],
+            });
+            agentContext.tagBuffer = '';
+            agentContext.thinkingState = 'normal';
+          }
+        } else if (agentContext.thinkingState === 'thinking') {
+          // In thinking mode, look for '<' to start buffering potential closing tag
+          const ltPos = remaining.indexOf('<');
+          if (ltPos === -1) {
+            // No '<', yield all as THINK
+            await graph.dispatchReasoningDelta(stepId, {
+              content: [{ type: ContentTypes.THINK, think: remaining }],
+            });
+            remaining = '';
+          } else if (ltPos > 0) {
+            // Yield thinking text before '<'
+            await graph.dispatchReasoningDelta(stepId, {
+              content: [
+                { type: ContentTypes.THINK, think: remaining.slice(0, ltPos) },
+              ],
+            });
+            remaining = remaining.slice(ltPos);
+          } else {
+            // Starts with '<', start buffering for closing tag
+            agentContext.thinkingState = 'buffering_close';
+            agentContext.tagBuffer = remaining;
+            remaining = '';
+
+            // Check immediately if we have enough to decide
+            const bufLower = agentContext.tagBuffer.toLowerCase();
+            if (bufLower.startsWith('</thinking>')) {
+              agentContext.thinkingState = 'normal';
+              agentContext.currentTokenType = ContentTypes.TEXT;
+              remaining = agentContext.tagBuffer.slice(11);
+              agentContext.tagBuffer = '';
+            } else if (bufLower.startsWith('</think>')) {
+              agentContext.thinkingState = 'normal';
+              agentContext.currentTokenType = ContentTypes.TEXT;
+              remaining = agentContext.tagBuffer.slice(8);
+              agentContext.tagBuffer = '';
+            } else if (
+              !(
+                '</thinking>'.startsWith(bufLower) ||
+                '</think>'.startsWith(bufLower)
+              )
+            ) {
+              // Definitely not a closing tag, yield as thinking
+              await graph.dispatchReasoningDelta(stepId, {
+                content: [
+                  { type: ContentTypes.THINK, think: agentContext.tagBuffer },
+                ],
+              });
+              agentContext.tagBuffer = '';
+              agentContext.thinkingState = 'thinking';
+            }
+            // else: partial match, keep buffering
+          }
+        } else {
+          // buffering_close: Accumulating potential </thinking> tag
+          agentContext.tagBuffer += remaining;
+          remaining = '';
+
+          const bufLower = agentContext.tagBuffer.toLowerCase();
+          if (bufLower.startsWith('</thinking>')) {
+            agentContext.thinkingState = 'normal';
+            agentContext.currentTokenType = ContentTypes.TEXT;
+            remaining = agentContext.tagBuffer.slice(11);
+            agentContext.tagBuffer = '';
+          } else if (bufLower.startsWith('</think>')) {
+            agentContext.thinkingState = 'normal';
+            agentContext.currentTokenType = ContentTypes.TEXT;
+            remaining = agentContext.tagBuffer.slice(8);
+            agentContext.tagBuffer = '';
+          } else if (
+            '</thinking>'.startsWith(bufLower) ||
+            '</think>'.startsWith(bufLower)
+          ) {
+            // Still could be a closing tag, keep buffering
+          } else {
+            // Not a closing tag, yield buffer as thinking and return to thinking mode
+            await graph.dispatchReasoningDelta(stepId, {
+              content: [
+                { type: ContentTypes.THINK, think: agentContext.tagBuffer },
+              ],
+            });
+            agentContext.tagBuffer = '';
+            agentContext.thinkingState = 'thinking';
+          }
         }
-      } else {
-        await graph.dispatchReasoningDelta(stepId, {
-          content: [
-            {
-              type: ContentTypes.THINK,
-              think: content,
-            },
-          ],
-        });
       }
     } else if (
       content.every((c) => c.type?.startsWith(ContentTypes.TEXT) ?? false)


### PR DESCRIPTION
Some models like Amazon Nova send their thoughts wrapped in <think>..</think> or <thinking>..</thinking> tags. It is not guaranteed that these strings arrive as single streaming events, in fact more often than not they don't and we may receive '<', 'thinking', '>' tokens separately.

This patch introduces a state machine that deals with such a fragmented stream, identifies the tags and properly emits the thoughts content as `ContentTypes.THINK` for a correct frontend rendering. Fixes the output from at least Amazon Nova and quite likely from other models that emit these tags too. 