### PR TITLE
Feat: Add crawl4ai as an option for local scrape

### DIFF
--- a/src/tools/search/crawl4ai-scraper.ts
+++ b/src/tools/search/crawl4ai-scraper.ts
@@ -1,0 +1,170 @@
+import axios from 'axios';
+import type * as t from './types';
+import { createDefaultLogger } from './utils';
+
+/**
+ * Crawl4AI scraper implementation
+ * Uses the Crawl4AI API to scrape web pages with advanced extraction capabilities
+ *
+ * Features:
+ * - Purpose-built for content extraction
+ * - Multiple extraction strategies (cosine, LLM, etc.)
+ * - Chunking strategies for large content
+ * - Returns markdown and text content
+ * - Includes metadata from scraped pages
+ *
+ * @example
+ * ```typescript
+ * const scraper = createCrawl4AIScraper({
+ *   apiKey: 'your-crawl4ai-api-key',
+ *   extractionStrategy: 'cosine',
+ *   chunkingStrategy: 'sliding_window',
+ *   timeout: 10000
+ * });
+ *
+ * const [url, response] = await scraper.scrapeUrl('https://example.com');
+ * if (response.success) {
+ *   const [content] = scraper.extractContent(response);
+ *   console.log(content);
+ * }
+ * ```
+ */
+export class Crawl4AIScraper implements t.BaseScraper {
+  private apiKey: string;
+  private apiUrl: string;
+  private timeout: number;
+  private logger: t.Logger;
+  private extractionStrategy?: string;
+  private chunkingStrategy?: string;
+
+  constructor(config: t.Crawl4AIScraperConfig = {}) {
+    this.apiKey = config.apiKey ?? process.env.CRAWL4AI_API_KEY ?? '';
+
+    this.apiUrl =
+      config.apiUrl ??
+      process.env.CRAWL4AI_API_URL ??
+      'https://api.crawl4ai.com';
+
+    this.timeout = config.timeout ?? 10000;
+    this.extractionStrategy = config.extractionStrategy;
+    this.chunkingStrategy = config.chunkingStrategy;
+
+    this.logger = config.logger || createDefaultLogger();
+
+    if (!this.apiKey) {
+      this.logger.warn('CRAWL4AI_API_KEY is not set. Scraping will not work.');
+    }
+
+    this.logger.debug(
+      `Crawl4AI scraper initialized with API URL: ${this.apiUrl}`
+    );
+  }
+
+  /**
+   * Scrape a single URL
+   * @param url URL to scrape
+   * @param options Scrape options
+   * @returns Scrape response
+   */
+  async scrapeUrl(
+    url: string,
+    options: t.Crawl4AIScrapeOptions = {}
+  ): Promise<[string, t.Crawl4AIScrapeResponse]> {
+    if (!this.apiKey) {
+      return [
+        url,
+        {
+          success: false,
+          error: 'CRAWL4AI_API_KEY is not set',
+        },
+      ];
+    }
+
+    try {
+      const payload: Record<string, unknown> = {
+        url,
+      };
+
+      // Add extraction strategy if provided
+      if (options.extractionStrategy ?? this.extractionStrategy) {
+        payload.extractionStrategy = options.extractionStrategy ?? this.extractionStrategy;
+      }
+
+      // Add chunking strategy if provided
+      if (options.chunkingStrategy ?? this.chunkingStrategy) {
+        payload.chunkingStrategy = options.chunkingStrategy ?? this.chunkingStrategy;
+      }
+
+      const response = await axios.post(this.apiUrl, payload, {
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: options.timeout ?? this.timeout,
+      });
+
+      return [url, { success: true, data: response.data }];
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      this.logger.error(`Crawl4AI scrape failed for ${url}:`, errorMessage);
+      return [
+        url,
+        {
+          success: false,
+          error: `Crawl4AI API request failed: ${errorMessage}`,
+        },
+      ];
+    }
+  }
+
+  /**
+   * Extract content from scrape response
+   * @param response Scrape response
+   * @returns Extracted content or empty string if not available
+   */
+  extractContent(
+    response: t.Crawl4AIScrapeResponse
+  ): [string, undefined | t.References] {
+    if (!response.success || !response.data) {
+      return ['', undefined];
+    }
+
+    // Prefer markdown over text
+    if (response.data.markdown != null) {
+      return [response.data.markdown, undefined];
+    }
+
+    if (response.data.text != null) {
+      return [response.data.text, undefined];
+    }
+
+    return ['', undefined];
+  }
+
+  /**
+   * Extract metadata from scrape response
+   * @param response Scrape response
+   * @returns Metadata object
+   */
+  extractMetadata(
+    response: t.Crawl4AIScrapeResponse
+  ): Record<string, string | number | boolean | null | undefined> {
+    if (!response.success || !response.data || !response.data.metadata) {
+      return {};
+    }
+
+    return response.data.metadata;
+  }
+}
+
+/**
+ * Create a Crawl4AI scraper instance
+ * @param config Scraper configuration
+ * @returns Crawl4AI scraper instance
+ */
+export const createCrawl4AIScraper = (
+  config: t.Crawl4AIScraperConfig = {}
+): Crawl4AIScraper => {
+  return new Crawl4AIScraper(config);
+};

--- a/src/tools/search/crawl4ai-scraper.ts
+++ b/src/tools/search/crawl4ai-scraper.ts
@@ -49,6 +49,7 @@ export class Crawl4AIScraper implements t.BaseScraper {
     this.timeout = config.timeout ?? 10000;
     this.extractionStrategy = config.extractionStrategy;
     this.chunkingStrategy = config.chunkingStrategy;
+    this.fitStrategy = config.fitStrategy;
 
     // crawl4ai has ways to filter raw markdown,
     // by default, we'll assume a fit (pruning) strategy

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -14,6 +14,7 @@ import {
 import { createSearchAPI, createSourceProcessor } from './search';
 import { createSerperScraper } from './serper-scraper';
 import { createFirecrawlScraper } from './firecrawl';
+import { createCrawl4AIScraper } from './crawl4ai-scraper';
 import { expandHighlights } from './highlights';
 import { formatResultsForLLM } from './format';
 import { createDefaultLogger } from './utils';
@@ -372,6 +373,9 @@ export const createSearchTool = (
     firecrawlVersion,
     firecrawlOptions,
     serperScraperOptions,
+    crawl4aiApiKey,
+    crawl4aiApiUrl,
+    crawl4aiOptions,
     scraperTimeout,
     jinaApiKey,
     jinaApiUrl,
@@ -418,6 +422,14 @@ export const createSearchTool = (
       ...serperScraperOptions,
       apiKey: serperApiKey,
       timeout: scraperTimeout ?? serperScraperOptions?.timeout,
+      logger,
+    });
+  } else if (scraperProvider === 'crawl4ai') {
+    scraperInstance = createCrawl4AIScraper({
+      ...crawl4aiOptions,
+      apiKey: crawl4aiApiKey,
+      apiUrl: crawl4aiApiUrl,
+      timeout: scraperTimeout ?? crawl4aiOptions?.timeout,
       logger,
     });
   } else {

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -5,7 +5,7 @@ import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
 export type SearchProvider = 'serper' | 'searxng';
-export type ScraperProvider = 'firecrawl' | 'serper';
+export type ScraperProvider = 'firecrawl' | 'serper' | 'crawl4ai';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
 export interface Highlight {
@@ -107,6 +107,15 @@ export interface SerperScraperConfig {
   includeMarkdown?: boolean;
 }
 
+export interface Crawl4AIScraperConfig {
+  apiKey?: string;
+  apiUrl?: string;
+  timeout?: number;
+  logger?: Logger;
+  extractionStrategy?: string;
+  chunkingStrategy?: string;
+}
+
 export interface ScraperContentResult {
   content: string;
 }
@@ -164,6 +173,9 @@ export interface SearchToolConfig
   scraperProvider?: ScraperProvider;
   scraperTimeout?: number;
   serperScraperOptions?: SerperScraperConfig;
+  crawl4aiApiKey?: string;
+  crawl4aiApiUrl?: string;
+  crawl4aiOptions?: Crawl4AIScraperConfig;
   onSearchResults?: (
     results: SearchResult,
     runnableConfig?: RunnableConfig
@@ -187,12 +199,12 @@ export interface BaseScraper {
   scrapeUrl(
     url: string,
     options?: unknown
-  ): Promise<[string, FirecrawlScrapeResponse | SerperScrapeResponse]>;
+  ): Promise<[string, FirecrawlScrapeResponse | SerperScrapeResponse | Crawl4AIScrapeResponse]>;
   extractContent(
-    response: FirecrawlScrapeResponse | SerperScrapeResponse
+    response: FirecrawlScrapeResponse | SerperScrapeResponse | Crawl4AIScrapeResponse
   ): [string, undefined | References];
   extractMetadata(
-    response: FirecrawlScrapeResponse | SerperScrapeResponse
+    response: FirecrawlScrapeResponse | SerperScrapeResponse | Crawl4AIScrapeResponse
   ):
     | ScrapeMetadata
     | Record<string, string | number | boolean | null | undefined>;
@@ -206,6 +218,11 @@ export type FirecrawlScrapeOptions = Omit<
 
 export type SerperScrapeOptions = Omit<
   SerperScraperConfig,
+  'apiKey' | 'apiUrl' | 'logger'
+>;
+
+export type Crawl4AIScrapeOptions = Omit<
+  Crawl4AIScraperConfig,
   'apiKey' | 'apiUrl' | 'logger'
 >;
 
@@ -291,6 +308,17 @@ export interface SerperScrapeResponse {
     markdown?: string;
     metadata?: Record<string, string | number | boolean | null | undefined>;
     credits?: number;
+  };
+  error?: string;
+}
+
+export interface Crawl4AIScrapeResponse {
+  success: boolean;
+  data?: {
+    markdown?: string;
+    text?: string;
+    html?: string;
+    metadata?: Record<string, string | number | boolean | null | undefined>;
   };
   error?: string;
 }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -324,7 +324,6 @@ export interface SerperScrapeResponse {
   error?: string;
 }
 
-// TODO
 export interface Crawl4AIScrapeResponse {
   success: boolean;
   data?: {

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -199,12 +199,23 @@ export interface BaseScraper {
   scrapeUrl(
     url: string,
     options?: unknown
-  ): Promise<[string, FirecrawlScrapeResponse | SerperScrapeResponse | Crawl4AIScrapeResponse]>;
+  ): Promise<
+    [
+      string,
+      FirecrawlScrapeResponse | SerperScrapeResponse | Crawl4AIScrapeResponse,
+    ]
+  >;
   extractContent(
-    response: FirecrawlScrapeResponse | SerperScrapeResponse | Crawl4AIScrapeResponse
+    response:
+      | FirecrawlScrapeResponse
+      | SerperScrapeResponse
+      | Crawl4AIScrapeResponse
   ): [string, undefined | References];
   extractMetadata(
-    response: FirecrawlScrapeResponse | SerperScrapeResponse | Crawl4AIScrapeResponse
+    response:
+      | FirecrawlScrapeResponse
+      | SerperScrapeResponse
+      | Crawl4AIScrapeResponse
   ):
     | ScrapeMetadata
     | Record<string, string | number | boolean | null | undefined>;
@@ -319,6 +330,17 @@ export interface Crawl4AIScrapeResponse {
     text?: string;
     html?: string;
     metadata?: Record<string, string | number | boolean | null | undefined>;
+    // /crawl endpoint returns results array
+    results?: Array<{
+      url?: string;
+      markdown?: {
+        raw_markdown?: string;
+        markdown_with_citations?: string;
+        references_markdown?: string;
+      };
+      html?: string;
+      metadata?: Record<string, string | number | boolean | null | undefined>;
+    }>;
   };
   error?: string;
 }

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -114,6 +114,7 @@ export interface Crawl4AIScraperConfig {
   logger?: Logger;
   extractionStrategy?: string;
   chunkingStrategy?: string;
+  fitStrategy?: string;
 }
 
 export interface ScraperContentResult {
@@ -323,6 +324,7 @@ export interface SerperScrapeResponse {
   error?: string;
 }
 
+// TODO
 export interface Crawl4AIScrapeResponse {
   success: boolean;
   data?: {
@@ -335,6 +337,7 @@ export interface Crawl4AIScrapeResponse {
       url?: string;
       markdown?: {
         raw_markdown?: string;
+        fit_markdown?: string;
         markdown_with_citations?: string;
         references_markdown?: string;
       };


### PR DESCRIPTION
This is a PR to add [crawl4ai](https://github.com/unclecode/crawl4ai) as an option for local crawl, to supplement the existing firecrawl option. There's going to be a complementary PR in the LibreChat main repo, which I've drafted [here](https://github.com/danny-avila/LibreChat/pull/11553)

This PR builds on @lukolszewski original work and adds `fit` as a default option for crawl4ai's `/md` endpoint, which uses adaptive filtering to filter the markdown, or returns just the raw markdown (`raw` for `fitStrategy`).

I've tested locally and it works fine. I have docker image for testing if anybody is interested (ghcr.io/relic664/librechat:latest). 

It's worth nothing that this is a _very basic_ implementation to provide a simple option for a self-hosted scrape option. This implementation doesn't provide options for the scrape beyond `fit` (filtered markdown) or `raw` (raw markdown). Given that there's only one self-hosted option for scrape, I thought it was prudent to go ahead and make a MVP PR for crawl4ai before a full featured implementation with all the configuration knobs. 

A simple quick start is to set the env var `CRAWL4AI_API_URL` to your instance, and in your `librechat.config`:

```
webSearch:
  crawl4aiApiUrl: "${CRAWL4AI_API_URL}"
  scraperProvider: "crawl4ai"
  ```
