### PR TITLE
feat: add responseModalities support for Gemini image generation

### DIFF
--- a/src/llm/google/index.ts
+++ b/src/llm/google/index.ts
@@ -21,6 +21,7 @@ import {
 
 export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
   thinkingConfig?: GeminiGenerationConfig['thinkingConfig'];
+  responseModalities?: ('TEXT' | 'IMAGE' | 'AUDIO')[];
 
   /**
    * Override to add gemini-3 model support for multimodal and function calling thought signatures
@@ -93,6 +94,8 @@ export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
     }
 
     this.thinkingConfig = fields.thinkingConfig ?? this.thinkingConfig;
+    this.responseModalities =
+      fields.responseModalities ?? this.responseModalities;
 
     this.streaming = fields.streaming ?? this.streaming;
     this.json = fields.json;
@@ -110,6 +113,9 @@ export class CustomChatGoogleGenerativeAI extends ChatGoogleGenerativeAI {
           topK: this.topK,
           ...(this.json != null
             ? { responseMimeType: 'application/json' }
+            : {}),
+          ...(this.responseModalities != null
+            ? { responseModalities: this.responseModalities }
             : {}),
         },
       },

--- a/src/llm/google/utils/common.ts
+++ b/src/llm/google/utils/common.ts
@@ -595,6 +595,11 @@ export function convertResponseContentToChatGenerationChunk(
             type: 'codeExecutionResult',
             codeExecutionResult: p.codeExecutionResult,
           };
+        } else if ('inlineData' in p && p.inlineData) {
+          return {
+            type: 'image_url' as const,
+            image_url: `data:${p.inlineData.mimeType};base64,${p.inlineData.data}`,
+          };
         }
         return p;
       })
@@ -752,6 +757,11 @@ export function mapGenerateContentResultToChatResult(
           return {
             type: 'codeExecutionResult',
             codeExecutionResult: p.codeExecutionResult,
+          };
+        } else if ('inlineData' in p && p.inlineData) {
+          return {
+            type: 'image_url' as const,
+            image_url: `data:${p.inlineData.mimeType};base64,${p.inlineData.data}`,
           };
         }
         return p;

--- a/src/llm/vertexai/index.ts
+++ b/src/llm/vertexai/index.ts
@@ -23,6 +23,18 @@ class CustomChatConnection extends ChatConnection<VertexAIClientOptions> {
     ) {
       formattedData.generationConfig.thinkingConfig.includeThoughts = true;
     }
+
+    // Add responseModalities if present in fields
+    const fields = (
+      this as unknown as { fields: VertexAIClientOptions | undefined }
+    ).fields;
+    if (fields?.responseModalities) {
+      formattedData.generationConfig = {
+        ...formattedData.generationConfig,
+        responseModalities: fields.responseModalities,
+      };
+    }
+
     return formattedData;
   }
 }

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -59,6 +59,7 @@ export type AnthropicClientOptions = AnthropicInput;
 export type MistralAIClientOptions = ChatMistralAIInput;
 export type VertexAIClientOptions = ChatVertexAIInput & {
   includeThoughts?: boolean;
+  responseModalities?: ('TEXT' | 'IMAGE' | 'AUDIO')[];
 };
 export type BedrockAnthropicInput = ChatBedrockConverseInput & {
   additionalModelRequestFields?: ChatBedrockConverseInput['additionalModelRequestFields'] &
@@ -70,6 +71,7 @@ export type BedrockAnthropicClientOptions = BedrockAnthropicInput;
 export type GoogleClientOptions = GoogleGenerativeAIChatInput & {
   customHeaders?: RequestOptions['customHeaders'];
   thinkingConfig?: GeminiGenerationConfig['thinkingConfig'];
+  responseModalities?: ('TEXT' | 'IMAGE' | 'AUDIO')[];
 };
 export type DeepSeekClientOptions = ChatDeepSeekCallOptions;
 export type XAIClientOptions = ChatXAIInput;


### PR DESCRIPTION
## Summary

Add support for the `responseModalities` parameter in Google and VertexAI LLM classes to enable native Gemini image generation models (`gemini-2.5-flash-image`, `gemini-3-pro-image-preview`, etc.) to return images alongside text.

### Changes

- Add `responseModalities?: ('TEXT' | 'IMAGE' | 'AUDIO')[]` to `GoogleClientOptions` and `VertexAIClientOptions` types
- Pass `responseModalities` to `generationConfig` in `CustomChatGoogleGenerativeAI` constructor
- Handle `inlineData` (image) parts in response processing (`convertResponseContentToChatGenerationChunk` and `mapGenerateContentResultToChatResult`), converting them to `image_url` content blocks with base64 data URLs
- Add `responseModalities` to generation config in VertexAI `CustomChatConnection.formatData`

### Usage

```typescript
const llmConfig = {
  provider: Providers.GOOGLE,
  model: 'gemini-2.5-flash-image',
  responseModalities: ['TEXT', 'IMAGE'],
};
```

### Tested Models

- `gemini-2.5-flash-image` - Returns text + PNG image
- `gemini-3-pro-image-preview` - Returns JPEG image

### Related

- LibreChat PR: https://github.com/danny-avila/LibreChat/pull/10676