### PR TITLE
feat: SkillTool primitive, injectedMessages, and catalog formatter

### DIFF
--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -182,6 +182,7 @@ export enum Constants {
   MCP_DELIMITER = '_mcp_',
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
+  SKILL_TOOL = 'skill',
 }
 
 export enum TitleMethod {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export * from './summarization';
 export * from './tools/Calculator';
 export * from './tools/CodeExecutor';
 export * from './tools/ProgrammaticToolCalling';
+export * from './tools/SkillTool';
+export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';
 export * from './tools/ToolNode';
 export * from './tools/schema';

--- a/src/tools/SkillTool.ts
+++ b/src/tools/SkillTool.ts
@@ -1,0 +1,68 @@
+// src/tools/SkillTool.ts
+import { z } from 'zod';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { Constants } from '@/common';
+
+export const SkillToolName = Constants.SKILL_TOOL;
+
+export const SkillToolSchema = z.object({
+  skillName: z
+    .string()
+    .describe(
+      'The kebab-case identifier of the skill to invoke (e.g. "financial-analyzer", "meeting-notes"). Must match a name from the "Available Skills" section.'
+    ),
+  args: z
+    .string()
+    .optional()
+    .describe('Optional freeform arguments string passed to the skill.'),
+});
+
+export const SkillToolDescription = `Invoke a skill from the user's library. Skills provide domain-specific instructions loaded into the conversation context, and may also provide files accessible via available tools depending on the runtime environment.
+
+WHEN TO USE:
+- The user's request matches a skill listed in the "Available Skills" section of the system prompt.
+- You MUST invoke the matching skill BEFORE attempting the task yourself.
+
+WHAT HAPPENS:
+- The skill's full instructions are loaded into the conversation as context.
+- Files bundled with the skill may become accessible via available tools.
+- Follow the skill's instructions to complete the task.
+
+CONSTRAINTS:
+- Do not invoke a skill that is already active in this conversation.
+- Skill names come from the catalog only — do not guess names.`;
+
+export const SkillToolDefinition = {
+  name: SkillToolName,
+  description: SkillToolDescription,
+  parameters: {
+    type: 'object' as const,
+    properties: {
+      skillName: {
+        type: 'string' as const,
+        description: 'The kebab-case identifier of the skill to invoke.',
+      },
+      args: {
+        type: 'string' as const,
+        description: 'Optional freeform arguments string passed to the skill.',
+      },
+    },
+    required: ['skillName'] as const,
+  },
+} as const;
+
+/** Creates the SkillTool DynamicStructuredTool instance for use in tool maps. */
+export function createSkillTool(): DynamicStructuredTool {
+  return tool(
+    async (): Promise<string> => {
+      throw new Error(
+        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
+      );
+    },
+    {
+      name: SkillToolName,
+      description: SkillToolDescription,
+      schema: SkillToolSchema,
+    }
+  );
+}

--- a/src/tools/SkillTool.ts
+++ b/src/tools/SkillTool.ts
@@ -1,6 +1,6 @@
 // src/tools/SkillTool.ts
-import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import { Constants } from '@/common';
 
 export const SkillToolName = Constants.SKILL_TOOL;

--- a/src/tools/SkillTool.ts
+++ b/src/tools/SkillTool.ts
@@ -1,21 +1,9 @@
 // src/tools/SkillTool.ts
-import { z } from 'zod';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
 import { Constants } from '@/common';
 
 export const SkillToolName = Constants.SKILL_TOOL;
-
-export const SkillToolSchema = z.object({
-  skillName: z
-    .string()
-    .describe(
-      'The kebab-case identifier of the skill to invoke (e.g. "financial-analyzer", "meeting-notes"). Must match a name from the "Available Skills" section.'
-    ),
-  args: z
-    .string()
-    .optional()
-    .describe('Optional freeform arguments string passed to the skill.'),
-});
 
 export const SkillToolDescription = `Invoke a skill from the user's library. Skills provide domain-specific instructions loaded into the conversation context, and may also provide files accessible via available tools depending on the runtime environment.
 
@@ -30,26 +18,48 @@ WHAT HAPPENS:
 
 CONSTRAINTS:
 - Do not invoke a skill that is already active in this conversation.
-- Skill names come from the catalog only — do not guess names.`;
+- Skill names come from the catalog only. Do not guess names.`;
+
+/**
+ * JSON Schema for the SkillTool parameters.
+ * Single source of truth used by both SkillToolDefinition (LCTool registry)
+ * and createSkillTool() (DynamicStructuredTool instance).
+ */
+export const SkillToolSchema = {
+  type: 'object',
+  properties: {
+    skillName: {
+      type: 'string',
+      description:
+        'The kebab-case identifier of the skill to invoke (e.g. "financial-analyzer", "meeting-notes"). Must match a name from the "Available Skills" section.',
+    },
+    args: {
+      type: 'string',
+      description: 'Optional freeform arguments string passed to the skill.',
+    },
+  },
+  required: ['skillName'],
+} as const;
 
 export const SkillToolDefinition = {
   name: SkillToolName,
   description: SkillToolDescription,
-  parameters: {
-    type: 'object' as const,
-    properties: {
-      skillName: {
-        type: 'string' as const,
-        description: 'The kebab-case identifier of the skill to invoke.',
-      },
-      args: {
-        type: 'string' as const,
-        description: 'Optional freeform arguments string passed to the skill.',
-      },
-    },
-    required: ['skillName'] as const,
-  },
+  parameters: SkillToolSchema,
 } as const;
+
+/**
+ * Zod schema derived from SkillToolSchema for DynamicStructuredTool type inference.
+ * Kept internal to createSkillTool — the JSON Schema above is the canonical definition.
+ */
+const skillToolZodSchema = z.object({
+  skillName: z
+    .string()
+    .describe(SkillToolSchema.properties.skillName.description),
+  args: z
+    .string()
+    .optional()
+    .describe(SkillToolSchema.properties.args.description),
+});
 
 /** Creates the SkillTool DynamicStructuredTool instance for use in tool maps. */
 export function createSkillTool(): DynamicStructuredTool {
@@ -62,7 +72,7 @@ export function createSkillTool(): DynamicStructuredTool {
     {
       name: SkillToolName,
       description: SkillToolDescription,
-      schema: SkillToolSchema,
+      schema: skillToolZodSchema,
     }
   );
 }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2,7 +2,6 @@ import { ToolCall } from '@langchain/core/messages/tool';
 import {
   ToolMessage,
   HumanMessage,
-  SystemMessage,
   isAIMessage,
   isBaseMessage,
 } from '@langchain/core/messages';
@@ -482,9 +481,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
-   * Converts InjectedMessage instances to LangChain BaseMessage objects.
-   * HumanMessage for role 'user', SystemMessage for role 'system'.
-   * Metadata (isMeta, source, skillName) stored in additional_kwargs.
+   * Converts InjectedMessage instances to LangChain HumanMessage objects.
+   * Both 'user' and 'system' roles become HumanMessage to avoid provider
+   * rejections (Anthropic/Google reject non-leading SystemMessages).
+   * The original role is preserved in additional_kwargs for downstream consumers.
    *
    * Array content (MessageContentComplex[]) is passed through directly since
    * LangChain BaseMessage constructors natively accept structured content arrays.
@@ -494,20 +494,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   ): BaseMessage[] {
     const converted: BaseMessage[] = [];
     for (const msg of messages) {
-      const additional_kwargs: Record<string, unknown> = {};
+      const additional_kwargs: Record<string, unknown> = {
+        role: msg.role,
+      };
       if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
       if (msg.source != null) additional_kwargs.source = msg.source;
       if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
 
-      if (msg.role === 'user') {
-        converted.push(
-          new HumanMessage({ content: msg.content, additional_kwargs })
-        );
-      } else {
-        converted.push(
-          new SystemMessage({ content: msg.content, additional_kwargs })
-        );
-      }
+      converted.push(
+        new HumanMessage({ content: msg.content, additional_kwargs })
+      );
     }
     return converted;
   }
@@ -568,7 +564,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     for (const result of results) {
       if (result.injectedMessages && result.injectedMessages.length > 0) {
-        injected.push(...this.convertInjectedMessages(result.injectedMessages));
+        try {
+          injected.push(
+            ...this.convertInjectedMessages(result.injectedMessages)
+          );
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[ToolNode] Failed to convert injectedMessages for toolCallId=${result.toolCallId}:`,
+            e instanceof Error ? e.message : e
+          );
+        }
       }
 
       const request = requests.find((r) => r.id === result.toolCallId);

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1,6 +1,8 @@
 import { ToolCall } from '@langchain/core/messages/tool';
 import {
   ToolMessage,
+  HumanMessage,
+  SystemMessage,
   isAIMessage,
   isBaseMessage,
 } from '@langchain/core/messages';
@@ -480,13 +482,42 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
-   * Dispatches tool calls to the host via ON_TOOL_EXECUTE event and returns raw ToolMessages.
+   * Converts InjectedMessage instances to LangChain BaseMessage objects.
+   * HumanMessage for role 'user', SystemMessage for role 'system'.
+   * Metadata (isMeta, source, skillName) stored in additional_kwargs.
+   */
+  private convertInjectedMessages(
+    messages: t.InjectedMessage[]
+  ): BaseMessage[] {
+    const converted: BaseMessage[] = [];
+    for (const msg of messages) {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : JSON.stringify(msg.content);
+      const additional_kwargs: Record<string, unknown> = {};
+      if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
+      if (msg.source != null) additional_kwargs.source = msg.source;
+      if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
+
+      if (msg.role === 'user') {
+        converted.push(new HumanMessage({ content, additional_kwargs }));
+      } else {
+        converted.push(new SystemMessage({ content, additional_kwargs }));
+      }
+    }
+    return converted;
+  }
+
+  /**
+   * Dispatches tool calls to the host via ON_TOOL_EXECUTE event and returns raw ToolMessages
+   * plus any injected messages from tool results.
    * Core logic for event-driven execution, separated from output shaping.
    */
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig
-  ): Promise<ToolMessage[]> {
+  ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const requests: t.ToolCallRequest[] = toolCalls.map((call) => {
       const turn = this.toolUsageCount.get(call.name) ?? 0;
       this.toolUsageCount.set(call.name, turn + 1);
@@ -529,7 +560,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     this.storeCodeSessionFromResults(results, requests);
 
-    return results.map((result) => {
+    const injected: BaseMessage[] = [];
+    const toolMessages: ToolMessage[] = [];
+
+    for (const result of results) {
+      if (result.injectedMessages && result.injectedMessages.length > 0) {
+        injected.push(...this.convertInjectedMessages(result.injectedMessages));
+      }
+
       const request = requests.find((r) => r.id === result.toolCallId);
       const toolName = request?.name ?? 'unknown';
       const stepId = this.toolCallStepIds?.get(result.toolCallId) ?? '';
@@ -597,13 +635,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         config
       );
 
-      return toolMessage;
-    });
+      toolMessages.push(toolMessage);
+    }
+
+    return { toolMessages, injected };
   }
 
   /**
    * Execute all tool calls via ON_TOOL_EXECUTE event dispatch.
    * Used in event-driven mode where the host handles actual tool execution.
+   * Injected messages from tool results are prepended before ToolMessages.
    */
   private async executeViaEvent(
     toolCalls: ToolCall[],
@@ -611,7 +652,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any
   ): Promise<T> {
-    const outputs = await this.dispatchToolEvents(toolCalls, config);
+    const { toolMessages, injected } = await this.dispatchToolEvents(
+      toolCalls,
+      config
+    );
+    const outputs: BaseMessage[] = [...injected, ...toolMessages];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
   }
 
@@ -707,12 +752,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           this.handleRunToolCompletions(directCalls, directOutputs, config);
         }
 
-        const eventOutputs: ToolMessage[] =
+        const eventResult =
           eventCalls.length > 0
             ? await this.dispatchToolEvents(eventCalls, config)
-            : [];
+            : {
+              toolMessages: [] as ToolMessage[],
+              injected: [] as BaseMessage[],
+            };
 
-        outputs = [...directOutputs, ...eventOutputs];
+        outputs = [
+          ...directOutputs,
+          ...eventResult.injected,
+          ...eventResult.toolMessages,
+        ];
       } else {
         outputs = await Promise.all(
           filteredCalls.map((call) => this.runTool(call, config))

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -485,25 +485,28 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * Converts InjectedMessage instances to LangChain BaseMessage objects.
    * HumanMessage for role 'user', SystemMessage for role 'system'.
    * Metadata (isMeta, source, skillName) stored in additional_kwargs.
+   *
+   * Array content (MessageContentComplex[]) is passed through directly since
+   * LangChain BaseMessage constructors natively accept structured content arrays.
    */
   private convertInjectedMessages(
     messages: t.InjectedMessage[]
   ): BaseMessage[] {
     const converted: BaseMessage[] = [];
     for (const msg of messages) {
-      const content =
-        typeof msg.content === 'string'
-          ? msg.content
-          : JSON.stringify(msg.content);
       const additional_kwargs: Record<string, unknown> = {};
       if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
       if (msg.source != null) additional_kwargs.source = msg.source;
       if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
 
       if (msg.role === 'user') {
-        converted.push(new HumanMessage({ content, additional_kwargs }));
+        converted.push(
+          new HumanMessage({ content: msg.content, additional_kwargs })
+        );
       } else {
-        converted.push(new SystemMessage({ content, additional_kwargs }));
+        converted.push(
+          new SystemMessage({ content: msg.content, additional_kwargs })
+        );
       }
     }
     return converted;
@@ -644,7 +647,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   /**
    * Execute all tool calls via ON_TOOL_EXECUTE event dispatch.
    * Used in event-driven mode where the host handles actual tool execution.
-   * Injected messages from tool results are prepended before ToolMessages.
+   *
+   * Injected messages are placed AFTER ToolMessages to respect provider message
+   * ordering contracts (AIMessage tool_calls must be immediately followed by their
+   * ToolMessage results). The host's message formatter merges injected user messages
+   * with the preceding tool_result turn for providers that require strict alternation.
    */
   private async executeViaEvent(
     toolCalls: ToolCall[],
@@ -656,7 +663,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       toolCalls,
       config
     );
-    const outputs: BaseMessage[] = [...injected, ...toolMessages];
+    const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
   }
 
@@ -762,8 +769,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         outputs = [
           ...directOutputs,
-          ...eventResult.injected,
           ...eventResult.toolMessages,
+          ...eventResult.injected,
         ];
       } else {
         outputs = await Promise.all(

--- a/src/tools/__tests__/SkillTool.test.ts
+++ b/src/tools/__tests__/SkillTool.test.ts
@@ -1,0 +1,248 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
+import { describe, it, expect } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import { ToolNode } from '../ToolNode';
+import { Constants } from '@/common';
+import {
+  SkillToolName,
+  SkillToolSchema,
+  SkillToolDescription,
+  SkillToolDefinition,
+  createSkillTool,
+} from '../SkillTool';
+
+describe('SkillTool', () => {
+  describe('schema validation', () => {
+    it('validates correct input with skillName only', () => {
+      const result = SkillToolSchema.safeParse({ skillName: 'pdf-processor' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.skillName).toBe('pdf-processor');
+        expect(result.data.args).toBeUndefined();
+      }
+    });
+
+    it('validates correct input with skillName and args', () => {
+      const result = SkillToolSchema.safeParse({
+        skillName: 'review-pr',
+        args: '123',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.skillName).toBe('review-pr');
+        expect(result.data.args).toBe('123');
+      }
+    });
+
+    it('rejects missing skillName', () => {
+      const result = SkillToolSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-string skillName', () => {
+      const result = SkillToolSchema.safeParse({ skillName: 123 });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('createSkillTool', () => {
+    it('throws on direct invocation', async () => {
+      const skillTool = createSkillTool();
+      await expect(skillTool.invoke({ skillName: 'test' })).rejects.toThrow(
+        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
+      );
+    });
+
+    it('has correct name', () => {
+      const skillTool = createSkillTool();
+      expect(skillTool.name).toBe('skill');
+    });
+  });
+
+  describe('SkillToolDefinition', () => {
+    it('has correct name', () => {
+      expect(SkillToolDefinition.name).toBe(Constants.SKILL_TOOL);
+    });
+
+    it('has correct parameter schema', () => {
+      expect(SkillToolDefinition.parameters.required).toContain('skillName');
+      expect(SkillToolDefinition.parameters.properties.skillName.type).toBe(
+        'string'
+      );
+      expect(SkillToolDefinition.parameters.properties.args.type).toBe(
+        'string'
+      );
+    });
+
+    it('has a description', () => {
+      expect(SkillToolDefinition.description).toBe(SkillToolDescription);
+      expect(SkillToolDefinition.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SkillToolName', () => {
+    it('equals Constants.SKILL_TOOL', () => {
+      expect(SkillToolName).toBe('skill');
+      expect(SkillToolName).toBe(Constants.SKILL_TOOL);
+    });
+  });
+
+  describe('InjectedMessage type-check', () => {
+    it('constructs a valid ToolExecuteResult with injectedMessages', () => {
+      const result: t.ToolExecuteResult = {
+        toolCallId: 'call_1',
+        content: 'Skill loaded successfully.',
+        status: 'success',
+        injectedMessages: [
+          {
+            role: 'user',
+            content: '# PDF Processor Instructions\n\nFollow these steps...',
+            isMeta: true,
+            source: 'skill',
+            skillName: 'pdf-processor',
+          },
+          {
+            role: 'system',
+            content: 'Skill files are available at /skills/pdf-processor/',
+            source: 'skill',
+            skillName: 'pdf-processor',
+          },
+        ],
+      };
+
+      expect(result.injectedMessages).toHaveLength(2);
+      expect(result.injectedMessages![0].role).toBe('user');
+      expect(result.injectedMessages![1].role).toBe('system');
+    });
+  });
+
+  describe('ToolNode injectedMessages plumbing (event-driven)', () => {
+    it('prepends injected messages before ToolMessages in output', async () => {
+      const dummyTool = tool(async () => 'dummy', {
+        name: 'dummy',
+        description: 'dummy',
+        schema: z.object({ x: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      const toolNode = new ToolNode({
+        tools: [dummyTool],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_1', 'step_1']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_1', name: 'dummy', args: { x: 'hello' } }],
+      });
+
+      const injectedMessages: t.InjectedMessage[] = [
+        {
+          role: 'user',
+          content: 'Injected skill body content',
+          isMeta: true,
+          source: 'skill',
+          skillName: 'test-skill',
+        },
+        {
+          role: 'system',
+          content: 'System context hint',
+          source: 'system',
+        },
+      ];
+
+      const mockResults: t.ToolExecuteResult[] = [
+        {
+          toolCallId: 'call_1',
+          content: 'Tool result text',
+          status: 'success',
+          injectedMessages,
+        },
+      ];
+
+      jest
+        .spyOn(await import('@/utils/events'), 'safeDispatchCustomEvent')
+        .mockImplementation(async (_event, data) => {
+          const request = data as t.ToolExecuteBatchRequest;
+          if (request.resolve) {
+            request.resolve(mockResults);
+          }
+        });
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(3);
+
+      const first = messages[0] as HumanMessage;
+      expect(first).toBeInstanceOf(HumanMessage);
+      expect(first.content).toBe('Injected skill body content');
+      expect(first.additional_kwargs.isMeta).toBe(true);
+      expect(first.additional_kwargs.source).toBe('skill');
+      expect(first.additional_kwargs.skillName).toBe('test-skill');
+
+      const second = messages[1] as SystemMessage;
+      expect(second).toBeInstanceOf(SystemMessage);
+      expect(second.content).toBe('System context hint');
+      expect(second.additional_kwargs.source).toBe('system');
+
+      const third = messages[2];
+      expect(third._getType()).toBe('tool');
+
+      jest.restoreAllMocks();
+    });
+
+    it('returns only ToolMessages when no injectedMessages present', async () => {
+      const dummyTool = tool(async () => 'dummy', {
+        name: 'dummy',
+        description: 'dummy',
+        schema: z.object({ x: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      const toolNode = new ToolNode({
+        tools: [dummyTool],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_2', 'step_2']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_2', name: 'dummy', args: { x: 'test' } }],
+      });
+
+      const mockResults: t.ToolExecuteResult[] = [
+        {
+          toolCallId: 'call_2',
+          content: 'Normal result',
+          status: 'success',
+        },
+      ];
+
+      jest
+        .spyOn(await import('@/utils/events'), 'safeDispatchCustomEvent')
+        .mockImplementation(async (_event, data) => {
+          const request = data as t.ToolExecuteBatchRequest;
+          if (request.resolve) {
+            request.resolve(mockResults);
+          }
+        });
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]._getType()).toBe('tool');
+
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/src/tools/__tests__/SkillTool.test.ts
+++ b/src/tools/__tests__/SkillTool.test.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { describe, it, expect } from '@jest/globals';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
@@ -199,6 +199,7 @@ describe('SkillTool', () => {
       const second = messages[1] as HumanMessage;
       expect(second).toBeInstanceOf(HumanMessage);
       expect(second.content).toBe('Injected skill body content');
+      expect(second.additional_kwargs.role).toBe('user');
       expect(second.additional_kwargs.isMeta).toBe(true);
       expect(second.additional_kwargs.source).toBe('skill');
       expect(second.additional_kwargs.skillName).toBe('test-skill');

--- a/src/tools/__tests__/SkillTool.test.ts
+++ b/src/tools/__tests__/SkillTool.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from '@jest/globals';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
+import * as events from '@/utils/events';
 import { ToolNode } from '../ToolNode';
 import { Constants } from '@/common';
 import {
@@ -20,36 +21,19 @@ import {
 } from '../SkillTool';
 
 describe('SkillTool', () => {
-  describe('schema validation', () => {
-    it('validates correct input with skillName only', () => {
-      const result = SkillToolSchema.safeParse({ skillName: 'pdf-processor' });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.skillName).toBe('pdf-processor');
-        expect(result.data.args).toBeUndefined();
-      }
+  describe('schema structure', () => {
+    it('has skillName as required string property', () => {
+      expect(SkillToolSchema.properties.skillName.type).toBe('string');
+      expect(SkillToolSchema.required).toContain('skillName');
     });
 
-    it('validates correct input with skillName and args', () => {
-      const result = SkillToolSchema.safeParse({
-        skillName: 'review-pr',
-        args: '123',
-      });
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.data.skillName).toBe('review-pr');
-        expect(result.data.args).toBe('123');
-      }
+    it('has args as optional string property', () => {
+      expect(SkillToolSchema.properties.args.type).toBe('string');
+      expect(SkillToolSchema.required).not.toContain('args');
     });
 
-    it('rejects missing skillName', () => {
-      const result = SkillToolSchema.safeParse({});
-      expect(result.success).toBe(false);
-    });
-
-    it('rejects non-string skillName', () => {
-      const result = SkillToolSchema.safeParse({ skillName: 123 });
-      expect(result.success).toBe(false);
+    it('is an object type schema', () => {
+      expect(SkillToolSchema.type).toBe('object');
     });
   });
 
@@ -65,6 +49,11 @@ describe('SkillTool', () => {
       const skillTool = createSkillTool();
       expect(skillTool.name).toBe('skill');
     });
+
+    it('validates skillName is required', async () => {
+      const skillTool = createSkillTool();
+      await expect(skillTool.invoke({})).rejects.toThrow();
+    });
   });
 
   describe('SkillToolDefinition', () => {
@@ -72,17 +61,11 @@ describe('SkillTool', () => {
       expect(SkillToolDefinition.name).toBe(Constants.SKILL_TOOL);
     });
 
-    it('has correct parameter schema', () => {
-      expect(SkillToolDefinition.parameters.required).toContain('skillName');
-      expect(SkillToolDefinition.parameters.properties.skillName.type).toBe(
-        'string'
-      );
-      expect(SkillToolDefinition.parameters.properties.args.type).toBe(
-        'string'
-      );
+    it('references the same SkillToolSchema object (no duplication)', () => {
+      expect(SkillToolDefinition.parameters).toBe(SkillToolSchema);
     });
 
-    it('has a description', () => {
+    it('has a non-empty description', () => {
       expect(SkillToolDefinition.description).toBe(SkillToolDescription);
       expect(SkillToolDefinition.description.length).toBeGreaterThan(0);
     });
@@ -122,18 +105,60 @@ describe('SkillTool', () => {
       expect(result.injectedMessages![0].role).toBe('user');
       expect(result.injectedMessages![1].role).toBe('system');
     });
+
+    it('accepts MessageContentComplex[] content', () => {
+      const result: t.ToolExecuteResult = {
+        toolCallId: 'call_1',
+        content: '',
+        status: 'success',
+        injectedMessages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Skill instructions here' },
+              { type: 'image_url', image_url: { url: 'data:image/png;...' } },
+            ],
+            isMeta: true,
+            source: 'skill',
+            skillName: 'visual-skill',
+          },
+        ],
+      };
+
+      expect(Array.isArray(result.injectedMessages![0].content)).toBe(true);
+    });
   });
 
   describe('ToolNode injectedMessages plumbing (event-driven)', () => {
-    it('prepends injected messages before ToolMessages in output', async () => {
-      const dummyTool = tool(async () => 'dummy', {
-        name: 'dummy',
+    const createDummyTool = (name = 'dummy'): StructuredToolInterface =>
+      tool(async () => 'dummy', {
+        name,
         description: 'dummy',
         schema: z.object({ x: z.string() }),
       }) as unknown as StructuredToolInterface;
 
+    function mockEventDispatch(
+      mockResults: t.ToolExecuteResult[]
+    ): jest.SpyInstance {
+      return jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (_event, data) => {
+          const request = data as Record<string, unknown>;
+          if (typeof request.resolve === 'function') {
+            (request.resolve as (r: t.ToolExecuteResult[]) => void)(
+              mockResults
+            );
+          }
+        });
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('appends injected messages AFTER ToolMessages in output', async () => {
       const toolNode = new ToolNode({
-        tools: [dummyTool],
+        tools: [createDummyTool()],
         eventDrivenMode: true,
         agentId: 'test-agent',
         toolCallStepIds: new Map([['call_1', 'step_1']]),
@@ -144,71 +169,53 @@ describe('SkillTool', () => {
         tool_calls: [{ id: 'call_1', name: 'dummy', args: { x: 'hello' } }],
       });
 
-      const injectedMessages: t.InjectedMessage[] = [
-        {
-          role: 'user',
-          content: 'Injected skill body content',
-          isMeta: true,
-          source: 'skill',
-          skillName: 'test-skill',
-        },
-        {
-          role: 'system',
-          content: 'System context hint',
-          source: 'system',
-        },
-      ];
-
-      const mockResults: t.ToolExecuteResult[] = [
+      mockEventDispatch([
         {
           toolCallId: 'call_1',
           content: 'Tool result text',
           status: 'success',
-          injectedMessages,
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected skill body content',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'test-skill',
+            },
+            {
+              role: 'system',
+              content: 'System context hint',
+              source: 'system',
+            },
+          ],
         },
-      ];
-
-      jest
-        .spyOn(await import('@/utils/events'), 'safeDispatchCustomEvent')
-        .mockImplementation(async (_event, data) => {
-          const request = data as t.ToolExecuteBatchRequest;
-          if (request.resolve) {
-            request.resolve(mockResults);
-          }
-        });
+      ]);
 
       const result = await toolNode.invoke({ messages: [aiMsg] });
       const messages = (result as { messages: BaseMessage[] }).messages;
 
       expect(messages).toHaveLength(3);
 
-      const first = messages[0] as HumanMessage;
-      expect(first).toBeInstanceOf(HumanMessage);
-      expect(first.content).toBe('Injected skill body content');
-      expect(first.additional_kwargs.isMeta).toBe(true);
-      expect(first.additional_kwargs.source).toBe('skill');
-      expect(first.additional_kwargs.skillName).toBe('test-skill');
+      // ToolMessage comes FIRST (preserves AIMessage -> ToolMessage adjacency)
+      expect(messages[0]._getType()).toBe('tool');
 
-      const second = messages[1] as SystemMessage;
-      expect(second).toBeInstanceOf(SystemMessage);
-      expect(second.content).toBe('System context hint');
-      expect(second.additional_kwargs.source).toBe('system');
+      // Injected messages come AFTER
+      const second = messages[1] as HumanMessage;
+      expect(second).toBeInstanceOf(HumanMessage);
+      expect(second.content).toBe('Injected skill body content');
+      expect(second.additional_kwargs.isMeta).toBe(true);
+      expect(second.additional_kwargs.source).toBe('skill');
+      expect(second.additional_kwargs.skillName).toBe('test-skill');
 
-      const third = messages[2];
-      expect(third._getType()).toBe('tool');
-
-      jest.restoreAllMocks();
+      const third = messages[2] as SystemMessage;
+      expect(third).toBeInstanceOf(SystemMessage);
+      expect(third.content).toBe('System context hint');
+      expect(third.additional_kwargs.source).toBe('system');
     });
 
     it('returns only ToolMessages when no injectedMessages present', async () => {
-      const dummyTool = tool(async () => 'dummy', {
-        name: 'dummy',
-        description: 'dummy',
-        schema: z.object({ x: z.string() }),
-      }) as unknown as StructuredToolInterface;
-
       const toolNode = new ToolNode({
-        tools: [dummyTool],
+        tools: [createDummyTool()],
         eventDrivenMode: true,
         agentId: 'test-agent',
         toolCallStepIds: new Map([['call_2', 'step_2']]),
@@ -219,30 +226,193 @@ describe('SkillTool', () => {
         tool_calls: [{ id: 'call_2', name: 'dummy', args: { x: 'test' } }],
       });
 
-      const mockResults: t.ToolExecuteResult[] = [
-        {
-          toolCallId: 'call_2',
-          content: 'Normal result',
-          status: 'success',
-        },
-      ];
-
-      jest
-        .spyOn(await import('@/utils/events'), 'safeDispatchCustomEvent')
-        .mockImplementation(async (_event, data) => {
-          const request = data as t.ToolExecuteBatchRequest;
-          if (request.resolve) {
-            request.resolve(mockResults);
-          }
-        });
+      mockEventDispatch([
+        { toolCallId: 'call_2', content: 'Normal result', status: 'success' },
+      ]);
 
       const result = await toolNode.invoke({ messages: [aiMsg] });
       const messages = (result as { messages: BaseMessage[] }).messages;
 
       expect(messages).toHaveLength(1);
       expect(messages[0]._getType()).toBe('tool');
+    });
 
-      jest.restoreAllMocks();
+    it('passes MessageContentComplex[] content through without stringifying', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_3', 'step_3']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_3', name: 'dummy', args: { x: 'test' } }],
+      });
+
+      const complexContent = [
+        { type: 'text', text: 'Multi-part skill instructions' },
+        { type: 'text', text: 'Second part of instructions' },
+      ];
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_3',
+          content: '',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user' as const,
+              content: complexContent,
+              isMeta: true,
+              source: 'skill' as const,
+              skillName: 'complex-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(2);
+      // ToolMessage first
+      expect(messages[0]._getType()).toBe('tool');
+      // Injected message second with array content preserved (not stringified)
+      const injected = messages[1] as HumanMessage;
+      expect(injected).toBeInstanceOf(HumanMessage);
+      expect(Array.isArray(injected.content)).toBe(true);
+      expect(injected.content).toEqual(complexContent);
+    });
+
+    it('aggregates injected messages from multiple tool calls', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('tool_a'), createDummyTool('tool_b')],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([
+          ['call_a', 'step_a'],
+          ['call_b', 'step_b'],
+        ]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call_a', name: 'tool_a', args: { x: 'a' } },
+          { id: 'call_b', name: 'tool_b', args: { x: 'b' } },
+        ],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_a',
+          content: 'Result A',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected from A',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'skill-a',
+            },
+          ],
+        },
+        {
+          toolCallId: 'call_b',
+          content: 'Result B',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected from B',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'skill-b',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      // 2 ToolMessages + 2 injected messages
+      expect(messages).toHaveLength(4);
+      // ToolMessages come first
+      expect(messages[0]._getType()).toBe('tool');
+      expect(messages[1]._getType()).toBe('tool');
+      // Injected messages come after all ToolMessages
+      expect(messages[2]).toBeInstanceOf(HumanMessage);
+      expect((messages[2] as HumanMessage).content).toBe('Injected from A');
+      expect(messages[3]).toBeInstanceOf(HumanMessage);
+      expect((messages[3] as HumanMessage).content).toBe('Injected from B');
+    });
+
+    it('handles mixed mode: direct tools + event-driven with injected messages', async () => {
+      const directTool = tool(async () => 'direct result', {
+        name: 'handoff_tool',
+        description: 'A direct tool',
+        schema: z.object({ target: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      const eventTool = createDummyTool('event_tool');
+
+      const toolNode = new ToolNode({
+        tools: [directTool, eventTool],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        directToolNames: new Set(['handoff_tool']),
+        toolCallStepIds: new Map([
+          ['call_direct', 'step_direct'],
+          ['call_event', 'step_event'],
+        ]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_direct',
+            name: 'handoff_tool',
+            args: { target: 'agent-2' },
+          },
+          { id: 'call_event', name: 'event_tool', args: { x: 'hello' } },
+        ],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_event',
+          content: 'Event result',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Skill body from event tool',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'my-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      // directOutputs first, then eventResult.toolMessages, then eventResult.injected
+      expect(messages.length).toBeGreaterThanOrEqual(3);
+      // Direct tool result (ToolMessage from runTool)
+      expect(messages[0]._getType()).toBe('tool');
+      // Event tool result (ToolMessage from dispatchToolEvents)
+      expect(messages[1]._getType()).toBe('tool');
+      // Injected message last
+      const last = messages[messages.length - 1] as HumanMessage;
+      expect(last).toBeInstanceOf(HumanMessage);
+      expect(last.content).toBe('Skill body from event tool');
+      expect(last.additional_kwargs.skillName).toBe('my-skill');
     });
   });
 });

--- a/src/tools/__tests__/SkillTool.test.ts
+++ b/src/tools/__tests__/SkillTool.test.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import {
-  AIMessage,
-  HumanMessage,
-  SystemMessage,
-} from '@langchain/core/messages';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { describe, it, expect } from '@jest/globals';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
@@ -207,9 +203,11 @@ describe('SkillTool', () => {
       expect(second.additional_kwargs.source).toBe('skill');
       expect(second.additional_kwargs.skillName).toBe('test-skill');
 
-      const third = messages[2] as SystemMessage;
-      expect(third).toBeInstanceOf(SystemMessage);
+      // role: 'system' also becomes HumanMessage (avoids provider rejections)
+      const third = messages[2] as HumanMessage;
+      expect(third).toBeInstanceOf(HumanMessage);
       expect(third.content).toBe('System context hint');
+      expect(third.additional_kwargs.role).toBe('system');
       expect(third.additional_kwargs.source).toBe('system');
     });
 
@@ -413,6 +411,51 @@ describe('SkillTool', () => {
       expect(last).toBeInstanceOf(HumanMessage);
       expect(last.content).toBe('Skill body from event tool');
       expect(last.additional_kwargs.skillName).toBe('my-skill');
+    });
+
+    it('includes injected messages even when tool result has error status', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_err', 'step_err']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_err', name: 'dummy', args: { x: 'fail' } }],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_err',
+          content: '',
+          status: 'error',
+          errorMessage: 'Skill not found',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Partial context before failure',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'broken-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(2);
+      // Error ToolMessage first
+      expect(messages[0]._getType()).toBe('tool');
+      expect(String(messages[0].content)).toContain('Skill not found');
+      // Injected message still included
+      const injected = messages[1] as HumanMessage;
+      expect(injected).toBeInstanceOf(HumanMessage);
+      expect(injected.content).toBe('Partial context before failure');
+      expect(injected.additional_kwargs.skillName).toBe('broken-skill');
     });
   });
 });

--- a/src/tools/__tests__/skillCatalog.test.ts
+++ b/src/tools/__tests__/skillCatalog.test.ts
@@ -72,7 +72,11 @@ describe('formatSkillCatalog', () => {
     });
     expect(result).toContain('## Available Skills');
     expect(result).toContain('- s0');
-    expect(result).not.toContain(':');
+    // Verify entry lines have no descriptions (names-only format)
+    const entryLines = result.split('\n').filter((l) => l.startsWith('- '));
+    for (const line of entryLines) {
+      expect(line).toMatch(/^- s\d+$/);
+    }
   });
 
   it('respects custom options', () => {

--- a/src/tools/__tests__/skillCatalog.test.ts
+++ b/src/tools/__tests__/skillCatalog.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatSkillCatalog } from '../skillCatalog';
+import type { SkillCatalogEntry } from '@/types';
+
+describe('formatSkillCatalog', () => {
+  it('returns empty string for empty array', () => {
+    expect(formatSkillCatalog([])).toBe('');
+  });
+
+  it('formats a single skill with header', () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: 'pdf-processor',
+        description: 'Processes PDF files into structured data.',
+      },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe(
+      '## Available Skills\n\n- pdf-processor: Processes PDF files into structured data.'
+    );
+  });
+
+  it('formats multiple skills within budget', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'pdf-processor', description: 'Processes PDF files.' },
+      { name: 'review-pr', description: 'Reviews pull requests.' },
+      { name: 'meeting-notes', description: 'Formats meeting transcripts.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('## Available Skills');
+    expect(result).toContain('- pdf-processor: Processes PDF files.');
+    expect(result).toContain('- review-pr: Reviews pull requests.');
+    expect(result).toContain('- meeting-notes: Formats meeting transcripts.');
+  });
+
+  it('caps per-entry descriptions at maxEntryChars', () => {
+    const longDesc = 'A'.repeat(300);
+    const skills: SkillCatalogEntry[] = [
+      { name: 'long-skill', description: longDesc },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('- long-skill: ' + 'A'.repeat(249) + '\u2026');
+    expect(result).not.toContain('A'.repeat(300));
+  });
+
+  it('truncates descriptions proportionally when over budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 20 }, (_, i) => ({
+      name: `skill-${i}`,
+      description: 'D'.repeat(200),
+    }));
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 1000,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    expect(result).toContain('## Available Skills');
+    for (let i = 0; i < 20; i++) {
+      expect(result).toContain(`skill-${i}`);
+    }
+    expect(result).not.toContain('D'.repeat(200));
+  });
+
+  it('falls back to names-only when extremely over budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 50 }, (_, i) => ({
+      name: `s${i}`,
+      description: 'Very detailed description here.',
+    }));
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 200,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    expect(result).toContain('## Available Skills');
+    expect(result).toContain('- s0');
+    expect(result).not.toContain(':');
+  });
+
+  it('respects custom options', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'test', description: 'A'.repeat(100) },
+    ];
+    const result = formatSkillCatalog(skills, { maxEntryChars: 50 });
+    expect(result).toContain('A'.repeat(49) + '\u2026');
+    expect(result).not.toContain('A'.repeat(100));
+  });
+
+  it('includes skills with descriptions shorter than minDescLength', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'short', description: 'Hi' },
+      { name: 'normal', description: 'A normal description here.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('- short: Hi');
+    expect(result).toContain('- normal: A normal description here.');
+  });
+
+  it('handles all skills with zero-length descriptions as names-only', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'alpha', description: '' },
+      { name: 'beta', description: '' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe('## Available Skills\n\n- alpha\n- beta');
+  });
+
+  it('has no trailing or leading whitespace', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'test', description: 'A test skill.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe(result.trim());
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(line).toBe(line.trimEnd());
+    }
+  });
+
+  it('ignores displayTitle in output', () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: 'my-skill',
+        description: 'Does stuff.',
+        displayTitle: 'My Fancy Skill',
+      },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).not.toContain('My Fancy Skill');
+    expect(result).toContain('- my-skill: Does stuff.');
+  });
+});

--- a/src/tools/__tests__/skillCatalog.test.ts
+++ b/src/tools/__tests__/skillCatalog.test.ts
@@ -44,29 +44,32 @@ describe('formatSkillCatalog', () => {
   });
 
   it('truncates descriptions proportionally when over budget', () => {
-    const skills: SkillCatalogEntry[] = Array.from({ length: 20 }, (_, i) => ({
-      name: `skill-${i}`,
+    const skills: SkillCatalogEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      name: `sk-${i}`,
       description: 'D'.repeat(200),
     }));
+    // Budget = 10000 * 0.01 * 4 = 400 chars — enough for names + short descs, not full 200-char descs
     const result = formatSkillCatalog(skills, {
-      contextWindowTokens: 1000,
+      contextWindowTokens: 10000,
       budgetPercent: 0.01,
       charsPerToken: 4,
     });
     expect(result).toContain('## Available Skills');
-    for (let i = 0; i < 20; i++) {
-      expect(result).toContain(`skill-${i}`);
+    for (let i = 0; i < 10; i++) {
+      expect(result).toContain(`sk-${i}`);
     }
+    // Full 200-char descriptions should be truncated
     expect(result).not.toContain('D'.repeat(200));
   });
 
   it('falls back to names-only when extremely over budget', () => {
-    const skills: SkillCatalogEntry[] = Array.from({ length: 50 }, (_, i) => ({
+    const skills: SkillCatalogEntry[] = Array.from({ length: 10 }, (_, i) => ({
       name: `s${i}`,
-      description: 'Very detailed description here.',
+      description: 'Very detailed description that is quite long and verbose.',
     }));
+    // Budget = 2000 * 0.01 * 4 = 80 chars — enough for names-only but not descriptions
     const result = formatSkillCatalog(skills, {
-      contextWindowTokens: 200,
+      contextWindowTokens: 2000,
       budgetPercent: 0.01,
       charsPerToken: 4,
     });
@@ -116,6 +119,30 @@ describe('formatSkillCatalog', () => {
     const lines = result.split('\n');
     for (const line of lines) {
       expect(line).toBe(line.trimEnd());
+    }
+  });
+
+  it('truncates names-only list when even names exceed budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 100 }, (_, i) => ({
+      name: `skill-with-a-long-name-${i}`,
+      description: 'Some description.',
+    }));
+    // Budget so small that even names-only for 100 skills exceeds it
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 100,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    // Should still have the header and at least one entry, but not all 100
+    if (result === '') {
+      // Budget too small for even one entry — valid edge case
+      expect(result).toBe('');
+    } else {
+      expect(result).toContain('## Available Skills');
+      const entryLines = result.split('\n').filter((l) => l.startsWith('- '));
+      expect(entryLines.length).toBeLessThan(100);
+      expect(entryLines.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(100 * 0.01 * 4);
     }
   });
 

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -35,7 +35,10 @@ export function formatSkillCatalog(
   const contextWindowTokens =
     opts?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS;
   const budgetPercent = opts?.budgetPercent ?? DEFAULT_BUDGET_PERCENT;
-  const maxEntryChars = opts?.maxEntryChars ?? DEFAULT_MAX_ENTRY_CHARS;
+  const maxEntryChars = Math.max(
+    1,
+    opts?.maxEntryChars ?? DEFAULT_MAX_ENTRY_CHARS
+  );
   const minDescLength = opts?.minDescLength ?? DEFAULT_MIN_DESC_LENGTH;
   const charsPerToken = opts?.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
 
@@ -105,7 +108,6 @@ function fitNamesOnly(
   const full = formatEntries(namesOnly);
   if (full.length <= budgetChars) return full;
 
-  // Trim entries from the end until the output fits
   for (let count = namesOnly.length - 1; count > 0; count--) {
     const trimmed = formatEntries(namesOnly.slice(0, count));
     if (trimmed.length <= budgetChars) return trimmed;

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -23,7 +23,7 @@ export type SkillCatalogOptions = {
 
 /**
  * Formats a skill catalog for injection into agent context.
- * Uses a truncation ladder: full descriptions → proportional truncation → names-only.
+ * Uses a truncation ladder: full descriptions, proportional truncation, names-only.
  * Returns empty string for empty input.
  */
 export function formatSkillCatalog(
@@ -55,7 +55,8 @@ export function formatSkillCatalog(
   if (fullOutput.length <= budgetChars) return fullOutput;
 
   const headerLen = HEADER.length + 2;
-  const availableChars = budgetChars - headerLen;
+  const newlineChars = capped.length > 1 ? capped.length - 1 : 0;
+  const availableChars = budgetChars - headerLen - newlineChars;
   const perEntryOverhead = 4;
   const nameCharsTotal = capped.reduce(
     (sum, s) => sum + s.name.length + perEntryOverhead,
@@ -63,11 +64,19 @@ export function formatSkillCatalog(
   );
   const availableForDescs = availableChars - nameCharsTotal;
 
-  if (availableForDescs <= 0) return formatNamesOnly(capped);
+  if (availableForDescs <= 0) {
+    return formatEntries(
+      capped.map((s) => ({ name: s.name, description: '' }))
+    );
+  }
 
   const maxDescPerEntry = Math.floor(availableForDescs / capped.length);
 
-  if (maxDescPerEntry < minDescLength) return formatNamesOnly(capped);
+  if (maxDescPerEntry < minDescLength) {
+    return formatEntries(
+      capped.map((s) => ({ name: s.name, description: '' }))
+    );
+  }
 
   const truncated = capped.map((s) => ({
     name: s.name,
@@ -77,7 +86,9 @@ export function formatSkillCatalog(
         : s.description,
   }));
 
-  return formatEntries(truncated);
+  const result = formatEntries(truncated);
+  if (result.length <= budgetChars) return result;
+  return formatEntries(capped.map((s) => ({ name: s.name, description: '' })));
 }
 
 function formatEntries(
@@ -86,10 +97,5 @@ function formatEntries(
   const lines = entries.map((e) =>
     e.description ? `- ${e.name}: ${e.description}` : `- ${e.name}`
   );
-  return `${HEADER}\n\n${lines.join('\n')}`;
-}
-
-function formatNamesOnly(entries: { name: string }[]): string {
-  const lines = entries.map((e) => `- ${e.name}`);
   return `${HEADER}\n\n${lines.join('\n')}`;
 }

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -65,17 +65,13 @@ export function formatSkillCatalog(
   const availableForDescs = availableChars - nameCharsTotal;
 
   if (availableForDescs <= 0) {
-    return formatEntries(
-      capped.map((s) => ({ name: s.name, description: '' }))
-    );
+    return fitNamesOnly(capped, budgetChars);
   }
 
   const maxDescPerEntry = Math.floor(availableForDescs / capped.length);
 
   if (maxDescPerEntry < minDescLength) {
-    return formatEntries(
-      capped.map((s) => ({ name: s.name, description: '' }))
-    );
+    return fitNamesOnly(capped, budgetChars);
   }
 
   const truncated = capped.map((s) => ({
@@ -88,7 +84,7 @@ export function formatSkillCatalog(
 
   const result = formatEntries(truncated);
   if (result.length <= budgetChars) return result;
-  return formatEntries(capped.map((s) => ({ name: s.name, description: '' })));
+  return fitNamesOnly(capped, budgetChars);
 }
 
 function formatEntries(
@@ -98,4 +94,21 @@ function formatEntries(
     e.description ? `- ${e.name}: ${e.description}` : `- ${e.name}`
   );
   return `${HEADER}\n\n${lines.join('\n')}`;
+}
+
+/** Names-only fallback that drops trailing entries if the list still exceeds budget. */
+function fitNamesOnly(
+  entries: { name: string }[],
+  budgetChars: number
+): string {
+  const namesOnly = entries.map((s) => ({ name: s.name, description: '' }));
+  const full = formatEntries(namesOnly);
+  if (full.length <= budgetChars) return full;
+
+  // Trim entries from the end until the output fits
+  for (let count = namesOnly.length - 1; count > 0; count--) {
+    const trimmed = formatEntries(namesOnly.slice(0, count));
+    if (trimmed.length <= budgetChars) return trimmed;
+  }
+  return '';
 }

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -1,0 +1,95 @@
+// src/tools/skillCatalog.ts
+import type { SkillCatalogEntry } from '@/types';
+
+const HEADER = '## Available Skills';
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+const DEFAULT_BUDGET_PERCENT = 0.01;
+const DEFAULT_MAX_ENTRY_CHARS = 250;
+const DEFAULT_MIN_DESC_LENGTH = 20;
+const DEFAULT_CHARS_PER_TOKEN = 4;
+
+export type SkillCatalogOptions = {
+  /** Total context window in tokens. Default: 200_000 */
+  contextWindowTokens?: number;
+  /** Fraction of context budget for catalog. Default: 0.01 (1%) */
+  budgetPercent?: number;
+  /** Max chars per entry description. Default: 250 */
+  maxEntryChars?: number;
+  /** Descriptions below this length trigger names-only fallback. Default: 20 */
+  minDescLength?: number;
+  /** Approximate chars per token for budget calculation. Default: 4 */
+  charsPerToken?: number;
+};
+
+/**
+ * Formats a skill catalog for injection into agent context.
+ * Uses a truncation ladder: full descriptions → proportional truncation → names-only.
+ * Returns empty string for empty input.
+ */
+export function formatSkillCatalog(
+  skills: SkillCatalogEntry[],
+  opts?: SkillCatalogOptions
+): string {
+  if (skills.length === 0) return '';
+
+  const contextWindowTokens =
+    opts?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS;
+  const budgetPercent = opts?.budgetPercent ?? DEFAULT_BUDGET_PERCENT;
+  const maxEntryChars = opts?.maxEntryChars ?? DEFAULT_MAX_ENTRY_CHARS;
+  const minDescLength = opts?.minDescLength ?? DEFAULT_MIN_DESC_LENGTH;
+  const charsPerToken = opts?.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+
+  const budgetChars = Math.floor(
+    contextWindowTokens * budgetPercent * charsPerToken
+  );
+
+  const capped = skills.map((s) => ({
+    name: s.name,
+    description:
+      s.description.length > maxEntryChars
+        ? s.description.slice(0, maxEntryChars - 1) + '\u2026'
+        : s.description,
+  }));
+
+  const fullOutput = formatEntries(capped);
+  if (fullOutput.length <= budgetChars) return fullOutput;
+
+  const headerLen = HEADER.length + 2;
+  const availableChars = budgetChars - headerLen;
+  const perEntryOverhead = 4;
+  const nameCharsTotal = capped.reduce(
+    (sum, s) => sum + s.name.length + perEntryOverhead,
+    0
+  );
+  const availableForDescs = availableChars - nameCharsTotal;
+
+  if (availableForDescs <= 0) return formatNamesOnly(capped);
+
+  const maxDescPerEntry = Math.floor(availableForDescs / capped.length);
+
+  if (maxDescPerEntry < minDescLength) return formatNamesOnly(capped);
+
+  const truncated = capped.map((s) => ({
+    name: s.name,
+    description:
+      s.description.length > maxDescPerEntry
+        ? s.description.slice(0, maxDescPerEntry - 1) + '\u2026'
+        : s.description,
+  }));
+
+  return formatEntries(truncated);
+}
+
+function formatEntries(
+  entries: { name: string; description: string }[]
+): string {
+  const lines = entries.map((e) =>
+    e.description ? `- ${e.name}: ${e.description}` : `- ${e.name}`
+  );
+  return `${HEADER}\n\n${lines.join('\n')}`;
+}
+
+function formatNamesOnly(entries: { name: string }[]): string {
+  const lines = entries.map((e) => `- ${e.name}`);
+  return `${HEADER}\n\n${lines.join('\n')}`;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@
 export * from './graph';
 export * from './llm';
 export * from './run';
+export * from './skill';
 export * from './stream';
 export * from './tools';
 export * from './summarize';

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -1,0 +1,42 @@
+// src/types/skill.ts
+import type { MessageContentComplex } from './stream';
+
+/**
+ * A message injected into graph state by any tool execution handler.
+ * Generic mechanism — not skill-specific. Any tool returning `injectedMessages`
+ * in its `ToolExecuteResult` will have these prepended to state before the ToolMessage.
+ */
+export type InjectedMessage = {
+  /** 'user' for skill body injection, 'system' for context hints */
+  role: 'user' | 'system';
+  /** Message content — string for simple text, array for complex multi-part content */
+  content: string | MessageContentComplex[];
+  /** When true, the message is framework-internal: not shown in UI, not counted as a user turn */
+  isMeta?: boolean;
+  /** Origin tag for downstream consumers (UI, pruner, compaction) */
+  source?: 'skill' | 'hook' | 'system';
+  /** Only set when source is 'skill', for compaction preservation */
+  skillName?: string;
+};
+
+/** Minimal skill metadata for catalog assembly. The host provides these from its own data layer. */
+export type SkillCatalogEntry = {
+  /** Kebab-case identifier (what the model passes to SkillTool) */
+  name: string;
+  /** One-line description for the catalog listing */
+  description: string;
+  /** Optional human-readable label (UI only, not shown to model) */
+  displayTitle?: string;
+};
+
+/**
+ * Documentation type for the resolved skill content the host passes back through ToolExecuteResult.
+ * The SDK doesn't interpret it, but hosts should follow this shape.
+ */
+export type SkillExecutionMeta = {
+  skillName: string;
+  executionMode: 'inline' | 'fork';
+  filesStaged: boolean;
+  /** Resolved skill directory path in the runtime, if files were staged */
+  skillDir?: string;
+};

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -1,23 +1,4 @@
 // src/types/skill.ts
-import type { MessageContentComplex } from './stream';
-
-/**
- * A message injected into graph state by any tool execution handler.
- * Generic mechanism — not skill-specific. Any tool returning `injectedMessages`
- * in its `ToolExecuteResult` will have these prepended to state before the ToolMessage.
- */
-export type InjectedMessage = {
-  /** 'user' for skill body injection, 'system' for context hints */
-  role: 'user' | 'system';
-  /** Message content — string for simple text, array for complex multi-part content */
-  content: string | MessageContentComplex[];
-  /** When true, the message is framework-internal: not shown in UI, not counted as a user turn */
-  isMeta?: boolean;
-  /** Origin tag for downstream consumers (UI, pruner, compaction) */
-  source?: 'skill' | 'hook' | 'system';
-  /** Only set when source is 'skill', for compaction preservation */
-  skillName?: string;
-};
 
 /** Minimal skill metadata for catalog assembly. The host provides these from its own data layer. */
 export type SkillCatalogEntry = {
@@ -27,16 +8,4 @@ export type SkillCatalogEntry = {
   description: string;
   /** Optional human-readable label (UI only, not shown to model) */
   displayTitle?: string;
-};
-
-/**
- * Documentation type for the resolved skill content the host passes back through ToolExecuteResult.
- * The SDK doesn't interpret it, but hosts should follow this shape.
- */
-export type SkillExecutionMeta = {
-  skillName: string;
-  executionMode: 'inline' | 'fork';
-  filesStaged: boolean;
-  /** Resolved skill directory path in the runtime, if files were staged */
-  skillDir?: string;
 };

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -3,6 +3,7 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { ToolErrorData } from './stream';
+import type { InjectedMessage } from './skill';
 import { EnvVar } from '@/common';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
@@ -198,6 +199,12 @@ export type ToolExecuteResult = {
   status: 'success' | 'error';
   /** Error message if status is 'error' */
   errorMessage?: string;
+  /**
+   * Messages to inject into graph state before the ToolMessage for this call.
+   * The model sees injected content first, then the tool result.
+   * Generic mechanism — any tool execution handler can use this.
+   */
+  injectedMessages?: InjectedMessage[];
 };
 
 /** Map of tool names to tool definitions */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -2,8 +2,7 @@
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
-import type { ToolErrorData } from './stream';
-import type { InjectedMessage } from './skill';
+import type { MessageContentComplex, ToolErrorData } from './stream';
 import { EnvVar } from '@/common';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
@@ -187,6 +186,24 @@ export type ToolExecuteBatchRequest = {
   reject: (error: Error) => void;
 };
 
+/**
+ * A message injected into graph state by any tool execution handler.
+ * Generic mechanism: any tool returning `injectedMessages` in its `ToolExecuteResult`
+ * will have these appended to state after the ToolMessage for this call.
+ */
+export type InjectedMessage = {
+  /** 'user' for skill body injection, 'system' for context hints */
+  role: 'user' | 'system';
+  /** Message content: string for simple text, array for complex multi-part content */
+  content: string | MessageContentComplex[];
+  /** When true, the message is framework-internal: not shown in UI, not counted as a user turn */
+  isMeta?: boolean;
+  /** Origin tag for downstream consumers (UI, pruner, compaction) */
+  source?: 'skill' | 'hook' | 'system';
+  /** Only set when source is 'skill', for compaction preservation */
+  skillName?: string;
+};
+
 /** Result for a single tool call in event-driven execution */
 export type ToolExecuteResult = {
   /** Matches ToolCallRequest.id */
@@ -200,9 +217,10 @@ export type ToolExecuteResult = {
   /** Error message if status is 'error' */
   errorMessage?: string;
   /**
-   * Messages to inject into graph state before the ToolMessage for this call.
-   * The model sees injected content first, then the tool result.
-   * Generic mechanism — any tool execution handler can use this.
+   * Messages to inject into graph state after the ToolMessage for this call.
+   * Placed after tool results to respect provider message ordering (tool_call → tool_result adjacency).
+   * The host's message formatter may merge injected user messages with the preceding tool_result turn.
+   * Generic mechanism: any tool execution handler can use this.
    */
   injectedMessages?: InjectedMessage[];
 };

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -192,7 +192,9 @@ export type ToolExecuteBatchRequest = {
  * will have these appended to state after the ToolMessage for this call.
  */
 export type InjectedMessage = {
-  /** 'user' for skill body injection, 'system' for context hints */
+  /** 'user' for skill body injection, 'system' for context hints.
+   *  Both are converted to HumanMessage at runtime; the original role
+   *  is preserved in additional_kwargs.role. */
   role: 'user' | 'system';
   /** Message content: string for simple text, array for complex multi-part content */
   content: string | MessageContentComplex[];


### PR DESCRIPTION
## Summary

- **Phase 1**: Adds the `SkillTool` definition (JSON Schema, description, `createSkillTool()` factory), the generic `injectedMessages` mechanism on `ToolExecuteResult`, and the ToolNode plumbing that converts `InjectedMessage[]` into LangChain `HumanMessage`/`SystemMessage` entries appended after `ToolMessage` results in graph state.
- **Phase 2**: Adds `formatSkillCatalog()` — a pure, budget-aware formatter with a truncation ladder (full descriptions → proportional truncation → names-only) for injecting skill catalogs into agent context.

### New files
| File | Purpose |
|------|---------|
| `src/types/skill.ts` | `SkillCatalogEntry` type |
| `src/tools/SkillTool.ts` | JSON Schema (single source of truth), LCTool definition, `createSkillTool()` |
| `src/tools/skillCatalog.ts` | `formatSkillCatalog()` pure function |
| `src/tools/__tests__/SkillTool.test.ts` | 16 tests |
| `src/tools/__tests__/skillCatalog.test.ts` | 11 tests |

### Modified files
| File | Change |
|------|--------|
| `src/common/enum.ts` | `Constants.SKILL_TOOL = 'skill'` |
| `src/types/tools.ts` | `InjectedMessage` type + `ToolExecuteResult.injectedMessages?: InjectedMessage[]` |
| `src/tools/ToolNode.ts` | `convertInjectedMessages()` (content passthrough), injected messages appended AFTER ToolMessages |
| `src/types/index.ts` | Re-export `./skill` |
| `src/index.ts` | Export `SkillTool` + `skillCatalog` |

### Design decisions
- `injectedMessages` is **generic** — any tool can use it, not just SkillTool
- Injected messages placed **after** ToolMessages to respect provider message ordering (AIMessage tool_calls → ToolMessage adjacency). The host's message formatter merges injected user messages with the preceding tool_result turn for providers requiring strict alternation.
- `SkillToolDescription` is runtime-agnostic: says files "*may* become accessible" (per §0.6 of the design report)
- `SkillToolSchema` is a single JSON Schema object used by both `SkillToolDefinition` and `createSkillTool()` (no DRY violation)
- `MessageContentComplex[]` content passed through directly (no JSON.stringify)
- Catalog formatter defaults: 1% of context budget, 250 chars/entry, 200k context window; budget accounts for newlines with a final length guard
- Zero new runtime dependencies

## Test plan
- [x] `npx jest src/tools/__tests__/SkillTool --verbose` — 16 tests pass (schema, factory, definition, type-checks, ToolNode integration: ordering, complex content passthrough, multi-tool aggregation, mixed mode)
- [x] `npx jest src/tools/__tests__/skillCatalog --verbose` — 11 tests pass (formatting, budget, truncation ladder, edge cases)
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on all new/modified files — zero errors
- [x] Existing `ToolNode.session.test.ts` still passes (no regressions)