### PR TITLE
feat: initialSessions on RunConfig + CODE_EXECUTION_TOOLS DRY helper

### DIFF
--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -187,6 +187,14 @@ export enum Constants {
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
 }
 
+/** Tool names that use the code execution environment (shared session, file tracking). */
+export const CODE_EXECUTION_TOOLS: ReadonlySet<string> = new Set([
+  Constants.EXECUTE_CODE,
+  Constants.BASH_TOOL,
+  Constants.PROGRAMMATIC_TOOL_CALLING,
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+]);
+
 export enum TitleMethod {
   STRUCTURED = 'structured',
   FUNCTIONS = 'functions',

--- a/src/run.ts
+++ b/src/run.ts
@@ -99,6 +99,12 @@ export class Run<_T extends t.BaseGraphState> {
       }
     }
 
+    if (config.initialSessions && this.Graph) {
+      for (const [key, value] of config.initialSessions) {
+        this.Graph.sessions.set(key, value);
+      }
+    }
+
     this.returnContent = config.returnContent ?? false;
     this.skipCleanup = config.skipCleanup ?? false;
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -28,7 +28,7 @@ import {
 } from '@/utils/truncation';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { executeHooks } from '@/hooks';
-import { Constants, GraphEvents } from '@/common';
+import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 
 /**
  * Helper to check if a value is a Send object
@@ -190,12 +190,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * session_id is always injected when available (even without tracked files)
        * so the CodeExecutor can fall back to the /files endpoint for session continuity.
        */
-      if (
-        call.name === Constants.EXECUTE_CODE ||
-        call.name === Constants.BASH_TOOL ||
-        call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-        call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
-      ) {
+      if (CODE_EXECUTION_TOOLS.has(call.name)) {
         const codeSession = this.sessions?.get(Constants.EXECUTE_CODE) as
           | t.CodeSessionContext
           | undefined;
@@ -338,13 +333,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const request = requests.find((r) => r.id === result.toolCallId);
-      if (
-        request?.name !== Constants.EXECUTE_CODE &&
-        request?.name !== Constants.BASH_TOOL &&
-        request?.name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
-        request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING &&
-        request?.name !== Constants.SKILL_TOOL
-      ) {
+      if (!request?.name || (!CODE_EXECUTION_TOOLS.has(request.name) && request.name !== Constants.SKILL_TOOL)) {
         continue;
       }
 
@@ -418,13 +407,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       // Store code session context from tool results
-      if (
-        this.sessions &&
-        (call.name === Constants.EXECUTE_CODE ||
-          call.name === Constants.BASH_TOOL ||
-          call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-          call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
-      ) {
+      if (this.sessions && CODE_EXECUTION_TOOLS.has(call.name)) {
         const artifact = toolMessage.artifact as
           | t.CodeExecutionArtifact
           | undefined;
@@ -621,13 +604,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           turn,
         };
 
-        if (
-          entry.call.name === Constants.EXECUTE_CODE ||
-          entry.call.name === Constants.BASH_TOOL ||
-          entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-          entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING ||
-          entry.call.name === Constants.SKILL_TOOL
-        ) {
+        if (CODE_EXECUTION_TOOLS.has(entry.call.name) || entry.call.name === Constants.SKILL_TOOL) {
           request.codeSessionContext = this.getCodeSessionContext();
         }
 

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -11,6 +11,7 @@ import type * as s from '@/types/stream';
 import type * as e from '@/common/enum';
 import type * as g from '@/types/graph';
 import type * as l from '@/types/llm';
+import type { ToolSessionMap } from '@/types/tools';
 import type { HookRegistry } from '@/hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -138,6 +139,12 @@ export type RunConfig = {
   calibrationRatio?: number;
   /** Skip post-stream cleanup (clearHeavyState) — useful for tests that inspect graph state after processStream */
   skipCleanup?: boolean;
+  /**
+   * Initial session state to seed the Graph's ToolSessionMap.
+   * Used to carry over code environment sessions from skill file priming
+   * at run start, so ToolNode can inject session_id + files into tool calls.
+   */
+  initialSessions?: ToolSessionMap;
 };
 
 export type ProvidedCallbacks =


### PR DESCRIPTION
Follow-up to #94 (merged). Two changes on the same branch:

**1. `initialSessions` on RunConfig** (`f42f014`)
- New `RunConfig.initialSessions?: ToolSessionMap` field
- Run constructor seeds `Graph.sessions` from it
- Enables hosts to carry over code env sessions from skill file priming at run start

**2. `CODE_EXECUTION_TOOLS` set** (`f00963d`)
- New `ReadonlySet<string>` in `common/enum.ts` with all 4 code execution tool constants
- Replaces 5 repeated inline 4-constant checks in ToolNode with `.has()`
- Exported for host consumption (LibreChat uses it in handlers.ts and callbacks.js)