### PR TITLE
feat: improve Langfuse trace quality with agent metadata and clean I/O

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -218,8 +218,7 @@ export class Run<_T extends t.BaseGraphState> {
    */
   private updateLangfuseTrace(
     handler: CallbackHandler,
-    inputs: t.IState,
-    agentName?: string
+    inputs: t.IState
   ): void {
     const traceId = handler.last_trace_id;
 
@@ -283,7 +282,6 @@ export class Run<_T extends t.BaseGraphState> {
             timestamp: new Date().toISOString(),
             body: {
               id: traceId,
-              ...(agentName != null && { name: agentName }),
               ...(cleanInput != null && { input: cleanInput }),
               ...(cleanOutput != null && { output: cleanOutput }),
             },
@@ -394,11 +392,7 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     if (langfuseEnabled && langfuseHandler?.last_trace_id != null) {
-      this.updateLangfuseTrace(
-        langfuseHandler,
-        inputs,
-        config.configurable.agent_name
-      );
+      this.updateLangfuseTrace(langfuseHandler, inputs);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add `agentId` and `agentName` to Langfuse trace metadata in both `processStream` and `generateTitle`, reading from `config.configurable.agent_id` / `agent_name` (set by LibreChat's `feat/langfuse-agent-name-metadata` branch)
- Add `agent_id` as a Langfuse tag for sidebar filtering in the trace list
- After the stream loop, fire-and-forget a delta-update to the Langfuse ingestion API that overwrites the trace-level `input` and `output` with clean, human-readable text (last human message as input, thinking + text content parts as output). All observation-level data (spans, generations, tool calls) is preserved untouched.

## Depends on

- LibreChat branch `feat/langfuse-agent-name-metadata` (passes `agent_id` and `agent_name` on `config.configurable`, and sets dynamic `runName` for trace naming) https://github.com/danny-avila/LibreChat/pull/12110

## Testing
<img width="1726" height="959" alt="Screenshot 2026-03-07 at 12 03 43 AM" src="https://github.com/user-attachments/assets/eeaa2696-64b9-42c9-a07f-2b46cd622ed4" />

<img width="1726" height="959" alt="Screenshot 2026-03-07 at 11 23 06 AM" src="https://github.com/user-attachments/assets/cb3d0492-e053-4035-b6b2-0b9c4dd367af" />

