### PR TITLE
feat: add staticInstructions for multi-block Anthropic prompt cache o…

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -37,6 +37,7 @@ export class AgentContext {
       toolRegistry,
       toolDefinitions,
       instructions,
+      staticInstructions,
       additional_instructions,
       streamBuffer,
       maxContextTokens,
@@ -57,6 +58,7 @@ export class AgentContext {
       toolRegistry,
       toolDefinitions,
       instructions,
+      staticInstructions,
       additionalInstructions: additional_instructions,
       reasoningKey,
       toolEnd,
@@ -134,6 +136,8 @@ export class AgentContext {
   discoveredToolNames: Set<string> = new Set();
   /** Instructions for this agent */
   instructions?: string;
+  /** Static portion of instructions for Anthropic prompt cache splitting */
+  staticInstructions?: string;
   /** Additional instructions for this agent */
   additionalInstructions?: string;
   /** Reasoning key for this agent */
@@ -187,6 +191,7 @@ export class AgentContext {
     toolRegistry,
     toolDefinitions,
     instructions,
+    staticInstructions,
     additionalInstructions,
     reasoningKey,
     toolEnd,
@@ -206,6 +211,7 @@ export class AgentContext {
     toolRegistry?: t.LCToolRegistry;
     toolDefinitions?: t.LCTool[];
     instructions?: string;
+    staticInstructions?: string;
     additionalInstructions?: string;
     reasoningKey?: 'reasoning_content' | 'reasoning';
     toolEnd?: boolean;
@@ -225,6 +231,7 @@ export class AgentContext {
     this.toolRegistry = toolRegistry;
     this.toolDefinitions = toolDefinitions;
     this.instructions = instructions;
+    this.staticInstructions = staticInstructions;
     this.additionalInstructions = additionalInstructions;
     if (reasoningKey) {
       this.reasoningKey = reasoningKey;
@@ -424,15 +431,41 @@ export class AgentContext {
         | t.AnthropicClientOptions
         | undefined;
       if (anthropicOptions?.promptCache === true) {
-        finalInstructions = {
-          content: [
-            {
-              type: 'text',
-              text: instructionsString,
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-        };
+        if (this.staticInstructions && this.staticInstructions.length >= 1024) {
+          // Multi-block: static part cached, dynamic part sent fresh
+          // Extract ONLY the dynamic portion to avoid sending static content twice
+          const dynamicContent = instructionsString
+            .replace(this.staticInstructions, '')
+            .trim();
+          finalInstructions = {
+            content: [
+              {
+                type: 'text',
+                text: this.staticInstructions,
+                cache_control: { type: 'ephemeral' },
+              },
+              ...(dynamicContent
+                ? [
+                  {
+                    type: 'text' as const,
+                    text: dynamicContent,
+                  },
+                ]
+                : []),
+            ],
+          };
+        } else {
+          // Original single-block behavior (backward-compatible)
+          finalInstructions = {
+            content: [
+              {
+                type: 'text',
+                text: instructionsString,
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          };
+        }
       }
     }
 

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -364,6 +364,14 @@ export interface AgentInputs {
   tools?: GraphTools;
   provider: Providers;
   instructions?: string;
+  /**
+   * Static portion of instructions for Anthropic prompt cache splitting.
+   * When provided with promptCache=true, this text gets cache_control
+   * while the remaining dynamic content does not.
+   * This allows the static base to be cached and shared across all users,
+   * while dynamic context (e.g., user-specific data) is sent fresh.
+   */
+  staticInstructions?: string;
   streamBuffer?: number;
   maxContextTokens?: number;
   clientOptions?: ClientOptions;


### PR DESCRIPTION
…ptimization

Adds optional staticInstructions field to AgentInputs that enables separating static system instructions from dynamic content for Anthropic prompt caching.

When staticInstructions is provided and promptCache is true, buildSystemRunnable() creates two content blocks: the static portion with cache_control (cached and shared across users) and the dynamic-only remainder without cache_control (sent fresh each request).

This dramatically improves cache hit rates in multi-user deployments where agents have large static base prompts (~90K tokens) but small per-user dynamic context (~5-15K tokens).

Changes:

- Add staticInstructions to AgentInputs interface (types/graph.ts)

- Add staticInstructions property, constructor param, and fromConfig() (AgentContext.ts)

- Add multi-block cache logic in buildSystemRunnable() with dynamic content extraction

- Fully backwards compatible: field is optional, single-block behavior unchanged when not provided