### PR TITLE
feat: wire tool hooks into event-driven ToolNode (phase 1/3)

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -538,7 +538,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       tools: allTraditionalTools,
       toolMap: traditionalToolMap,
       toolCallStepIds: this.toolCallStepIds,
-      hookRegistry: this.hookRegistry,
       errorHandler: (data, metadata) =>
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       toolRegistry: agentContext?.toolRegistry,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -509,6 +509,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentId: agentContext?.agentId,
         toolCallStepIds: this.toolCallStepIds,
         toolRegistry: agentContext?.toolRegistry,
+        hookRegistry: this.hookRegistry,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,
         maxToolResultChars: agentContext?.maxToolResultChars,
@@ -537,6 +538,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       tools: allTraditionalTools,
       toolMap: traditionalToolMap,
       toolCallStepIds: this.toolCallStepIds,
+      hookRegistry: this.hookRegistry,
       errorHandler: (data, metadata) =>
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       toolRegistry: agentContext?.toolRegistry,

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -382,6 +382,7 @@ describe('Tool-level hook integration (event-driven mode)', () => {
 
       const messages = run.Graph!.getRunMessages() ?? [];
       const toolMsg = messages.find((m) => m.getType() === 'tool');
+      expect(toolMsg).toBeDefined();
       if (toolMsg != null) {
         resolvedContent =
           typeof toolMsg.content === 'string'

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -1,0 +1,404 @@
+// src/hooks/__tests__/toolHooks.test.ts
+import { ToolCall } from '@langchain/core/messages/tool';
+import { HumanMessage } from '@langchain/core/messages';
+import { HookRegistry } from '../HookRegistry';
+import { Run } from '@/run';
+import {
+  GraphEvents,
+  Providers,
+  ToolEndHandler,
+  ModelEndHandler,
+} from '@/index';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  PreToolUseHookOutput,
+  PostToolUseHookOutput,
+  PostToolUseFailureHookOutput,
+  PermissionDeniedHookInput,
+  PermissionDeniedHookOutput,
+  PreToolUseHookInput,
+  PostToolUseHookInput,
+  PostToolUseFailureHookInput,
+} from '../types';
+
+const llmConfig: t.LLMConfig = {
+  provider: Providers.OPENAI,
+  streaming: true,
+  streamUsage: false,
+};
+
+const callerConfig = {
+  configurable: { thread_id: 'test-thread' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+const echoToolDef: t.LCTool = {
+  name: 'echo',
+  description: 'Echoes input',
+  parameters: {
+    type: 'object' as const,
+    properties: { text: { type: 'string' } },
+    required: ['text'],
+  },
+};
+
+function makeToolCall(text = 'hello'): ToolCall {
+  return {
+    name: 'echo',
+    args: { text },
+    id: `call_${Date.now()}`,
+    type: 'tool_call',
+  };
+}
+
+function createToolExecuteHandler(): t.EventHandler {
+  return {
+    handle: async (_event: string, rawData: unknown): Promise<void> => {
+      const data = rawData as t.ToolExecuteBatchRequest;
+      const results: t.ToolExecuteResult[] = data.toolCalls.map(
+        (tc: t.ToolCallRequest) => ({
+          toolCallId: tc.id,
+          content: `echo: ${(tc.args as Record<string, string>).text}`,
+          status: 'success' as const,
+        })
+      );
+      data.resolve(results);
+    },
+  };
+}
+
+function createErrorToolExecuteHandler(): t.EventHandler {
+  return {
+    handle: async (_event: string, rawData: unknown): Promise<void> => {
+      const data = rawData as t.ToolExecuteBatchRequest;
+      const results: t.ToolExecuteResult[] = data.toolCalls.map(
+        (tc: t.ToolCallRequest) => ({
+          toolCallId: tc.id,
+          content: '',
+          status: 'error' as const,
+          errorMessage: `tool ${tc.name} failed deliberately`,
+        })
+      );
+      data.resolve(results);
+    },
+  };
+}
+
+async function createEventDrivenRun(
+  hooks: HookRegistry,
+  toolHandler: t.EventHandler = createToolExecuteHandler(),
+  runId = 'tool-hook-run'
+): Promise<Run<t.IState>> {
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.ON_TOOL_EXECUTE]: toolHandler,
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+  };
+
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig,
+      toolDefinitions: [echoToolDef],
+      instructions: 'Use the echo tool when asked.',
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers,
+    hooks,
+  });
+}
+
+describe('Tool-level hook integration (event-driven mode)', () => {
+  jest.setTimeout(15000);
+
+  describe('PreToolUse', () => {
+    it('fires with toolName, toolInput, and toolUseId', async () => {
+      const registry = new HookRegistry();
+      let captured: PreToolUseHookInput | undefined;
+      const hook: HookCallback<'PreToolUse'> = async (
+        input
+      ): Promise<PreToolUseHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PreToolUse', { hooks: [hook] });
+
+      const tc = makeToolCall('world');
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [tc]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo world')] },
+        callerConfig
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PreToolUse');
+      expect(captured!.toolName).toBe('echo');
+      expect(captured!.toolInput).toEqual({ text: 'world' });
+      expect(captured!.toolUseId).toBe(tc.id);
+    });
+
+    it('deny blocks tool execution and produces error ToolMessage', async () => {
+      const registry = new HookRegistry();
+      let toolExecuted = false;
+      const denyHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'not allowed',
+      });
+      registry.register('PreToolUse', {
+        pattern: '^echo$',
+        hooks: [denyHook],
+      });
+
+      const spyHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          toolExecuted = true;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: 'should not reach',
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, spyHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hello')] },
+        callerConfig
+      );
+
+      expect(toolExecuted).toBe(false);
+    });
+
+    it('ask blocks tool execution in v1 (same as deny)', async () => {
+      const registry = new HookRegistry();
+      let toolExecuted = false;
+      const askHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'ask',
+        reason: 'needs confirmation',
+      });
+      registry.register('PreToolUse', { hooks: [askHook] });
+
+      const spyHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          toolExecuted = true;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: 'x',
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, spyHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hello')] },
+        callerConfig
+      );
+
+      expect(toolExecuted).toBe(false);
+    });
+
+    it('updatedInput rewrites tool args before dispatch', async () => {
+      const registry = new HookRegistry();
+      let receivedArgs: Record<string, unknown> | undefined;
+      const rewriteHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        updatedInput: { text: 'sanitized' },
+      });
+      registry.register('PreToolUse', { hooks: [rewriteHook] });
+
+      const captureHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          receivedArgs = data.toolCalls[0]?.args;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: `echo: ${(tc.args as Record<string, string>).text}`,
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, captureHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [
+        makeToolCall('dangerous'),
+      ]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      expect(receivedArgs).toEqual({ text: 'sanitized' });
+    });
+
+    it('hook errors are non-fatal — tool still executes', async () => {
+      const registry = new HookRegistry();
+      let toolExecuted = false;
+      const throwingHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => {
+        throw new Error('hook crash');
+      };
+      registry.register('PreToolUse', { hooks: [throwingHook] });
+
+      const spyHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          toolExecuted = true;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: 'ok',
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, spyHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      expect(toolExecuted).toBe(true);
+    });
+  });
+
+  describe('PermissionDenied', () => {
+    it('fires after PreToolUse deny with the reason', async () => {
+      const registry = new HookRegistry();
+      let captured: PermissionDeniedHookInput | undefined;
+      const denyHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'security policy',
+      });
+      const pdHook: HookCallback<'PermissionDenied'> = async (
+        input
+      ): Promise<PermissionDeniedHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PreToolUse', { hooks: [denyHook] });
+      registry.register('PermissionDenied', { hooks: [pdHook] });
+
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      await new Promise<void>((r) => setTimeout(r, 50));
+      expect(captured).toBeDefined();
+      expect(captured!.reason).toBe('security policy');
+      expect(captured!.toolName).toBe('echo');
+    });
+  });
+
+  describe('PostToolUse', () => {
+    it('fires after successful tool execution with output', async () => {
+      const registry = new HookRegistry();
+      let captured: PostToolUseHookInput | undefined;
+      const hook: HookCallback<'PostToolUse'> = async (
+        input
+      ): Promise<PostToolUseHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PostToolUse', { hooks: [hook] });
+
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall('hi')]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hi')] },
+        callerConfig
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PostToolUse');
+      expect(captured!.toolName).toBe('echo');
+      expect(captured!.toolOutput).toBe('echo: hi');
+    });
+  });
+
+  describe('PostToolUseFailure', () => {
+    it('fires when tool execution returns an error', async () => {
+      const registry = new HookRegistry();
+      let captured: PostToolUseFailureHookInput | undefined;
+      const hook: HookCallback<'PostToolUseFailure'> = async (
+        input
+      ): Promise<PostToolUseFailureHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PostToolUseFailure', { hooks: [hook] });
+
+      const run = await createEventDrivenRun(
+        registry,
+        createErrorToolExecuteHandler()
+      );
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PostToolUseFailure');
+      expect(captured!.toolName).toBe('echo');
+      expect(captured!.error).toContain('failed deliberately');
+    });
+  });
+
+  describe('no-hooks baseline', () => {
+    it('event-driven tool execution works identically without hooks', async () => {
+      const run = await Run.create<t.IState>({
+        runId: 'no-hooks-tool-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef],
+          instructions: 'Use echo.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: createToolExecuteHandler(),
+          [GraphEvents.TOOL_END]: new ToolEndHandler(),
+          [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        },
+      });
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall('test')]);
+      const result = await run.processStream(
+        { messages: [new HumanMessage('echo test')] },
+        callerConfig
+      );
+
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -44,11 +44,13 @@ const echoToolDef: t.LCTool = {
   },
 };
 
-function makeToolCall(text = 'hello'): ToolCall {
+let callCounter = 0;
+
+function makeToolCall(text = 'hello', name = 'echo'): ToolCall {
   return {
-    name: 'echo',
+    name,
     args: { text },
-    id: `call_${Date.now()}`,
+    id: `call_${++callCounter}`,
     type: 'tool_call',
   };
 }
@@ -113,6 +115,9 @@ async function createEventDrivenRun(
 }
 
 describe('Tool-level hook integration (event-driven mode)', () => {
+  beforeEach(() => {
+    callCounter = 0;
+  });
   jest.setTimeout(15000);
 
   describe('PreToolUse', () => {
@@ -420,6 +425,164 @@ describe('Tool-level hook integration (event-driven mode)', () => {
       expect(captured!.hook_event_name).toBe('PostToolUseFailure');
       expect(captured!.toolName).toBe('echo');
       expect(captured!.error).toContain('failed deliberately');
+    });
+  });
+
+  describe('multi-call batch', () => {
+    const mathToolDef: t.LCTool = {
+      name: 'math',
+      description: 'Does math',
+      parameters: {
+        type: 'object' as const,
+        properties: { expr: { type: 'string' } },
+        required: ['expr'],
+      },
+    };
+
+    function createMultiToolRun(
+      hooks: HookRegistry,
+      runId = 'multi-run'
+    ): Promise<Run<t.IState>> {
+      const handler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          data.resolve(
+            data.toolCalls.map(
+              (tc: t.ToolCallRequest): t.ToolExecuteResult => ({
+                toolCallId: tc.id,
+                content: `${tc.name}: ok`,
+                status: 'success' as const,
+              })
+            )
+          );
+        },
+      };
+      return Run.create<t.IState>({
+        runId,
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef, mathToolDef],
+          instructions: 'Use tools.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: handler,
+          [GraphEvents.TOOL_END]: new ToolEndHandler(),
+          [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        },
+        hooks,
+      });
+    }
+
+    it('partial deny: denied call produces error, approved call executes, order preserved', async () => {
+      const registry = new HookRegistry();
+      const denyEcho: HookCallback<'PreToolUse'> = async (
+        input
+      ): Promise<PreToolUseHookOutput> =>
+        input.toolName === 'echo'
+          ? { decision: 'deny', reason: 'echo blocked' }
+          : {};
+      registry.register('PreToolUse', { hooks: [denyEcho] });
+
+      const echoCall = makeToolCall('hi', 'echo');
+      const mathCall = makeToolCall('1+1', 'math');
+      const run = await createMultiToolRun(registry);
+      run.Graph!.overrideTestModel(['calling tools'], 5, [echoCall, mathCall]);
+      await run.processStream(
+        { messages: [new HumanMessage('do both')] },
+        callerConfig
+      );
+
+      const messages = run.Graph!.getRunMessages() ?? [];
+      const toolMsgs = messages.filter((m) => m.getType() === 'tool');
+
+      expect(toolMsgs).toHaveLength(2);
+      const first = toolMsgs[0];
+      const second = toolMsgs[1];
+      expect(typeof first.content === 'string' && first.content).toContain(
+        'Blocked'
+      );
+      expect(typeof second.content === 'string' && second.content).toContain(
+        'math: ok'
+      );
+    });
+
+    it('all denied: no ON_TOOL_EXECUTE dispatch, all error messages', async () => {
+      const registry = new HookRegistry();
+      let handlerCalled = false;
+      const denyAll: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'all blocked',
+      });
+      registry.register('PreToolUse', { hooks: [denyAll] });
+
+      const handler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          handlerCalled = true;
+          const data = rawData as t.ToolExecuteBatchRequest;
+          data.resolve([]);
+        },
+      };
+
+      const run = await Run.create<t.IState>({
+        runId: 'all-denied-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef, mathToolDef],
+          instructions: 'Use tools.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: handler,
+          [GraphEvents.TOOL_END]: new ToolEndHandler(),
+          [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        },
+        hooks: registry,
+      });
+      run.Graph!.overrideTestModel(['calling tools'], 5, [
+        makeToolCall('a', 'echo'),
+        makeToolCall('b', 'math'),
+      ]);
+      await run.processStream(
+        { messages: [new HumanMessage('do both')] },
+        callerConfig
+      );
+
+      expect(handlerCalled).toBe(false);
+    });
+  });
+
+  describe('PostToolUse error resilience', () => {
+    it('PostToolUse hook errors are non-fatal — original output preserved', async () => {
+      const registry = new HookRegistry();
+      const throwingHook: HookCallback<
+        'PostToolUse'
+      > = async (): Promise<PostToolUseHookOutput> => {
+        throw new Error('post hook crash');
+      };
+      registry.register('PostToolUse', { hooks: [throwingHook] });
+
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall('hi')]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hi')] },
+        callerConfig
+      );
+
+      const messages = run.Graph!.getRunMessages() ?? [];
+      const toolMsg = messages.find((m) => m.getType() === 'tool');
+      expect(toolMsg).toBeDefined();
+      const content =
+        typeof toolMsg!.content === 'string'
+          ? toolMsg!.content
+          : JSON.stringify(toolMsg!.content);
+      expect(content).toContain('echo: hi');
     });
   });
 

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -289,6 +289,10 @@ describe('Tool-level hook integration (event-driven mode)', () => {
   describe('PermissionDenied', () => {
     it('fires after PreToolUse deny with the reason', async () => {
       const registry = new HookRegistry();
+      let pdResolve: () => void;
+      const pdDone = new Promise<void>((r) => {
+        pdResolve = r;
+      });
       let captured: PermissionDeniedHookInput | undefined;
       const denyHook: HookCallback<
         'PreToolUse'
@@ -300,6 +304,7 @@ describe('Tool-level hook integration (event-driven mode)', () => {
         input
       ): Promise<PermissionDeniedHookOutput> => {
         captured = input;
+        pdResolve();
         return {};
       };
       registry.register('PreToolUse', { hooks: [denyHook] });
@@ -312,7 +317,7 @@ describe('Tool-level hook integration (event-driven mode)', () => {
         callerConfig
       );
 
-      await new Promise<void>((r) => setTimeout(r, 50));
+      await pdDone;
       expect(captured).toBeDefined();
       expect(captured!.reason).toBe('security policy');
       expect(captured!.toolName).toBe('echo');
@@ -342,6 +347,49 @@ describe('Tool-level hook integration (event-driven mode)', () => {
       expect(captured!.hook_event_name).toBe('PostToolUse');
       expect(captured!.toolName).toBe('echo');
       expect(captured!.toolOutput).toBe('echo: hi');
+    });
+
+    it('updatedOutput replaces the ToolMessage content', async () => {
+      const registry = new HookRegistry();
+      const replaceHook: HookCallback<
+        'PostToolUse'
+      > = async (): Promise<PostToolUseHookOutput> => ({
+        updatedOutput: 'REDACTED',
+      });
+      registry.register('PostToolUse', { hooks: [replaceHook] });
+
+      let resolvedContent: string | undefined;
+      const captureHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          const results = data.toolCalls.map(
+            (tc: t.ToolCallRequest): t.ToolExecuteResult => ({
+              toolCallId: tc.id,
+              content: 'original secret output',
+              status: 'success' as const,
+            })
+          );
+          data.resolve(results);
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, captureHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      const messages = run.Graph!.getRunMessages() ?? [];
+      const toolMsg = messages.find((m) => m.getType() === 'tool');
+      if (toolMsg != null) {
+        resolvedContent =
+          typeof toolMsg.content === 'string'
+            ? toolMsg.content
+            : JSON.stringify(toolMsg.content);
+      }
+
+      expect(resolvedContent).toBe('REDACTED');
     });
   });
 

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -501,12 +501,8 @@ describe('Tool-level hook integration (event-driven mode)', () => {
       expect(toolMsgs).toHaveLength(2);
       const first = toolMsgs[0];
       const second = toolMsgs[1];
-      expect(typeof first.content === 'string' && first.content).toContain(
-        'Blocked'
-      );
-      expect(typeof second.content === 'string' && second.content).toContain(
-        'math: ok'
-      );
+      expect(first.content).toContain('Blocked');
+      expect(second.content).toContain('math: ok');
     });
 
     it('all denied: no ON_TOOL_EXECUTE dispatch, all error messages', async () => {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,8 +2,8 @@
 //
 // Hook lifecycle system for `@librechat/agents`. Re-exported from
 // `src/index.ts` and consumed by `Run.processStream` (RunStart,
-// UserPromptSubmit, Stop, StopFailure) and — once the tool-hook PR
-// lands — by `ToolNode` (PreToolUse, PostToolUse, etc.).
+// UserPromptSubmit, Stop, StopFailure) and `ToolNode.dispatchToolEvents`
+// (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -71,6 +71,12 @@ export interface PreToolUseHookInput extends BaseHookInput {
   toolInput: Record<string, unknown>;
   toolUseId: string;
   stepId?: string;
+  /**
+   * Number of times this tool has been invoked in prior batches within the
+   * current run. Within a single batch of parallel calls, all calls to the
+   * same tool share the same turn value — per-call discrimination within a
+   * batch is not supported in v1.
+   */
   turn?: number;
 }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -88,7 +88,6 @@ export class Run<_T extends t.BaseGraphState> {
       this.graphRunnable = this.createMultiAgentGraph(config.graphConfig);
       if (this.Graph) {
         this.Graph.handlerRegistry = handlerRegistry;
-        this.Graph.hookRegistry = this.hookRegistry;
       }
     } else {
       /** Default to legacy graph for 'standard' or undefined type */
@@ -97,7 +96,6 @@ export class Run<_T extends t.BaseGraphState> {
         this.Graph.compileOptions =
           config.graphConfig.compileOptions ?? this.Graph.compileOptions;
         this.Graph.handlerRegistry = handlerRegistry;
-        this.Graph.hookRegistry = this.hookRegistry;
       }
     }
 
@@ -149,6 +147,7 @@ export class Run<_T extends t.BaseGraphState> {
     });
     /** Propagate compile options from graph config */
     standardGraph.compileOptions = config.compileOptions;
+    standardGraph.hookRegistry = this.hookRegistry;
     this.Graph = standardGraph;
     return standardGraph.createWorkflow();
   }
@@ -171,6 +170,7 @@ export class Run<_T extends t.BaseGraphState> {
       multiAgentGraph.compileOptions = compileOptions;
     }
 
+    multiAgentGraph.hookRegistry = this.hookRegistry;
     this.Graph = multiAgentGraph;
     return multiAgentGraph.createWorkflow();
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -531,7 +531,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               toolInput: entry.args,
               toolUseId: entry.call.id!,
               stepId: entry.stepId,
-              turn: this.toolUsageCount.get(entry.call.name),
+              turn: this.toolUsageCount.get(entry.call.name) ?? 0,
             },
             sessionId: runId,
             matchQuery: entry.call.name,
@@ -738,7 +738,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           toolName,
           request?.args ?? {},
           contentString,
-          config
+          config,
+          request?.turn
         );
 
         messageByCallId.set(result.toolCallId, toolMessage);
@@ -755,7 +756,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolName: string,
     args: Record<string, unknown>,
     output: string,
-    config: RunnableConfig
+    config: RunnableConfig,
+    turn?: number
   ): void {
     const stepId = this.toolCallStepIds?.get(toolCallId) ?? '';
     if (!stepId) {
@@ -772,7 +774,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       {
         result: {
           id: stepId,
-          index: this.toolUsageCount.get(toolName) ?? 0,
+          index: turn ?? this.toolUsageCount.get(toolName) ?? 0,
           type: 'tool_call' as const,
           tool_call: {
             args: JSON.stringify(args),

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -512,10 +512,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     const messageByCallId = new Map<string, ToolMessage>();
     const approvedEntries: typeof preToolCalls = [];
-    const emptyResult: AggregatedHookResult = {
-      additionalContexts: [],
-      errors: [],
-    };
+    const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
+      additionalContexts: [] as string[],
+      errors: [] as string[],
+    });
 
     if (this.hookRegistry?.hasHookFor('PreToolUse', runId) === true) {
       const preResults = await Promise.all(
@@ -535,7 +535,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             },
             sessionId: runId,
             matchQuery: entry.call.name,
-          }).catch((): AggregatedHookResult => emptyResult)
+          }).catch((): AggregatedHookResult => HOOK_FALLBACK)
         )
       );
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -19,12 +19,14 @@ import type {
 import type { BaseMessage, AIMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
+import type { HookRegistry } from '@/hooks';
 import { RunnableCallable } from '@/utils';
 import {
   calculateMaxToolResultChars,
   truncateToolResultContent,
 } from '@/utils/truncation';
 import { safeDispatchCustomEvent } from '@/utils/events';
+import { executeHooks } from '@/hooks';
 import { Constants, GraphEvents } from '@/common';
 
 /**
@@ -59,6 +61,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private directToolNames?: Set<string>;
   /** Maximum characters allowed in a single tool result before truncation. */
   private maxToolResultChars: number;
+  /** Hook registry for PreToolUse/PostToolUse lifecycle hooks */
+  private hookRegistry?: HookRegistry;
 
   constructor({
     tools,
@@ -76,6 +80,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     directToolNames,
     maxContextTokens,
     maxToolResultChars,
+    hookRegistry,
   }: t.ToolNodeConstructorParams) {
     super({ name, tags, func: (input, config) => this.run(input, config) });
     this.toolMap = toolMap ?? new Map(tools.map((tool) => [tool.name, tool]));
@@ -91,6 +96,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.directToolNames = directToolNames;
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
+    this.hookRegistry = hookRegistry;
   }
 
   /**
@@ -482,26 +488,119 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   /**
    * Dispatches tool calls to the host via ON_TOOL_EXECUTE event and returns raw ToolMessages.
    * Core logic for event-driven execution, separated from output shaping.
+   *
+   * Hook lifecycle (when `hookRegistry` is set):
+   * 1. **PreToolUse** fires per call in parallel before dispatch. Denied
+   *    calls produce error ToolMessages and fire **PermissionDenied**;
+   *    surviving calls proceed with optional `updatedInput`.
+   * 2. Surviving calls are dispatched to the host via `ON_TOOL_EXECUTE`.
+   * 3. **PostToolUse** / **PostToolUseFailure** fire per result. Post hooks
+   *    can replace tool output via `updatedOutput`.
    */
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig
   ): Promise<ToolMessage[]> {
-    const requests: t.ToolCallRequest[] = toolCalls.map((call) => {
+    const runId = (config.configurable?.run_id as string | undefined) ?? '';
+    const threadId = config.configurable?.thread_id as string | undefined;
+
+    const preToolCalls = toolCalls.map((call) => {
       const turn = this.toolUsageCount.get(call.name) ?? 0;
       this.toolUsageCount.set(call.name, turn + 1);
-
-      const request: t.ToolCallRequest = {
-        id: call.id!,
-        name: call.name,
-        args: call.args as Record<string, unknown>,
-        stepId: this.toolCallStepIds?.get(call.id!),
+      return {
+        call,
         turn,
+        stepId: this.toolCallStepIds?.get(call.id!) ?? '',
+        args: call.args as Record<string, unknown>,
+      };
+    });
+
+    const deniedMessages: ToolMessage[] = [];
+    const approved: typeof preToolCalls = [];
+
+    if (this.hookRegistry?.hasHookFor('PreToolUse', runId) === true) {
+      const preResults = await Promise.all(
+        preToolCalls.map((entry) =>
+          executeHooks({
+            registry: this.hookRegistry!,
+            input: {
+              hook_event_name: 'PreToolUse',
+              runId,
+              threadId,
+              agentId: this.agentId,
+              toolName: entry.call.name,
+              toolInput: entry.args,
+              toolUseId: entry.call.id!,
+              stepId: entry.stepId,
+              turn: entry.turn,
+            },
+            sessionId: runId,
+            matchQuery: entry.call.name,
+          })
+        )
+      );
+
+      for (let i = 0; i < preToolCalls.length; i++) {
+        const hookResult = preResults[i];
+        const entry = preToolCalls[i];
+        const isDenied =
+          hookResult.decision === 'deny' || hookResult.decision === 'ask';
+        if (isDenied) {
+          const reason = hookResult.reason ?? 'Blocked by hook';
+          deniedMessages.push(
+            new ToolMessage({
+              status: 'error',
+              content: `Blocked: ${reason}`,
+              name: entry.call.name,
+              tool_call_id: entry.call.id!,
+            })
+          );
+          if (this.hookRegistry.hasHookFor('PermissionDenied', runId)) {
+            executeHooks({
+              registry: this.hookRegistry,
+              input: {
+                hook_event_name: 'PermissionDenied',
+                runId,
+                threadId,
+                agentId: this.agentId,
+                toolName: entry.call.name,
+                toolInput: entry.args,
+                toolUseId: entry.call.id!,
+                reason,
+              },
+              sessionId: runId,
+              matchQuery: entry.call.name,
+            }).catch(() => {
+              /* PermissionDenied is observational — swallow errors */
+            });
+          }
+          continue;
+        }
+        if (hookResult.updatedInput != null) {
+          entry.args = hookResult.updatedInput;
+        }
+        approved.push(entry);
+      }
+    } else {
+      approved.push(...preToolCalls);
+    }
+
+    if (approved.length === 0) {
+      return deniedMessages;
+    }
+
+    const requests: t.ToolCallRequest[] = approved.map((entry) => {
+      const request: t.ToolCallRequest = {
+        id: entry.call.id!,
+        name: entry.call.name,
+        args: entry.args,
+        stepId: entry.stepId,
+        turn: entry.turn,
       };
 
       if (
-        call.name === Constants.EXECUTE_CODE ||
-        call.name === Constants.PROGRAMMATIC_TOOL_CALLING
+        entry.call.name === Constants.EXECUTE_CODE ||
+        entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING
       ) {
         request.codeSessionContext = this.getCodeSessionContext();
       }
@@ -529,7 +628,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     this.storeCodeSessionFromResults(results, requests);
 
-    return results.map((result) => {
+    const hasPostHook =
+      this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;
+    const hasFailureHook =
+      this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
+
+    const executedMessages: ToolMessage[] = [];
+    for (const result of results) {
       const request = requests.find((r) => r.id === result.toolCallId);
       const toolName = request?.name ?? 'unknown';
       const stepId = this.toolCallStepIds?.get(result.toolCallId) ?? '';
@@ -542,17 +647,32 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
       }
 
-      let toolMessage: ToolMessage;
       let contentString: string;
 
       if (result.status === 'error') {
         contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
-        toolMessage = new ToolMessage({
-          status: 'error',
-          content: contentString,
-          name: toolName,
-          tool_call_id: result.toolCallId,
-        });
+
+        if (hasFailureHook) {
+          await executeHooks({
+            registry: this.hookRegistry!,
+            input: {
+              hook_event_name: 'PostToolUseFailure',
+              runId,
+              threadId,
+              agentId: this.agentId,
+              toolName,
+              toolInput: request?.args ?? {},
+              toolUseId: result.toolCallId,
+              error: result.errorMessage ?? 'Unknown error',
+              stepId,
+              turn: request?.turn,
+            },
+            sessionId: runId,
+            matchQuery: toolName,
+          }).catch(() => {
+            /* PostToolUseFailure is observational — swallow errors */
+          });
+        }
       } else {
         const rawContent =
           typeof result.content === 'string'
@@ -562,14 +682,53 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           rawContent,
           this.maxToolResultChars
         );
-        toolMessage = new ToolMessage({
-          status: 'success',
-          name: toolName,
-          content: contentString,
-          artifact: result.artifact,
-          tool_call_id: result.toolCallId,
-        });
+
+        if (hasPostHook) {
+          const hookResult = await executeHooks({
+            registry: this.hookRegistry!,
+            input: {
+              hook_event_name: 'PostToolUse',
+              runId,
+              threadId,
+              agentId: this.agentId,
+              toolName,
+              toolInput: request?.args ?? {},
+              toolOutput: result.content,
+              toolUseId: result.toolCallId,
+              stepId,
+              turn: request?.turn,
+            },
+            sessionId: runId,
+            matchQuery: toolName,
+          }).catch((): undefined => undefined);
+          if (hookResult?.updatedOutput != null) {
+            const replaced =
+              typeof hookResult.updatedOutput === 'string'
+                ? hookResult.updatedOutput
+                : JSON.stringify(hookResult.updatedOutput);
+            contentString = truncateToolResultContent(
+              replaced,
+              this.maxToolResultChars
+            );
+          }
+        }
       }
+
+      const toolMessage =
+        result.status === 'error'
+          ? new ToolMessage({
+            status: 'error',
+            content: contentString,
+            name: toolName,
+            tool_call_id: result.toolCallId,
+          })
+          : new ToolMessage({
+            status: 'success',
+            name: toolName,
+            content: contentString,
+            artifact: result.artifact,
+            tool_call_id: result.toolCallId,
+          });
 
       const tool_call: t.ProcessedToolCall = {
         args:
@@ -582,23 +741,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         progress: 1,
       };
 
-      const runStepCompletedData = {
-        result: {
-          id: stepId,
-          index: request?.turn ?? 0,
-          type: 'tool_call' as const,
-          tool_call,
-        },
-      };
-
       safeDispatchCustomEvent(
         GraphEvents.ON_RUN_STEP_COMPLETED,
-        runStepCompletedData,
+        {
+          result: {
+            id: stepId,
+            index: request?.turn ?? 0,
+            type: 'tool_call' as const,
+            tool_call,
+          },
+        },
         config
       );
 
-      return toolMessage;
-    });
+      executedMessages.push(toolMessage);
+    }
+
+    return [...deniedMessages, ...executedMessages];
   }
 
   /**

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -19,7 +19,7 @@ import type {
 import type { BaseMessage, AIMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
-import type { HookRegistry } from '@/hooks';
+import type { HookRegistry, AggregatedHookResult } from '@/hooks';
 import { RunnableCallable } from '@/utils';
 import {
   calculateMaxToolResultChars,
@@ -504,19 +504,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const threadId = config.configurable?.thread_id as string | undefined;
 
-    const preToolCalls = toolCalls.map((call) => {
-      const turn = this.toolUsageCount.get(call.name) ?? 0;
-      this.toolUsageCount.set(call.name, turn + 1);
-      return {
-        call,
-        turn,
-        stepId: this.toolCallStepIds?.get(call.id!) ?? '',
-        args: call.args as Record<string, unknown>,
-      };
-    });
+    const preToolCalls = toolCalls.map((call) => ({
+      call,
+      stepId: this.toolCallStepIds?.get(call.id!) ?? '',
+      args: call.args as Record<string, unknown>,
+    }));
 
-    const deniedMessages: ToolMessage[] = [];
-    const approved: typeof preToolCalls = [];
+    const messageByCallId = new Map<string, ToolMessage>();
+    const approvedEntries: typeof preToolCalls = [];
+    const emptyResult: AggregatedHookResult = {
+      additionalContexts: [],
+      errors: [],
+    };
 
     if (this.hookRegistry?.hasHookFor('PreToolUse', runId) === true) {
       const preResults = await Promise.all(
@@ -532,11 +531,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               toolInput: entry.args,
               toolUseId: entry.call.id!,
               stepId: entry.stepId,
-              turn: entry.turn,
+              turn: this.toolUsageCount.get(entry.call.name),
             },
             sessionId: runId,
             matchQuery: entry.call.name,
-          })
+          }).catch((): AggregatedHookResult => emptyResult)
         )
       );
 
@@ -547,13 +546,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           hookResult.decision === 'deny' || hookResult.decision === 'ask';
         if (isDenied) {
           const reason = hookResult.reason ?? 'Blocked by hook';
-          deniedMessages.push(
+          const contentString = `Blocked: ${reason}`;
+          messageByCallId.set(
+            entry.call.id!,
             new ToolMessage({
               status: 'error',
-              content: `Blocked: ${reason}`,
+              content: contentString,
               name: entry.call.name,
               tool_call_id: entry.call.id!,
             })
+          );
+          this.dispatchStepCompleted(
+            entry.call.id!,
+            entry.call.name,
+            entry.args,
+            contentString,
+            config
           );
           if (this.hookRegistry.hasHookFor('PermissionDenied', runId)) {
             executeHooks({
@@ -579,185 +587,204 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         if (hookResult.updatedInput != null) {
           entry.args = hookResult.updatedInput;
         }
-        approved.push(entry);
+        approvedEntries.push(entry);
       }
     } else {
-      approved.push(...preToolCalls);
+      approvedEntries.push(...preToolCalls);
     }
 
-    if (approved.length === 0) {
-      return deniedMessages;
-    }
+    if (approvedEntries.length > 0) {
+      const requests: t.ToolCallRequest[] = approvedEntries.map((entry) => {
+        const turn = this.toolUsageCount.get(entry.call.name) ?? 0;
+        this.toolUsageCount.set(entry.call.name, turn + 1);
 
-    const requests: t.ToolCallRequest[] = approved.map((entry) => {
-      const request: t.ToolCallRequest = {
-        id: entry.call.id!,
-        name: entry.call.name,
-        args: entry.args,
-        stepId: entry.stepId,
-        turn: entry.turn,
-      };
-
-      if (
-        entry.call.name === Constants.EXECUTE_CODE ||
-        entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING
-      ) {
-        request.codeSessionContext = this.getCodeSessionContext();
-      }
-
-      return request;
-    });
-
-    const results = await new Promise<t.ToolExecuteResult[]>(
-      (resolve, reject) => {
-        const request: t.ToolExecuteBatchRequest = {
-          toolCalls: requests,
-          userId: config.configurable?.user_id as string | undefined,
-          agentId: this.agentId,
-          configurable: config.configurable as
-            | Record<string, unknown>
-            | undefined,
-          metadata: config.metadata as Record<string, unknown> | undefined,
-          resolve,
-          reject,
+        const request: t.ToolCallRequest = {
+          id: entry.call.id!,
+          name: entry.call.name,
+          args: entry.args,
+          stepId: entry.stepId,
+          turn,
         };
 
-        safeDispatchCustomEvent(GraphEvents.ON_TOOL_EXECUTE, request, config);
-      }
-    );
-
-    this.storeCodeSessionFromResults(results, requests);
-
-    const hasPostHook =
-      this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;
-    const hasFailureHook =
-      this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
-
-    const executedMessages: ToolMessage[] = [];
-    for (const result of results) {
-      const request = requests.find((r) => r.id === result.toolCallId);
-      const toolName = request?.name ?? 'unknown';
-      const stepId = this.toolCallStepIds?.get(result.toolCallId) ?? '';
-      if (!stepId) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[ToolNode] toolCallStepIds missing entry for toolCallId=${result.toolCallId} (tool=${toolName}). ` +
-            'This indicates a race between the stream consumer and graph execution. ' +
-            `Map size: ${this.toolCallStepIds?.size ?? 0}`
-        );
-      }
-
-      let contentString: string;
-
-      if (result.status === 'error') {
-        contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
-
-        if (hasFailureHook) {
-          await executeHooks({
-            registry: this.hookRegistry!,
-            input: {
-              hook_event_name: 'PostToolUseFailure',
-              runId,
-              threadId,
-              agentId: this.agentId,
-              toolName,
-              toolInput: request?.args ?? {},
-              toolUseId: result.toolCallId,
-              error: result.errorMessage ?? 'Unknown error',
-              stepId,
-              turn: request?.turn,
-            },
-            sessionId: runId,
-            matchQuery: toolName,
-          }).catch(() => {
-            /* PostToolUseFailure is observational — swallow errors */
-          });
+        if (
+          entry.call.name === Constants.EXECUTE_CODE ||
+          entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING
+        ) {
+          request.codeSessionContext = this.getCodeSessionContext();
         }
-      } else {
-        const rawContent =
-          typeof result.content === 'string'
-            ? result.content
-            : JSON.stringify(result.content);
-        contentString = truncateToolResultContent(
-          rawContent,
-          this.maxToolResultChars
-        );
 
-        if (hasPostHook) {
-          const hookResult = await executeHooks({
-            registry: this.hookRegistry!,
-            input: {
-              hook_event_name: 'PostToolUse',
-              runId,
-              threadId,
-              agentId: this.agentId,
-              toolName,
-              toolInput: request?.args ?? {},
-              toolOutput: result.content,
-              toolUseId: result.toolCallId,
-              stepId,
-              turn: request?.turn,
-            },
-            sessionId: runId,
-            matchQuery: toolName,
-          }).catch((): undefined => undefined);
-          if (hookResult?.updatedOutput != null) {
-            const replaced =
-              typeof hookResult.updatedOutput === 'string'
-                ? hookResult.updatedOutput
-                : JSON.stringify(hookResult.updatedOutput);
-            contentString = truncateToolResultContent(
-              replaced,
-              this.maxToolResultChars
-            );
-          }
+        return request;
+      });
+
+      const requestMap = new Map(requests.map((r) => [r.id, r]));
+
+      const results = await new Promise<t.ToolExecuteResult[]>(
+        (resolve, reject) => {
+          const batchRequest: t.ToolExecuteBatchRequest = {
+            toolCalls: requests,
+            userId: config.configurable?.user_id as string | undefined,
+            agentId: this.agentId,
+            configurable: config.configurable as
+              | Record<string, unknown>
+              | undefined,
+            metadata: config.metadata as Record<string, unknown> | undefined,
+            resolve,
+            reject,
+          };
+
+          safeDispatchCustomEvent(
+            GraphEvents.ON_TOOL_EXECUTE,
+            batchRequest,
+            config
+          );
         }
-      }
+      );
 
-      const toolMessage =
-        result.status === 'error'
-          ? new ToolMessage({
+      this.storeCodeSessionFromResults(results, requests);
+
+      const hasPostHook =
+        this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;
+      const hasFailureHook =
+        this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
+
+      for (const result of results) {
+        const request = requestMap.get(result.toolCallId);
+        const toolName = request?.name ?? 'unknown';
+
+        let contentString: string;
+        let toolMessage: ToolMessage;
+
+        if (result.status === 'error') {
+          contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
+          toolMessage = new ToolMessage({
             status: 'error',
             content: contentString,
             name: toolName,
             tool_call_id: result.toolCallId,
-          })
-          : new ToolMessage({
+          });
+
+          if (hasFailureHook) {
+            await executeHooks({
+              registry: this.hookRegistry!,
+              input: {
+                hook_event_name: 'PostToolUseFailure',
+                runId,
+                threadId,
+                agentId: this.agentId,
+                toolName,
+                toolInput: request?.args ?? {},
+                toolUseId: result.toolCallId,
+                error: result.errorMessage ?? 'Unknown error',
+                stepId: request?.stepId,
+                turn: request?.turn,
+              },
+              sessionId: runId,
+              matchQuery: toolName,
+            }).catch(() => {
+              /* PostToolUseFailure is observational — swallow errors */
+            });
+          }
+        } else {
+          const rawContent =
+            typeof result.content === 'string'
+              ? result.content
+              : JSON.stringify(result.content);
+          contentString = truncateToolResultContent(
+            rawContent,
+            this.maxToolResultChars
+          );
+
+          if (hasPostHook) {
+            const hookResult = await executeHooks({
+              registry: this.hookRegistry!,
+              input: {
+                hook_event_name: 'PostToolUse',
+                runId,
+                threadId,
+                agentId: this.agentId,
+                toolName,
+                toolInput: request?.args ?? {},
+                toolOutput: result.content,
+                toolUseId: result.toolCallId,
+                stepId: request?.stepId,
+                turn: request?.turn,
+              },
+              sessionId: runId,
+              matchQuery: toolName,
+            }).catch((): undefined => undefined);
+            if (hookResult?.updatedOutput != null) {
+              const replaced =
+                typeof hookResult.updatedOutput === 'string'
+                  ? hookResult.updatedOutput
+                  : JSON.stringify(hookResult.updatedOutput);
+              contentString = truncateToolResultContent(
+                replaced,
+                this.maxToolResultChars
+              );
+            }
+          }
+
+          toolMessage = new ToolMessage({
             status: 'success',
             name: toolName,
             content: contentString,
             artifact: result.artifact,
             tool_call_id: result.toolCallId,
           });
+        }
 
-      const tool_call: t.ProcessedToolCall = {
-        args:
-          typeof request?.args === 'string'
-            ? request.args
-            : JSON.stringify(request?.args ?? {}),
-        name: toolName,
-        id: result.toolCallId,
-        output: contentString,
-        progress: 1,
-      };
+        this.dispatchStepCompleted(
+          result.toolCallId,
+          toolName,
+          request?.args ?? {},
+          contentString,
+          config
+        );
 
-      safeDispatchCustomEvent(
-        GraphEvents.ON_RUN_STEP_COMPLETED,
-        {
-          result: {
-            id: stepId,
-            index: request?.turn ?? 0,
-            type: 'tool_call' as const,
-            tool_call,
-          },
-        },
-        config
-      );
-
-      executedMessages.push(toolMessage);
+        messageByCallId.set(result.toolCallId, toolMessage);
+      }
     }
 
-    return [...deniedMessages, ...executedMessages];
+    return toolCalls
+      .map((call) => messageByCallId.get(call.id!))
+      .filter((m): m is ToolMessage => m != null);
+  }
+
+  private dispatchStepCompleted(
+    toolCallId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    output: string,
+    config: RunnableConfig
+  ): void {
+    const stepId = this.toolCallStepIds?.get(toolCallId) ?? '';
+    if (!stepId) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ToolNode] toolCallStepIds missing entry for toolCallId=${toolCallId} (tool=${toolName}). ` +
+          'This indicates a race between the stream consumer and graph execution. ' +
+          `Map size: ${this.toolCallStepIds?.size ?? 0}`
+      );
+    }
+
+    safeDispatchCustomEvent(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: stepId,
+          index: this.toolUsageCount.get(toolName) ?? 0,
+          type: 'tool_call' as const,
+          tool_call: {
+            args: JSON.stringify(args),
+            name: toolName,
+            id: toolCallId,
+            output,
+            progress: 1,
+          } as t.ProcessedToolCall,
+        },
+      },
+      config
+    );
   }
 
   /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -50,7 +50,11 @@ export type ToolNodeOptions = {
   agentId?: string;
   /** Tool names that must be executed directly (via runTool) even in event-driven mode (e.g., graph-managed handoff tools) */
   directToolNames?: Set<string>;
-  /** Hook registry for PreToolUse/PostToolUse lifecycle hooks */
+  /**
+   * Hook registry for PreToolUse/PostToolUse lifecycle hooks.
+   * Only fires for event-driven tool calls (`dispatchToolEvents`). Tools
+   * routed through `directToolNames` bypass hook dispatch entirely.
+   */
   hookRegistry?: HookRegistry;
   /** Max context tokens for the agent — used to compute tool result truncation limits. */
   maxContextTokens?: number;

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -2,6 +2,7 @@
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
+import type { HookRegistry } from '@/hooks';
 import type { ToolErrorData } from './stream';
 import { EnvVar } from '@/common';
 
@@ -49,6 +50,8 @@ export type ToolNodeOptions = {
   agentId?: string;
   /** Tool names that must be executed directly (via runTool) even in event-driven mode (e.g., graph-managed handoff tools) */
   directToolNames?: Set<string>;
+  /** Hook registry for PreToolUse/PostToolUse lifecycle hooks */
+  hookRegistry?: HookRegistry;
   /** Max context tokens for the agent — used to compute tool result truncation limits. */
   maxContextTokens?: number;
   /**


### PR DESCRIPTION
## Summary

Final Phase 1 PR. Wires `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, and `PermissionDenied` hooks into `ToolNode.dispatchToolEvents` — the single chokepoint for all event-driven tool execution that LibreChat uses.

After this PR, hosts can register hooks that:
- **Block a tool call** — `PreToolUse` returns `{decision: 'deny'}`, tool is skipped, error ToolMessage produced
- **Rewrite tool input** — `PreToolUse` returns `{updatedInput: {...}}`, args are modified before dispatch to host
- **Replace tool output** — `PostToolUse` returns `{updatedOutput: '...'}`, ToolMessage content is replaced
- **Observe failures** — `PostToolUseFailure` fires per error result with the error string
- **Audit denials** — `PermissionDenied` fires after a deny with the reason

All without modifying tool implementations.

### Hook lifecycle in `dispatchToolEvents`

1. **PreToolUse** fires per call in parallel (via `Promise.all`) before `ON_TOOL_EXECUTE`
2. Denied calls produce error ToolMessages + fire `PermissionDenied` (fire-and-forget)
3. Only approved calls proceed to `ON_TOOL_EXECUTE` batch dispatch
4. **PostToolUse** / **PostToolUseFailure** fire per result after the batch completes
5. Post hooks are awaited so `updatedOutput` takes effect before the ToolMessage is consumed

### Files changed

| File | Change |
|---|---|
| `src/types/tools.ts` | Added `hookRegistry?: HookRegistry` to `ToolNodeOptions` |
| `src/tools/ToolNode.ts` | Hook fire points in `dispatchToolEvents`, `hookRegistry` field |
| `src/graphs/Graph.ts` | Pass `hookRegistry` at both `CustomToolNode` construction sites |
| `src/run.ts` | Set `hookRegistry` on Graph BEFORE `createWorkflow()` (timing fix) |
| `src/hooks/__tests__/toolHooks.test.ts` | 9 new integration tests |

### Key implementation detail

`hookRegistry` must be set on Graph **before** `createWorkflow()` is called, because ToolNode is constructed during workflow compilation and reads `this.hookRegistry` from Graph at that point. Moved the assignment from the post-create block in Run's constructor into `createLegacyGraph` and `createMultiAgentGraph`.

## Test plan

- [x] 9 new tool hook tests (PreToolUse fields/deny/ask/updatedInput/non-fatal, PermissionDenied, PostToolUse, PostToolUseFailure, no-hooks baseline)
- [x] All 94 existing hook tests still pass (103 total)
- [x] `custom-event-await.test.ts` still passes (no regression)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean