### PR TITLE
refactor: remove task instructions from handoff context in AgentContext

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -176,8 +176,6 @@ export class AgentContext {
     sourceAgentName: string;
     /** Names of sibling agents executing in parallel (empty if sequential) */
     parallelSiblings: string[];
-    /** Task-specific instructions passed through the handoff tool */
-    instructions?: string;
   };
 
   constructor({
@@ -382,8 +380,7 @@ export class AgentContext {
     if (!this.handoffContext) return '';
 
     const displayName = this.name ?? this.agentId;
-    const { sourceAgentName, parallelSiblings, instructions } =
-      this.handoffContext;
+    const { sourceAgentName, parallelSiblings } = this.handoffContext;
     const isParallel = parallelSiblings.length > 0;
 
     const lines: string[] = [];
@@ -399,12 +396,6 @@ export class AgentContext {
     lines.push(
       'Execute only tasks relevant to your role. Routing is already handled if requested, unless you can route further.'
     );
-
-    if (instructions != null && instructions !== '') {
-      lines.push('');
-      lines.push('## Task Instructions');
-      lines.push(instructions);
-    }
 
     return lines.join('\n');
   }
@@ -577,14 +568,9 @@ export class AgentContext {
    * Marks system runnable as stale to include handoff context in system message.
    * @param sourceAgentName - Name of the agent that transferred control
    * @param parallelSiblings - Names of other agents executing in parallel with this one
-   * @param instructions - Optional task instructions passed through the handoff tool
    */
-  setHandoffContext(
-    sourceAgentName: string,
-    parallelSiblings: string[],
-    instructions?: string
-  ): void {
-    this.handoffContext = { sourceAgentName, parallelSiblings, instructions };
+  setHandoffContext(sourceAgentName: string, parallelSiblings: string[]): void {
+    this.handoffContext = { sourceAgentName, parallelSiblings };
     this.systemRunnableStale = true;
   }
 

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -773,40 +773,56 @@ export class MultiAgentGraph extends StandardGraph {
           /**
            * Set handoff context on the receiving agent.
            * Uses pre-computed graph position for depth and parallel info.
-           *
-           * Task instructions from the handoff are injected into the system
-           * prompt (via buildIdentityPreamble) rather than appended as a
-           * HumanMessage.  This avoids the "400 Unexpected role 'user' after
-           * role 'tool'" error that occurs when the router runs a non-handoff
-           * tool before handing off, leaving a ToolMessage as the last
-           * filtered message (see issue #54).
            */
           const agentContext = this.agentContexts.get(agentId);
-          const hasInstructions = instructions !== null && instructions !== '';
           if (
             agentContext &&
             sourceAgentName != null &&
             sourceAgentName !== ''
           ) {
-            agentContext.setHandoffContext(
-              sourceAgentName,
-              parallelSiblings,
-              hasInstructions ? instructions : undefined
-            );
+            agentContext.setHandoffContext(sourceAgentName, parallelSiblings);
           }
 
           /** Build messages for the receiving agent */
-          const messagesForAgent = filteredMessages;
+          let messagesForAgent = filteredMessages;
 
           /**
-           * Update token map to reflect the filtered message set.
-           * Instructions are now part of the system message (via handoff
-           * context), so we only need to rebuild the map for the filtered
-           * messages and let initializeSystemRunnable account for the
-           * updated system message tokens.
+           * If there are instructions, inject them as a HumanMessage to
+           * ground the receiving agent.
+           *
+           * When the last filtered message is a ToolMessage (e.g. from a
+           * non-handoff tool the router called before handing off), a
+           * synthetic AIMessage is inserted first to satisfy the
+           * tool → assistant role ordering required by chat APIs.  Without
+           * this bridge, appending a HumanMessage directly after a
+           * ToolMessage causes "400 Unexpected role 'user' after role
+           * 'tool'" errors (see issue #54).
            */
+          const hasInstructions = instructions !== null && instructions !== '';
+          if (hasInstructions) {
+            const lastMsg =
+              filteredMessages.length > 0
+                ? filteredMessages[filteredMessages.length - 1]
+                : null;
+
+            if (lastMsg != null && lastMsg.getType() === 'tool') {
+              messagesForAgent = [
+                ...filteredMessages,
+                new AIMessage(
+                  `[Processed tool result and transferring to ${agentId}]`
+                ),
+                new HumanMessage(instructions),
+              ];
+            } else {
+              messagesForAgent = [
+                ...filteredMessages,
+                new HumanMessage(instructions),
+              ];
+            }
+          }
+
+          /** Update token map if we have a token counter */
           if (agentContext?.tokenCounter && hasInstructions) {
-            agentContext.initializeSystemRunnable();
             const freshTokenMap: Record<string, number> = {};
             for (
               let i = 0;
@@ -817,6 +833,14 @@ export class MultiAgentGraph extends StandardGraph {
               if (tokenCount !== undefined) {
                 freshTokenMap[i] = tokenCount;
               }
+            }
+            /** Add tokens for the bridge AIMessage + instructions HumanMessage */
+            for (
+              let i = filteredMessages.length;
+              i < messagesForAgent.length;
+              i++
+            ) {
+              freshTokenMap[i] = agentContext.tokenCounter(messagesForAgent[i]);
             }
             agentContext.updateTokenMapWithInstructions(freshTokenMap);
           }


### PR DESCRIPTION
This commit simplifies the handoff context by removing the optional task instructions from the AgentContext class. The instructions are now handled directly in the MultiAgentGraph, where they are injected into the system prompt instead of being passed through the handoff context. This change enhances the clarity of the handoff process and resolves potential issues with message role ordering in chat APIs.