### PR TITLE
fix: forward LangGraph config through MultiAgentGraph agentWrapper

### DIFF
--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -15,6 +15,7 @@ import {
   getCurrentTaskInput,
   messagesStateReducer,
 } from '@langchain/langgraph';
+import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type { BaseMessage, AIMessageChunk } from '@langchain/core/messages';
 import type { ToolRunnableConfig } from '@langchain/core/tools';
 import type * as t from '@/types';
@@ -745,7 +746,8 @@ export class MultiAgentGraph extends StandardGraph {
 
       /** Wrapper function that handles agentMessages channel, handoff reception, and conditional routing */
       const agentWrapper = async (
-        state: t.MultiAgentGraphState
+        state: t.MultiAgentGraphState,
+        config?: LangGraphRunnableConfig
       ): Promise<t.MultiAgentGraphState | Command> => {
         let result: t.MultiAgentGraphState;
 
@@ -817,7 +819,7 @@ export class MultiAgentGraph extends StandardGraph {
             ...state,
             messages: messagesForAgent,
           };
-          result = await agentSubgraph.invoke(transformedState);
+          result = await agentSubgraph.invoke(transformedState, config);
           result = {
             ...result,
             agentMessages: [],
@@ -863,14 +865,14 @@ export class MultiAgentGraph extends StandardGraph {
             ...state,
             messages: state.agentMessages,
           };
-          result = await agentSubgraph.invoke(transformedState);
+          result = await agentSubgraph.invoke(transformedState, config);
           result = {
             ...result,
             /** Clear agentMessages for next agent */
             agentMessages: [],
           };
         } else {
-          result = await agentSubgraph.invoke(state);
+          result = await agentSubgraph.invoke(state, config);
         }
 
         /** If agent has both handoff and direct edges, use Command for exclusive routing */


### PR DESCRIPTION
## Problem

The `agentWrapper` function in `MultiAgentGraph.createWorkflow()` only accepts `state`, silently dropping the `config` parameter that LangGraph passes to all node functions. This means `configurable.user` is lost when agent subgraphs are invoked during handoffs.

**Impact:** Any feature that relies on `config.configurable` during tool execution — such as MCP header placeholders (`{{LIBRECHAT_USER_ID}}`) — works for direct agent calls but breaks during agent-to-agent handoffs.

## Root Cause

```
graphRunnable.streamEvents(inputs, config)
  → MultiAgentGraph node: agentWrapper(state)     ← config dropped
    → agentSubgraph.invoke(state)                 ← config not forwarded
      → ToolNode.runTool(call, config)             ← config is empty
```

`StandardGraph` doesn't have this issue because it doesn't wrap subgraph invocations — config flows naturally through LangGraph.

## Fix

Add `config` to the `agentWrapper` signature and forward it through all three `agentSubgraph.invoke()` calls. This is the standard LangGraph node pattern (`(state, config)`) and is consistent with how other node functions in the codebase work.

## Testing

Verified in a production LibreChat deployment (v0.8.2, `@librechat/agents` v3.0.776):
- Agent handoff + MCP tool calls: `{{LIBRECHAT_USER_ID}}` resolves correctly
- Direct MCP calls (no handoff): still works
- Agent handoffs without MCP tools: no regression
- Non-agent conversations: no regression

Fixes #9821, #10211, #10569, #10969, #11467