### PR TITLE
🔍 fix: Preserve Anthropic `server_tool_use` block types

### DIFF
--- a/src/llm/anthropic/types.ts
+++ b/src/llm/anthropic/types.ts
@@ -6,7 +6,7 @@ export type AnthropicMessageDeltaEvent = Anthropic.MessageDeltaEvent;
 export type AnthropicMessageStartEvent = Anthropic.MessageStartEvent;
 
 export type AnthropicToolResponse = {
-  type: 'tool_use';
+  type: 'tool_use' | 'server_tool_use';
   id: string;
   name: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -696,9 +696,38 @@ export function _convertMessagesToAnthropicPayload(
     }
   });
   return {
-    messages: mergeMessages(formattedMessages),
+    messages: _fixServerToolBlocks(mergeMessages(formattedMessages)),
     system,
   } as AnthropicMessageCreateParams;
+}
+
+/**
+ * Final-pass sanitizer: corrects any `tool_use` blocks whose `id` starts with
+ * `srvtoolu_` back to `server_tool_use`. This runs on the fully-formatted
+ * messages array as a catch-all — regardless of which code-path produced the
+ * wrong type (chunk concatenation, state deserialization, etc.).
+ */
+function _fixServerToolBlocks(
+  messages: AnthropicMessageCreateParams['messages']
+): AnthropicMessageCreateParams['messages'] {
+  for (const msg of messages) {
+    if (msg.role !== 'assistant' || typeof msg.content === 'string') {
+      continue;
+    }
+    for (let i = 0; i < msg.content.length; i++) {
+      const block = msg.content[i];
+      if (
+        block.type === 'tool_use' &&
+        'id' in block &&
+        typeof block.id === 'string' &&
+        block.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+      ) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (block as any).type = 'server_tool_use';
+      }
+    }
+  }
+  return messages;
 }
 
 function mergeMessages(messages: AnthropicMessageCreateParams['messages']) {

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -540,6 +540,15 @@ function _formatContent(message: BaseMessage) {
           contentPartCopy.type = 'tool_use';
         }
 
+        if (
+          contentPartCopy.type === 'tool_use' &&
+          'id' in contentPartCopy &&
+          typeof contentPartCopy.id === 'string' &&
+          contentPartCopy.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+        ) {
+          contentPartCopy.type = 'server_tool_use';
+        }
+
         if ('input' in contentPartCopy) {
           // Anthropic tool use inputs should be valid objects, when applicable.
           if (typeof contentPartCopy.input === 'string') {
@@ -631,19 +640,26 @@ export function _convertMessagesToAnthropicPayload(
     }
     if (isAIMessage(message) && !!message.tool_calls?.length) {
       if (typeof message.content === 'string') {
+        const clientToolCalls = message.tool_calls.filter(
+          (tc) =>
+            !(
+              tc.id?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) ?? false
+            )
+        );
         if (message.content === '') {
           return {
             role,
-            content: message.tool_calls.map(
-              _convertLangChainToolCallToAnthropic
-            ),
+            content:
+              clientToolCalls.length > 0
+                ? clientToolCalls.map(_convertLangChainToolCallToAnthropic)
+                : [{ type: 'text' as const, text: '' }],
           };
         } else {
           return {
             role,
             content: [
-              { type: 'text', text: message.content },
-              ...message.tool_calls.map(_convertLangChainToolCallToAnthropic),
+              { type: 'text' as const, text: message.content },
+              ...clientToolCalls.map(_convertLangChainToolCallToAnthropic),
             ],
           };
         }

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -648,6 +648,23 @@ export function _convertMessagesToAnthropicPayload(
       throw new Error(`Message type "${message._getType()}" is not supported.`);
     }
     if (isAIMessage(message) && !!message.tool_calls?.length) {
+      const hasServerToolCalls = message.tool_calls.some(
+        (tc) =>
+          tc.id?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) ?? false
+      );
+      if (hasServerToolCalls) {
+        const contentTypes = Array.isArray(message.content)
+          ? (message.content as Array<{ type?: string }>).map(
+            (b) => b.type ?? '?'
+          )
+          : [`string(${(message.content as string).length})`];
+        console.warn(
+          '[server-tool-debug] AI message with srvtoolu_ calls:',
+          `contentIsString=${typeof message.content === 'string'}`,
+          `tool_calls=${message.tool_calls.length}`,
+          `contentTypes=${JSON.stringify(contentTypes)}`
+        );
+      }
       if (typeof message.content === 'string') {
         const clientToolCalls = message.tool_calls.filter(
           (tc) =>
@@ -656,11 +673,12 @@ export function _convertMessagesToAnthropicPayload(
             )
         );
         if (message.content === '') {
-          const callsToConvert =
-            clientToolCalls.length > 0 ? clientToolCalls : message.tool_calls;
           return {
             role,
-            content: callsToConvert.map(_convertLangChainToolCallToAnthropic),
+            content:
+              clientToolCalls.length > 0
+                ? clientToolCalls.map(_convertLangChainToolCallToAnthropic)
+                : [{ type: 'text' as const, text: ' ' }],
           };
         } else {
           return {

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -366,10 +366,76 @@ function _formatContent(message: BaseMessage) {
   } else {
     const contentBlocks = content.map((contentPart) => {
       /**
-       * Handle malformed blocks that have server tool fields mixed with text type.
-       * These can occur when server_tool_use blocks get mislabeled during aggregation.
-       * Correct their type ONLY if we can confirm it's a server tool by checking the ID prefix.
-       * Anthropic needs both server_tool_use and web_search_tool_result blocks for citations to work.
+       * Normalize server_tool_use blocks into a clean shape the API accepts.
+       * These blocks may arrive with the correct type (server_tool_use) or mislabeled
+       * as text/tool_use after chunk concatenation or state serialization.
+       * Regardless of current type, if the id starts with 'srvtoolu_' we rebuild
+       * a clean block with only the properties the API expects.
+       */
+      if (
+        'id' in contentPart &&
+        typeof (contentPart as Record<string, unknown>).id === 'string' &&
+        ((contentPart as Record<string, unknown>).id as string).startsWith(
+          Constants.ANTHROPIC_SERVER_TOOL_PREFIX
+        ) &&
+        'name' in contentPart
+      ) {
+        const rawPart = contentPart as Record<string, unknown>;
+        let input = rawPart.input;
+        if (typeof input === 'string') {
+          try {
+            input = JSON.parse(input);
+          } catch {
+            input = {};
+          }
+        }
+        const corrected: AnthropicServerToolUseBlockParam = {
+          type: 'server_tool_use',
+          id: rawPart.id as string,
+          name: (rawPart.name ?? 'web_search') as 'web_search',
+          input: (input ?? {}) as Record<string, unknown>,
+        };
+        return corrected;
+      }
+
+      /**
+       * Normalize web_search_tool_result blocks into a clean shape.
+       * Same rationale as above — the block may carry extra properties from
+       * streaming (input, index, etc.) that the API rejects. Rebuild cleanly.
+       */
+      if (
+        'tool_use_id' in contentPart &&
+        typeof (contentPart as Record<string, unknown>).tool_use_id ===
+          'string' &&
+        (
+          (contentPart as Record<string, unknown>).tool_use_id as string
+        ).startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) &&
+        'content' in contentPart
+      ) {
+        const rawPart = contentPart as Record<string, unknown>;
+        const content = rawPart.content;
+        const isValidContent =
+          Array.isArray(content) ||
+          (content != null &&
+            typeof content === 'object' &&
+            'type' in content &&
+            (content as Record<string, unknown>).type ===
+              'web_search_tool_result_error');
+
+        if (isValidContent) {
+          const corrected: AnthropicWebSearchToolResultBlockParam = {
+            type: 'web_search_tool_result',
+            tool_use_id: rawPart.tool_use_id as string,
+            content:
+              content as AnthropicWebSearchToolResultBlockParam['content'],
+          };
+          return corrected;
+        }
+        return null;
+      }
+
+      /**
+       * Skip non-server malformed blocks that have tool fields mixed with text type.
        */
       if (
         'id' in contentPart &&
@@ -377,76 +443,13 @@ function _formatContent(message: BaseMessage) {
         'input' in contentPart &&
         contentPart.type === 'text'
       ) {
-        const rawPart = contentPart as Record<string, unknown>;
-        const id = rawPart.id as string;
-
-        if (id && id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)) {
-          let input = rawPart.input;
-
-          // Ensure input is an object
-          if (typeof input === 'string') {
-            try {
-              input = JSON.parse(input);
-            } catch {
-              input = {};
-            }
-          }
-
-          const corrected: AnthropicServerToolUseBlockParam = {
-            type: 'server_tool_use',
-            id,
-            name: 'web_search',
-            input: input as Record<string, unknown>,
-          };
-
-          return corrected;
-        }
-
-        // If it's not a server tool, skip it (return null to filter it out)
         return null;
       }
-
-      /**
-       * Handle malformed web_search_tool_result blocks marked as text.
-       * These have tool_use_id and nested content - fix their type instead of filtering.
-       * Only correct if we can confirm it's a web search result by checking the tool_use_id prefix.
-       *
-       * Handles both success results (array content) and error results (object with error_code).
-       */
       if (
         'tool_use_id' in contentPart &&
         'content' in contentPart &&
         contentPart.type === 'text'
       ) {
-        const rawPart = contentPart as Record<string, unknown>;
-        const toolUseId = rawPart.tool_use_id as string;
-        const content = rawPart.content;
-
-        if (
-          toolUseId &&
-          toolUseId.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
-        ) {
-          // Verify content is either an array (success) or error object
-          const isValidContent =
-            Array.isArray(content) ||
-            (content != null &&
-              typeof content === 'object' &&
-              'type' in content &&
-              (content as Record<string, unknown>).type ===
-                'web_search_tool_result_error');
-
-          if (isValidContent) {
-            const corrected: AnthropicWebSearchToolResultBlockParam = {
-              type: 'web_search_tool_result',
-              tool_use_id: toolUseId,
-              content:
-                content as AnthropicWebSearchToolResultBlockParam['content'],
-            };
-            return corrected;
-          }
-        }
-
-        // If it's not a recognized server tool result format, skip it (return null to filter it out)
         return null;
       }
 

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -603,7 +603,11 @@ function _formatContent(message: BaseMessage) {
         throw new Error('Unsupported message content format');
       }
     });
-    return contentBlocks.filter((block) => block !== null);
+    return contentBlocks.filter(
+      (block) =>
+        block !== null &&
+        !(block.type === 'text' && 'text' in block && block.text === '')
+    );
   }
 }
 
@@ -647,12 +651,11 @@ export function _convertMessagesToAnthropicPayload(
             )
         );
         if (message.content === '') {
+          const callsToConvert =
+            clientToolCalls.length > 0 ? clientToolCalls : message.tool_calls;
           return {
             role,
-            content:
-              clientToolCalls.length > 0
-                ? clientToolCalls.map(_convertLangChainToolCallToAnthropic)
-                : [{ type: 'text' as const, text: '' }],
+            content: callsToConvert.map(_convertLangChainToolCallToAnthropic),
           };
         } else {
           return {

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -648,23 +648,6 @@ export function _convertMessagesToAnthropicPayload(
       throw new Error(`Message type "${message._getType()}" is not supported.`);
     }
     if (isAIMessage(message) && !!message.tool_calls?.length) {
-      const hasServerToolCalls = message.tool_calls.some(
-        (tc) =>
-          tc.id?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) ?? false
-      );
-      if (hasServerToolCalls) {
-        const contentTypes = Array.isArray(message.content)
-          ? (message.content as Array<{ type?: string }>).map(
-            (b) => b.type ?? '?'
-          )
-          : [`string(${(message.content as string).length})`];
-        console.warn(
-          '[server-tool-debug] AI message with srvtoolu_ calls:',
-          `contentIsString=${typeof message.content === 'string'}`,
-          `tool_calls=${message.tool_calls.length}`,
-          `contentTypes=${JSON.stringify(contentTypes)}`
-        );
-      }
       if (typeof message.content === 'string') {
         const clientToolCalls = message.tool_calls.filter(
           (tc) =>

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -144,7 +144,9 @@ export function _convertLangChainToolCallToAnthropic(
     throw new Error('Anthropic requires all tool calls to have an "id".');
   }
   return {
-    type: 'tool_use',
+    type: toolCall.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+      ? 'server_tool_use'
+      : 'tool_use',
     id: toolCall.id,
     name: toolCall.name,
     input: toolCall.args,
@@ -696,38 +698,9 @@ export function _convertMessagesToAnthropicPayload(
     }
   });
   return {
-    messages: _fixServerToolBlocks(mergeMessages(formattedMessages)),
+    messages: mergeMessages(formattedMessages),
     system,
   } as AnthropicMessageCreateParams;
-}
-
-/**
- * Final-pass sanitizer: corrects any `tool_use` blocks whose `id` starts with
- * `srvtoolu_` back to `server_tool_use`. This runs on the fully-formatted
- * messages array as a catch-all — regardless of which code-path produced the
- * wrong type (chunk concatenation, state deserialization, etc.).
- */
-function _fixServerToolBlocks(
-  messages: AnthropicMessageCreateParams['messages']
-): AnthropicMessageCreateParams['messages'] {
-  for (const msg of messages) {
-    if (msg.role !== 'assistant' || typeof msg.content === 'string') {
-      continue;
-    }
-    for (let i = 0; i < msg.content.length; i++) {
-      const block = msg.content[i];
-      if (
-        block.type === 'tool_use' &&
-        'id' in block &&
-        typeof block.id === 'string' &&
-        block.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
-      ) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (block as any).type = 'server_tool_use';
-      }
-    }
-  }
-  return messages;
 }
 
 function mergeMessages(messages: AnthropicMessageCreateParams['messages']) {

--- a/src/llm/anthropic/utils/server-tool-inputs.test.ts
+++ b/src/llm/anthropic/utils/server-tool-inputs.test.ts
@@ -204,7 +204,8 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
     const assistantContent = messages[1].content as any[];
     expect(assistantContent).toHaveLength(1);
-    expect(assistantContent[0]).toEqual({ type: 'text', text: '' });
+    expect(assistantContent[0].type).toBe('tool_use');
+    expect(assistantContent[0].id).toBe('srvtoolu_1');
   });
 
   it('preserves regular tool_use blocks alongside corrected server tool blocks', () => {
@@ -279,5 +280,58 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     expect(webSearchResult).toHaveLength(1);
     expect(regularToolUse).toHaveLength(1);
     expect(regularToolUse[0].id).toBe('toolu_calc');
+  });
+
+  it('filters out empty text blocks from array content', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('search for X'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: '' },
+          {
+            type: 'server_tool_use',
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            input: { query: 'X' },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_1',
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com',
+                title: 'Result',
+                encrypted_content: 'abc',
+                page_age: '1d',
+              },
+            ],
+          },
+          { type: 'text', text: '' },
+          { type: 'text', text: 'Here are the results.' },
+        ],
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'X' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new HumanMessage('follow up'),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    const assistantContent = messages[1].content as any[];
+
+    const emptyTextBlocks = assistantContent.filter(
+      (b: any) => b.type === 'text' && b.text === ''
+    );
+    expect(emptyTextBlocks).toHaveLength(0);
+
+    const textBlocks = assistantContent.filter((b: any) => b.type === 'text');
+    expect(textBlocks).toHaveLength(1);
+    expect(textBlocks[0].text).toBe('Here are the results.');
   });
 });

--- a/src/llm/anthropic/utils/server-tool-inputs.test.ts
+++ b/src/llm/anthropic/utils/server-tool-inputs.test.ts
@@ -85,6 +85,18 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     expect(serverToolBlocks).toHaveLength(2);
     expect(searchResultBlocks).toHaveLength(2);
     expect(regularToolUseBlocks).toHaveLength(0);
+
+    // Verify blocks are clean (no extra streaming properties)
+    for (const b of serverToolBlocks) {
+      expect(Object.keys(b).sort()).toEqual(
+        ['id', 'input', 'name', 'type'].sort()
+      );
+    }
+    for (const b of searchResultBlocks) {
+      expect(Object.keys(b).sort()).toEqual(
+        ['content', 'tool_use_id', 'type'].sort()
+      );
+    }
   });
 
   it('corrects text-typed server tool blocks back to correct types', () => {

--- a/src/llm/anthropic/utils/server-tool-inputs.test.ts
+++ b/src/llm/anthropic/utils/server-tool-inputs.test.ts
@@ -204,7 +204,7 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
     const assistantContent = messages[1].content as any[];
     expect(assistantContent).toHaveLength(1);
-    expect(assistantContent[0].type).toBe('tool_use');
+    expect(assistantContent[0].type).toBe('server_tool_use');
     expect(assistantContent[0].id).toBe('srvtoolu_1');
   });
 

--- a/src/llm/anthropic/utils/server-tool-inputs.test.ts
+++ b/src/llm/anthropic/utils/server-tool-inputs.test.ts
@@ -1,0 +1,283 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { _convertMessagesToAnthropicPayload } from './message_inputs';
+
+describe('_convertMessagesToAnthropicPayload — server tool use (web search) multi-turn', () => {
+  it('corrects tool_use blocks with srvtoolu_ IDs to server_tool_use', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('search for X and Y'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'I will search for that.' },
+          {
+            type: 'tool_use',
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            input: { query: 'X' },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_1',
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com',
+                title: 'Result',
+                encrypted_content: 'abc',
+                page_age: '1d',
+              },
+            ],
+          },
+          {
+            type: 'tool_use',
+            id: 'srvtoolu_2',
+            name: 'web_search',
+            input: { query: 'Y' },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_2',
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example2.com',
+                title: 'Result 2',
+                encrypted_content: 'def',
+                page_age: '2d',
+              },
+            ],
+          },
+          { type: 'text', text: 'Here are the results.' },
+        ],
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'X' },
+            type: 'tool_call',
+          },
+          {
+            id: 'srvtoolu_2',
+            name: 'web_search',
+            args: { query: 'Y' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new HumanMessage('follow up question'),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    expect(messages).toHaveLength(3);
+
+    const assistantContent = messages[1].content as any[];
+    const serverToolBlocks = assistantContent.filter(
+      (b: any) => b.type === 'server_tool_use'
+    );
+    const searchResultBlocks = assistantContent.filter(
+      (b: any) => b.type === 'web_search_tool_result'
+    );
+    const regularToolUseBlocks = assistantContent.filter(
+      (b: any) => b.type === 'tool_use' && b.id?.startsWith('srvtoolu_')
+    );
+
+    expect(serverToolBlocks).toHaveLength(2);
+    expect(searchResultBlocks).toHaveLength(2);
+    expect(regularToolUseBlocks).toHaveLength(0);
+  });
+
+  it('corrects text-typed server tool blocks back to correct types', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('search for X'),
+      new AIMessage({
+        content: [
+          {
+            type: 'text',
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            input: '{"query":"X"}',
+          },
+          {
+            type: 'text',
+            tool_use_id: 'srvtoolu_1',
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com',
+                title: 'Result',
+                encrypted_content: 'abc',
+                page_age: '1d',
+              },
+            ],
+          },
+          { type: 'text', text: 'Found results.' },
+        ],
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'X' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new HumanMessage('follow up'),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    const assistantContent = messages[1].content as any[];
+
+    expect(assistantContent[0]).toEqual({
+      type: 'server_tool_use',
+      id: 'srvtoolu_1',
+      name: 'web_search',
+      input: { query: 'X' },
+    });
+    expect(assistantContent[1].type).toBe('web_search_tool_result');
+    expect(assistantContent[1].tool_use_id).toBe('srvtoolu_1');
+    expect(assistantContent[2]).toEqual({
+      type: 'text',
+      text: 'Found results.',
+    });
+  });
+
+  it('filters server tool calls when content is a string', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('search for X'),
+      new AIMessage({
+        content: 'I searched and found results.',
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'X' },
+            type: 'tool_call',
+          },
+          {
+            id: 'toolu_regular',
+            name: 'calculator',
+            args: { expr: '2+2' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: '4',
+        tool_call_id: 'toolu_regular',
+      }),
+      new HumanMessage('follow up'),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    const assistantContent = messages[1].content as any[];
+
+    const toolUseBlocks = assistantContent.filter(
+      (b: any) => b.type === 'tool_use'
+    );
+    expect(toolUseBlocks).toHaveLength(1);
+    expect(toolUseBlocks[0].id).toBe('toolu_regular');
+
+    const serverToolBlocks = assistantContent.filter((b: any) =>
+      b.id?.startsWith('srvtoolu_')
+    );
+    expect(serverToolBlocks).toHaveLength(0);
+  });
+
+  it('handles empty string content with only server tool calls', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('search for X'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'X' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new HumanMessage('follow up'),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    const assistantContent = messages[1].content as any[];
+    expect(assistantContent).toHaveLength(1);
+    expect(assistantContent[0]).toEqual({ type: 'text', text: '' });
+  });
+
+  it('preserves regular tool_use blocks alongside corrected server tool blocks', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('search for X and calculate 2+2'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Let me help.' },
+          {
+            type: 'tool_use',
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            input: { query: 'X' },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_1',
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com',
+                title: 'Result',
+                encrypted_content: 'abc',
+                page_age: '1d',
+              },
+            ],
+          },
+          {
+            type: 'tool_use',
+            id: 'toolu_calc',
+            name: 'calculator',
+            input: { expr: '2+2' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'X' },
+            type: 'tool_call',
+          },
+          {
+            id: 'toolu_calc',
+            name: 'calculator',
+            args: { expr: '2+2' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: '4',
+        tool_call_id: 'toolu_calc',
+      }),
+      new HumanMessage('follow up'),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    const assistantContent = messages[1].content as any[];
+
+    const serverToolUse = assistantContent.filter(
+      (b: any) => b.type === 'server_tool_use'
+    );
+    const webSearchResult = assistantContent.filter(
+      (b: any) => b.type === 'web_search_tool_result'
+    );
+    const regularToolUse = assistantContent.filter(
+      (b: any) => b.type === 'tool_use' && !b.id?.startsWith('srvtoolu_')
+    );
+
+    expect(serverToolUse).toHaveLength(1);
+    expect(serverToolUse[0].id).toBe('srvtoolu_1');
+    expect(webSearchResult).toHaveLength(1);
+    expect(regularToolUse).toHaveLength(1);
+    expect(regularToolUse[0].id).toBe('toolu_calc');
+  });
+});

--- a/src/llm/anthropic/utils/server-tool-inputs.test.ts
+++ b/src/llm/anthropic/utils/server-tool-inputs.test.ts
@@ -216,8 +216,8 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
     const assistantContent = messages[1].content as any[];
     expect(assistantContent).toHaveLength(1);
-    expect(assistantContent[0].type).toBe('server_tool_use');
-    expect(assistantContent[0].id).toBe('srvtoolu_1');
+    expect(assistantContent[0].type).toBe('text');
+    expect(assistantContent[0].text).toBe(' ');
   });
 
   it('preserves regular tool_use blocks alongside corrected server tool blocks', () => {

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -41,7 +41,14 @@ User: ${userMessage[1]}
 const _allowedTypes = ['image_url', 'text', 'tool_use', 'tool_result'];
 const allowedTypesByProvider: Record<string, string[]> = {
   default: _allowedTypes,
-  [Providers.ANTHROPIC]: [..._allowedTypes, 'thinking', 'redacted_thinking'],
+  [Providers.ANTHROPIC]: [
+    ..._allowedTypes,
+    'thinking',
+    'redacted_thinking',
+    'server_tool_use',
+    'web_search_tool_result',
+    'web_search_result',
+  ],
   [Providers.BEDROCK]: [..._allowedTypes, 'reasoning_content'],
   [Providers.OPENAI]: _allowedTypes,
 };


### PR DESCRIPTION
## Summary
- Server tool blocks (`web_search` with `srvtoolu_` IDs) were losing their `server_tool_use` type through the message pipeline during multi-turn conversations, becoming regular `tool_use` blocks
- On the second turn, the Anthropic API rejected the request because `tool_use` requires a matching `tool_result` block, but server tools use inline `web_search_tool_result` instead
- This only reproduced when the first run had multiple web searches via the official Anthropic API (not Azure)

## Root Cause
Three places in the pipeline could degrade `server_tool_use` → `tool_use`:
1. **`modifyDeltaProperties`** (`core.ts`): The Anthropic allowed-types list was missing `server_tool_use`/`web_search_tool_result`/`web_search_result`, causing them to be converted to `text`
2. **`_formatContent`** (`message_inputs.ts`): After LangChain's `concat()` merges `server_tool_use` + `input_json_delta` by index, the type becomes `input_json_delta` → then gets normalized to `tool_use` — but was never corrected back to `server_tool_use`
3. **String content path** (`message_inputs.ts`): When `message.content` is a string, all `tool_calls` (including `srvtoolu_` ones) were converted to `tool_use` blocks with no matching result

## Changes
- **`src/messages/core.ts`**: Add `server_tool_use`, `web_search_tool_result`, `web_search_result` to Anthropic allowed types
- **`src/llm/anthropic/utils/message_inputs.ts`**: Correct `tool_use` blocks with `srvtoolu_` IDs back to `server_tool_use`; filter server tool calls from string content path
- **`src/llm/anthropic/utils/server-tool-inputs.test.ts`**: 5 tests covering all fix scenarios

## Test plan
- [x] `npx jest server-tool-inputs` — 5 new tests pass
- [x] `npx jest prune` — 48 existing tests pass  
- [x] `npx jest content.test` — 14 existing tests pass
- [x] `npx tsc --noEmit` — clean

Closes danny-avila/LibreChat#12576