### PR TITLE
fix(handoff): return wrong-tool correction to LLM instead of silent execute

### DIFF
--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -84,6 +84,29 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
+   * Resolves a handoff tool call name that may be slightly wrong (e.g. LLM
+   * duplicated a suffix) to the actual direct tool name. When a match is found,
+   * we return a ToolMessage to the LLM with the correct name so it can call the
+   * right tool itself, instead of executing the handoff silently or dispatching
+   * via ON_TOOL_EXECUTE (where the host has no handoff tools).
+   */
+  private resolveHandoffToolName(callName: string): string | undefined {
+    if (
+      !callName.startsWith(Constants.LC_TRANSFER_TO_) ||
+      this.directToolNames == null ||
+      this.directToolNames.size === 0
+    ) {
+      return undefined;
+    }
+    const handoffDirect = Array.from(this.directToolNames).filter((d) =>
+      d.startsWith(Constants.LC_TRANSFER_TO_)
+    );
+    const prefixMatches = handoffDirect.filter((d) => callName.startsWith(d));
+    if (prefixMatches.length === 0) return undefined;
+    return prefixMatches.reduce((a, b) => (a.length >= b.length ? a : b));
+  }
+
+  /**
    * Returns cached programmatic tools, computing once on first access.
    * Single iteration builds both toolMap and toolDefs simultaneously.
    */
@@ -670,8 +693,28 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const directCalls = filteredCalls.filter((c) =>
           this.directToolNames!.has(c.name)
         );
+        const handoffSentToEvent = filteredCalls.filter(
+          (c) =>
+            !this.directToolNames!.has(c.name) &&
+            c.name.startsWith(Constants.LC_TRANSFER_TO_)
+        );
+        const resolvedHandoffs: Array<{
+          call: ToolCall;
+          resolvedName: string;
+        }> = handoffSentToEvent
+          .map((c) => {
+            const resolved = this.resolveHandoffToolName(c.name);
+            return resolved != null
+              ? { call: c, resolvedName: resolved }
+              : null;
+          })
+          .filter(
+            (x): x is { call: ToolCall; resolvedName: string } => x !== null
+          );
         const eventCalls = filteredCalls.filter(
-          (c) => !this.directToolNames!.has(c.name)
+          (c) =>
+            !this.directToolNames!.has(c.name) &&
+            !resolvedHandoffs.some((r) => r.call === c)
         );
 
         const directOutputs: (BaseMessage | Command)[] =
@@ -681,8 +724,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             )
             : [];
 
+        const handoffCorrectionMessages: ToolMessage[] = resolvedHandoffs.map(
+          ({ call, resolvedName }) =>
+            new ToolMessage({
+              content: `The tool name you used does not match a registered handoff tool. You used: "${call.name}". The correct tool for this handoff is: "${resolvedName}". Please call that tool instead to transfer to the intended agent.`,
+              name: call.name,
+              tool_call_id: call.id ?? '',
+            })
+        );
+
         if (directCalls.length > 0 && directOutputs.length > 0) {
           this.handleRunToolCompletions(directCalls, directOutputs, config);
+        }
+        if (handoffCorrectionMessages.length > 0) {
+          this.handleRunToolCompletions(
+            resolvedHandoffs.map((r) => r.call),
+            handoffCorrectionMessages,
+            config
+          );
         }
 
         const eventOutputs: ToolMessage[] =
@@ -690,7 +749,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             ? await this.dispatchToolEvents(eventCalls, config)
             : [];
 
-        outputs = [...directOutputs, ...eventOutputs];
+        outputs = [
+          ...directOutputs,
+          ...handoffCorrectionMessages,
+          ...eventOutputs,
+        ];
       } else {
         outputs = await Promise.all(
           filteredCalls.map((call) => this.runTool(call, config))


### PR DESCRIPTION
When the model calls a handoff tool with a **wrong name** (e.g. duplicated suffix like `lc_transfer_to_agent_...7yu7yu` instead of `...7yu`), we no longer execute the handoff silently with the resolved name. We return a **ToolMessage** that tells the LLM the used name was wrong and suggests the correct tool name, so the LLM can call the correct tool in the next turn and select the right agent itself.

### Out of Scope?

I understand that the PR is out of scope and may simply be a problem with the model used. I have integrated it as a workaround and didn't want to leave it unmentioned and is more likely a workaround.

### Problem

- Handoff tools are graph-managed; the host’s `loadTools` does not provide them.
- If the model emits a slightly wrong tool name (e.g. duplicated suffix), the call was previously resolved via prefix match and executed as a direct handoff with the correct name.
- That hid the mistake from the model and didn’t give it a chance to correct itself.

### Solution

- **ToolNode** (`dev/agents/src/tools/ToolNode.ts`): For handoff calls that are not in `directToolNames` but can be resolved via `resolveHandoffToolName()` (prefix match), we **do not** add them to direct execution.
- Instead we create a **ToolMessage** per such call with:
  - a short explanation that the used tool name doesn’t match a registered handoff tool,
  - the name that was used,
  - the **correct** handoff tool name,
  - an instruction to call that tool instead.
- These messages are appended to the tool outputs; `handleRunToolCompletions` is called for them so the UI shows the step and the correction.
- The LLM sees the correction as a normal tool result and can issue a follow-up call with the suggested tool name.

### Changes

- **ToolNode.ts**
  - Removed execution of resolved handoffs via `directCallsResolved`.
  - Added `handoffCorrectionMessages`: one ToolMessage per resolved handoff with the text above.
  - Outputs are now `directOutputs` + `handoffCorrectionMessages` + `eventOutputs`.
  - JSDoc for `resolveHandoffToolName` updated to describe the new behaviour.
  - Explicit null/size check for `directToolNames` to satisfy lint.
- **docs/HANDOFF_TOOL_NAME_ANALYSIS.md**: Conclusion and “Defensive fix” step updated to describe “return correction message to LLM” instead of “execute as direct”.

### Related

- Fixes #60 