### PR TITLE
fix: update getEventDrivenToolsForBinding to merge schema-only tools with native tools

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -633,7 +633,7 @@ export class AgentContext {
     return filtered;
   }
 
-  /** Creates schema-only tools from toolDefinitions for event-driven mode */
+  /** Creates schema-only tools from toolDefinitions for event-driven mode, merged with native tools */
   private getEventDrivenToolsForBinding(): t.GraphTools {
     if (!this.toolDefinitions) {
       return this.graphTools ?? [];
@@ -655,11 +655,17 @@ export class AgentContext {
 
     const schemaTools = createSchemaOnlyTools(defsToInclude) as t.GraphTools;
 
+    const allTools = [...schemaTools];
+
     if (this.graphTools && this.graphTools.length > 0) {
-      return [...schemaTools, ...this.graphTools];
+      allTools.push(...this.graphTools);
     }
 
-    return schemaTools;
+    if (this.tools && this.tools.length > 0) {
+      allTools.push(...this.tools);
+    }
+
+    return allTools;
   }
 
   /** Filters tool instances for binding based on registry config */


### PR DESCRIPTION
Closes #56 

This commit modifies the getEventDrivenToolsForBinding method in the AgentContext class to merge schema-only tools with existing native tools. The updated logic ensures that both graphTools and tools are included in the final output, enhancing the flexibility and completeness of tool definitions for event-driven mode.