### PR TITLE
feat: add SKILL_TOOL to ToolNode session storage and context

### DIFF
--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -342,7 +342,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         request?.name !== Constants.EXECUTE_CODE &&
         request?.name !== Constants.BASH_TOOL &&
         request?.name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
-        request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+        request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING &&
+        request?.name !== Constants.SKILL_TOOL
       ) {
         continue;
       }
@@ -624,7 +625,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           entry.call.name === Constants.EXECUTE_CODE ||
           entry.call.name === Constants.BASH_TOOL ||
           entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-          entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+          entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING ||
+          entry.call.name === Constants.SKILL_TOOL
         ) {
           request.codeSessionContext = this.getCodeSessionContext();
         }


### PR DESCRIPTION
When the skill handler uploads files to the code env and returns \`artifact: { session_id, files }\`, ToolNode now stores that session context via \`storeCodeSessionFromResults\`. This makes skill-primed files available to subsequent bash/code tool calls in the same run.

Also adds \`SKILL_TOOL\` to the \`codeSessionContext\` request building in \`dispatchToolEvents\`, so the handler receives the current session context and can check if files are already uploaded.

**Changes:**
- \`storeCodeSessionFromResults\`: add \`Constants.SKILL_TOOL\` to the name check
- \`dispatchToolEvents\` request building: add \`Constants.SKILL_TOOL\` to the \`codeSessionContext\` attachment check