### PR TITLE
feat: add hook registry and executor scaffolding (phase 1/1)

### DIFF
--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -1,0 +1,208 @@
+// src/hooks/HookRegistry.ts
+import type { HookEvent, HookMatcher } from './types';
+
+/**
+ * Internal matcher storage type.
+ *
+ * Matchers registered via the public `register<E>` API are strictly typed
+ * to a single `E`, but the storage needs one uniform slot type per event.
+ * We store them as `HookMatcher<HookEvent>` and cast once at the variance
+ * boundary — see `ensureList` and `snapshot` below. The invariant (every
+ * matcher in `bucket[event]` was registered with that exact event) is
+ * enforced by the public API; breaking it requires bypassing the types.
+ */
+type MatcherBucket = Partial<Record<HookEvent, HookMatcher<HookEvent>[]>>;
+
+/**
+ * Run-scoped storage for hook matchers with an additional layer for
+ * session-scoped matchers that should be cleaned up between sessions.
+ *
+ * Hosts construct one registry per `Run` (mirroring how `HandlerRegistry` is
+ * scoped) and register global matchers + per-session matchers against it.
+ * Registration is strictly additive — nothing in this class mutates a
+ * matcher's callbacks or flags after insertion.
+ *
+ * ## Why `Map<sessionId, MatcherBucket>` and not `Record`
+ *
+ * LibreChat runs thousands of parallel sessions in one Node process, and
+ * hook registration happens inside hot paths (tool loading, agent spawning).
+ * A `Record<sessionId, ...>` has to be spread on every insertion, which is
+ * O(n) per call and O(n²) total for a batch of parallel registrations. A
+ * Map mutates in place, keeping insertions O(1). This mirrors the reasoning
+ * Claude Code documents at `utils/hooks/sessionHooks.ts:62`.
+ */
+export class HookRegistry {
+  private readonly global: MatcherBucket = {};
+  private readonly sessions: Map<string, MatcherBucket> = new Map();
+
+  /**
+   * Register a matcher for the lifetime of this registry (= one Run).
+   * Returns an unregister function that removes the matcher by reference.
+   */
+  register<E extends HookEvent>(event: E, matcher: HookMatcher<E>): () => void {
+    const list = ensureList(this.global, event);
+    list.push(widen(matcher));
+    return () => {
+      removeFromList(list, matcher);
+    };
+  }
+
+  /**
+   * Register a matcher for a specific session. Cleared automatically when
+   * `clearSession(sessionId)` is called, or can be removed directly via the
+   * returned unregister function.
+   */
+  registerSession<E extends HookEvent>(
+    sessionId: string,
+    event: E,
+    matcher: HookMatcher<E>
+  ): () => void {
+    const bucket = this.ensureSessionBucket(sessionId);
+    const list = ensureList(bucket, event);
+    list.push(widen(matcher));
+    return () => {
+      removeFromList(list, matcher);
+    };
+  }
+
+  /**
+   * Returns all matchers registered for `event`, concatenating global first
+   * and then session-specific (when `sessionId` is supplied). The caller
+   * receives a fresh array, so iterating it is safe even if a matcher is
+   * removed mid-iteration (e.g. via `once: true`).
+   */
+  getMatchers<E extends HookEvent>(
+    event: E,
+    sessionId?: string
+  ): HookMatcher<E>[] {
+    const globalList = readList(this.global, event);
+    if (sessionId === undefined) {
+      return snapshot<E>(globalList);
+    }
+    const bucket = this.sessions.get(sessionId);
+    if (bucket === undefined) {
+      return snapshot<E>(globalList);
+    }
+    const sessionList = readList(bucket, event);
+    if (globalList.length === 0) {
+      return snapshot<E>(sessionList);
+    }
+    if (sessionList.length === 0) {
+      return snapshot<E>(globalList);
+    }
+    return snapshot<E>([...globalList, ...sessionList]);
+  }
+
+  /**
+   * Removes `matcher` by reference from global storage first, falling back
+   * to the session bucket when `sessionId` is supplied. Used by
+   * `executeHooks` to drop `once: true` matchers after they fire.
+   */
+  removeMatcher<E extends HookEvent>(
+    event: E,
+    matcher: HookMatcher<E>,
+    sessionId?: string
+  ): boolean {
+    if (removeFromList(readList(this.global, event), matcher)) {
+      return true;
+    }
+    if (sessionId === undefined) {
+      return false;
+    }
+    const bucket = this.sessions.get(sessionId);
+    if (bucket === undefined) {
+      return false;
+    }
+    return removeFromList(readList(bucket, event), matcher);
+  }
+
+  /**
+   * Drops every session-scoped matcher for `sessionId`. Call this in the
+   * `finally` block around a Run so a `once: true` hook that never fired
+   * cannot leak into the next session on the same registry.
+   */
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  /** True if at least one matcher exists for `event` (global + session). */
+  hasHookFor(event: HookEvent, sessionId?: string): boolean {
+    if (readList(this.global, event).length > 0) {
+      return true;
+    }
+    if (sessionId === undefined) {
+      return false;
+    }
+    const bucket = this.sessions.get(sessionId);
+    if (bucket === undefined) {
+      return false;
+    }
+    return readList(bucket, event).length > 0;
+  }
+
+  private ensureSessionBucket(sessionId: string): MatcherBucket {
+    const existing = this.sessions.get(sessionId);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const fresh: MatcherBucket = {};
+    this.sessions.set(sessionId, fresh);
+    return fresh;
+  }
+}
+
+function ensureList(
+  bucket: MatcherBucket,
+  event: HookEvent
+): HookMatcher<HookEvent>[] {
+  const existing = bucket[event];
+  if (existing !== undefined) {
+    return existing;
+  }
+  const fresh: HookMatcher<HookEvent>[] = [];
+  bucket[event] = fresh;
+  return fresh;
+}
+
+function readList(
+  bucket: MatcherBucket,
+  event: HookEvent
+): HookMatcher<HookEvent>[] {
+  return bucket[event] ?? [];
+}
+
+function removeFromList<E extends HookEvent>(
+  list: HookMatcher<HookEvent>[],
+  matcher: HookMatcher<E>
+): boolean {
+  const idx = list.indexOf(widen(matcher));
+  if (idx < 0) {
+    return false;
+  }
+  list.splice(idx, 1);
+  return true;
+}
+
+/**
+ * Widen a per-event matcher to the storage's uniform slot type. Unsound at
+ * the type level (function parameters are contravariant) but safe by
+ * construction: `HookRegistry.register<E>` only ever puts matchers into the
+ * bucket slot for their own event, and reads go through `snapshot<E>`
+ * which is only called with the same `E`.
+ */
+function widen<E extends HookEvent>(
+  matcher: HookMatcher<E>
+): HookMatcher<HookEvent> {
+  return matcher as unknown as HookMatcher<HookEvent>;
+}
+
+/**
+ * Narrow a storage list back to a per-event matcher list on the way out.
+ * Sound counterpart to `widen`: the list only contains matchers that were
+ * registered against `E`, because the public API enforces it on insert.
+ */
+function snapshot<E extends HookEvent>(
+  list: readonly HookMatcher<HookEvent>[]
+): HookMatcher<E>[] {
+  return list.slice() as unknown as HookMatcher<E>[];
+}

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -16,7 +16,7 @@ const noopPost: HookCallback<
 
 function makePreToolUseMatcher(pattern?: string): HookMatcher<'PreToolUse'> {
   return {
-    matcher: pattern,
+    pattern,
     hooks: [noop],
   };
 }
@@ -183,7 +183,7 @@ describe('HookRegistry', () => {
       for (const sid of sessions) {
         const matchers = registry.getMatchers('PreToolUse', sid);
         expect(matchers).toHaveLength(1);
-        expect(matchers[0]?.matcher).toBe(sid);
+        expect(matchers[0]?.pattern).toBe(sid);
       }
     });
   });

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -1,0 +1,190 @@
+// src/hooks/__tests__/HookRegistry.test.ts
+import { HookRegistry } from '../HookRegistry';
+import type {
+  HookMatcher,
+  HookCallback,
+  PreToolUseHookOutput,
+  PostToolUseHookOutput,
+} from '../types';
+
+const noop: HookCallback<
+  'PreToolUse'
+> = async (): Promise<PreToolUseHookOutput> => ({});
+const noopPost: HookCallback<
+  'PostToolUse'
+> = async (): Promise<PostToolUseHookOutput> => ({});
+
+function makePreToolUseMatcher(pattern?: string): HookMatcher<'PreToolUse'> {
+  return {
+    matcher: pattern,
+    hooks: [noop],
+  };
+}
+
+function makePostToolUseMatcher(): HookMatcher<'PostToolUse'> {
+  return {
+    hooks: [noopPost],
+  };
+}
+
+describe('HookRegistry', () => {
+  describe('global registration', () => {
+    it('stores a matcher and returns it via getMatchers', () => {
+      const registry = new HookRegistry();
+      const matcher = makePreToolUseMatcher('Bash');
+      registry.register('PreToolUse', matcher);
+      const matchers = registry.getMatchers('PreToolUse');
+      expect(matchers).toHaveLength(1);
+      expect(matchers[0]).toBe(matcher);
+    });
+
+    it('keeps registrations isolated across events', () => {
+      const registry = new HookRegistry();
+      const pre = makePreToolUseMatcher('Bash');
+      const post = makePostToolUseMatcher();
+      registry.register('PreToolUse', pre);
+      registry.register('PostToolUse', post);
+      expect(registry.getMatchers('PreToolUse')).toEqual([pre]);
+      expect(registry.getMatchers('PostToolUse')).toEqual([post]);
+      expect(registry.getMatchers('Stop')).toEqual([]);
+    });
+
+    it('unregister removes the matcher from the registry', () => {
+      const registry = new HookRegistry();
+      const matcher = makePreToolUseMatcher();
+      const unregister = registry.register('PreToolUse', matcher);
+      expect(registry.getMatchers('PreToolUse')).toHaveLength(1);
+      unregister();
+      expect(registry.getMatchers('PreToolUse')).toHaveLength(0);
+    });
+
+    it('hasHookFor reflects registration state', () => {
+      const registry = new HookRegistry();
+      expect(registry.hasHookFor('PreToolUse')).toBe(false);
+      registry.register('PreToolUse', makePreToolUseMatcher());
+      expect(registry.hasHookFor('PreToolUse')).toBe(true);
+      expect(registry.hasHookFor('PostToolUse')).toBe(false);
+    });
+
+    it('supports multiple matchers on the same event', () => {
+      const registry = new HookRegistry();
+      const a = makePreToolUseMatcher('Bash');
+      const b = makePreToolUseMatcher('Edit');
+      registry.register('PreToolUse', a);
+      registry.register('PreToolUse', b);
+      const matchers = registry.getMatchers('PreToolUse');
+      expect(matchers).toHaveLength(2);
+      expect(matchers).toContain(a);
+      expect(matchers).toContain(b);
+    });
+
+    it('returns a fresh array on each getMatchers call', () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', makePreToolUseMatcher());
+      const first = registry.getMatchers('PreToolUse');
+      const second = registry.getMatchers('PreToolUse');
+      expect(first).not.toBe(second);
+      first.length = 0;
+      expect(registry.getMatchers('PreToolUse')).toHaveLength(1);
+    });
+  });
+
+  describe('session registration', () => {
+    it('scopes matchers to a single session', () => {
+      const registry = new HookRegistry();
+      const sessionA = makePreToolUseMatcher('Bash');
+      const sessionB = makePreToolUseMatcher('Edit');
+      registry.registerSession('run-a', 'PreToolUse', sessionA);
+      registry.registerSession('run-b', 'PreToolUse', sessionB);
+
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([sessionA]);
+      expect(registry.getMatchers('PreToolUse', 'run-b')).toEqual([sessionB]);
+      expect(registry.getMatchers('PreToolUse')).toEqual([]);
+    });
+
+    it('merges global matchers in front of session matchers', () => {
+      const registry = new HookRegistry();
+      const global = makePreToolUseMatcher('global');
+      const session = makePreToolUseMatcher('session');
+      registry.register('PreToolUse', global);
+      registry.registerSession('run-a', 'PreToolUse', session);
+
+      const matchers = registry.getMatchers('PreToolUse', 'run-a');
+      expect(matchers).toEqual([global, session]);
+    });
+
+    it('clearSession drops only the given session', () => {
+      const registry = new HookRegistry();
+      const a = makePreToolUseMatcher('a');
+      const b = makePreToolUseMatcher('b');
+      registry.registerSession('run-a', 'PreToolUse', a);
+      registry.registerSession('run-b', 'PreToolUse', b);
+
+      registry.clearSession('run-a');
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([]);
+      expect(registry.getMatchers('PreToolUse', 'run-b')).toEqual([b]);
+    });
+
+    it('removeMatcher removes from the correct scope', () => {
+      const registry = new HookRegistry();
+      const global = makePreToolUseMatcher('global');
+      const session = makePreToolUseMatcher('session');
+      registry.register('PreToolUse', global);
+      registry.registerSession('run-a', 'PreToolUse', session);
+
+      expect(registry.removeMatcher('PreToolUse', session, 'run-a')).toBe(true);
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([global]);
+
+      expect(registry.removeMatcher('PreToolUse', global)).toBe(true);
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([]);
+    });
+
+    it('removeMatcher returns false when the matcher is not found', () => {
+      const registry = new HookRegistry();
+      const orphan = makePreToolUseMatcher('orphan');
+      expect(registry.removeMatcher('PreToolUse', orphan)).toBe(false);
+      expect(registry.removeMatcher('PreToolUse', orphan, 'run-a')).toBe(false);
+    });
+
+    it('session unregister function removes only that matcher', () => {
+      const registry = new HookRegistry();
+      const a = makePreToolUseMatcher('a');
+      const b = makePreToolUseMatcher('b');
+      const unregisterA = registry.registerSession('run-a', 'PreToolUse', a);
+      registry.registerSession('run-a', 'PreToolUse', b);
+
+      unregisterA();
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([b]);
+    });
+
+    it('hasHookFor honours the sessionId parameter', () => {
+      const registry = new HookRegistry();
+      registry.registerSession('run-a', 'PreToolUse', makePreToolUseMatcher());
+      expect(registry.hasHookFor('PreToolUse')).toBe(false);
+      expect(registry.hasHookFor('PreToolUse', 'run-a')).toBe(true);
+      expect(registry.hasHookFor('PreToolUse', 'run-b')).toBe(false);
+    });
+  });
+
+  describe('session isolation under parallel registration', () => {
+    it('does not leak matchers between sessions registered in parallel', async () => {
+      const registry = new HookRegistry();
+      const sessions = Array.from({ length: 50 }, (_, i) => `run-${i}`);
+      await Promise.all(
+        sessions.map(async (sid): Promise<void> => {
+          registry.registerSession(
+            sid,
+            'PreToolUse',
+            makePreToolUseMatcher(sid)
+          );
+        })
+      );
+
+      for (const sid of sessions) {
+        const matchers = registry.getMatchers('PreToolUse', sid);
+        expect(matchers).toHaveLength(1);
+        expect(matchers[0]?.matcher).toBe(sid);
+      }
+    });
+  });
+});

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -1,0 +1,804 @@
+// src/hooks/__tests__/executeHooks.test.ts
+import { HookRegistry } from '../HookRegistry';
+import { executeHooks } from '../executeHooks';
+import type {
+  HookCallback,
+  HookMatcher,
+  RunStartHookInput,
+  RunStartHookOutput,
+  StopHookInput,
+  StopHookOutput,
+  PreToolUseHookInput,
+  PreToolUseHookOutput,
+  PostToolUseHookInput,
+  PostToolUseHookOutput,
+} from '../types';
+
+function preToolUseInput(
+  toolName: string,
+  overrides: Partial<PreToolUseHookInput> = {}
+): PreToolUseHookInput {
+  return {
+    hook_event_name: 'PreToolUse',
+    runId: 'run-1',
+    threadId: 'thread-1',
+    toolName,
+    toolInput: { cmd: 'ls' },
+    toolUseId: 'tool-call-1',
+    ...overrides,
+  };
+}
+
+function postToolUseInput(
+  toolName: string,
+  overrides: Partial<PostToolUseHookInput> = {}
+): PostToolUseHookInput {
+  return {
+    hook_event_name: 'PostToolUse',
+    runId: 'run-1',
+    toolName,
+    toolInput: {},
+    toolOutput: null,
+    toolUseId: 'tc-1',
+    ...overrides,
+  };
+}
+
+function stopInput(overrides: Partial<StopHookInput> = {}): StopHookInput {
+  return {
+    hook_event_name: 'Stop',
+    runId: 'run-1',
+    messages: [],
+    stopHookActive: false,
+    ...overrides,
+  };
+}
+
+function runStartInput(): RunStartHookInput {
+  return {
+    hook_event_name: 'RunStart',
+    runId: 'run-1',
+    messages: [],
+  };
+}
+
+function preToolHook(
+  fn: HookCallback<'PreToolUse'>
+): HookCallback<'PreToolUse'> {
+  return fn;
+}
+
+function postToolHook(
+  fn: HookCallback<'PostToolUse'>
+): HookCallback<'PostToolUse'> {
+  return fn;
+}
+
+function runStartHook(fn: HookCallback<'RunStart'>): HookCallback<'RunStart'> {
+  return fn;
+}
+
+function stopHook(fn: HookCallback<'Stop'>): HookCallback<'Stop'> {
+  return fn;
+}
+
+const emptyPreOutput: PreToolUseHookOutput = {};
+const emptyRunStartOutput: RunStartHookOutput = {};
+
+const noopPreHook = preToolHook(
+  async (): Promise<PreToolUseHookOutput> => emptyPreOutput
+);
+const noopRunStartHook = runStartHook(
+  async (): Promise<RunStartHookOutput> => emptyRunStartOutput
+);
+
+describe('executeHooks', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation((): void => {
+        /* silence expected warnings */
+      });
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('empty matcher set', () => {
+    it('returns an empty aggregated result when no matchers are registered', async () => {
+      const registry = new HookRegistry();
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result).toEqual({ additionalContexts: [], errors: [] });
+    });
+
+    it('returns an empty result when no matcher pattern matches the query', async () => {
+      const registry = new HookRegistry();
+      let called = false;
+      registry.register('PreToolUse', {
+        matcher: '^Edit$',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            called = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(called).toBe(false);
+      expect(result).toEqual({ additionalContexts: [], errors: [] });
+    });
+  });
+
+  describe('matcher regex filtering', () => {
+    it('fires hooks whose matcher regex matches the query', async () => {
+      const registry = new HookRegistry();
+      const calls: string[] = [];
+      registry.register('PreToolUse', {
+        matcher: '^Bash$',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            calls.push('bash-only');
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      registry.register('PreToolUse', {
+        matcher: 'Bash|Edit',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            calls.push('bash-or-edit');
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      registry.register('PreToolUse', {
+        matcher: '^Edit$',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            calls.push('edit-only');
+            return emptyPreOutput;
+          }),
+        ],
+      });
+
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(calls.sort()).toEqual(['bash-only', 'bash-or-edit']);
+    });
+
+    it('fires matchers with no pattern regardless of query', async () => {
+      const registry = new HookRegistry();
+      let fired = false;
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            fired = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(fired).toBe(true);
+    });
+  });
+
+  describe('decision precedence (deny > ask > allow)', () => {
+    it('deny beats allow', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'allow',
+              reason: 'all good',
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'deny',
+              reason: 'forbidden',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toBe('forbidden');
+    });
+
+    it('deny beats ask', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'ask',
+              reason: 'needs prompt',
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'deny',
+              reason: 'forbidden',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toBe('forbidden');
+    });
+
+    it('ask beats allow but not deny', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({ decision: 'allow' })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'ask',
+              reason: 'please confirm',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('ask');
+      expect(result.reason).toBe('please confirm');
+    });
+
+    it('allow is the default when any hook returned allow and none denied or asked', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'allow',
+              reason: 'ok',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toBe('ok');
+    });
+
+    it('no decision is set when no hook returns one', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [noopPreHook],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBeUndefined();
+    });
+  });
+
+  describe('stop decision folding', () => {
+    it('any block wins over continue', async () => {
+      const registry = new HookRegistry();
+      registry.register('Stop', {
+        hooks: [
+          stopHook(
+            async (): Promise<StopHookOutput> => ({ decision: 'continue' })
+          ),
+        ],
+      });
+      registry.register('Stop', {
+        hooks: [
+          stopHook(
+            async (): Promise<StopHookOutput> => ({
+              decision: 'block',
+              reason: 'more work to do',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({ registry, input: stopInput() });
+      expect(result.stopDecision).toBe('block');
+      expect(result.reason).toBe('more work to do');
+    });
+
+    it('continue is the aggregated result when no hook blocks', async () => {
+      const registry = new HookRegistry();
+      registry.register('Stop', {
+        hooks: [
+          stopHook(
+            async (): Promise<StopHookOutput> => ({ decision: 'continue' })
+          ),
+        ],
+      });
+      const result = await executeHooks({ registry, input: stopInput() });
+      expect(result.stopDecision).toBe('continue');
+    });
+  });
+
+  describe('additionalContext accumulation', () => {
+    it('accumulates non-empty additionalContext from every hook', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              additionalContext: 'context one',
+            })
+          ),
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              additionalContext: '',
+            })
+          ),
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              additionalContext: 'context two',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.additionalContexts.sort()).toEqual([
+        'context one',
+        'context two',
+      ]);
+    });
+  });
+
+  describe('updatedInput handling', () => {
+    it('last-writer-wins on updatedInput when multiple hooks set it', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'echo safe' },
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'echo safer' },
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedInput).toBeDefined();
+      expect(result.updatedInput?.cmd).toBeDefined();
+    });
+  });
+
+  describe('preventContinuation', () => {
+    it('propagates preventContinuation and stopReason', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+              stopReason: 'budget exhausted',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.preventContinuation).toBe(true);
+      expect(result.stopReason).toBe('budget exhausted');
+    });
+  });
+
+  describe('session scoping', () => {
+    it('runs session matchers only when sessionId is supplied', async () => {
+      const registry = new HookRegistry();
+      let globalFired = false;
+      let sessionFired = false;
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            globalFired = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      registry.registerSession('run-1', 'PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            sessionFired = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(globalFired).toBe(true);
+      expect(sessionFired).toBe(false);
+
+      globalFired = false;
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        sessionId: 'run-1',
+      });
+      expect(globalFired).toBe(true);
+      expect(sessionFired).toBe(true);
+    });
+  });
+
+  describe('once: true self-removal', () => {
+    it('removes the matcher after a successful fire', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            calls++;
+            return emptyRunStartOutput;
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      await executeHooks({ registry, input: runStartInput() });
+      expect(calls).toBe(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+
+      await executeHooks({ registry, input: runStartInput() });
+      expect(calls).toBe(1);
+    });
+
+    it('does not remove the matcher when every hook in it throws', async () => {
+      const registry = new HookRegistry();
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            throw new Error('hook failed');
+          }),
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            throw new Error('hook also failed');
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      const result = await executeHooks({ registry, input: runStartInput() });
+      expect(result.errors).toHaveLength(2);
+      expect(registry.getMatchers('RunStart')).toHaveLength(1);
+    });
+
+    it('removes the matcher when at least one hook succeeds', async () => {
+      const registry = new HookRegistry();
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            throw new Error('boom');
+          }),
+          noopRunStartHook,
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      const result = await executeHooks({ registry, input: runStartInput() });
+      expect(result.errors).toHaveLength(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+    });
+
+    it('removes once-matchers registered for a session from the session scope', async () => {
+      const registry = new HookRegistry();
+      const matcher: HookMatcher<'PreToolUse'> = {
+        once: true,
+        hooks: [noopPreHook],
+      };
+      registry.registerSession('run-1', 'PreToolUse', matcher);
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        sessionId: 'run-1',
+      });
+      expect(registry.getMatchers('PreToolUse', 'run-1')).toHaveLength(0);
+    });
+  });
+
+  describe('timeout enforcement', () => {
+    it('aborts hooks that exceed the matcher timeout', async () => {
+      const registry = new HookRegistry();
+      registry.register('RunStart', {
+        timeout: 20,
+        hooks: [
+          runStartHook(
+            (_input, signal): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((_resolve, reject) => {
+                const id = setTimeout((): void => {
+                  reject(new Error('hook should have been aborted'));
+                }, 500);
+                signal.addEventListener('abort', (): void => {
+                  clearTimeout(id);
+                  reject(new Error('aborted'));
+                });
+              })
+          ),
+        ],
+      });
+
+      const start = Date.now();
+      const result = await executeHooks({ registry, input: runStartInput() });
+      const elapsed = Date.now() - start;
+
+      expect(result.errors).toHaveLength(1);
+      expect(elapsed).toBeLessThan(400);
+    });
+
+    it('surfaces a TimeoutError label when the signal times out without the hook listening', async () => {
+      const registry = new HookRegistry();
+      registry.register('RunStart', {
+        timeout: 15,
+        hooks: [
+          runStartHook(
+            (): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((resolve): void => {
+                setTimeout((): void => resolve(emptyRunStartOutput), 500);
+              })
+          ),
+        ],
+      });
+
+      const start = Date.now();
+      const result = await executeHooks({ registry, input: runStartInput() });
+      const elapsed = Date.now() - start;
+
+      expect(result.errors).toHaveLength(1);
+      expect(elapsed).toBeLessThan(400);
+    });
+
+    it('honours the batch timeoutMs default when the matcher does not set its own', async () => {
+      const registry = new HookRegistry();
+      registry.register('RunStart', {
+        hooks: [
+          runStartHook(
+            (_input, signal): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((_resolve, reject) => {
+                signal.addEventListener('abort', (): void =>
+                  reject(new Error('aborted'))
+                );
+              })
+          ),
+        ],
+      });
+
+      const start = Date.now();
+      const result = await executeHooks({
+        registry,
+        input: runStartInput(),
+        timeoutMs: 25,
+      });
+      const elapsed = Date.now() - start;
+
+      expect(result.errors).toHaveLength(1);
+      expect(elapsed).toBeLessThan(400);
+    });
+  });
+
+  describe('error non-fatality', () => {
+    it('swallows synchronous throws into the errors array and keeps going', async () => {
+      const registry = new HookRegistry();
+      let otherRan = false;
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook((): Promise<PreToolUseHookOutput> => {
+            throw new Error('sync boom');
+          }),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            otherRan = true;
+            return { additionalContext: 'still ran' };
+          }),
+        ],
+      });
+
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(otherRan).toBe(true);
+      expect(result.additionalContexts).toEqual(['still ran']);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('sync boom');
+    });
+
+    it('swallows async rejections', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('async boom'))
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('async boom');
+    });
+
+    it('excludes internal matcher errors from the errors array', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        internal: true,
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('internal failure'))
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('routes non-internal errors through an optional logger instead of console', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('oops'))
+          ),
+        ],
+      });
+      const warnings: string[] = [];
+      const fakeLogger = {
+        warn: (msg: string): void => {
+          warnings.push(msg);
+        },
+      } as unknown as import('winston').Logger;
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        logger: fakeLogger,
+      });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('oops');
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to console.warn when no logger is supplied', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('fallback'))
+          ),
+        ],
+      });
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      const firstCall = consoleWarnSpy.mock.calls[0] as unknown[];
+      expect(String(firstCall[0])).toContain('fallback');
+    });
+  });
+
+  describe('parent AbortSignal combination', () => {
+    it('aborts hooks when the caller signal fires', async () => {
+      const registry = new HookRegistry();
+      registry.register('RunStart', {
+        hooks: [
+          runStartHook(
+            (_input, signal): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((_resolve, reject) => {
+                signal.addEventListener('abort', (): void =>
+                  reject(new Error('aborted'))
+                );
+              })
+          ),
+        ],
+      });
+
+      const controller = new AbortController();
+      setTimeout((): void => controller.abort(), 20);
+
+      const start = Date.now();
+      const result = await executeHooks({
+        registry,
+        input: runStartInput(),
+        signal: controller.signal,
+        timeoutMs: 5_000,
+      });
+      const elapsed = Date.now() - start;
+
+      expect(result.errors).toHaveLength(1);
+      expect(elapsed).toBeLessThan(400);
+    });
+  });
+});

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -122,7 +122,7 @@ describe('executeHooks', () => {
       const registry = new HookRegistry();
       let called = false;
       registry.register('PreToolUse', {
-        matcher: '^Edit$',
+        pattern: '^Edit$',
         hooks: [
           preToolHook(async (): Promise<PreToolUseHookOutput> => {
             called = true;
@@ -145,7 +145,7 @@ describe('executeHooks', () => {
       const registry = new HookRegistry();
       const calls: string[] = [];
       registry.register('PreToolUse', {
-        matcher: '^Bash$',
+        pattern: '^Bash$',
         hooks: [
           preToolHook(async (): Promise<PreToolUseHookOutput> => {
             calls.push('bash-only');
@@ -154,7 +154,7 @@ describe('executeHooks', () => {
         ],
       });
       registry.register('PreToolUse', {
-        matcher: 'Bash|Edit',
+        pattern: 'Bash|Edit',
         hooks: [
           preToolHook(async (): Promise<PreToolUseHookOutput> => {
             calls.push('bash-or-edit');
@@ -163,7 +163,7 @@ describe('executeHooks', () => {
         ],
       });
       registry.register('PreToolUse', {
-        matcher: '^Edit$',
+        pattern: '^Edit$',
         hooks: [
           preToolHook(async (): Promise<PreToolUseHookOutput> => {
             calls.push('edit-only');
@@ -400,13 +400,13 @@ describe('executeHooks', () => {
   });
 
   describe('updatedInput handling', () => {
-    it('last-writer-wins on updatedInput when multiple hooks set it', async () => {
+    it('last-writer-wins on updatedInput follows registration order', async () => {
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
         hooks: [
           preToolHook(
             async (): Promise<PreToolUseHookOutput> => ({
-              updatedInput: { cmd: 'echo safe' },
+              updatedInput: { cmd: 'first' },
             })
           ),
         ],
@@ -415,7 +415,16 @@ describe('executeHooks', () => {
         hooks: [
           preToolHook(
             async (): Promise<PreToolUseHookOutput> => ({
-              updatedInput: { cmd: 'echo safer' },
+              updatedInput: { cmd: 'second' },
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'third' },
             })
           ),
         ],
@@ -425,8 +434,93 @@ describe('executeHooks', () => {
         input: preToolUseInput('Bash'),
         matchQuery: 'Bash',
       });
-      expect(result.updatedInput).toBeDefined();
-      expect(result.updatedInput?.cmd).toBeDefined();
+      expect(result.updatedInput).toEqual({ cmd: 'third' });
+    });
+
+    it('last-writer-wins within a single matcher follows hook array order', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'inner-first' },
+            })
+          ),
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'inner-second' },
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedInput).toEqual({ cmd: 'inner-second' });
+    });
+  });
+
+  describe('updatedOutput handling', () => {
+    it('flows updatedOutput through the aggregated result', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              updatedOutput: 'redacted',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedOutput).toBe('redacted');
+    });
+
+    it('last-writer-wins on updatedOutput follows registration order', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              updatedOutput: { tag: 'first' },
+            })
+          ),
+        ],
+      });
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              updatedOutput: { tag: 'second' },
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedOutput).toEqual({ tag: 'second' });
+    });
+
+    it('leaves updatedOutput undefined when no hook sets it', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [postToolHook(async (): Promise<PostToolUseHookOutput> => ({}))],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedOutput).toBeUndefined();
     });
   });
 
@@ -450,6 +544,57 @@ describe('executeHooks', () => {
       });
       expect(result.preventContinuation).toBe(true);
       expect(result.stopReason).toBe('budget exhausted');
+    });
+
+    it('keeps the first stopReason when multiple hooks set preventContinuation', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+              stopReason: 'first writer',
+            })
+          ),
+        ],
+      });
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+              stopReason: 'second writer',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.preventContinuation).toBe(true);
+      expect(result.stopReason).toBe('first writer');
+    });
+
+    it('sets preventContinuation even if only the flag, no reason, is present', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.preventContinuation).toBe(true);
+      expect(result.stopReason).toBeUndefined();
     });
   });
 
@@ -571,6 +716,29 @@ describe('executeHooks', () => {
       });
       expect(registry.getMatchers('PreToolUse', 'run-1')).toHaveLength(0);
     });
+
+    it('documents the concurrent-dispatch race: once fires per concurrent call, not globally', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            calls++;
+            return emptyRunStartOutput;
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      await Promise.all([
+        executeHooks({ registry, input: runStartInput() }),
+        executeHooks({ registry, input: runStartInput() }),
+      ]);
+
+      expect(calls).toBe(2);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+    });
   });
 
   describe('timeout enforcement', () => {
@@ -602,15 +770,20 @@ describe('executeHooks', () => {
       expect(elapsed).toBeLessThan(400);
     });
 
-    it('surfaces a TimeoutError label when the signal times out without the hook listening', async () => {
+    it('times out hooks that ignore the signal and surfaces an abort-shaped error', async () => {
       const registry = new HookRegistry();
+      const pendingTimers: NodeJS.Timeout[] = [];
       registry.register('RunStart', {
         timeout: 15,
         hooks: [
           runStartHook(
             (): Promise<RunStartHookOutput> =>
               new Promise<RunStartHookOutput>((resolve): void => {
-                setTimeout((): void => resolve(emptyRunStartOutput), 500);
+                const id = setTimeout(
+                  (): void => resolve(emptyRunStartOutput),
+                  500
+                );
+                pendingTimers.push(id);
               })
           ),
         ],
@@ -620,7 +793,13 @@ describe('executeHooks', () => {
       const result = await executeHooks({ registry, input: runStartInput() });
       const elapsed = Date.now() - start;
 
+      for (const id of pendingTimers) {
+        clearTimeout(id);
+      }
       expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.toLowerCase()).toMatch(
+        /timeout|timed out|abort/
+      );
       expect(elapsed).toBeLessThan(400);
     });
 

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -663,7 +663,7 @@ describe('executeHooks', () => {
       expect(calls).toBe(1);
     });
 
-    it('does not remove the matcher when every hook in it throws', async () => {
+    it('removes the matcher even when every hook in it throws (at-most-once dispatch)', async () => {
       const registry = new HookRegistry();
       const matcher: HookMatcher<'RunStart'> = {
         once: true,
@@ -680,7 +680,7 @@ describe('executeHooks', () => {
 
       const result = await executeHooks({ registry, input: runStartInput() });
       expect(result.errors).toHaveLength(2);
-      expect(registry.getMatchers('RunStart')).toHaveLength(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
     });
 
     it('removes the matcher when at least one hook succeeds', async () => {
@@ -717,7 +717,7 @@ describe('executeHooks', () => {
       expect(registry.getMatchers('PreToolUse', 'run-1')).toHaveLength(0);
     });
 
-    it('documents the concurrent-dispatch race: once fires per concurrent call, not globally', async () => {
+    it('fires exactly once across concurrent executeHooks calls (atomic claim)', async () => {
       const registry = new HookRegistry();
       let calls = 0;
       const matcher: HookMatcher<'RunStart'> = {
@@ -734,9 +734,37 @@ describe('executeHooks', () => {
       await Promise.all([
         executeHooks({ registry, input: runStartInput() }),
         executeHooks({ registry, input: runStartInput() }),
+        executeHooks({ registry, input: runStartInput() }),
       ]);
 
-      expect(calls).toBe(2);
+      expect(calls).toBe(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+    });
+
+    it('fires exactly once across concurrent dispatch even when hooks are slow', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            calls++;
+            await new Promise<void>((resolve): void => {
+              setTimeout(resolve, 10);
+            });
+            return emptyRunStartOutput;
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      await Promise.all(
+        Array.from({ length: 8 }, () =>
+          executeHooks({ registry, input: runStartInput() })
+        )
+      );
+
+      expect(calls).toBe(1);
       expect(registry.getMatchers('RunStart')).toHaveLength(0);
     });
   });

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -1,6 +1,7 @@
 // src/hooks/__tests__/executeHooks.test.ts
 import { HookRegistry } from '../HookRegistry';
 import { executeHooks } from '../executeHooks';
+import { clearMatcherCache } from '../matchers';
 import type {
   HookCallback,
   HookMatcher,
@@ -96,6 +97,7 @@ describe('executeHooks', () => {
   let consoleWarnSpy: jest.SpyInstance;
 
   beforeEach(() => {
+    clearMatcherCache();
     consoleWarnSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation((): void => {

--- a/src/hooks/__tests__/matchers.test.ts
+++ b/src/hooks/__tests__/matchers.test.ts
@@ -1,0 +1,33 @@
+// src/hooks/__tests__/matchers.test.ts
+import { matchesQuery } from '../matchers';
+
+describe('matchesQuery', () => {
+  it('treats undefined pattern as a wildcard match', () => {
+    expect(matchesQuery(undefined, 'Bash')).toBe(true);
+    expect(matchesQuery(undefined, '')).toBe(true);
+    expect(matchesQuery(undefined, undefined)).toBe(true);
+  });
+
+  it('treats empty-string pattern as a wildcard match', () => {
+    expect(matchesQuery('', 'Bash')).toBe(true);
+    expect(matchesQuery('', undefined)).toBe(true);
+  });
+
+  it('returns false when the pattern is set but the query is absent', () => {
+    expect(matchesQuery('Bash', undefined)).toBe(false);
+    expect(matchesQuery('Bash', '')).toBe(false);
+  });
+
+  it('runs the pattern as a regex against the query', () => {
+    expect(matchesQuery('Bash', 'Bash')).toBe(true);
+    expect(matchesQuery('^Bash$', 'Bash')).toBe(true);
+    expect(matchesQuery('^Bash$', 'BashExtra')).toBe(false);
+    expect(matchesQuery('Bash|Shell', 'Shell')).toBe(true);
+    expect(matchesQuery('mcp_.*_search', 'mcp_github_search')).toBe(true);
+  });
+
+  it('does not throw on invalid regex and returns false instead', () => {
+    expect(() => matchesQuery('[unclosed', 'anything')).not.toThrow();
+    expect(matchesQuery('[unclosed', 'anything')).toBe(false);
+  });
+});

--- a/src/hooks/__tests__/matchers.test.ts
+++ b/src/hooks/__tests__/matchers.test.ts
@@ -1,7 +1,15 @@
 // src/hooks/__tests__/matchers.test.ts
-import { matchesQuery } from '../matchers';
+import {
+  matchesQuery,
+  clearMatcherCache,
+  MAX_PATTERN_LENGTH,
+} from '../matchers';
 
 describe('matchesQuery', () => {
+  beforeEach(() => {
+    clearMatcherCache();
+  });
+
   it('treats undefined pattern as a wildcard match', () => {
     expect(matchesQuery(undefined, 'Bash')).toBe(true);
     expect(matchesQuery(undefined, '')).toBe(true);
@@ -29,5 +37,55 @@ describe('matchesQuery', () => {
   it('does not throw on invalid regex and returns false instead', () => {
     expect(() => matchesQuery('[unclosed', 'anything')).not.toThrow();
     expect(matchesQuery('[unclosed', 'anything')).toBe(false);
+  });
+
+  describe('pattern length bound', () => {
+    it('rejects patterns longer than MAX_PATTERN_LENGTH', () => {
+      const tooLong = 'a'.repeat(MAX_PATTERN_LENGTH + 1);
+      expect(matchesQuery(tooLong, 'aaa')).toBe(false);
+    });
+
+    it('accepts patterns exactly at MAX_PATTERN_LENGTH', () => {
+      const atLimit = 'a'.repeat(MAX_PATTERN_LENGTH);
+      expect(matchesQuery(atLimit, 'a'.repeat(MAX_PATTERN_LENGTH))).toBe(true);
+    });
+  });
+
+  describe('compilation cache', () => {
+    it('caches successful compiles so the same RegExp object is reused', () => {
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('^Bash$', 'Bash');
+        matchesQuery('^Bash$', 'Edit');
+        matchesQuery('^Bash$', 'Bash');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('caches failed compiles so invalid patterns do not re-enter the compiler', () => {
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('[unclosed', 'any');
+        matchesQuery('[unclosed', 'any');
+        matchesQuery('[unclosed', 'other');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('clearMatcherCache drops cached compiles', () => {
+      matchesQuery('^Bash$', 'Bash');
+      clearMatcherCache();
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('^Bash$', 'Bash');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 });

--- a/src/hooks/__tests__/matchers.test.ts
+++ b/src/hooks/__tests__/matchers.test.ts
@@ -171,6 +171,53 @@ describe('matchesQuery', () => {
       expect(hasNestedQuantifier('(\\+)+')).toBe(false);
       expect(hasNestedQuantifier('(a\\*)+')).toBe(false);
     });
+
+    describe('group-syntax prefixes are not misread as quantifiers', () => {
+      it('allows non-capturing groups with optional quantifier', () => {
+        expect(hasNestedQuantifier('(?:pre_)?tool_name')).toBe(false);
+        expect(hasNestedQuantifier('(?:ab)?')).toBe(false);
+      });
+
+      it('allows non-capturing groups with + or * quantifier', () => {
+        expect(hasNestedQuantifier('(?:Bash|Shell)+')).toBe(false);
+        expect(hasNestedQuantifier('(?:ab)*')).toBe(false);
+        expect(hasNestedQuantifier('(?:ab){2,5}')).toBe(false);
+      });
+
+      it('allows lookahead and negative lookahead', () => {
+        expect(hasNestedQuantifier('(?=foo)bar')).toBe(false);
+        expect(hasNestedQuantifier('(?!foo)bar')).toBe(false);
+        expect(hasNestedQuantifier('(?=\\w+)bar')).toBe(false);
+      });
+
+      it('allows lookbehind and negative lookbehind', () => {
+        expect(hasNestedQuantifier('(?<=\\s)\\w+')).toBe(false);
+        expect(hasNestedQuantifier('(?<!^)\\w+')).toBe(false);
+      });
+
+      it('allows named capture groups with trailing quantifier', () => {
+        expect(hasNestedQuantifier('(?<name>\\d+)')).toBe(false);
+        expect(hasNestedQuantifier('(?<digits>\\d)+')).toBe(false);
+      });
+    });
+
+    describe('risk propagation across non-capturing wrappers', () => {
+      it('flags (?:(a+))+ — outer quantifier over a wrapped quantified group', () => {
+        expect(hasNestedQuantifier('(?:(a+))+')).toBe(true);
+      });
+
+      it('flags (?:a+)+ — non-capturing group with internal quantifier', () => {
+        expect(hasNestedQuantifier('(?:a+)+')).toBe(true);
+      });
+
+      it('does not flag (?:(ab))+ — quantified wrapper, no inner quantifier', () => {
+        expect(hasNestedQuantifier('(?:(ab))+')).toBe(false);
+      });
+
+      it('flags ((ab)+)+ — multiply-wrapped but contains quantified subgroup', () => {
+        expect(hasNestedQuantifier('((ab)+)+')).toBe(true);
+      });
+    });
   });
 
   describe('ReDoS mitigation via matchesQuery', () => {

--- a/src/hooks/__tests__/matchers.test.ts
+++ b/src/hooks/__tests__/matchers.test.ts
@@ -2,7 +2,10 @@
 import {
   matchesQuery,
   clearMatcherCache,
+  getMatcherCacheSize,
+  hasNestedQuantifier,
   MAX_PATTERN_LENGTH,
+  MAX_CACHE_SIZE,
 } from '../matchers';
 
 describe('matchesQuery', () => {
@@ -86,6 +89,103 @@ describe('matchesQuery', () => {
       } finally {
         spy.mockRestore();
       }
+    });
+
+    it('evicts the oldest entry once the cache is full (LRU)', () => {
+      for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+        matchesQuery(`^pattern${i}$`, `pattern${i}`);
+      }
+      expect(getMatcherCacheSize()).toBe(MAX_CACHE_SIZE);
+
+      matchesQuery('^overflow$', 'overflow');
+      expect(getMatcherCacheSize()).toBe(MAX_CACHE_SIZE);
+
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('^pattern0$', 'pattern0');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('refreshes LRU position on hit so hot patterns are not evicted', () => {
+      const hotPattern = '^hot$';
+      matchesQuery(hotPattern, 'hot');
+      for (let i = 0; i < MAX_CACHE_SIZE - 1; i++) {
+        matchesQuery(`^cold${i}$`, `cold${i}`);
+      }
+      matchesQuery(hotPattern, 'hot');
+
+      matchesQuery('^overflow$', 'overflow');
+
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery(hotPattern, 'hot');
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe('hasNestedQuantifier', () => {
+    it('detects the classic (a+)+ shape', () => {
+      expect(hasNestedQuantifier('(a+)+')).toBe(true);
+      expect(hasNestedQuantifier('(a+)+$')).toBe(true);
+    });
+
+    it('detects (.*)* and (.+)+', () => {
+      expect(hasNestedQuantifier('(.*)*')).toBe(true);
+      expect(hasNestedQuantifier('(.+)+')).toBe(true);
+    });
+
+    it('detects nested quantifier with ? outside', () => {
+      expect(hasNestedQuantifier('(a+)?')).toBe(true);
+    });
+
+    it('detects nested quantifier with {n,} outside', () => {
+      expect(hasNestedQuantifier('(a+){2,}')).toBe(true);
+    });
+
+    it('detects nested quantifier inside deeper groups', () => {
+      expect(hasNestedQuantifier('((a+)+)')).toBe(true);
+      expect(hasNestedQuantifier('prefix(\\w+)+suffix')).toBe(true);
+    });
+
+    it('allows quantifiers that are not nested', () => {
+      expect(hasNestedQuantifier('a+')).toBe(false);
+      expect(hasNestedQuantifier('^Bash$')).toBe(false);
+      expect(hasNestedQuantifier('(a)(b)')).toBe(false);
+      expect(hasNestedQuantifier('(a)+(b)')).toBe(false);
+      expect(hasNestedQuantifier('(ab)+')).toBe(false);
+      expect(hasNestedQuantifier('mcp_\\w+_search')).toBe(false);
+    });
+
+    it('ignores quantifier-looking chars inside character classes', () => {
+      expect(hasNestedQuantifier('([a+b])+')).toBe(false);
+      expect(hasNestedQuantifier('[*+?]+')).toBe(false);
+    });
+
+    it('ignores escaped quantifier characters', () => {
+      expect(hasNestedQuantifier('(\\+)+')).toBe(false);
+      expect(hasNestedQuantifier('(a\\*)+')).toBe(false);
+    });
+  });
+
+  describe('ReDoS mitigation via matchesQuery', () => {
+    it('rejects nested-quantifier patterns as never-matching', () => {
+      expect(matchesQuery('(a+)+', 'aaaaaaaaaa')).toBe(false);
+      expect(matchesQuery('(.*)*', 'hello')).toBe(false);
+    });
+
+    it('does not stall on an adversarial input that would backtrack', () => {
+      const adversarial = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!';
+      const start = Date.now();
+      const result = matchesQuery('(a+)+$', adversarial);
+      const elapsed = Date.now() - start;
+      expect(result).toBe(false);
+      expect(elapsed).toBeLessThan(50);
     });
   });
 });

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -1,0 +1,361 @@
+/* eslint-disable no-console */
+// src/hooks/executeHooks.ts
+import type { Logger } from 'winston';
+import type { HookRegistry } from './HookRegistry';
+import type {
+  HookInput,
+  HookEvent,
+  HookOutput,
+  HookMatcher,
+  ToolDecision,
+  StopDecision,
+  HookCallback,
+  AggregatedHookResult,
+} from './types';
+import { matchesQuery } from './matchers';
+
+/** Default per-hook timeout when a matcher doesn't set its own. */
+export const DEFAULT_HOOK_TIMEOUT_MS = 30_000;
+
+/**
+ * Options for a single `executeHooks` call. The `input` drives everything —
+ * the event name is read from `input.hook_event_name`, matchers are looked
+ * up against that event, and each hook receives `input` directly.
+ */
+export interface ExecuteHooksOptions {
+  registry: HookRegistry;
+  input: HookInput;
+  /** Scope lookup to this session (in addition to global matchers). */
+  sessionId?: string;
+  /** Query string matched against each matcher's regex (tool name, etc.). */
+  matchQuery?: string;
+  /** Parent AbortSignal — combined with per-hook timeout into the hook signal. */
+  signal?: AbortSignal;
+  /** Default per-hook timeout; overridden by `matcher.timeout` when present. */
+  timeoutMs?: number;
+  /** Optional winston logger for non-internal hook errors. */
+  logger?: Logger;
+}
+
+type WideMatcher = HookMatcher<HookEvent>;
+type WideCallback = HookCallback<HookEvent>;
+
+interface HookOutcome {
+  matcher: WideMatcher;
+  output: HookOutput | null;
+  error: string | null;
+  timedOut: boolean;
+}
+
+function freshResult(): AggregatedHookResult {
+  return {
+    additionalContexts: [],
+    errors: [],
+  };
+}
+
+function combineSignals(
+  parent: AbortSignal | undefined,
+  timeoutMs: number
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  if (parent === undefined) {
+    return timeoutSignal;
+  }
+  return AbortSignal.any([parent, timeoutSignal]);
+}
+
+function isTimeout(err: unknown): boolean {
+  if (err instanceof Error) {
+    return err.name === 'TimeoutError' || err.name === 'AbortError';
+  }
+  return false;
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message !== '' ? err.message : err.name;
+  }
+  return String(err);
+}
+
+function makeAbortPromise(signal: AbortSignal): {
+  promise: Promise<never>;
+  cleanup: () => void;
+} {
+  let onAbort: (() => void) | undefined;
+  const promise = new Promise<never>((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(
+        signal.reason instanceof Error ? signal.reason : new Error('aborted')
+      );
+      return;
+    }
+    onAbort = (): void => {
+      reject(
+        signal.reason instanceof Error ? signal.reason : new Error('aborted')
+      );
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  const cleanup = (): void => {
+    if (onAbort !== undefined) {
+      signal.removeEventListener('abort', onAbort);
+      onAbort = undefined;
+    }
+  };
+  return { promise, cleanup };
+}
+
+async function runHook(
+  hook: WideCallback,
+  input: HookInput,
+  signal: AbortSignal,
+  matcher: WideMatcher
+): Promise<HookOutcome> {
+  const hookPromise = Promise.resolve().then(() => hook(input, signal));
+  const { promise: abortPromise, cleanup } = makeAbortPromise(signal);
+  try {
+    const output = await Promise.race([hookPromise, abortPromise]);
+    return { matcher, output, error: null, timedOut: false };
+  } catch (err) {
+    return {
+      matcher,
+      output: null,
+      error: describeError(err),
+      timedOut: isTimeout(err),
+    };
+  } finally {
+    cleanup();
+  }
+}
+
+function reportErrors(
+  outcomes: readonly HookOutcome[],
+  event: HookEvent,
+  logger: Logger | undefined
+): void {
+  for (const outcome of outcomes) {
+    if (outcome.error === null) {
+      continue;
+    }
+    if (outcome.matcher.internal === true) {
+      continue;
+    }
+    const label = outcome.timedOut ? 'timed out' : 'threw an error';
+    const message = `Hook for ${event} ${label}: ${outcome.error}`;
+    if (logger !== undefined) {
+      logger.warn(message);
+      continue;
+    }
+    console.warn(message);
+  }
+}
+
+function applyToolDecision(
+  agg: AggregatedHookResult,
+  decision: ToolDecision,
+  reason: string | undefined
+): void {
+  if (decision === 'deny') {
+    if (agg.decision === 'deny') {
+      return;
+    }
+    agg.decision = 'deny';
+    agg.reason = reason;
+    return;
+  }
+  if (decision === 'ask') {
+    if (agg.decision === 'deny' || agg.decision === 'ask') {
+      return;
+    }
+    agg.decision = 'ask';
+    agg.reason = reason;
+    return;
+  }
+  if (agg.decision === undefined) {
+    agg.decision = 'allow';
+    agg.reason = reason;
+  }
+}
+
+function applyStopDecision(
+  agg: AggregatedHookResult,
+  decision: StopDecision,
+  reason: string | undefined
+): void {
+  if (decision === 'block') {
+    if (agg.stopDecision === 'block') {
+      return;
+    }
+    agg.stopDecision = 'block';
+    agg.reason = reason;
+    return;
+  }
+  if (agg.stopDecision === undefined) {
+    agg.stopDecision = 'continue';
+    if (agg.reason === undefined) {
+      agg.reason = reason;
+    }
+  }
+}
+
+function applyDecision(agg: AggregatedHookResult, output: HookOutput): void {
+  if (!('decision' in output) || output.decision === undefined) {
+    return;
+  }
+  const decision = output.decision;
+  const reason =
+    'reason' in output && typeof output.reason === 'string'
+      ? output.reason
+      : undefined;
+  if (decision === 'deny' || decision === 'ask' || decision === 'allow') {
+    applyToolDecision(agg, decision, reason);
+    return;
+  }
+  applyStopDecision(agg, decision, reason);
+}
+
+function applyContext(agg: AggregatedHookResult, output: HookOutput): void {
+  if (
+    typeof output.additionalContext === 'string' &&
+    output.additionalContext.length > 0
+  ) {
+    agg.additionalContexts.push(output.additionalContext);
+  }
+}
+
+function applyStopFlag(agg: AggregatedHookResult, output: HookOutput): void {
+  if (output.preventContinuation !== true) {
+    return;
+  }
+  agg.preventContinuation = true;
+  if (typeof output.stopReason === 'string' && agg.stopReason === undefined) {
+    agg.stopReason = output.stopReason;
+  }
+}
+
+function applyUpdatedInput(
+  agg: AggregatedHookResult,
+  output: HookOutput
+): void {
+  if (!('updatedInput' in output) || output.updatedInput === undefined) {
+    return;
+  }
+  agg.updatedInput = output.updatedInput;
+}
+
+function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
+  const agg = freshResult();
+  for (const outcome of outcomes) {
+    if (outcome.error !== null) {
+      if (outcome.matcher.internal !== true) {
+        agg.errors.push(outcome.error);
+      }
+      continue;
+    }
+    const output = outcome.output;
+    if (output === null) {
+      continue;
+    }
+    applyContext(agg, output);
+    applyStopFlag(agg, output);
+    applyDecision(agg, output);
+    applyUpdatedInput(agg, output);
+  }
+  return agg;
+}
+
+function collectOnceMatchersForRemoval(
+  outcomes: readonly HookOutcome[]
+): WideMatcher[] {
+  const successByMatcher = new Map<WideMatcher, boolean>();
+  for (const outcome of outcomes) {
+    if (outcome.matcher.once !== true) {
+      continue;
+    }
+    const prior = successByMatcher.get(outcome.matcher) ?? false;
+    successByMatcher.set(outcome.matcher, prior || outcome.error === null);
+  }
+  const removable: WideMatcher[] = [];
+  for (const [matcher, hasSuccess] of successByMatcher) {
+    if (hasSuccess) {
+      removable.push(matcher);
+    }
+  }
+  return removable;
+}
+
+/**
+ * Fires every matcher registered against `input.hook_event_name`, folding
+ * their results per `deny > ask > allow` precedence and accumulating
+ * context/errors.
+ *
+ * ## Parallelism and determinism
+ *
+ * All matching hooks fire simultaneously via `Promise.all`. Outputs are
+ * folded in completion order, so a `PreToolUse` hook that returns
+ * `updatedInput` in a multi-hook matcher will race with its siblings —
+ * registration-time ordering is not respected. If the caller needs a
+ * deterministic input rewrite, it must ensure only one hook per matcher
+ * writes `updatedInput`.
+ *
+ * ## Timeouts and cancellation
+ *
+ * Each hook receives its own `AbortSignal` derived from (a) the caller's
+ * parent signal and (b) a timeout from `matcher.timeout` (falling back to
+ * `opts.timeoutMs`, default {@link DEFAULT_HOOK_TIMEOUT_MS}). When either
+ * fires, the hook's signal aborts. Timeout/abort errors are swallowed into
+ * the aggregated result's `errors` array (non-fatal by default).
+ *
+ * ## Internal matchers
+ *
+ * A matcher with `internal: true` is excluded from both the `errors` array
+ * and the logger output. Use it for infrastructure hooks whose failures
+ * should not pollute user-visible diagnostics.
+ *
+ * ## Once semantics
+ *
+ * A matcher with `once: true` is removed from the registry after at least
+ * one of its hooks completes without throwing. If every hook in the matcher
+ * throws, the matcher is retained so the caller can retry.
+ */
+export async function executeHooks(
+  opts: ExecuteHooksOptions
+): Promise<AggregatedHookResult> {
+  const {
+    registry,
+    input,
+    sessionId,
+    matchQuery,
+    signal,
+    timeoutMs = DEFAULT_HOOK_TIMEOUT_MS,
+    logger,
+  } = opts;
+  const event = input.hook_event_name;
+  const matchers = registry.getMatchers(event, sessionId);
+  if (matchers.length === 0) {
+    return freshResult();
+  }
+  const filtered = matchers.filter((m) => matchesQuery(m.matcher, matchQuery));
+  if (filtered.length === 0) {
+    return freshResult();
+  }
+
+  const tasks: Promise<HookOutcome>[] = [];
+  for (const matcher of filtered) {
+    const perHookTimeout = matcher.timeout ?? timeoutMs;
+    for (const hook of matcher.hooks) {
+      const hookSignal = combineSignals(signal, perHookTimeout);
+      tasks.push(runHook(hook, input, hookSignal, matcher));
+    }
+  }
+
+  const outcomes = await Promise.all(tasks);
+  const toRemove = collectOnceMatchersForRemoval(outcomes);
+  for (const matcher of toRemove) {
+    registry.removeMatcher(event, matcher, sessionId);
+  }
+  reportErrors(outcomes, event, logger);
+  return fold(outcomes);
+}

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -277,26 +277,6 @@ function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
   return agg;
 }
 
-function collectOnceMatchersForRemoval(
-  outcomes: readonly HookOutcome[]
-): WideMatcher[] {
-  const successByMatcher = new Map<WideMatcher, boolean>();
-  for (const outcome of outcomes) {
-    if (outcome.matcher.once !== true) {
-      continue;
-    }
-    const prior = successByMatcher.get(outcome.matcher) ?? false;
-    successByMatcher.set(outcome.matcher, prior || outcome.error === null);
-  }
-  const removable: WideMatcher[] = [];
-  for (const [matcher, hasSuccess] of successByMatcher) {
-    if (hasSuccess) {
-      removable.push(matcher);
-    }
-  }
-  return removable;
-}
-
 /**
  * Fires every matcher registered against `input.hook_event_name`, folding
  * their results per `deny > ask > allow` precedence and accumulating
@@ -319,10 +299,13 @@ function collectOnceMatchersForRemoval(
  *
  * ## Timeouts and cancellation
  *
- * Each hook receives its own `AbortSignal` derived from (a) the caller's
- * parent signal and (b) a timeout from `matcher.timeout` (falling back to
- * `opts.timeoutMs`, default {@link DEFAULT_HOOK_TIMEOUT_MS}). The hook call
- * is raced against the signal, so even a hook that ignores the signal is
+ * Each matcher receives **one shared `AbortSignal`** derived from the
+ * caller's parent signal combined with `matcher.timeout` (falling back to
+ * `opts.timeoutMs`, default {@link DEFAULT_HOOK_TIMEOUT_MS}). Sharing the
+ * signal across hooks in a matcher collapses N timer allocations into
+ * one, which matters on the PreToolUse hot path where a matcher with
+ * several hooks fires on every tool call. Each hook call is raced
+ * against the shared signal, so even a hook that ignores the signal is
  * force-unblocked when the timeout fires. Timeout/abort errors are
  * swallowed into the aggregated result's `errors` array (non-fatal by
  * default).
@@ -333,18 +316,20 @@ function collectOnceMatchersForRemoval(
  * and the logger output. Use it for infrastructure hooks whose failures
  * should not pollute user-visible diagnostics.
  *
- * ## Once semantics and concurrency
+ * ## Once semantics — atomic at-most-once
  *
- * A matcher with `once: true` is removed from the registry after at least
- * one of its hooks completes without throwing. If every hook in the matcher
- * throws, the matcher is retained so the caller can retry.
+ * A matcher with `once: true` is removed from the registry **before any
+ * hook runs**, inside the synchronous prefix of `executeHooks` (between
+ * `getMatchers` and the first `await`). Because Node's event loop serialises
+ * sync work, two concurrent `executeHooks` calls can never both observe
+ * and dispatch the same `once` matcher — whichever call runs its sync
+ * prefix first consumes it, and the loser sees an empty bucket.
  *
- * **Removal is not atomic across concurrent `executeHooks` calls.** Two
- * calls that start before either has finished will each snapshot the
- * matcher list via `getMatchers`, both fire the matcher's hooks, and both
- * attempt removal. `once` therefore means "once per `executeHooks` call",
- * not "once globally across the registry". Use it only for idempotent
- * one-shot hooks.
+ * Trade-off: if every hook in a `once` matcher throws, the matcher is
+ * still gone. "Once" here means "at most one dispatch, ever", not "at
+ * most one successful execution with retry on failure". Hosts that need
+ * retry semantics should register a normal matcher and self-unregister
+ * via the `unregister` callback returned from `registry.register`.
  */
 export async function executeHooks(
   opts: ExecuteHooksOptions
@@ -369,10 +354,13 @@ export async function executeHooks(
     if (!matchesQuery(matcher.pattern, matchQuery)) {
       continue;
     }
+    if (matcher.once === true) {
+      registry.removeMatcher(event, matcher, sessionId);
+    }
     const perHookTimeout = matcher.timeout ?? timeoutMs;
+    const matcherSignal = combineSignals(signal, perHookTimeout);
     for (const hook of matcher.hooks) {
-      const hookSignal = combineSignals(signal, perHookTimeout);
-      tasks.push(runHook(hook, input, hookSignal, matcher));
+      tasks.push(runHook(hook, input, matcherSignal, matcher));
     }
   }
   if (tasks.length === 0) {
@@ -380,10 +368,6 @@ export async function executeHooks(
   }
 
   const outcomes = await Promise.all(tasks);
-  const toRemove = collectOnceMatchersForRemoval(outcomes);
-  for (const matcher of toRemove) {
-    registry.removeMatcher(event, matcher, sessionId);
-  }
   reportErrors(outcomes, event, logger);
   return fold(outcomes);
 }

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 // src/hooks/executeHooks.ts
 import type { Logger } from 'winston';
 import type { HookRegistry } from './HookRegistry';
@@ -27,7 +26,7 @@ export interface ExecuteHooksOptions {
   input: HookInput;
   /** Scope lookup to this session (in addition to global matchers). */
   sessionId?: string;
-  /** Query string matched against each matcher's regex (tool name, etc.). */
+  /** Query string matched against each matcher's pattern (tool name, etc.). */
   matchQuery?: string;
   /** Parent AbortSignal — combined with per-hook timeout into the hook signal. */
   signal?: AbortSignal;
@@ -148,6 +147,7 @@ function reportErrors(
       logger.warn(message);
       continue;
     }
+    // eslint-disable-next-line no-console
     console.warn(message);
   }
 }
@@ -245,6 +245,16 @@ function applyUpdatedInput(
   agg.updatedInput = output.updatedInput;
 }
 
+function applyUpdatedOutput(
+  agg: AggregatedHookResult,
+  output: HookOutput
+): void {
+  if (!('updatedOutput' in output) || output.updatedOutput === undefined) {
+    return;
+  }
+  agg.updatedOutput = output.updatedOutput;
+}
+
 function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
   const agg = freshResult();
   for (const outcome of outcomes) {
@@ -262,6 +272,7 @@ function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
     applyStopFlag(agg, output);
     applyDecision(agg, output);
     applyUpdatedInput(agg, output);
+    applyUpdatedOutput(agg, output);
   }
   return agg;
 }
@@ -293,20 +304,28 @@ function collectOnceMatchersForRemoval(
  *
  * ## Parallelism and determinism
  *
- * All matching hooks fire simultaneously via `Promise.all`. Outputs are
- * folded in completion order, so a `PreToolUse` hook that returns
- * `updatedInput` in a multi-hook matcher will race with its siblings —
- * registration-time ordering is not respected. If the caller needs a
- * deterministic input rewrite, it must ensure only one hook per matcher
- * writes `updatedInput`.
+ * All matching hooks fire simultaneously and are awaited via `Promise.all`,
+ * which preserves input-array order in its returned results. The fold
+ * therefore iterates outcomes in **registration order** — outer loop over
+ * matchers as they sit in the registry (global first, then session), inner
+ * loop over each matcher's `hooks` array. Last-writer-wins fields
+ * (`updatedInput`, `updatedOutput`) are deterministic in that order, even
+ * though hooks may complete in arbitrary wall-clock order.
+ *
+ * Consumers that need a single authoritative rewrite should still scope
+ * `updatedInput`/`updatedOutput` to one hook per matcher to avoid subtle
+ * precedence bugs when matchers are added in a different order than
+ * expected.
  *
  * ## Timeouts and cancellation
  *
  * Each hook receives its own `AbortSignal` derived from (a) the caller's
  * parent signal and (b) a timeout from `matcher.timeout` (falling back to
- * `opts.timeoutMs`, default {@link DEFAULT_HOOK_TIMEOUT_MS}). When either
- * fires, the hook's signal aborts. Timeout/abort errors are swallowed into
- * the aggregated result's `errors` array (non-fatal by default).
+ * `opts.timeoutMs`, default {@link DEFAULT_HOOK_TIMEOUT_MS}). The hook call
+ * is raced against the signal, so even a hook that ignores the signal is
+ * force-unblocked when the timeout fires. Timeout/abort errors are
+ * swallowed into the aggregated result's `errors` array (non-fatal by
+ * default).
  *
  * ## Internal matchers
  *
@@ -314,11 +333,18 @@ function collectOnceMatchersForRemoval(
  * and the logger output. Use it for infrastructure hooks whose failures
  * should not pollute user-visible diagnostics.
  *
- * ## Once semantics
+ * ## Once semantics and concurrency
  *
  * A matcher with `once: true` is removed from the registry after at least
  * one of its hooks completes without throwing. If every hook in the matcher
  * throws, the matcher is retained so the caller can retry.
+ *
+ * **Removal is not atomic across concurrent `executeHooks` calls.** Two
+ * calls that start before either has finished will each snapshot the
+ * matcher list via `getMatchers`, both fire the matcher's hooks, and both
+ * attempt removal. `once` therefore means "once per `executeHooks` call",
+ * not "once globally across the registry". Use it only for idempotent
+ * one-shot hooks.
  */
 export async function executeHooks(
   opts: ExecuteHooksOptions
@@ -337,18 +363,20 @@ export async function executeHooks(
   if (matchers.length === 0) {
     return freshResult();
   }
-  const filtered = matchers.filter((m) => matchesQuery(m.matcher, matchQuery));
-  if (filtered.length === 0) {
-    return freshResult();
-  }
 
   const tasks: Promise<HookOutcome>[] = [];
-  for (const matcher of filtered) {
+  for (const matcher of matchers) {
+    if (!matchesQuery(matcher.pattern, matchQuery)) {
+      continue;
+    }
     const perHookTimeout = matcher.timeout ?? timeoutMs;
     for (const hook of matcher.hooks) {
       const hookSignal = combineSignals(signal, perHookTimeout);
       tasks.push(runHook(hook, input, hookSignal, matcher));
     }
+  }
+  if (tasks.length === 0) {
+    return freshResult();
   }
 
   const outcomes = await Promise.all(tasks);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,7 +7,11 @@
 // until the integration layer is in place.
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
-export { matchesQuery } from './matchers';
+export {
+  matchesQuery,
+  clearMatcherCache,
+  MAX_PATTERN_LENGTH,
+} from './matchers';
 export { HOOK_EVENTS } from './types';
 export type {
   HookEvent,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,51 @@
+// src/hooks/index.ts
+//
+// Phase 1 PR 1: this directory is purely additive and is NOT re-exported
+// from `src/index.ts`. The types and classes below are consumed internally
+// in subsequent PRs that wire the registry into `Run`, `Graph`, and
+// `ToolNode`. Leaving it unexported keeps the public API surface frozen
+// until the integration layer is in place.
+export { HookRegistry } from './HookRegistry';
+export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
+export { matchesQuery } from './matchers';
+export { HOOK_EVENTS } from './types';
+export type {
+  HookEvent,
+  HookInput,
+  HookOutput,
+  HookCallback,
+  HookMatcher,
+  HooksByEvent,
+  HookInputByEvent,
+  HookOutputByEvent,
+  BaseHookInput,
+  BaseHookOutput,
+  ToolDecision,
+  StopDecision,
+  AggregatedHookResult,
+  RunStartHookInput,
+  UserPromptSubmitHookInput,
+  PreToolUseHookInput,
+  PostToolUseHookInput,
+  PostToolUseFailureHookInput,
+  PermissionDeniedHookInput,
+  SubagentStartHookInput,
+  SubagentStopHookInput,
+  StopHookInput,
+  StopFailureHookInput,
+  PreCompactHookInput,
+  PostCompactHookInput,
+  RunStartHookOutput,
+  UserPromptSubmitHookOutput,
+  PreToolUseHookOutput,
+  PostToolUseHookOutput,
+  PostToolUseFailureHookOutput,
+  PermissionDeniedHookOutput,
+  SubagentStartHookOutput,
+  SubagentStopHookOutput,
+  StopHookOutput,
+  StopFailureHookOutput,
+  PreCompactHookOutput,
+  PostCompactHookOutput,
+} from './types';
+export type { ExecuteHooksOptions } from './executeHooks';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,7 +10,10 @@ export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {
   matchesQuery,
   clearMatcherCache,
+  getMatcherCacheSize,
+  hasNestedQuantifier,
   MAX_PATTERN_LENGTH,
+  MAX_CACHE_SIZE,
 } from './matchers';
 export { HOOK_EVENTS } from './types';
 export type {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,8 +9,6 @@ export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {
   matchesQuery,
-  clearMatcherCache,
-  getMatcherCacheSize,
   hasNestedQuantifier,
   MAX_PATTERN_LENGTH,
   MAX_CACHE_SIZE,

--- a/src/hooks/matchers.ts
+++ b/src/hooks/matchers.ts
@@ -40,7 +40,19 @@ interface CacheEntry {
  */
 const patternCache: Map<string, CacheEntry> = new Map();
 
+/**
+ * Threshold above which `touchCacheEntry` actually performs the LRU
+ * refresh. Below this watermark the cache has zero eviction pressure, so
+ * the delete+set on every hit would be pure overhead. Above it we refresh
+ * properly so hot patterns survive evictions. 75% of capacity is the
+ * standard sweet spot.
+ */
+const LRU_REFRESH_THRESHOLD = Math.floor((MAX_CACHE_SIZE * 3) / 4);
+
 function touchCacheEntry(pattern: string, entry: CacheEntry): void {
+  if (patternCache.size < LRU_REFRESH_THRESHOLD) {
+    return;
+  }
   patternCache.delete(pattern);
   patternCache.set(pattern, entry);
 }
@@ -55,26 +67,72 @@ function setCacheEntry(pattern: string, entry: CacheEntry): void {
   patternCache.set(pattern, entry);
 }
 
+interface QuantifierFrame {
+  hasBacktrackRisk: boolean;
+}
+
+function skipGroupSyntaxPrefix(pattern: string, start: number): number {
+  if (start >= pattern.length || pattern[start] !== '?') {
+    return start;
+  }
+  let i = start + 1;
+  if (i >= pattern.length) {
+    return i;
+  }
+  const modifier = pattern[i];
+  if (modifier === ':' || modifier === '=' || modifier === '!') {
+    return i + 1;
+  }
+  if (modifier !== '<') {
+    return i;
+  }
+  i++;
+  if (i < pattern.length && (pattern[i] === '=' || pattern[i] === '!')) {
+    return i + 1;
+  }
+  while (i < pattern.length && pattern[i] !== '>') {
+    i++;
+  }
+  if (i < pattern.length) {
+    i++;
+  }
+  return i;
+}
+
 /**
  * Cheap syntactic detector for the most common catastrophic-backtracking
  * shape: a quantified group that contains another quantifier (e.g.
- * `(a+)+`, `(.*)*`, `(\w+)+$`). This is the "nested quantifier" class of
- * ReDoS — runs in polynomial-or-worse time on adversarial inputs.
+ * `(a+)+`, `(.*)*`, `(\w+)+$`, `(?:(a+))+`). This is the "nested
+ * quantifier" class of ReDoS — runs in polynomial-or-worse time on
+ * adversarial inputs.
  *
- * The scan walks the pattern linearly, tracking parenthesis depth and
- * whether the innermost group has seen a quantifier. When a group closes,
- * if it contained a quantifier AND the closing paren is followed by a
- * quantifier, the pattern is flagged.
+ * The scan walks the pattern linearly using an explicit stack of group
+ * frames. For each group it tracks whether the group's contents include
+ * "backtrack risk" — meaning a direct quantifier OR a nested group that
+ * carries risk up. When a group closes with a trailing quantifier AND its
+ * frame carries backtrack risk, the pattern is flagged. Risk propagates
+ * to the enclosing frame when a child group closes (whether the child
+ * itself was quantified or not), so `(?:(a+))+` — equivalent to `(a+)+`
+ * — is flagged correctly even though the outer non-capturing wrapper is
+ * one level removed from the inner quantifier.
  *
- * This is a heuristic, not a proof — it rejects many unsafe patterns
- * and allows some that safe-regex libraries would flag. It is a floor,
- * not a ceiling: hosts that accept user-supplied patterns must still
- * validate upstream. The goal is to stop trivially bad patterns from
- * reaching the compiler on a multi-tenant hot path.
+ * ## Group-syntax prefixes
+ *
+ * Non-capturing groups (`(?:`), lookaheads (`(?=`, `(?!`), lookbehinds
+ * (`(?<=`, `(?<!`), and named groups (`(?<name>`) are skipped over at
+ * the `(` so their `?` is not misread as a quantifier. Without this,
+ * `(?:pre_)?tool_name` would be incorrectly rejected because the scanner
+ * would see the group-syntax `?` as a quantifier at depth 1.
+ *
+ * ## Heuristic, not a proof
+ *
+ * This catches the common forms but not all. Ambiguous-alternation ReDoS
+ * like `(a|a)+` is not detected. Pathologically long patterns are also
+ * caught by {@link MAX_PATTERN_LENGTH}. Hosts that accept user-supplied
+ * patterns must still validate upstream.
  */
 export function hasNestedQuantifier(pattern: string): boolean {
-  const quantifiedAtDepth: boolean[] = [];
-  let depth = 0;
+  const stack: QuantifierFrame[] = [];
   let i = 0;
   while (i < pattern.length) {
     const ch = pattern[i];
@@ -83,32 +141,35 @@ export function hasNestedQuantifier(pattern: string): boolean {
       continue;
     }
     if (ch === '[') {
-      const end = findCharClassEnd(pattern, i);
-      i = end + 1;
+      i = findCharClassEnd(pattern, i) + 1;
       continue;
     }
     if (ch === '(') {
-      depth++;
-      quantifiedAtDepth[depth] = false;
-      i++;
+      stack.push({ hasBacktrackRisk: false });
+      i = skipGroupSyntaxPrefix(pattern, i + 1);
       continue;
     }
     if (ch === ')') {
-      const innerHadQuantifier = quantifiedAtDepth[depth] === true;
-      depth--;
+      const frame = stack.pop();
+      if (frame === undefined) {
+        i++;
+        continue;
+      }
       const next = pattern[i + 1];
-      if (
-        innerHadQuantifier &&
-        (next === '*' || next === '+' || next === '?' || next === '{')
-      ) {
+      const isQuantifier =
+        next === '*' || next === '+' || next === '?' || next === '{';
+      if (isQuantifier && frame.hasBacktrackRisk) {
         return true;
+      }
+      if (stack.length > 0 && (frame.hasBacktrackRisk || isQuantifier)) {
+        stack[stack.length - 1].hasBacktrackRisk = true;
       }
       i++;
       continue;
     }
     if (ch === '*' || ch === '+' || ch === '?' || ch === '{') {
-      if (depth > 0) {
-        quantifiedAtDepth[depth] = true;
+      if (stack.length > 0) {
+        stack[stack.length - 1].hasBacktrackRisk = true;
       }
     }
     i++;

--- a/src/hooks/matchers.ts
+++ b/src/hooks/matchers.ts
@@ -1,0 +1,28 @@
+// src/hooks/matchers.ts
+
+/**
+ * Tests whether a hook matcher pattern matches the given query string.
+ *
+ * Rules:
+ * - `undefined` or empty `pattern` matches any query (wildcard).
+ * - `undefined` or empty `query` only matches wildcard patterns.
+ * - Invalid regex patterns never match — they silently return `false`
+ *   rather than throwing, so a bad matcher registered by one hook cannot
+ *   take out the whole executeHooks batch.
+ */
+export function matchesQuery(
+  pattern: string | undefined,
+  query: string | undefined
+): boolean {
+  if (pattern === undefined || pattern === '') {
+    return true;
+  }
+  if (query === undefined || query === '') {
+    return false;
+  }
+  try {
+    return new RegExp(pattern).test(query);
+  } catch {
+    return false;
+  }
+}

--- a/src/hooks/matchers.ts
+++ b/src/hooks/matchers.ts
@@ -1,14 +1,87 @@
 // src/hooks/matchers.ts
 
 /**
+ * Upper bound on hook-matcher pattern length. Patterns longer than this
+ * are rejected outright — the goal is a cheap cap on pathological inputs
+ * (repeated quantifiers, huge alternation groups) without pulling in a
+ * safe-regex dependency.
+ *
+ * Legitimate matchers are almost always under 50 characters (tool names,
+ * short alternations, simple prefix anchors); 512 leaves generous
+ * headroom while preventing 10KB regexes.
+ */
+export const MAX_PATTERN_LENGTH = 512;
+
+interface CacheEntry {
+  regex: RegExp | null;
+}
+
+/**
+ * Module-level compilation cache. Patterns are compiled on first use and
+ * reused on subsequent calls — keeping hot paths (every tool dispatch
+ * filtering matchers) out of the regex compiler.
+ *
+ * Failed compiles are cached as `{ regex: null }` so a malformed pattern
+ * does not re-enter the compiler on each call.
+ *
+ * A `Map` (not `Record`) is used so entries can be evicted in the future
+ * without object-churn. The cache is unbounded for now; bounding it
+ * requires a use-case that generates unbounded unique patterns, which is
+ * not expected from current hook consumers — every pattern is baked into
+ * a matcher registration and is reused across calls.
+ */
+const patternCache: Map<string, CacheEntry> = new Map();
+
+function compile(pattern: string): RegExp | null {
+  const cached = patternCache.get(pattern);
+  if (cached !== undefined) {
+    return cached.regex;
+  }
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    patternCache.set(pattern, { regex: null });
+    return null;
+  }
+  try {
+    const regex = new RegExp(pattern);
+    patternCache.set(pattern, { regex });
+    return regex;
+  } catch {
+    patternCache.set(pattern, { regex: null });
+    return null;
+  }
+}
+
+/**
  * Tests whether a hook matcher pattern matches the given query string.
  *
- * Rules:
- * - `undefined` or empty `pattern` matches any query (wildcard).
- * - `undefined` or empty `query` only matches wildcard patterns.
- * - Invalid regex patterns never match — they silently return `false`
- *   rather than throwing, so a bad matcher registered by one hook cannot
- *   take out the whole executeHooks batch.
+ * ## Semantics
+ *
+ * - `undefined` or empty `pattern` matches any query (wildcard). This is
+ *   the intended shape for events that do not supply a query string at
+ *   all (`RunStart`, `Stop`, etc.) — register such matchers without a
+ *   pattern.
+ * - `undefined` or empty `query` with a non-empty `pattern` never matches.
+ *   Setting a pattern on a query-less event is therefore inert: the
+ *   matcher will simply never fire. This is intentional — it keeps
+ *   query-based filtering out of event types where "query" has no meaning,
+ *   and is documented on `HookMatcher.pattern`.
+ * - Otherwise, the pattern is compiled once (via a module-level cache) and
+ *   tested against the query. Patterns longer than {@link MAX_PATTERN_LENGTH}
+ *   never compile and never match.
+ * - Invalid regex patterns never throw — a failed compile is cached as
+ *   "never matches" so a single malformed pattern cannot take out a whole
+ *   `executeHooks` batch.
+ *
+ * ## Trust model for pattern authors
+ *
+ * Patterns are compiled with `new RegExp(pattern)` without any runtime
+ * sandbox, so catastrophic backtracking on a pathological pattern can
+ * block the event loop. Hosts are expected to treat pattern registration
+ * as a trusted-code operation: the design report (§3.8) routes
+ * persistable hooks through a host-side compiler before they reach this
+ * module. Patterns that originate from end-user input — for example, a
+ * host that exposes hook configuration in an agent-editing UI — must be
+ * length-bounded, validated, or run through a safe-regex check upstream.
  */
 export function matchesQuery(
   pattern: string | undefined,
@@ -20,9 +93,14 @@ export function matchesQuery(
   if (query === undefined || query === '') {
     return false;
   }
-  try {
-    return new RegExp(pattern).test(query);
-  } catch {
+  const regex = compile(pattern);
+  if (regex === null) {
     return false;
   }
+  return regex.test(query);
+}
+
+/** Clears the regex compilation cache. Intended for test isolation. */
+export function clearMatcherCache(): void {
+  patternCache.clear();
 }

--- a/src/hooks/matchers.ts
+++ b/src/hooks/matchers.ts
@@ -12,41 +12,146 @@
  */
 export const MAX_PATTERN_LENGTH = 512;
 
+/**
+ * Upper bound on the compilation cache. Chosen to comfortably hold every
+ * distinct pattern a single multi-tenant run is likely to see (tools,
+ * agent types, basename filters) without growing without bound.
+ *
+ * Under hosts that register unique patterns per tenant, LRU eviction
+ * keeps the working set bounded — cold patterns are re-compiled on next
+ * use, which is the correct cost trade-off for long-running processes
+ * that must not leak memory.
+ */
+export const MAX_CACHE_SIZE = 256;
+
 interface CacheEntry {
   regex: RegExp | null;
 }
 
 /**
- * Module-level compilation cache. Patterns are compiled on first use and
- * reused on subsequent calls — keeping hot paths (every tool dispatch
- * filtering matchers) out of the regex compiler.
+ * Module-level LRU cache keyed by pattern string. Map iteration order is
+ * insertion order in ECMAScript, so refreshing an entry's position means
+ * "delete then re-set". On overflow we evict the first key (least
+ * recently used).
  *
  * Failed compiles are cached as `{ regex: null }` so a malformed pattern
- * does not re-enter the compiler on each call.
- *
- * A `Map` (not `Record`) is used so entries can be evicted in the future
- * without object-churn. The cache is unbounded for now; bounding it
- * requires a use-case that generates unbounded unique patterns, which is
- * not expected from current hook consumers — every pattern is baked into
- * a matcher registration and is reused across calls.
+ * does not re-enter the compiler — and so a tenant spamming bad patterns
+ * doesn't burn CPU on every call.
  */
 const patternCache: Map<string, CacheEntry> = new Map();
+
+function touchCacheEntry(pattern: string, entry: CacheEntry): void {
+  patternCache.delete(pattern);
+  patternCache.set(pattern, entry);
+}
+
+function setCacheEntry(pattern: string, entry: CacheEntry): void {
+  if (patternCache.size >= MAX_CACHE_SIZE) {
+    const oldestKey = patternCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      patternCache.delete(oldestKey);
+    }
+  }
+  patternCache.set(pattern, entry);
+}
+
+/**
+ * Cheap syntactic detector for the most common catastrophic-backtracking
+ * shape: a quantified group that contains another quantifier (e.g.
+ * `(a+)+`, `(.*)*`, `(\w+)+$`). This is the "nested quantifier" class of
+ * ReDoS — runs in polynomial-or-worse time on adversarial inputs.
+ *
+ * The scan walks the pattern linearly, tracking parenthesis depth and
+ * whether the innermost group has seen a quantifier. When a group closes,
+ * if it contained a quantifier AND the closing paren is followed by a
+ * quantifier, the pattern is flagged.
+ *
+ * This is a heuristic, not a proof — it rejects many unsafe patterns
+ * and allows some that safe-regex libraries would flag. It is a floor,
+ * not a ceiling: hosts that accept user-supplied patterns must still
+ * validate upstream. The goal is to stop trivially bad patterns from
+ * reaching the compiler on a multi-tenant hot path.
+ */
+export function hasNestedQuantifier(pattern: string): boolean {
+  const quantifiedAtDepth: boolean[] = [];
+  let depth = 0;
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === '[') {
+      const end = findCharClassEnd(pattern, i);
+      i = end + 1;
+      continue;
+    }
+    if (ch === '(') {
+      depth++;
+      quantifiedAtDepth[depth] = false;
+      i++;
+      continue;
+    }
+    if (ch === ')') {
+      const innerHadQuantifier = quantifiedAtDepth[depth] === true;
+      depth--;
+      const next = pattern[i + 1];
+      if (
+        innerHadQuantifier &&
+        (next === '*' || next === '+' || next === '?' || next === '{')
+      ) {
+        return true;
+      }
+      i++;
+      continue;
+    }
+    if (ch === '*' || ch === '+' || ch === '?' || ch === '{') {
+      if (depth > 0) {
+        quantifiedAtDepth[depth] = true;
+      }
+    }
+    i++;
+  }
+  return false;
+}
+
+function findCharClassEnd(pattern: string, start: number): number {
+  let i = start + 1;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === ']') {
+      return i;
+    }
+    i++;
+  }
+  return pattern.length - 1;
+}
 
 function compile(pattern: string): RegExp | null {
   const cached = patternCache.get(pattern);
   if (cached !== undefined) {
+    touchCacheEntry(pattern, cached);
     return cached.regex;
   }
   if (pattern.length > MAX_PATTERN_LENGTH) {
-    patternCache.set(pattern, { regex: null });
+    setCacheEntry(pattern, { regex: null });
+    return null;
+  }
+  if (hasNestedQuantifier(pattern)) {
+    setCacheEntry(pattern, { regex: null });
     return null;
   }
   try {
     const regex = new RegExp(pattern);
-    patternCache.set(pattern, { regex });
+    setCacheEntry(pattern, { regex });
     return regex;
   } catch {
-    patternCache.set(pattern, { regex: null });
+    setCacheEntry(pattern, { regex: null });
     return null;
   }
 }
@@ -65,23 +170,26 @@ function compile(pattern: string): RegExp | null {
  *   matcher will simply never fire. This is intentional — it keeps
  *   query-based filtering out of event types where "query" has no meaning,
  *   and is documented on `HookMatcher.pattern`.
- * - Otherwise, the pattern is compiled once (via a module-level cache) and
- *   tested against the query. Patterns longer than {@link MAX_PATTERN_LENGTH}
- *   never compile and never match.
+ * - Otherwise, the pattern is compiled once (via a bounded LRU cache) and
+ *   tested against the query.
  * - Invalid regex patterns never throw — a failed compile is cached as
  *   "never matches" so a single malformed pattern cannot take out a whole
  *   `executeHooks` batch.
  *
- * ## Trust model for pattern authors
+ * ## ReDoS mitigations
  *
- * Patterns are compiled with `new RegExp(pattern)` without any runtime
- * sandbox, so catastrophic backtracking on a pathological pattern can
- * block the event loop. Hosts are expected to treat pattern registration
- * as a trusted-code operation: the design report (§3.8) routes
+ * Patterns compile through three cheap gates before reaching `new RegExp`:
+ *
+ * 1. {@link MAX_PATTERN_LENGTH} length cap rejects oversized inputs.
+ * 2. {@link hasNestedQuantifier} rejects the most common catastrophic-
+ *    backtracking shape (quantified group containing a quantifier).
+ * 3. Successful compiles are cached in a bounded LRU so repeated calls
+ *    never re-enter the regex compiler.
+ *
+ * These are a floor, not a ceiling. Hosts that accept user-supplied
+ * patterns should still validate upstream. The design report §3.8 routes
  * persistable hooks through a host-side compiler before they reach this
- * module. Patterns that originate from end-user input — for example, a
- * host that exposes hook configuration in an agent-editing UI — must be
- * length-bounded, validated, or run through a safe-regex check upstream.
+ * module.
  */
 export function matchesQuery(
   pattern: string | undefined,
@@ -103,4 +211,9 @@ export function matchesQuery(
 /** Clears the regex compilation cache. Intended for test isolation. */
 export function clearMatcherCache(): void {
   patternCache.clear();
+}
+
+/** Returns the current size of the compilation cache. Intended for tests. */
+export function getMatcherCacheSize(): number {
+  return patternCache.size;
 }

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -308,14 +308,18 @@ export interface HookMatcher<E extends HookEvent = HookEvent> {
   /** Per-matcher timeout in ms. Defaults to the executor's batch timeout. */
   timeout?: number;
   /**
-   * Remove the matcher after its first successful invocation (at least one
-   * hook in the matcher returned without throwing).
+   * Atomically remove the matcher before its first dispatch.
    *
-   * **Not atomic under concurrent dispatch.** Two concurrent `executeHooks`
-   * calls for the same event will both observe the matcher in their
-   * respective snapshots, both fire its hooks, and both attempt removal;
-   * the hook will run once per concurrent call, not once globally. Use
-   * `once` for idempotent one-shot hooks only.
+   * `executeHooks` claims `once: true` matchers synchronously — between
+   * `getMatchers` and its first `await` — so two concurrent calls cannot
+   * both dispatch the same matcher. Whichever call runs its sync prefix
+   * first wins the matcher; the other sees an empty bucket.
+   *
+   * Semantics are "at most one dispatch, ever" — if every hook in the
+   * matcher throws, the matcher is still gone. Use `once` for
+   * fire-and-forget bootstrapping (registration, telemetry, setup). Hosts
+   * that need retry semantics should register a normal matcher and
+   * self-unregister via the callback returned from `registry.register`.
    */
   once?: boolean;
   /** Internal hooks are excluded from telemetry and non-fatal error logging. */

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,0 +1,332 @@
+// src/hooks/types.ts
+import type { BaseMessage } from '@langchain/core/messages';
+
+/**
+ * Closed set of hook lifecycle events supported by the hooks system.
+ *
+ * These mirror the subset of Claude Code's event surface that makes sense
+ * for a library context (no filesystem/CLI-specific events). See
+ * `docs/hooks-design-report.md` §3.2 for the mapping to existing
+ * `@librechat/agents` emission points.
+ */
+export const HOOK_EVENTS = [
+  'RunStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionDenied',
+  'SubagentStart',
+  'SubagentStop',
+  'Stop',
+  'StopFailure',
+  'PreCompact',
+  'PostCompact',
+] as const;
+
+export type HookEvent = (typeof HOOK_EVENTS)[number];
+
+/** Tool-gating decision; executeHooks folds with `deny > ask > allow` precedence. */
+export type ToolDecision = 'allow' | 'deny' | 'ask';
+
+/** Stop-loop decision; `block` means "do not stop, run another turn". Any `block` wins. */
+export type StopDecision = 'continue' | 'block';
+
+/**
+ * Fields shared by every `HookInput`. Discriminated by `hook_event_name`.
+ *
+ * - `runId` identifies the current agent run and is always present.
+ * - `threadId` identifies the conversation thread when the host has one.
+ * - `agentId` is only set when the hook fires inside a subagent scope.
+ */
+export interface BaseHookInput {
+  runId: string;
+  threadId?: string;
+  agentId?: string;
+}
+
+export interface RunStartHookInput extends BaseHookInput {
+  hook_event_name: 'RunStart';
+  messages: BaseMessage[];
+}
+
+export interface UserPromptSubmitHookInput extends BaseHookInput {
+  hook_event_name: 'UserPromptSubmit';
+  prompt: string;
+  attachments?: BaseMessage[];
+}
+
+/**
+ * Fires before a tool is invoked. Hook may return `deny`/`ask`/`allow` and/or
+ * an `updatedInput` that replaces the tool arguments before invocation.
+ *
+ * `toolInput` is intentionally typed as `Record<string, unknown>` because the
+ * SDK is tool-agnostic — concrete tool argument shapes are only known at the
+ * call site and are narrowed by the host. This is the one escape hatch in
+ * the hook type system.
+ */
+export interface PreToolUseHookInput extends BaseHookInput {
+  hook_event_name: 'PreToolUse';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId: string;
+  stepId?: string;
+  turn?: number;
+}
+
+export interface PostToolUseHookInput extends BaseHookInput {
+  hook_event_name: 'PostToolUse';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolOutput: unknown;
+  toolUseId: string;
+  stepId?: string;
+  turn?: number;
+}
+
+export interface PostToolUseFailureHookInput extends BaseHookInput {
+  hook_event_name: 'PostToolUseFailure';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId: string;
+  error: string;
+  stepId?: string;
+  turn?: number;
+}
+
+export interface PermissionDeniedHookInput extends BaseHookInput {
+  hook_event_name: 'PermissionDenied';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId: string;
+  reason: string;
+}
+
+export interface SubagentStartHookInput extends BaseHookInput {
+  hook_event_name: 'SubagentStart';
+  parentAgentId?: string;
+  agentId: string;
+  agentType: string;
+  inputs: BaseMessage[];
+}
+
+export interface SubagentStopHookInput extends BaseHookInput {
+  hook_event_name: 'SubagentStop';
+  agentId: string;
+  agentType: string;
+  messages: BaseMessage[];
+}
+
+export interface StopHookInput extends BaseHookInput {
+  hook_event_name: 'Stop';
+  messages: BaseMessage[];
+  stopReason?: string;
+  stopHookActive: boolean;
+}
+
+export interface StopFailureHookInput extends BaseHookInput {
+  hook_event_name: 'StopFailure';
+  error: string;
+  lastAssistantMessage?: BaseMessage;
+}
+
+export interface PreCompactHookInput extends BaseHookInput {
+  hook_event_name: 'PreCompact';
+  messagesBeforeCount: number;
+  trigger: 'threshold' | 'manual' | 'error';
+}
+
+export interface PostCompactHookInput extends BaseHookInput {
+  hook_event_name: 'PostCompact';
+  summary: string;
+  messagesAfterCount: number;
+}
+
+/** Discriminated union of every hook input shape. */
+export type HookInput =
+  | RunStartHookInput
+  | UserPromptSubmitHookInput
+  | PreToolUseHookInput
+  | PostToolUseHookInput
+  | PostToolUseFailureHookInput
+  | PermissionDeniedHookInput
+  | SubagentStartHookInput
+  | SubagentStopHookInput
+  | StopHookInput
+  | StopFailureHookInput
+  | PreCompactHookInput
+  | PostCompactHookInput;
+
+/** Compile-time map from event name to its input shape. */
+export type HookInputByEvent = {
+  RunStart: RunStartHookInput;
+  UserPromptSubmit: UserPromptSubmitHookInput;
+  PreToolUse: PreToolUseHookInput;
+  PostToolUse: PostToolUseHookInput;
+  PostToolUseFailure: PostToolUseFailureHookInput;
+  PermissionDenied: PermissionDeniedHookInput;
+  SubagentStart: SubagentStartHookInput;
+  SubagentStop: SubagentStopHookInput;
+  Stop: StopHookInput;
+  StopFailure: StopFailureHookInput;
+  PreCompact: PreCompactHookInput;
+  PostCompact: PostCompactHookInput;
+};
+
+/**
+ * Fields common to every hook output. Hooks that have nothing to say simply
+ * return `{}` (or omit the fields below).
+ */
+export interface BaseHookOutput {
+  /** Context string to inject into the conversation. Accumulated across hooks. */
+  additionalContext?: string;
+  /** True to prevent the next model turn. Any hook can set this. */
+  preventContinuation?: boolean;
+  /** Reason reported alongside `preventContinuation`. */
+  stopReason?: string;
+}
+
+export type RunStartHookOutput = BaseHookOutput;
+
+export interface UserPromptSubmitHookOutput extends BaseHookOutput {
+  decision?: ToolDecision;
+  reason?: string;
+}
+
+export interface PreToolUseHookOutput extends BaseHookOutput {
+  decision?: ToolDecision;
+  reason?: string;
+  /**
+   * Replacement tool input. Merged into the pending tool call by the host.
+   *
+   * WARNING: with multiple parallel hooks, the winner is non-deterministic
+   * (last writer wins in Promise.all resolution order). If deterministic
+   * replacement is required, register a single hook per matcher.
+   */
+  updatedInput?: Record<string, unknown>;
+}
+
+export interface PostToolUseHookOutput extends BaseHookOutput {
+  updatedOutput?: unknown;
+}
+
+export type PostToolUseFailureHookOutput = BaseHookOutput;
+
+export type PermissionDeniedHookOutput = BaseHookOutput;
+
+export interface SubagentStartHookOutput extends BaseHookOutput {
+  decision?: ToolDecision;
+  reason?: string;
+}
+
+export type SubagentStopHookOutput = BaseHookOutput;
+
+export interface StopHookOutput extends BaseHookOutput {
+  decision?: StopDecision;
+  reason?: string;
+}
+
+export type StopFailureHookOutput = BaseHookOutput;
+
+export type PreCompactHookOutput = BaseHookOutput;
+
+export type PostCompactHookOutput = BaseHookOutput;
+
+/** Compile-time map from event name to its output shape. */
+export type HookOutputByEvent = {
+  RunStart: RunStartHookOutput;
+  UserPromptSubmit: UserPromptSubmitHookOutput;
+  PreToolUse: PreToolUseHookOutput;
+  PostToolUse: PostToolUseHookOutput;
+  PostToolUseFailure: PostToolUseFailureHookOutput;
+  PermissionDenied: PermissionDeniedHookOutput;
+  SubagentStart: SubagentStartHookOutput;
+  SubagentStop: SubagentStopHookOutput;
+  Stop: StopHookOutput;
+  StopFailure: StopFailureHookOutput;
+  PreCompact: PreCompactHookOutput;
+  PostCompact: PostCompactHookOutput;
+};
+
+/** Superset output shape used by the executor's fold loop. */
+export type HookOutput =
+  | RunStartHookOutput
+  | UserPromptSubmitHookOutput
+  | PreToolUseHookOutput
+  | PostToolUseHookOutput
+  | PostToolUseFailureHookOutput
+  | PermissionDeniedHookOutput
+  | SubagentStartHookOutput
+  | SubagentStopHookOutput
+  | StopHookOutput
+  | StopFailureHookOutput
+  | PreCompactHookOutput
+  | PostCompactHookOutput;
+
+/**
+ * A hook callback is a plain async function registered against a specific
+ * event. The `signal` is always supplied by `executeHooks` and combines the
+ * batch's parent signal with the per-hook timeout — callbacks that perform
+ * long-running work should observe it.
+ */
+export type HookCallback<E extends HookEvent = HookEvent> = (
+  input: HookInputByEvent[E],
+  signal: AbortSignal
+) => HookOutputByEvent[E] | Promise<HookOutputByEvent[E]>;
+
+/**
+ * A matcher groups one or more callbacks under a shared regex filter and
+ * shared timeout/once/internal flags. The generic `E` ties the callback
+ * types to the event the matcher is registered against.
+ */
+export interface HookMatcher<E extends HookEvent = HookEvent> {
+  /** Regex matched against the event's primary query field (e.g. tool name). */
+  matcher?: string;
+  /** Callbacks that fire when the matcher hits. Executed in parallel. */
+  hooks: HookCallback<E>[];
+  /** Per-matcher timeout in ms. Defaults to the executor's batch timeout. */
+  timeout?: number;
+  /** Remove the matcher after its first successful invocation. */
+  once?: boolean;
+  /** Internal hooks are excluded from telemetry and non-fatal error logging. */
+  internal?: boolean;
+}
+
+/**
+ * Storage shape for matchers keyed by event. Each event's matcher list is
+ * a generic array parameterized by that event type, so lookup via
+ * `HooksByEvent[E]` preserves type-safe callback signatures.
+ */
+export type HooksByEvent = {
+  [E in HookEvent]?: HookMatcher<E>[];
+};
+
+/**
+ * Aggregated result of a single `executeHooks` call. Fields are populated
+ * according to the fold rules in `executeHooks.ts`.
+ */
+export interface AggregatedHookResult {
+  /** Folded tool-gating decision; `deny > ask > allow`. */
+  decision?: ToolDecision;
+  /** Folded stop decision; any `block` wins. */
+  stopDecision?: StopDecision;
+  /** Reason from the hook that set the winning decision. */
+  reason?: string;
+  /**
+   * Replacement tool input from a `PreToolUse` hook.
+   *
+   * NOTE: parallel hooks resolve in non-deterministic order, so with more
+   * than one hook setting `updatedInput` the last writer wins by resolution
+   * order, not by registration order. Consumers that need determinism should
+   * ensure at most one hook per matcher writes `updatedInput`.
+   */
+  updatedInput?: Record<string, unknown>;
+  /** Accumulated `additionalContext` strings from every hook, in order. */
+  additionalContexts: string[];
+  /** True if any hook returned `preventContinuation`. */
+  preventContinuation?: boolean;
+  /** Reason recorded alongside `preventContinuation`. */
+  stopReason?: string;
+  /** Error messages from hooks that threw; always present (possibly empty). */
+  errors: string[];
+}

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -199,14 +199,23 @@ export interface PreToolUseHookOutput extends BaseHookOutput {
   /**
    * Replacement tool input. Merged into the pending tool call by the host.
    *
-   * WARNING: with multiple parallel hooks, the winner is non-deterministic
-   * (last writer wins in Promise.all resolution order). If deterministic
-   * replacement is required, register a single hook per matcher.
+   * When multiple hooks set `updatedInput` within a single `executeHooks`
+   * call, the last writer in registration order wins (outer loop: matcher
+   * registration order; inner loop: hook position within the matcher). The
+   * winner is deterministic — `Promise.all` preserves input-array order.
+   * Consumers that need a single authoritative rewrite should still scope
+   * `updatedInput` to one hook per matcher to avoid confusing precedence.
    */
   updatedInput?: Record<string, unknown>;
 }
 
 export interface PostToolUseHookOutput extends BaseHookOutput {
+  /**
+   * Replacement tool output. Flows through the aggregated result so the
+   * host can substitute it before appending the tool result message.
+   * Ordering semantics match `PreToolUseHookOutput.updatedInput`:
+   * last-writer-wins in registration order.
+   */
   updatedOutput?: unknown;
 }
 
@@ -280,13 +289,34 @@ export type HookCallback<E extends HookEvent = HookEvent> = (
  * types to the event the matcher is registered against.
  */
 export interface HookMatcher<E extends HookEvent = HookEvent> {
-  /** Regex matched against the event's primary query field (e.g. tool name). */
-  matcher?: string;
+  /**
+   * Regex pattern matched against the event's primary query string (e.g.
+   * the tool name for `PreToolUse`, the agent type for `SubagentStart`).
+   *
+   * Omitted or empty means "always match". For events that do not supply a
+   * query string (`RunStart`, `Stop`, etc.), only wildcard matchers fire —
+   * a non-empty pattern on such events will never match.
+   *
+   * Patterns are treated as trusted input: `executeHooks` compiles them
+   * with `new RegExp(pattern)` without any sandbox, and a pathological
+   * pattern can block the event loop. Host registration code is expected
+   * to validate or length-bound patterns that originate from user input.
+   */
+  pattern?: string;
   /** Callbacks that fire when the matcher hits. Executed in parallel. */
   hooks: HookCallback<E>[];
   /** Per-matcher timeout in ms. Defaults to the executor's batch timeout. */
   timeout?: number;
-  /** Remove the matcher after its first successful invocation. */
+  /**
+   * Remove the matcher after its first successful invocation (at least one
+   * hook in the matcher returned without throwing).
+   *
+   * **Not atomic under concurrent dispatch.** Two concurrent `executeHooks`
+   * calls for the same event will both observe the matcher in their
+   * respective snapshots, both fire its hooks, and both attempt removal;
+   * the hook will run once per concurrent call, not once globally. Use
+   * `once` for idempotent one-shot hooks only.
+   */
   once?: boolean;
   /** Internal hooks are excluded from telemetry and non-fatal error logging. */
   internal?: boolean;
@@ -315,17 +345,33 @@ export interface AggregatedHookResult {
   /**
    * Replacement tool input from a `PreToolUse` hook.
    *
-   * NOTE: parallel hooks resolve in non-deterministic order, so with more
-   * than one hook setting `updatedInput` the last writer wins by resolution
-   * order, not by registration order. Consumers that need determinism should
-   * ensure at most one hook per matcher writes `updatedInput`.
+   * Last-writer-wins in **registration order**: `executeHooks` uses
+   * `Promise.all`, which preserves input-array order, so the fold iterates
+   * outcomes in the same order they were pushed — outer loop over matchers
+   * as they sit in the registry, inner loop over each matcher's `hooks`
+   * array. The winner is therefore deterministic but may not match the
+   * order in which hooks actually completed. Consumers that want a single
+   * authoritative rewrite should still register one `updatedInput`-setting
+   * hook per matcher to avoid subtle precedence bugs.
    */
   updatedInput?: Record<string, unknown>;
+  /**
+   * Replacement tool output from a `PostToolUse` hook.
+   *
+   * Same last-writer-wins-in-registration-order semantics as
+   * `updatedInput`. Present only when at least one hook set it; `undefined`
+   * means "use the original tool output".
+   */
+  updatedOutput?: unknown;
   /** Accumulated `additionalContext` strings from every hook, in order. */
   additionalContexts: string[];
   /** True if any hook returned `preventContinuation`. */
   preventContinuation?: boolean;
-  /** Reason recorded alongside `preventContinuation`. */
+  /**
+   * Reason recorded alongside `preventContinuation`. First winner wins:
+   * once a hook sets both flags, later hooks that also set
+   * `preventContinuation` do not overwrite the reason.
+   */
   stopReason?: string;
   /** Error messages from hooks that threw; always present (possibly empty). */
   errors: string[];


### PR DESCRIPTION
## Summary

Phase 1 of the hooks system for `@librechat/agents` — types, registry, and executor only. Purely additive and **inert**: not exported from `src/index.ts` and not yet wired into `Run`/`Graph`/`ToolNode`. Hosts that don't opt in see zero behavior change.

Follows the research + scaffolding plan in `docs/hooks-design-report.md` (§3.3–§3.6 for the file layout/types, §3.9 for multi-user rules).

### What ships

- **12-event discriminated union** (`RunStart`, `UserPromptSubmit`, `Pre/Post/Failed ToolUse`, `PermissionDenied`, `Subagent Start/Stop`, `Stop`, `StopFailure`, `Pre/PostCompact`) with per-event input and output types. Generic `HookCallback<E>` / `HookMatcher<E>` give type-safe registration.
- **`HookRegistry`** backed by `Map<sessionId, bucket>` (not `Record`) to avoid O(n²) churn under parallel registration in multi-tenant hosts. Mirrors the reasoning Claude Code calls out at `utils/hooks/sessionHooks.ts:62`.
- **`executeHooks`** — parallel fan-out that races each hook against a combined parent + timeout `AbortSignal` (using `AbortSignal.any` + `AbortSignal.timeout`) so non-listening hooks still time out. Folds results with `deny > ask > allow` precedence and a separate `any-block-wins` rule for `Stop` hooks. Accumulates `additionalContext` strings, applies last-writer-wins to `updatedInput` (non-deterministic, documented on the output type), and self-removes `once: true` matchers after at least one successful invocation.
- **Non-fatal errors** swallowed into `AggregatedHookResult.errors` and routed through an optional winston logger with a `console.warn` fallback. `internal: true` matchers are suppressed from both the errors array and the logger.
- **`src/hooks/index.ts`** re-exports internally but is **not** pulled into `src/index.ts`. The directory is dormant until the next PR wires it into `Run`.

### What's deferred

- Run-level integration (`RunStart`/`Stop`/`StopFailure`/`UserPromptSubmit`) — next PR.
- Tool-level integration (`PreToolUse`/`PostToolUse`/`PostToolUseFailure`/`PermissionDenied`) — PR after that.
- Subagent, compaction, and LibreChat-side `Agent.hooks` compiler — Phase 2.

### Design decisions (from §3.12)

- **Callback-only for v1.** No shell/http/prompt/agent hook types — hosts that need subprocess hooks can shell out inside a callback.
- **`updatedInput` is last-writer-wins** with a loud JSDoc on the output type; consumers that need determinism should register a single hook per matcher.
- `HookRegistry` is zero-arg constructable so the integration PR can do `config.hooks ?? new HookRegistry()`, mirroring the existing `customHandlers` pattern.

### Files

- `src/hooks/types.ts` — 12-event discriminated union + generic matcher/callback types.
- `src/hooks/matchers.ts` — regex helper with safe fallback on invalid patterns.
- `src/hooks/HookRegistry.ts` — run-scoped storage with global + session buckets.
- `src/hooks/executeHooks.ts` — parallel executor, signal racing, fold logic.
- `src/hooks/index.ts` — internal exports (not in `src/index.ts`).
- `src/hooks/__tests__/matchers.test.ts`
- `src/hooks/__tests__/HookRegistry.test.ts`
- `src/hooks/__tests__/executeHooks.test.ts`

## Test plan

- [x] \`npx jest src/hooks\` — 47/47 passing (registry scoping, regex filtering, precedence folding, \`once: true\` success/failure/mixed, per-matcher timeout, non-listening-hook timeout via signal race, batch timeout, sync/async error swallowing, internal matcher suppression, logger vs console fallback, parent AbortSignal combination).
- [x] \`npx tsc --noEmit\` — clean.
- [x] \`npx eslint src/hooks/\` — clean.
- [x] No changes to \`src/index.ts\`, \`src/run.ts\`, \`src/graphs/Graph.ts\`, or \`src/tools/ToolNode.ts\`.
- [x] Hosts that don't register any hooks see no behavior change (the module is not wired into any execution path).