### PR TITLE
fix: reranked websearch content don't overload the model anymore

### DIFF
--- a/src/tools/search/highlights.ts
+++ b/src/tools/search/highlights.ts
@@ -240,7 +240,8 @@ export function expandHighlights(
         !result.highlights ||
         result.highlights.length === 0
       ) {
-        return result; // No modification needed
+        const { content: _content, ...resultWithoutContent } = result;
+        return resultWithoutContent as typeof result;
       }
 
       // Create a shallow copy with expanded highlights

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -711,6 +711,7 @@ export const createSourceProcessor = (
 
       if (news && topStories.length > 0) {
         updateSourcesWithContent(topStories, sourceMap);
+        result.data.topStories = topStories.slice(0, numElements);
       }
 
       return result.data;

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -65,6 +65,12 @@ const chunker = {
   },
 };
 
+/** Maximum chars of scraped content passed to the chunker/reranker per source.
+ *  Overridable via SEARCH_MAX_CONTENT_LENGTH env var. */
+const DEFAULT_MAX_CONTENT_LENGTH = 50000;
+const MAX_CONTENT_LENGTH =
+  Number(process.env.SEARCH_MAX_CONTENT_LENGTH) || DEFAULT_MAX_CONTENT_LENGTH;
+
 function createSourceUpdateCallback(sourceMap: Map<string, t.ValidSource>) {
   return (link: string, update?: Partial<t.ValidSource>): void => {
     const source = sourceMap.get(link);
@@ -82,12 +88,14 @@ const getHighlights = async ({
   content,
   reranker,
   topResults = 5,
+  maxContentLength = MAX_CONTENT_LENGTH,
   logger,
 }: {
   content: string;
   query: string;
   reranker?: BaseReranker;
   topResults?: number;
+  maxContentLength?: number;
   logger?: t.Logger;
 }): Promise<t.Highlight[] | undefined> => {
   const logger_ = logger || createDefaultLogger();
@@ -102,7 +110,11 @@ const getHighlights = async ({
   }
 
   try {
-    const documents = await chunker.splitText(content);
+    const cappedContent =
+      content.length > maxContentLength
+        ? content.slice(0, maxContentLength)
+        : content;
+    const documents = await chunker.splitText(cappedContent);
     if (Array.isArray(documents)) {
       return await reranker.rerank(query, documents, topResults);
     } else {
@@ -445,6 +457,7 @@ export const createSourceProcessor = (
   }
   const {
     topResults = 5,
+    maxContentLength = MAX_CONTENT_LENGTH,
     // strategies = ['no_extraction'],
     // filterContent = true,
     reranker,
@@ -479,11 +492,15 @@ export const createSourceProcessor = (
               );
               if (response.success && response.data) {
                 const [content, references] = scraper.extractContent(response);
+                const cleanedContent = chunker.cleanText(content);
                 return {
                   url,
                   references,
                   attribution,
-                  content: chunker.cleanText(content),
+                  content:
+                    cleanedContent.length > maxContentLength
+                      ? cleanedContent.slice(0, maxContentLength)
+                      : cleanedContent,
                 } as t.ScrapeResult;
               } else {
                 logger_.error(
@@ -512,6 +529,7 @@ export const createSourceProcessor = (
                   query,
                   reranker,
                   content: result.content,
+                  maxContentLength,
                   logger: logger_,
                 });
                 if (onGetHighlights) {

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -353,6 +353,7 @@ export const createSearchTool = (
     searxngApiKey,
     rerankerType = 'cohere',
     topResults = 5,
+    maxContentLength,
     strategies = ['no_extraction'],
     filterContent = true,
     safeSearch = 1,
@@ -435,6 +436,7 @@ export const createSearchTool = (
     {
       reranker: selectedReranker,
       topResults,
+      maxContentLength,
       strategies,
       filterContent,
       logger,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -85,6 +85,8 @@ export interface ScrapeResult {
 
 export interface ProcessSourcesConfig {
   topResults?: number;
+  /** Max chars of scraped content per source before chunking. Overridable via SEARCH_MAX_CONTENT_LENGTH. */
+  maxContentLength?: number;
   strategies?: string[];
   filterContent?: boolean;
   reranker?: BaseReranker;


### PR DESCRIPTION
Hi Danny, 
I was searching for why my local websearch, webcrawler and reranker always killed my model context, which led to completely lobotomized models as the context/kv-cache got overwritten. This is already 6 months ago ( see https://www.reddit.com/r/LocalLLaMA/comments/1mucj1p/which_models_are_suitable_for_websearch/ )

I had to dig deep to figure out what is going on in the complex of Librechat -> agent and flow between searXNG, Firecrawl, Jina-reranker and local models which usually have a limited amount of kv-cache.

I used the last weeks to add more and more debug code to the agents code and found this:

## First fix: expandHighlights sending whole content.


With default `expandHighlights` parameters (`mainExpandBy=300`,
`separatorExpandBy=150`), every web search query overflowed the context window:

```
[formatResultsForLLM] output size: 3,204,513 chars, ~**801,128 tokens**
-> empty_messages: Message pruning removed all messages as none fit in the context window
```

```
[formatResultsForLLM] output size: 2,174,069 chars, ~**543,517 tokens**
-> empty_messages: Message pruning removed all messages as none fit in the context window
```

Per-source JSON size inspection confirmed sources were carrying full page content:
individual source sizes in the hundreds of thousands of characters.

`expandHighlights()` had an early-return path for sources with no highlights that returned the original result object unmodified, including the full raw scraped page content from Firecrawl. This caused the entire scraped content of those pages to pass through into `formatResultsForLLM` and be sent to the LLM as part of the tool output, producing context window overflows on every web search query.

### What I found:

In `src/tools/search/highlights.ts`, the `expandHighlights()` function maps over organic results and top stories to expand highlight boundaries. For sources that had no highlights (either because the reranker returned nothing, the source failed to
scrape, or content was empty), the function returned early:

```typescript
// Before
if (
  result.content == null ||
  result.content === '' ||
  !result.highlights ||
  result.highlights.length === 0
) {
  return result; // ← returned the original object, full content included
}
```

The normal code path (when highlights exist) correctly creates a shallow copy and
deletes content:
```typescript
const resultCopy = { ...result };
// ... process highlights ...
delete resultCopy.content;
return resultCopy;
```

But the early-return path bypassed this entirely, passing `result.content` the full scraped markdown from Firecrawl, potentially hundreds of kilobytes per page directly into the output.


### The Change

Strip `content` from the result in the early-return path before returning:

```typescript
// After
if (
  result.content == null ||
  result.content === '' ||
  !result.highlights ||
  result.highlights.length === 0
) {
  const { content: _content, ...resultWithoutContent } = result;
  return resultWithoutContent as typeof result;
}
```

`content` is now always removed before a result leaves `expandHighlights()`,
regardless of whether highlights exist.


## Second fix: content passed to the reranker was not capped

While chasing the overflow, I found a second problem that became visible once the early-return content leak was closed.

With the first fix in place, sources that *do* have highlights now correctly delete `content` after expansion. But `content` was still being stored uncapped on the `ScrapeResult` object before ever reaching `expandHighlights`. A large page with around 80k respectively 200k, or more chars was stored in full, then `expandHighlights` ran `content.indexOf(highlight.text)` and boundary searches across the entire string. More critically, `getHighlights()` was also receiving the full uncapped content and handing it to `RecursiveCharacterTextSplitter`, which would happily produce hundreds of small chunks and send all of them to the reranker in a single request.

### The fix is in three places:

**At storage time** (`search.ts`  `scrapeMany`): after cleaning the text, the content is capped before being stored on the result object:

```typescript
// Before
content: chunker.cleanText(content),

// After
const cleanedContent = chunker.cleanText(content);
content: cleanedContent.length > maxContentLength
  ? cleanedContent.slice(0, maxContentLength)
  : cleanedContent,
```

**Before chunking** (`search.ts`  `getHighlights`): even if the content arrived uncapped through a different code path, it gets capped again before the text splitter runs:

```typescript
const cappedContent =
  content.length > maxContentLength
    ? content.slice(0, maxContentLength)
    : content;
const documents = await chunker.splitText(cappedContent);
```

**The cap itself** is set to 50000 chars by default, overridable per-deployment via the `SEARCH_MAX_CONTENT_LENGTH` environment variable. It is wired through `ProcessSourcesConfig.maxContentLength` -> `createSourceProcessor` -> both call sites above, so `createSearchTool` callers can tune it without touching the source.

**Why 50000?**

With the default `chunkSize=150` and `chunkOverlap=50`, a 50 000-char page produces roughly 330 chunks. That is already a lot for a reranker to score. In practice, clean Firecrawl markdown from a well-structured page is 5–40k chars, so the cap rarely fires, but it prevents a degenerate case (minified content, dense tables, very long articles) from saturating the reranker or causing latency spikes.

## Third fix: reducing news for SearXNG similar to Serper 

After the first two fixes brought output sizes down to manageable levels, I figured out that SearXNG when news results are enabled, it is sending far too much (duplicated) news. 

`executeParallelSearches` in `tool.ts` fires a main SearXNG search alongside an optional parallel news sub-search. Both return news items that will be merged into `topStories`. SearXNG's general search also includes its own `news` category which gets converted to `topStories` moreover. The result is entering `processSources` can carry 24–37 `topStories` items instead of the expected 5.

This is a SearXNG-specific issue. The Serper adapter already slices `topStories` to 5 before the data leaves `createSerperAPI`:

```typescript
// Serper is already capped at source
const topStories = newsResults.slice(0, 5);
```

SearXNG has no equivalent cap, so all 24–37 items were scraped, reranked, and passed to `formatResultsForLLM`. In practice this produced `n=32` sources entering `expandHighlights` and output of 114,771 chars / ~28,693 tokens which is enough to overflow smaller context windows and leave almost no room for conversation history or a model response.

**The fix** (`search.ts` `processSources`): slice `topStories` to `numElements` after `updateSourcesWithContent`, consistent with how organic results are already limited via the `target` parameter in `fetchContents`. The slice happens after enrichment so SearXNG's relevance ordering is preserved:

```typescript
if (news && topStories.length > 0) {
  updateSourcesWithContent(topStories, sourceMap);
  result.data.topStories = topStories.slice(0, numElements); // ← added
}
```

After this fix, the same query dropped from `n=32` to `n=13` (5 organic + up to 5 capped topStories + a small number from the main search's own news field) and output fell to ~35,687 chars / ~8,922 tokens.



## Infrastructure and codebase:

I tested this LibreChat 0.8.3rc1 and agents 3.1.52 (and last test with 3.1.53 and 3.1.54) against a self-hosted instance using:
- **Search**: SearXNG (self-hosted)
- **Scraper**: highly updated and optimized Firecrawl-simple (self-hosted, v1 API)   (released soon, already in my github repos, but I needed Librechat to work first)
- **Reranker**: open-reranker (self-hosted, Jina-compatible API)      (released soon, but I needed Librechat to work first)
- **Model**: qwen3-14b (41,000 token KV-cache context window)

### Before the fixes

With default `expandHighlights` parameters (`mainExpandBy=300`,
`separatorExpandBy=150`), every web search query overflowed the context window:

```
[formatResultsForLLM] output size: 3,204,513 chars, ~801,128 tokens
-> empty_messages: Message pruning removed all messages as none fit in the context window
```

```
[formatResultsForLLM] output size: 2,174,069 chars, ~543,517 tokens
-> empty_messages: Message pruning removed all messages as none fit in the context window
```

Per-source JSON size inspection confirmed sources were carrying full page content: individual source sizes in the hundreds of thousands of characters.

### After the fixes

With identical parameters and the same queries, output sizes dropped to normal:

```
[formatResultsForLLM] output size: 22,799 chars, ~5,700 tokens    ← broad navigational query
[formatResultsForLLM] output size: 115,161 chars, ~28,790 tokens  ← specific factual query
```

Per-source JSON sizes after the fixes: all sources between 176-655 chars (title + URL + snippet + highlights only,  No content field). Both queries completed successfully, and the model produced correct, well-cited answers.

### Why the first bug was challenging to spot

The bug was masked during an earlier investigation where I tried reducing the expansion parameters (`mainExpandBy=150`, `separatorExpandBy=75`). With smaller expansion, more sources successfully produced highlights and hit the normal code path (which correctly deletes content). Only when I restored the original default values did the early-return path become dominant, exposing the leak.

A parameter tuning session that appeared to "fix" the overflow by halving the expansion values was in fact masking this underlying bug. The actual fix is a 2-line change independent of any expansion parameter values.

## Testing

I verified end-to-end on:
- Broad navigational query ("search the web and tell me what are todays news from heise.de newsticker?"):
pipeline completes, output ~5,700 tokens, model receives title/snippet/URL metadata only for sources without highlights (correct behavior)

- Specific factual query ("Was ist mit dem Entwickler von Moltbot geschehen?"):
pipeline completes, output ~28,790 tokens (within 41k context window), model produces accurate answer with correct source citations, name history (ClawdBot -> Moltbot -> OpenClaw), security context, and project future

No regressions are observed in sources that do have highlights. The normal expansion and content deletion path is unchanged. With the content cap in place, reranker request sizes stay bounded regardless of page length.