### PR TITLE
feat: wire run-level hooks into processStream

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -53,6 +53,7 @@ import { isThinkingEnabled } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
 import { ChatOpenAI } from '@/llm/openai';
+import type { HookRegistry } from '@/hooks';
 
 const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 
@@ -123,6 +124,7 @@ export abstract class Graph<
   /** Set of invoked tool call IDs from non-message run steps completed mid-run, if any */
   invokedToolIds?: Set<string>;
   handlerRegistry: HandlerRegistry | undefined;
+  hookRegistry: HookRegistry | undefined;
   /**
    * Tool session contexts for automatic state persistence across tool invocations.
    * Keyed by tool name (e.g., Constants.EXECUTE_CODE).
@@ -147,6 +149,7 @@ export abstract class Graph<
     this.prelimMessageIdsByStepKey = new Map();
     this.invokedToolIds = undefined;
     this.handlerRegistry = undefined;
+    this.hookRegistry = undefined;
     this.sessions.clear();
   }
 }

--- a/src/hooks/__tests__/integration.test.ts
+++ b/src/hooks/__tests__/integration.test.ts
@@ -87,6 +87,79 @@ describe('Run-level hook integration', () => {
       expect(capturedPrompt).toBe('hello world');
     });
 
+    it('extracts prompt from multi-part content (text + non-text blocks)', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt = '';
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['ok']);
+      const msg = new HumanMessage({
+        content: [
+          { type: 'text', text: 'hello' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,...' },
+          },
+          { type: 'text', text: 'world' },
+        ],
+      });
+      await run.processStream({ messages: [msg] }, callerConfig);
+
+      expect(capturedPrompt).toBe('hello\nworld');
+    });
+
+    it('yields empty prompt for image-only content', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt: string | undefined;
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['ok']);
+      const msg = new HumanMessage({
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,...' },
+          },
+        ],
+      });
+      await run.processStream({ messages: [msg] }, callerConfig);
+
+      expect(capturedPrompt).toBe('');
+    });
+
+    it('fires with empty prompt when human message has no text blocks', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt: string | undefined;
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['ok']);
+      const msg = new HumanMessage({ content: [] });
+      await run.processStream({ messages: [msg] }, callerConfig);
+
+      expect(capturedPrompt).toBe('');
+    });
+
     it('aborts the run when hook returns deny', async () => {
       const registry = new HookRegistry();
       let stopFired = false;
@@ -204,7 +277,8 @@ describe('Run-level hook integration', () => {
       }
 
       expect(thrownError).toBeDefined();
-      expect(capturedError).toBeTruthy();
+      expect(typeof capturedError).toBe('string');
+      expect(capturedError.length).toBeGreaterThan(0);
     });
   });
 

--- a/src/hooks/__tests__/integration.test.ts
+++ b/src/hooks/__tests__/integration.test.ts
@@ -1,0 +1,263 @@
+// src/hooks/__tests__/integration.test.ts
+import { HumanMessage } from '@langchain/core/messages';
+import { HookRegistry } from '../HookRegistry';
+import { Run } from '@/run';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  RunStartHookInput,
+  RunStartHookOutput,
+  UserPromptSubmitHookOutput,
+  StopHookInput,
+  StopHookOutput,
+  StopFailureHookOutput,
+} from '../types';
+import { Providers } from '@/common';
+
+const llmConfig: t.LLMConfig = {
+  provider: Providers.OPENAI,
+  streaming: true,
+  streamUsage: false,
+};
+
+const callerConfig = {
+  configurable: { thread_id: 'test-thread' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+function createRun(
+  hooks: HookRegistry,
+  runId = 'test-run'
+): Promise<Run<t.IState>> {
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: { type: 'standard', llmConfig },
+    returnContent: true,
+    skipCleanup: true,
+    hooks,
+  });
+}
+
+describe('Run-level hook integration', () => {
+  jest.setTimeout(15000);
+
+  describe('RunStart', () => {
+    it('fires with runId, threadId, and messages before the stream', async () => {
+      const registry = new HookRegistry();
+      let captured: RunStartHookInput | undefined;
+      const hook: HookCallback<'RunStart'> = async (
+        input
+      ): Promise<RunStartHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('RunStart', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['hello']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('RunStart');
+      expect(captured!.runId).toBe('test-run');
+      expect(captured!.threadId).toBe('test-thread');
+      expect(captured!.messages).toHaveLength(1);
+    });
+  });
+
+  describe('UserPromptSubmit', () => {
+    it('extracts prompt text from the last human message', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt = '';
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['response']);
+      const inputs = { messages: [new HumanMessage('hello world')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(capturedPrompt).toBe('hello world');
+    });
+
+    it('aborts the run when hook returns deny', async () => {
+      const registry = new HookRegistry();
+      let stopFired = false;
+      const denyHook: HookCallback<
+        'UserPromptSubmit'
+      > = async (): Promise<UserPromptSubmitHookOutput> => ({
+        decision: 'deny',
+        reason: 'blocked by policy',
+      });
+      const stopHook: HookCallback<
+        'Stop'
+      > = async (): Promise<StopHookOutput> => {
+        stopFired = true;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [denyHook] });
+      registry.register('Stop', { hooks: [stopHook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['should not reach']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeUndefined();
+      expect(stopFired).toBe(false);
+    });
+
+    it('aborts the run when hook returns ask (v1 — no interactive flow)', async () => {
+      const registry = new HookRegistry();
+      const askHook: HookCallback<
+        'UserPromptSubmit'
+      > = async (): Promise<UserPromptSubmitHookOutput> => ({
+        decision: 'ask',
+        reason: 'needs confirmation',
+      });
+      registry.register('UserPromptSubmit', { hooks: [askHook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['should not reach']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('Stop', () => {
+    it('fires after a successful stream with accumulated messages', async () => {
+      const registry = new HookRegistry();
+      let captured: StopHookInput | undefined;
+      const hook: HookCallback<'Stop'> = async (
+        input
+      ): Promise<StopHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('Stop', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['agent reply']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('Stop');
+      expect(captured!.runId).toBe('test-run');
+      expect(captured!.stopHookActive).toBe(false);
+      expect(captured!.messages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not fire when the stream throws an error', async () => {
+      const registry = new HookRegistry();
+      let stopFired = false;
+      const hook: HookCallback<'Stop'> = async (): Promise<StopHookOutput> => {
+        stopFired = true;
+        return {};
+      };
+      registry.register('Stop', { hooks: [hook] });
+
+      const run = await createRun(registry, 'error-run');
+      run.Graph!.overrideTestModel([]);
+
+      const inputs = { messages: [new HumanMessage('hi')] };
+      try {
+        await run.processStream(inputs, callerConfig);
+      } catch {
+        /* expected */
+      }
+
+      expect(stopFired).toBe(false);
+    });
+  });
+
+  describe('StopFailure', () => {
+    it('fires when the stream throws and preserves the original error', async () => {
+      const registry = new HookRegistry();
+      let capturedError = '';
+      const hook: HookCallback<'StopFailure'> = async (
+        input
+      ): Promise<StopFailureHookOutput> => {
+        capturedError = input.error;
+        return {};
+      };
+      registry.register('StopFailure', { hooks: [hook] });
+
+      const run = await createRun(registry, 'fail-run');
+      run.Graph!.overrideTestModel([]);
+
+      const inputs = { messages: [new HumanMessage('hi')] };
+      let thrownError: Error | undefined;
+      try {
+        await run.processStream(inputs, callerConfig);
+      } catch (err) {
+        thrownError = err instanceof Error ? err : new Error(String(err));
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(capturedError).toBeTruthy();
+    });
+  });
+
+  describe('session teardown', () => {
+    it('clears session matchers after processStream completes', async () => {
+      const registry = new HookRegistry();
+      registry.registerSession('test-run', 'RunStart', {
+        hooks: [async (): Promise<RunStartHookOutput> => ({})],
+      });
+      expect(registry.getMatchers('RunStart', 'test-run')).toHaveLength(1);
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['done']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(registry.getMatchers('RunStart', 'test-run')).toHaveLength(0);
+    });
+
+    it('clears session even when the stream errors', async () => {
+      const registry = new HookRegistry();
+      registry.registerSession('error-run', 'RunStart', {
+        hooks: [async (): Promise<RunStartHookOutput> => ({})],
+      });
+
+      const run = await createRun(registry, 'error-run');
+      run.Graph!.overrideTestModel([]);
+
+      const inputs = { messages: [new HumanMessage('hi')] };
+      try {
+        await run.processStream(inputs, callerConfig);
+      } catch {
+        /* expected */
+      }
+
+      expect(registry.getMatchers('RunStart', 'error-run')).toHaveLength(0);
+    });
+  });
+
+  describe('no-hooks baseline', () => {
+    it('works identically when no hooks registry is provided', async () => {
+      const run = await Run.create<t.IState>({
+        runId: 'no-hooks-run',
+        graphConfig: { type: 'standard', llmConfig },
+        returnContent: true,
+        skipCleanup: true,
+      });
+      run.Graph!.overrideTestModel(['response']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeDefined();
+      expect(result!.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,10 +1,9 @@
 // src/hooks/index.ts
 //
-// Phase 1 PR 1: this directory is purely additive and is NOT re-exported
-// from `src/index.ts`. The types and classes below are consumed internally
-// in subsequent PRs that wire the registry into `Run`, `Graph`, and
-// `ToolNode`. Leaving it unexported keeps the public API surface frozen
-// until the integration layer is in place.
+// Hook lifecycle system for `@librechat/agents`. Re-exported from
+// `src/index.ts` and consumed by `Run.processStream` (RunStart,
+// UserPromptSubmit, Stop, StopFailure) and — once the tool-hook PR
+// lands — by `ToolNode` (PreToolUse, PostToolUse, etc.).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export * from './tools/search';
 export * from './common';
 export * from './utils';
 
+/* Hooks */
+export * from './hooks';
+
 /* Types */
 export type * from './types';
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -353,7 +353,7 @@ export class Run<_T extends t.BaseGraphState> {
         sessionId: this.id,
       });
 
-      const lastHuman = findLastHumanMessage(inputs.messages);
+      const lastHuman = findLastMessageOfType(inputs.messages, 'human');
       if (lastHuman != null) {
         const promptResult = await executeHooks({
           registry: this.hookRegistry,
@@ -363,6 +363,8 @@ export class Run<_T extends t.BaseGraphState> {
             threadId,
             agentId: this.Graph.defaultAgentId,
             prompt: extractPromptText(lastHuman),
+            // attachments: not yet wired — Phase 2 will extract
+            // non-text content blocks (images, files) from messages
           },
           sessionId: this.id,
         });
@@ -371,6 +373,7 @@ export class Run<_T extends t.BaseGraphState> {
           promptResult.decision === 'ask'
         ) {
           this.hookRegistry.clearSession(this.id);
+          config.callbacks = undefined;
           return undefined;
         }
       }
@@ -406,7 +409,7 @@ export class Run<_T extends t.BaseGraphState> {
         }
       }
 
-      if (this.hookRegistry != null) {
+      if (this.hookRegistry?.hasHookFor('Stop', this.id) === true) {
         await executeHooks({
           registry: this.hookRegistry,
           input: {
@@ -415,13 +418,15 @@ export class Run<_T extends t.BaseGraphState> {
             threadId,
             agentId: this.Graph.defaultAgentId,
             messages: this.Graph.getRunMessages() ?? inputs.messages,
-            stopHookActive: false,
+            stopHookActive: false, // will be true when stop is triggered by a hook (Phase 2)
           },
           sessionId: this.id,
+        }).catch(() => {
+          /* Stop hook errors must not masquerade as stream failures */
         });
       }
     } catch (err) {
-      if (this.hookRegistry != null) {
+      if (this.hookRegistry?.hasHookFor('StopFailure', this.id) === true) {
         const runMessages = this.Graph.getRunMessages() ?? [];
         await executeHooks({
           registry: this.hookRegistry,
@@ -431,7 +436,7 @@ export class Run<_T extends t.BaseGraphState> {
             threadId,
             agentId: this.Graph.defaultAgentId,
             error: err instanceof Error ? err.message : String(err),
-            lastAssistantMessage: findLastAssistantMessage(runMessages),
+            lastAssistantMessage: findLastMessageOfType(runMessages, 'ai'),
           },
           sessionId: this.id,
         }).catch(() => {
@@ -638,22 +643,12 @@ export class Run<_T extends t.BaseGraphState> {
   }
 }
 
-function findLastHumanMessage(
-  messages: BaseMessage[]
+function findLastMessageOfType(
+  messages: BaseMessage[],
+  type: string
 ): BaseMessage | undefined {
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].getType() === 'human') {
-      return messages[i];
-    }
-  }
-  return undefined;
-}
-
-function findLastAssistantMessage(
-  messages: BaseMessage[]
-): BaseMessage | undefined {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].getType() === 'ai') {
+    if (messages[i].getType() === type) {
       return messages[i];
     }
   }
@@ -665,23 +660,20 @@ function extractPromptText(message: BaseMessage): string {
   if (typeof content === 'string') {
     return content;
   }
-  if (Array.isArray(content)) {
-    return content
-      .filter(
-        (
-          block
-        ): block is {
-          type: 'text';
-          text: string;
-        } =>
-          typeof block === 'object' &&
-          'type' in block &&
-          block.type === 'text' &&
-          'text' in block &&
-          typeof block.text === 'string'
-      )
-      .map((block) => block.text)
-      .join('\n');
+  if (!Array.isArray(content)) {
+    return String(content);
   }
-  return String(content);
+  const parts: string[] = [];
+  for (const block of content) {
+    if (
+      typeof block === 'object' &&
+      'type' in block &&
+      block.type === 'text' &&
+      'text' in block &&
+      typeof block.text === 'string'
+    ) {
+      parts.push(block.text);
+    }
+  }
+  return parts.join('\n');
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -22,8 +22,10 @@ import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import { StandardGraph } from '@/graphs/Graph';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
+import { executeHooks } from '@/hooks';
 import { isOpenAILike } from '@/utils/llm';
 import { isPresent } from '@/utils/misc';
+import type { HookRegistry } from '@/hooks';
 
 export const defaultOmitOptions = new Set([
   'stream',
@@ -42,6 +44,7 @@ export class Run<_T extends t.BaseGraphState> {
   id: string;
   private tokenCounter?: t.TokenCounter;
   private handlerRegistry?: HandlerRegistry;
+  private hookRegistry?: HookRegistry;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   graphRunnable?: t.CompiledStateWorkflow;
@@ -74,6 +77,7 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     this.handlerRegistry = handlerRegistry;
+    this.hookRegistry = config.hooks;
 
     if (!config.graphConfig) {
       throw new Error('Graph config not provided');
@@ -84,6 +88,7 @@ export class Run<_T extends t.BaseGraphState> {
       this.graphRunnable = this.createMultiAgentGraph(config.graphConfig);
       if (this.Graph) {
         this.Graph.handlerRegistry = handlerRegistry;
+        this.Graph.hookRegistry = this.hookRegistry;
       }
     } else {
       /** Default to legacy graph for 'standard' or undefined type */
@@ -92,6 +97,7 @@ export class Run<_T extends t.BaseGraphState> {
         this.Graph.compileOptions =
           config.graphConfig.compileOptions ?? this.Graph.compileOptions;
         this.Graph.handlerRegistry = handlerRegistry;
+        this.Graph.hookRegistry = this.hookRegistry;
       }
     }
 
@@ -332,6 +338,44 @@ export class Run<_T extends t.BaseGraphState> {
       run_id: this.id,
     });
 
+    const threadId = config.configurable.thread_id as string | undefined;
+
+    if (this.hookRegistry != null) {
+      await executeHooks({
+        registry: this.hookRegistry,
+        input: {
+          hook_event_name: 'RunStart',
+          runId: this.id,
+          threadId,
+          agentId: this.Graph.defaultAgentId,
+          messages: inputs.messages,
+        },
+        sessionId: this.id,
+      });
+
+      const lastHuman = findLastHumanMessage(inputs.messages);
+      if (lastHuman != null) {
+        const promptResult = await executeHooks({
+          registry: this.hookRegistry,
+          input: {
+            hook_event_name: 'UserPromptSubmit',
+            runId: this.id,
+            threadId,
+            agentId: this.Graph.defaultAgentId,
+            prompt: extractPromptText(lastHuman),
+          },
+          sessionId: this.id,
+        });
+        if (
+          promptResult.decision === 'deny' ||
+          promptResult.decision === 'ask'
+        ) {
+          this.hookRegistry.clearSession(this.id);
+          return undefined;
+        }
+      }
+    }
+
     const stream = this.graphRunnable.streamEvents(inputs, config, {
       raiseError: true,
       /**
@@ -361,7 +405,43 @@ export class Run<_T extends t.BaseGraphState> {
           await handler.handle(eventName, data, metadata, this.Graph);
         }
       }
+
+      if (this.hookRegistry != null) {
+        await executeHooks({
+          registry: this.hookRegistry,
+          input: {
+            hook_event_name: 'Stop',
+            runId: this.id,
+            threadId,
+            agentId: this.Graph.defaultAgentId,
+            messages: this.Graph.getRunMessages() ?? inputs.messages,
+            stopHookActive: false,
+          },
+          sessionId: this.id,
+        });
+      }
+    } catch (err) {
+      if (this.hookRegistry != null) {
+        const runMessages = this.Graph.getRunMessages() ?? [];
+        await executeHooks({
+          registry: this.hookRegistry,
+          input: {
+            hook_event_name: 'StopFailure',
+            runId: this.id,
+            threadId,
+            agentId: this.Graph.defaultAgentId,
+            error: err instanceof Error ? err.message : String(err),
+            lastAssistantMessage: findLastAssistantMessage(runMessages),
+          },
+          sessionId: this.id,
+        }).catch(() => {
+          /* swallow hook errors — the original error must propagate */
+        });
+      }
+      throw err;
     } finally {
+      this.hookRegistry?.clearSession(this.id);
+
       /**
        * Break the reference chain that keeps heavy data alive via
        * LangGraph's internal `__pregel_scratchpad.currentTaskInput` →
@@ -556,4 +636,52 @@ export class Run<_T extends t.BaseGraphState> {
       );
     }
   }
+}
+
+function findLastHumanMessage(
+  messages: BaseMessage[]
+): BaseMessage | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].getType() === 'human') {
+      return messages[i];
+    }
+  }
+  return undefined;
+}
+
+function findLastAssistantMessage(
+  messages: BaseMessage[]
+): BaseMessage | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].getType() === 'ai') {
+      return messages[i];
+    }
+  }
+  return undefined;
+}
+
+function extractPromptText(message: BaseMessage): string {
+  const content = message.content;
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (
+          block
+        ): block is {
+          type: 'text';
+          text: string;
+        } =>
+          typeof block === 'object' &&
+          'type' in block &&
+          block.type === 'text' &&
+          'text' in block &&
+          typeof block.text === 'string'
+      )
+      .map((block) => block.text)
+      .join('\n');
+  }
+  return String(content);
 }

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -11,6 +11,7 @@ import type * as s from '@/types/stream';
 import type * as e from '@/common/enum';
 import type * as g from '@/types/graph';
 import type * as l from '@/types/llm';
+import type { HookRegistry } from '@/hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ZodObjectAny = z.ZodObject<any, any, any, any>;
@@ -112,6 +113,17 @@ export type RunConfig = {
   runId: string;
   graphConfig: LegacyGraphConfig | StandardGraphConfig | MultiAgentGraphConfig;
   customHandlers?: Record<string, g.EventHandler>;
+  /**
+   * Pre-constructed hook registry for this run. Hooks fire at lifecycle
+   * points in `processStream` (RunStart, UserPromptSubmit, Stop,
+   * StopFailure) and — once the tool-hook PR lands — around tool calls.
+   *
+   * Pass `undefined` (the default) to skip all hook dispatch. When a
+   * registry is provided, the run attaches it to the `Graph` so internal
+   * nodes can fire hooks too, and clears the session in the `finally`
+   * block to prevent leaks.
+   */
+  hooks?: HookRegistry;
   returnContent?: boolean;
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;


### PR DESCRIPTION
## Summary

Phase 1 PR 2 of the hooks system. Makes the inert `src/hooks/` module from #87 live by firing four lifecycle hooks from `Run.processStream`. Hosts pass a pre-constructed `HookRegistry` via `RunConfig.hooks`; when absent, all hook dispatch is skipped with zero overhead.

- **RunStart** — fires after config setup, before stream creation
- **UserPromptSubmit** — fires with extracted prompt text from the last human message. `deny` or `ask` decisions abort the run (returns `undefined`). The `ask` case is an abort in v1 — the SDK returns the decision and the host implements interactive approval in its own layer (Phase 2 plan added to `docs/skills-runtime-design-report.md`)
- **Stop** — fires at the end of the try block on successful completion only
- **StopFailure** — fires in a new catch block on error, swallows hook errors to preserve the original exception
- **Session teardown** — `hookRegistry.clearSession(runId)` guaranteed in the finally block

Also re-exports `src/hooks/` from `src/index.ts` so hosts can import `HookRegistry`, `executeHooks`, and all hook types from `@librechat/agents`.

### Files changed

| File | Change |
|---|---|
| `src/types/run.ts` | Added `hooks?: HookRegistry` to `RunConfig` |
| `src/graphs/Graph.ts` | Added `hookRegistry` field, cleared in `clearHeavyState()` |
| `src/run.ts` | Constructor wiring + 4 hook fire points + 3 helper functions |
| `src/index.ts` | Re-export `./hooks` |
| `src/hooks/index.ts` | Updated barrel comment (no longer "not re-exported") |
| `src/hooks/__tests__/integration.test.ts` | 10 new integration tests |
| `docs/skills-runtime-design-report.md` | Added Phase 6: interactive `ask` flow via GenerationJobManager |

## Test plan

- [x] 10 new integration tests: RunStart fields, UserPromptSubmit extract/deny/ask, Stop fires on success, Stop skipped on error, StopFailure fires on error, session teardown on success + error, no-hooks baseline
- [x] All 81 existing Phase 1 tests still pass (91 total)
- [x] Existing e2e test `custom-event-await.test.ts` still passes (no regression)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/hooks/ src/run.ts src/types/run.ts src/graphs/Graph.ts` — clean
- [x] No changes to `ToolNode.ts`, `MultiAgentGraph.ts`, or `summarization/node.ts`