### PR TITLE
fix: use valid semver in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.00",
+  "version": "3.1.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
`3.1.00` is not valid semver (leading zeros are not allowed). npm rejects it e.g. when using `npm link`.

Change: `3.1.00` → `3.1.0`.