### PR TITLE
feat(CodeExecutor): Add X-User-Id header for session isolation

### DIFF
--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -84,6 +84,9 @@ function createCodeExecutionTool(
     throw new Error('No API key provided for code execution tool.');
   }
 
+  // Extract user_id for session isolation
+  const userId = params.user_id ?? '';
+
   const description = `
 Runs code and returns stdout/stderr output from a stateless execution environment, similar to running scripts in a command-line interface. Each execution is isolated and independent.
 
@@ -110,6 +113,7 @@ Usage:
             headers: {
               'User-Agent': 'LibreChat/1.0',
               'X-API-Key': apiKey,
+              'X-User-Id': userId,
             },
           };
 
@@ -157,6 +161,7 @@ Usage:
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
             'X-API-Key': apiKey,
+            'X-User-Id': userId,
           },
           body: JSON.stringify(postData),
         };


### PR DESCRIPTION
Add X-User-Id header to both GET and POST requests to enable proper user-based session isolation in Code Interpreter deployments.

- Extract user_id from params at tool creation time
- Add X-User-Id header to GET request (session files fetch)
- Add X-User-Id header to POST request (code execution)

This fixes a critical security issue where all users fall back to 'anonymous' session, causing session data leakage between users.

Fixes #44