### PR TITLE
feat: SkillTool primitive, injectedMessages, and catalog formatter

### DIFF
--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -182,6 +182,7 @@ export enum Constants {
   MCP_DELIMITER = '_mcp_',
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
+  SKILL_TOOL = 'skill',
 }
 
 export enum TitleMethod {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export * from './summarization';
 export * from './tools/Calculator';
 export * from './tools/CodeExecutor';
 export * from './tools/ProgrammaticToolCalling';
+export * from './tools/SkillTool';
+export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';
 export * from './tools/ToolNode';
 export * from './tools/schema';

--- a/src/tools/SkillTool.ts
+++ b/src/tools/SkillTool.ts
@@ -1,0 +1,78 @@
+// src/tools/SkillTool.ts
+import { z } from 'zod';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { Constants } from '@/common';
+
+export const SkillToolName = Constants.SKILL_TOOL;
+
+export const SkillToolDescription = `Invoke a skill from the user's library. Skills provide domain-specific instructions loaded into the conversation context, and may also provide files accessible via available tools depending on the runtime environment.
+
+WHEN TO USE:
+- The user's request matches a skill listed in the "Available Skills" section of the system prompt.
+- You MUST invoke the matching skill BEFORE attempting the task yourself.
+
+WHAT HAPPENS:
+- The skill's full instructions are loaded into the conversation as context.
+- Files bundled with the skill may become accessible via available tools.
+- Follow the skill's instructions to complete the task.
+
+CONSTRAINTS:
+- Do not invoke a skill that is already active in this conversation.
+- Skill names come from the catalog only. Do not guess names.`;
+
+/**
+ * JSON Schema for the SkillTool parameters.
+ * Single source of truth used by both SkillToolDefinition (LCTool registry)
+ * and createSkillTool() (DynamicStructuredTool instance).
+ */
+export const SkillToolSchema = {
+  type: 'object',
+  properties: {
+    skillName: {
+      type: 'string',
+      description:
+        'The kebab-case identifier of the skill to invoke (e.g. "financial-analyzer", "meeting-notes"). Must match a name from the "Available Skills" section.',
+    },
+    args: {
+      type: 'string',
+      description: 'Optional freeform arguments string passed to the skill.',
+    },
+  },
+  required: ['skillName'],
+} as const;
+
+export const SkillToolDefinition = {
+  name: SkillToolName,
+  description: SkillToolDescription,
+  parameters: SkillToolSchema,
+} as const;
+
+/**
+ * Zod schema derived from SkillToolSchema for DynamicStructuredTool type inference.
+ * Kept internal to createSkillTool — the JSON Schema above is the canonical definition.
+ */
+const skillToolZodSchema = z.object({
+  skillName: z
+    .string()
+    .describe(SkillToolSchema.properties.skillName.description),
+  args: z
+    .string()
+    .optional()
+    .describe(SkillToolSchema.properties.args.description),
+});
+
+/** Creates the SkillTool DynamicStructuredTool instance for use in tool maps. */
+export function createSkillTool(): DynamicStructuredTool {
+  return tool(
+    async (): Promise<string> => {
+      throw new Error(
+        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
+      );
+    },
+    {
+      name: SkillToolName,
+      description: SkillToolDescription,
+      schema: skillToolZodSchema,
+    }
+  );
+}

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1,6 +1,7 @@
 import { ToolCall } from '@langchain/core/messages/tool';
 import {
   ToolMessage,
+  HumanMessage,
   isAIMessage,
   isBaseMessage,
 } from '@langchain/core/messages';
@@ -496,11 +497,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * 2. Surviving calls are dispatched to the host via `ON_TOOL_EXECUTE`.
    * 3. **PostToolUse** / **PostToolUseFailure** fire per result. Post hooks
    *    can replace tool output via `updatedOutput`.
+   * 4. Injected messages from results are collected and returned alongside
+   *    ToolMessages (appended AFTER to respect provider ordering).
    */
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig
-  ): Promise<ToolMessage[]> {
+  ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const threadId = config.configurable?.thread_id as string | undefined;
 
@@ -593,6 +596,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       approvedEntries.push(...preToolCalls);
     }
 
+    const injected: BaseMessage[] = [];
+
     if (approvedEntries.length > 0) {
       const requests: t.ToolCallRequest[] = approvedEntries.map((entry) => {
         const turn = this.toolUsageCount.get(entry.call.name) ?? 0;
@@ -648,6 +653,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
 
       for (const result of results) {
+        if (result.injectedMessages && result.injectedMessages.length > 0) {
+          try {
+            injected.push(
+              ...this.convertInjectedMessages(result.injectedMessages)
+            );
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[ToolNode] Failed to convert injectedMessages for toolCallId=${result.toolCallId}:`,
+              e instanceof Error ? e.message : e
+            );
+          }
+        }
         const request = requestMap.get(result.toolCallId);
         const toolName = request?.name ?? 'unknown';
 
@@ -746,9 +764,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
     }
 
-    return toolCalls
+    const toolMessages = toolCalls
       .map((call) => messageByCallId.get(call.id!))
       .filter((m): m is ToolMessage => m != null);
+    return { toolMessages, injected };
   }
 
   private dispatchStepCompleted(
@@ -790,8 +809,35 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
+   * Converts InjectedMessage instances to LangChain HumanMessage objects.
+   * Both 'user' and 'system' roles become HumanMessage to avoid provider
+   * rejections (Anthropic/Google reject non-leading SystemMessages).
+   * The original role is preserved in additional_kwargs for downstream consumers.
+   */
+  private convertInjectedMessages(
+    messages: t.InjectedMessage[]
+  ): BaseMessage[] {
+    const converted: BaseMessage[] = [];
+    for (const msg of messages) {
+      const additional_kwargs: Record<string, unknown> = {
+        role: msg.role,
+      };
+      if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
+      if (msg.source != null) additional_kwargs.source = msg.source;
+      if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
+
+      converted.push(
+        new HumanMessage({ content: msg.content, additional_kwargs })
+      );
+    }
+    return converted;
+  }
+
+  /**
    * Execute all tool calls via ON_TOOL_EXECUTE event dispatch.
-   * Used in event-driven mode where the host handles actual tool execution.
+   * Injected messages are placed AFTER ToolMessages to respect provider
+   * message ordering (AIMessage tool_calls must be immediately followed
+   * by their ToolMessage results).
    */
   private async executeViaEvent(
     toolCalls: ToolCall[],
@@ -799,7 +845,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any
   ): Promise<T> {
-    const outputs = await this.dispatchToolEvents(toolCalls, config);
+    const { toolMessages, injected } = await this.dispatchToolEvents(
+      toolCalls,
+      config
+    );
+    const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
   }
 
@@ -895,12 +945,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           this.handleRunToolCompletions(directCalls, directOutputs, config);
         }
 
-        const eventOutputs: ToolMessage[] =
+        const eventResult =
           eventCalls.length > 0
             ? await this.dispatchToolEvents(eventCalls, config)
-            : [];
+            : {
+              toolMessages: [] as ToolMessage[],
+              injected: [] as BaseMessage[],
+            };
 
-        outputs = [...directOutputs, ...eventOutputs];
+        outputs = [
+          ...directOutputs,
+          ...eventResult.toolMessages,
+          ...eventResult.injected,
+        ];
       } else {
         outputs = await Promise.all(
           filteredCalls.map((call) => this.runTool(call, config))

--- a/src/tools/__tests__/SkillTool.test.ts
+++ b/src/tools/__tests__/SkillTool.test.ts
@@ -1,0 +1,462 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { describe, it, expect } from '@jest/globals';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import * as events from '@/utils/events';
+import { ToolNode } from '../ToolNode';
+import { Constants } from '@/common';
+import {
+  SkillToolName,
+  SkillToolSchema,
+  SkillToolDescription,
+  SkillToolDefinition,
+  createSkillTool,
+} from '../SkillTool';
+
+describe('SkillTool', () => {
+  describe('schema structure', () => {
+    it('has skillName as required string property', () => {
+      expect(SkillToolSchema.properties.skillName.type).toBe('string');
+      expect(SkillToolSchema.required).toContain('skillName');
+    });
+
+    it('has args as optional string property', () => {
+      expect(SkillToolSchema.properties.args.type).toBe('string');
+      expect(SkillToolSchema.required).not.toContain('args');
+    });
+
+    it('is an object type schema', () => {
+      expect(SkillToolSchema.type).toBe('object');
+    });
+  });
+
+  describe('createSkillTool', () => {
+    it('throws on direct invocation', async () => {
+      const skillTool = createSkillTool();
+      await expect(skillTool.invoke({ skillName: 'test' })).rejects.toThrow(
+        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
+      );
+    });
+
+    it('has correct name', () => {
+      const skillTool = createSkillTool();
+      expect(skillTool.name).toBe('skill');
+    });
+
+    it('validates skillName is required', async () => {
+      const skillTool = createSkillTool();
+      await expect(skillTool.invoke({})).rejects.toThrow();
+    });
+  });
+
+  describe('SkillToolDefinition', () => {
+    it('has correct name', () => {
+      expect(SkillToolDefinition.name).toBe(Constants.SKILL_TOOL);
+    });
+
+    it('references the same SkillToolSchema object (no duplication)', () => {
+      expect(SkillToolDefinition.parameters).toBe(SkillToolSchema);
+    });
+
+    it('has a non-empty description', () => {
+      expect(SkillToolDefinition.description).toBe(SkillToolDescription);
+      expect(SkillToolDefinition.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SkillToolName', () => {
+    it('equals Constants.SKILL_TOOL', () => {
+      expect(SkillToolName).toBe('skill');
+      expect(SkillToolName).toBe(Constants.SKILL_TOOL);
+    });
+  });
+
+  describe('InjectedMessage type-check', () => {
+    it('constructs a valid ToolExecuteResult with injectedMessages', () => {
+      const result: t.ToolExecuteResult = {
+        toolCallId: 'call_1',
+        content: 'Skill loaded successfully.',
+        status: 'success',
+        injectedMessages: [
+          {
+            role: 'user',
+            content: '# PDF Processor Instructions\n\nFollow these steps...',
+            isMeta: true,
+            source: 'skill',
+            skillName: 'pdf-processor',
+          },
+          {
+            role: 'system',
+            content: 'Skill files are available at /skills/pdf-processor/',
+            source: 'skill',
+            skillName: 'pdf-processor',
+          },
+        ],
+      };
+
+      expect(result.injectedMessages).toHaveLength(2);
+      expect(result.injectedMessages![0].role).toBe('user');
+      expect(result.injectedMessages![1].role).toBe('system');
+    });
+
+    it('accepts MessageContentComplex[] content', () => {
+      const result: t.ToolExecuteResult = {
+        toolCallId: 'call_1',
+        content: '',
+        status: 'success',
+        injectedMessages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Skill instructions here' },
+              { type: 'image_url', image_url: { url: 'data:image/png;...' } },
+            ],
+            isMeta: true,
+            source: 'skill',
+            skillName: 'visual-skill',
+          },
+        ],
+      };
+
+      expect(Array.isArray(result.injectedMessages![0].content)).toBe(true);
+    });
+  });
+
+  describe('ToolNode injectedMessages plumbing (event-driven)', () => {
+    const createDummyTool = (name = 'dummy'): StructuredToolInterface =>
+      tool(async () => 'dummy', {
+        name,
+        description: 'dummy',
+        schema: z.object({ x: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+    function mockEventDispatch(
+      mockResults: t.ToolExecuteResult[]
+    ): jest.SpyInstance {
+      return jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (_event, data) => {
+          const request = data as Record<string, unknown>;
+          if (typeof request.resolve === 'function') {
+            (request.resolve as (r: t.ToolExecuteResult[]) => void)(
+              mockResults
+            );
+          }
+        });
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('appends injected messages AFTER ToolMessages in output', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_1', 'step_1']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_1', name: 'dummy', args: { x: 'hello' } }],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_1',
+          content: 'Tool result text',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected skill body content',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'test-skill',
+            },
+            {
+              role: 'system',
+              content: 'System context hint',
+              source: 'system',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(3);
+
+      // ToolMessage comes FIRST (preserves AIMessage -> ToolMessage adjacency)
+      expect(messages[0]._getType()).toBe('tool');
+
+      // Injected messages come AFTER
+      const second = messages[1] as HumanMessage;
+      expect(second).toBeInstanceOf(HumanMessage);
+      expect(second.content).toBe('Injected skill body content');
+      expect(second.additional_kwargs.role).toBe('user');
+      expect(second.additional_kwargs.isMeta).toBe(true);
+      expect(second.additional_kwargs.source).toBe('skill');
+      expect(second.additional_kwargs.skillName).toBe('test-skill');
+
+      // role: 'system' also becomes HumanMessage (avoids provider rejections)
+      const third = messages[2] as HumanMessage;
+      expect(third).toBeInstanceOf(HumanMessage);
+      expect(third.content).toBe('System context hint');
+      expect(third.additional_kwargs.role).toBe('system');
+      expect(third.additional_kwargs.source).toBe('system');
+    });
+
+    it('returns only ToolMessages when no injectedMessages present', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_2', 'step_2']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_2', name: 'dummy', args: { x: 'test' } }],
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'call_2', content: 'Normal result', status: 'success' },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]._getType()).toBe('tool');
+    });
+
+    it('passes MessageContentComplex[] content through without stringifying', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_3', 'step_3']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_3', name: 'dummy', args: { x: 'test' } }],
+      });
+
+      const complexContent = [
+        { type: 'text', text: 'Multi-part skill instructions' },
+        { type: 'text', text: 'Second part of instructions' },
+      ];
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_3',
+          content: '',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user' as const,
+              content: complexContent,
+              isMeta: true,
+              source: 'skill' as const,
+              skillName: 'complex-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(2);
+      // ToolMessage first
+      expect(messages[0]._getType()).toBe('tool');
+      // Injected message second with array content preserved (not stringified)
+      const injected = messages[1] as HumanMessage;
+      expect(injected).toBeInstanceOf(HumanMessage);
+      expect(Array.isArray(injected.content)).toBe(true);
+      expect(injected.content).toEqual(complexContent);
+    });
+
+    it('aggregates injected messages from multiple tool calls', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('tool_a'), createDummyTool('tool_b')],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([
+          ['call_a', 'step_a'],
+          ['call_b', 'step_b'],
+        ]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call_a', name: 'tool_a', args: { x: 'a' } },
+          { id: 'call_b', name: 'tool_b', args: { x: 'b' } },
+        ],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_a',
+          content: 'Result A',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected from A',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'skill-a',
+            },
+          ],
+        },
+        {
+          toolCallId: 'call_b',
+          content: 'Result B',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected from B',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'skill-b',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      // 2 ToolMessages + 2 injected messages
+      expect(messages).toHaveLength(4);
+      // ToolMessages come first
+      expect(messages[0]._getType()).toBe('tool');
+      expect(messages[1]._getType()).toBe('tool');
+      // Injected messages come after all ToolMessages
+      expect(messages[2]).toBeInstanceOf(HumanMessage);
+      expect((messages[2] as HumanMessage).content).toBe('Injected from A');
+      expect(messages[3]).toBeInstanceOf(HumanMessage);
+      expect((messages[3] as HumanMessage).content).toBe('Injected from B');
+    });
+
+    it('handles mixed mode: direct tools + event-driven with injected messages', async () => {
+      const directTool = tool(async () => 'direct result', {
+        name: 'handoff_tool',
+        description: 'A direct tool',
+        schema: z.object({ target: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      const eventTool = createDummyTool('event_tool');
+
+      const toolNode = new ToolNode({
+        tools: [directTool, eventTool],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        directToolNames: new Set(['handoff_tool']),
+        toolCallStepIds: new Map([
+          ['call_direct', 'step_direct'],
+          ['call_event', 'step_event'],
+        ]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_direct',
+            name: 'handoff_tool',
+            args: { target: 'agent-2' },
+          },
+          { id: 'call_event', name: 'event_tool', args: { x: 'hello' } },
+        ],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_event',
+          content: 'Event result',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Skill body from event tool',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'my-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      // directOutputs first, then eventResult.toolMessages, then eventResult.injected
+      expect(messages.length).toBeGreaterThanOrEqual(3);
+      // Direct tool result (ToolMessage from runTool)
+      expect(messages[0]._getType()).toBe('tool');
+      // Event tool result (ToolMessage from dispatchToolEvents)
+      expect(messages[1]._getType()).toBe('tool');
+      // Injected message last
+      const last = messages[messages.length - 1] as HumanMessage;
+      expect(last).toBeInstanceOf(HumanMessage);
+      expect(last.content).toBe('Skill body from event tool');
+      expect(last.additional_kwargs.skillName).toBe('my-skill');
+    });
+
+    it('includes injected messages even when tool result has error status', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_err', 'step_err']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_err', name: 'dummy', args: { x: 'fail' } }],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_err',
+          content: '',
+          status: 'error',
+          errorMessage: 'Skill not found',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Partial context before failure',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'broken-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(2);
+      // Error ToolMessage first
+      expect(messages[0]._getType()).toBe('tool');
+      expect(String(messages[0].content)).toContain('Skill not found');
+      // Injected message still included
+      const injected = messages[1] as HumanMessage;
+      expect(injected).toBeInstanceOf(HumanMessage);
+      expect(injected.content).toBe('Partial context before failure');
+      expect(injected.additional_kwargs.skillName).toBe('broken-skill');
+    });
+  });
+});

--- a/src/tools/__tests__/skillCatalog.test.ts
+++ b/src/tools/__tests__/skillCatalog.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatSkillCatalog } from '../skillCatalog';
+import type { SkillCatalogEntry } from '@/types';
+
+describe('formatSkillCatalog', () => {
+  it('returns empty string for empty array', () => {
+    expect(formatSkillCatalog([])).toBe('');
+  });
+
+  it('formats a single skill with header', () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: 'pdf-processor',
+        description: 'Processes PDF files into structured data.',
+      },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe(
+      '## Available Skills\n\n- pdf-processor: Processes PDF files into structured data.'
+    );
+  });
+
+  it('formats multiple skills within budget', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'pdf-processor', description: 'Processes PDF files.' },
+      { name: 'review-pr', description: 'Reviews pull requests.' },
+      { name: 'meeting-notes', description: 'Formats meeting transcripts.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('## Available Skills');
+    expect(result).toContain('- pdf-processor: Processes PDF files.');
+    expect(result).toContain('- review-pr: Reviews pull requests.');
+    expect(result).toContain('- meeting-notes: Formats meeting transcripts.');
+  });
+
+  it('caps per-entry descriptions at maxEntryChars', () => {
+    const longDesc = 'A'.repeat(300);
+    const skills: SkillCatalogEntry[] = [
+      { name: 'long-skill', description: longDesc },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('- long-skill: ' + 'A'.repeat(249) + '\u2026');
+    expect(result).not.toContain('A'.repeat(300));
+  });
+
+  it('truncates descriptions proportionally when over budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      name: `sk-${i}`,
+      description: 'D'.repeat(200),
+    }));
+    // Budget = 10000 * 0.01 * 4 = 400 chars — enough for names + short descs, not full 200-char descs
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 10000,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    expect(result).toContain('## Available Skills');
+    for (let i = 0; i < 10; i++) {
+      expect(result).toContain(`sk-${i}`);
+    }
+    // Full 200-char descriptions should be truncated
+    expect(result).not.toContain('D'.repeat(200));
+  });
+
+  it('falls back to names-only when extremely over budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      name: `s${i}`,
+      description: 'Very detailed description that is quite long and verbose.',
+    }));
+    // Budget = 2000 * 0.01 * 4 = 80 chars — enough for names-only but not descriptions
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 2000,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    expect(result).toContain('## Available Skills');
+    expect(result).toContain('- s0');
+    // Verify entry lines have no descriptions (names-only format)
+    const entryLines = result.split('\n').filter((l) => l.startsWith('- '));
+    for (const line of entryLines) {
+      expect(line).toMatch(/^- s\d+$/);
+    }
+  });
+
+  it('respects custom options', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'test', description: 'A'.repeat(100) },
+    ];
+    const result = formatSkillCatalog(skills, { maxEntryChars: 50 });
+    expect(result).toContain('A'.repeat(49) + '\u2026');
+    expect(result).not.toContain('A'.repeat(100));
+  });
+
+  it('includes skills with descriptions shorter than minDescLength', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'short', description: 'Hi' },
+      { name: 'normal', description: 'A normal description here.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('- short: Hi');
+    expect(result).toContain('- normal: A normal description here.');
+  });
+
+  it('handles all skills with zero-length descriptions as names-only', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'alpha', description: '' },
+      { name: 'beta', description: '' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe('## Available Skills\n\n- alpha\n- beta');
+  });
+
+  it('has no trailing or leading whitespace', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'test', description: 'A test skill.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe(result.trim());
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(line).toBe(line.trimEnd());
+    }
+  });
+
+  it('truncates names-only list when even names exceed budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 100 }, (_, i) => ({
+      name: `skill-with-a-long-name-${i}`,
+      description: 'Some description.',
+    }));
+    // Budget so small that even names-only for 100 skills exceeds it
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 100,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    // Should still have the header and at least one entry, but not all 100
+    if (result === '') {
+      // Budget too small for even one entry — valid edge case
+      expect(result).toBe('');
+    } else {
+      expect(result).toContain('## Available Skills');
+      const entryLines = result.split('\n').filter((l) => l.startsWith('- '));
+      expect(entryLines.length).toBeLessThan(100);
+      expect(entryLines.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(100 * 0.01 * 4);
+    }
+  });
+
+  it('ignores displayTitle in output', () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: 'my-skill',
+        description: 'Does stuff.',
+        displayTitle: 'My Fancy Skill',
+      },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).not.toContain('My Fancy Skill');
+    expect(result).toContain('- my-skill: Does stuff.');
+  });
+});

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -1,0 +1,116 @@
+// src/tools/skillCatalog.ts
+import type { SkillCatalogEntry } from '@/types';
+
+const HEADER = '## Available Skills';
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+const DEFAULT_BUDGET_PERCENT = 0.01;
+const DEFAULT_MAX_ENTRY_CHARS = 250;
+const DEFAULT_MIN_DESC_LENGTH = 20;
+const DEFAULT_CHARS_PER_TOKEN = 4;
+
+export type SkillCatalogOptions = {
+  /** Total context window in tokens. Default: 200_000 */
+  contextWindowTokens?: number;
+  /** Fraction of context budget for catalog. Default: 0.01 (1%) */
+  budgetPercent?: number;
+  /** Max chars per entry description. Default: 250 */
+  maxEntryChars?: number;
+  /** Descriptions below this length trigger names-only fallback. Default: 20 */
+  minDescLength?: number;
+  /** Approximate chars per token for budget calculation. Default: 4 */
+  charsPerToken?: number;
+};
+
+/**
+ * Formats a skill catalog for injection into agent context.
+ * Uses a truncation ladder: full descriptions, proportional truncation, names-only.
+ * Returns empty string for empty input.
+ */
+export function formatSkillCatalog(
+  skills: SkillCatalogEntry[],
+  opts?: SkillCatalogOptions
+): string {
+  if (skills.length === 0) return '';
+
+  const contextWindowTokens =
+    opts?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS;
+  const budgetPercent = opts?.budgetPercent ?? DEFAULT_BUDGET_PERCENT;
+  const maxEntryChars = Math.max(
+    1,
+    opts?.maxEntryChars ?? DEFAULT_MAX_ENTRY_CHARS
+  );
+  const minDescLength = opts?.minDescLength ?? DEFAULT_MIN_DESC_LENGTH;
+  const charsPerToken = opts?.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+
+  const budgetChars = Math.floor(
+    contextWindowTokens * budgetPercent * charsPerToken
+  );
+
+  const capped = skills.map((s) => ({
+    name: s.name,
+    description:
+      s.description.length > maxEntryChars
+        ? s.description.slice(0, maxEntryChars - 1) + '\u2026'
+        : s.description,
+  }));
+
+  const fullOutput = formatEntries(capped);
+  if (fullOutput.length <= budgetChars) return fullOutput;
+
+  const headerLen = HEADER.length + 2;
+  const newlineChars = capped.length > 1 ? capped.length - 1 : 0;
+  const availableChars = budgetChars - headerLen - newlineChars;
+  const perEntryOverhead = 4;
+  const nameCharsTotal = capped.reduce(
+    (sum, s) => sum + s.name.length + perEntryOverhead,
+    0
+  );
+  const availableForDescs = availableChars - nameCharsTotal;
+
+  if (availableForDescs <= 0) {
+    return fitNamesOnly(capped, budgetChars);
+  }
+
+  const maxDescPerEntry = Math.floor(availableForDescs / capped.length);
+
+  if (maxDescPerEntry < minDescLength) {
+    return fitNamesOnly(capped, budgetChars);
+  }
+
+  const truncated = capped.map((s) => ({
+    name: s.name,
+    description:
+      s.description.length > maxDescPerEntry
+        ? s.description.slice(0, maxDescPerEntry - 1) + '\u2026'
+        : s.description,
+  }));
+
+  const result = formatEntries(truncated);
+  if (result.length <= budgetChars) return result;
+  return fitNamesOnly(capped, budgetChars);
+}
+
+function formatEntries(
+  entries: { name: string; description: string }[]
+): string {
+  const lines = entries.map((e) =>
+    e.description ? `- ${e.name}: ${e.description}` : `- ${e.name}`
+  );
+  return `${HEADER}\n\n${lines.join('\n')}`;
+}
+
+/** Names-only fallback that drops trailing entries if the list still exceeds budget. */
+function fitNamesOnly(
+  entries: { name: string }[],
+  budgetChars: number
+): string {
+  const namesOnly = entries.map((s) => ({ name: s.name, description: '' }));
+  const full = formatEntries(namesOnly);
+  if (full.length <= budgetChars) return full;
+
+  for (let count = namesOnly.length - 1; count > 0; count--) {
+    const trimmed = formatEntries(namesOnly.slice(0, count));
+    if (trimmed.length <= budgetChars) return trimmed;
+  }
+  return '';
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@
 export * from './graph';
 export * from './llm';
 export * from './run';
+export * from './skill';
 export * from './stream';
 export * from './tools';
 export * from './summarize';

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -1,0 +1,11 @@
+// src/types/skill.ts
+
+/** Minimal skill metadata for catalog assembly. The host provides these from its own data layer. */
+export type SkillCatalogEntry = {
+  /** Kebab-case identifier (what the model passes to SkillTool) */
+  name: string;
+  /** One-line description for the catalog listing */
+  description: string;
+  /** Optional human-readable label (UI only, not shown to model) */
+  displayTitle?: string;
+};

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -3,7 +3,7 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { HookRegistry } from '@/hooks';
-import type { ToolErrorData } from './stream';
+import type { MessageContentComplex, ToolErrorData } from './stream';
 import { EnvVar } from '@/common';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
@@ -193,6 +193,26 @@ export type ToolExecuteBatchRequest = {
   reject: (error: Error) => void;
 };
 
+/**
+ * A message injected into graph state by any tool execution handler.
+ * Generic mechanism: any tool returning `injectedMessages` in its `ToolExecuteResult`
+ * will have these appended to state after the ToolMessage for this call.
+ */
+export type InjectedMessage = {
+  /** 'user' for skill body injection, 'system' for context hints.
+   *  Both are converted to HumanMessage at runtime; the original role
+   *  is preserved in additional_kwargs.role. */
+  role: 'user' | 'system';
+  /** Message content: string for simple text, array for complex multi-part content */
+  content: string | MessageContentComplex[];
+  /** When true, the message is framework-internal: not shown in UI, not counted as a user turn */
+  isMeta?: boolean;
+  /** Origin tag for downstream consumers (UI, pruner, compaction) */
+  source?: 'skill' | 'hook' | 'system';
+  /** Only set when source is 'skill', for compaction preservation */
+  skillName?: string;
+};
+
 /** Result for a single tool call in event-driven execution */
 export type ToolExecuteResult = {
   /** Matches ToolCallRequest.id */
@@ -205,6 +225,13 @@ export type ToolExecuteResult = {
   status: 'success' | 'error';
   /** Error message if status is 'error' */
   errorMessage?: string;
+  /**
+   * Messages to inject into graph state after the ToolMessage for this call.
+   * Placed after tool results to respect provider message ordering (tool_call -> tool_result adjacency).
+   * The host's message formatter may merge injected user messages with the preceding tool_result turn.
+   * Generic mechanism: any tool execution handler can use this.
+   */
+  injectedMessages?: InjectedMessage[];
 };
 
 /** Map of tool names to tool definitions */


### PR DESCRIPTION
Supersedes #89 (rebased on hooks PRs #88, #90 to resolve conflicts).

## Summary

- **Phase 1**: `SkillTool` definition (JSON Schema, `createSkillTool()` factory), generic `injectedMessages` mechanism on `ToolExecuteResult`, and ToolNode plumbing that converts `InjectedMessage[]` to `HumanMessage` entries appended after `ToolMessage` results. Integrates cleanly with the hooks-based `dispatchToolEvents` from #90.
- **Phase 2**: `formatSkillCatalog()` budget-aware formatter with truncation ladder.

### New files
| File | Purpose |
|------|---------|
| `src/types/skill.ts` | `SkillCatalogEntry` type |
| `src/tools/SkillTool.ts` | JSON Schema, LCTool definition, `createSkillTool()` |
| `src/tools/skillCatalog.ts` | `formatSkillCatalog()` pure function |
| `src/tools/__tests__/SkillTool.test.ts` | 18 tests |
| `src/tools/__tests__/skillCatalog.test.ts` | 12 tests |

### Modified files
| File | Change |
|------|--------|
| `src/common/enum.ts` | `Constants.SKILL_TOOL = 'skill'` |
| `src/types/tools.ts` | `InjectedMessage` type + `ToolExecuteResult.injectedMessages` |
| `src/tools/ToolNode.ts` | `convertInjectedMessages()`, `dispatchToolEvents` returns `{ toolMessages, injected }`, error isolation via try/catch |
| `src/types/index.ts` | Re-export `./skill` |
| `src/index.ts` | Export `SkillTool` + `skillCatalog` |

### Design decisions
- `injectedMessages` is generic (any tool can use it)
- Both `role: 'user'` and `role: 'system'` become `HumanMessage` (avoids Anthropic/Google provider rejections). Original role preserved in `additional_kwargs.role`.
- Injected messages placed AFTER ToolMessages (respects provider ordering)
- `SkillToolDescription` is runtime-agnostic ("may become accessible")
- `SkillToolSchema` is single JSON Schema source of truth
- Budget-aware catalog: 1% of context, 250 chars/entry, newline-aware, final length guard
- `fitNamesOnly` drops trailing entries when even names exceed budget
- Error isolation: try/catch around `convertInjectedMessages` per result
- Zero new runtime dependencies

## Test plan
- [x] `npx jest src/tools/__tests__/SkillTool --verbose` — 18 tests pass
- [x] `npx jest src/tools/__tests__/skillCatalog --verbose` — 12 tests pass
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx eslint` on all files — zero errors
- [x] Existing `ToolNode.session.test.ts` passes (no regressions)