### PR TITLE
fix: skill body reconstruction token distribution + review fixes

### DIFF
--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -797,12 +797,29 @@ function contentPartCharLength(part: MessageContentComplex): number {
   return len;
 }
 
+/** Extracts the skillName from a skill tool_call's args (string or object). */
+function extractSkillName(args: unknown): string | undefined {
+  let parsed: Record<string, unknown> | undefined;
+  if (typeof args === 'string') {
+    try {
+      parsed = JSON.parse(args) as Record<string, unknown>;
+    } catch {
+      /* malformed args — skip */
+    }
+  } else {
+    parsed = args as Record<string, unknown> | undefined;
+  }
+  const name = parsed?.skillName;
+  return typeof name === 'string' && name !== '' ? name : undefined;
+}
+
 /**
  * Formats an array of messages for LangChain, handling tool calls and creating ToolMessage instances.
  *
  * @param payload - The array of messages to format.
  * @param indexTokenCountMap - Optional map of message indices to token counts.
  * @param tools - Optional set of tool names that are allowed in the request.
+ * @param skills - Optional map of skill name to body for reconstructing skill HumanMessages.
  * @returns - Object containing formatted messages and updated indexTokenCountMap if provided.
  */
 export const formatAgentMessages = (
@@ -906,7 +923,7 @@ export const formatAgentMessages = (
      * - Dynamically expand the set when tool_search results are encountered
      */
     let processedMessage = message;
-    const pendingSkillBodies: string[] = [];
+    let pendingSkillNames: Set<string> | undefined;
     if (discoveredTools) {
       const content = message.content;
       if (content != null && Array.isArray(content)) {
@@ -954,29 +971,14 @@ export const formatAgentMessages = (
             }
           }
 
-          if (discoveredTools?.has(toolName)) {
-            /** Valid tool - keep it */
+          if (discoveredTools.has(toolName)) {
             filteredContent.push(part);
-            /** Collect invoked skill names for body reconstruction (only for allowed calls) */
             if (toolName === Constants.SKILL_TOOL && skills?.size) {
-              const rawArgs = part.tool_call.args;
-              const parsedArgs =
-                typeof rawArgs === 'string'
-                  ? (() => {
-                    try {
-                      return JSON.parse(rawArgs) as Record<string, unknown>;
-                    } catch {
-                      return {};
-                    }
-                  })()
-                  : rawArgs;
-              const sn = parsedArgs?.skillName;
-              if (typeof sn === 'string' && sn !== '') {
-                pendingSkillBodies.push(sn);
+              const skillName = extractSkillName(part.tool_call.args);
+              if (skillName) {
+                (pendingSkillNames ??= new Set()).add(skillName);
               }
             }
-          } else if (!discoveredTools) {
-            filteredContent.push(part);
           } else {
             /** Invalid tool - convert to string for context preservation */
             if (
@@ -1060,20 +1062,9 @@ export const formatAgentMessages = (
           if (part.type !== ContentTypes.TOOL_CALL || part.tool_call?.name !== Constants.SKILL_TOOL) {
             continue;
           }
-          const rawArgs = part.tool_call.args;
-          const parsedArgs =
-            typeof rawArgs === 'string'
-              ? (() => {
-                try {
-                  return JSON.parse(rawArgs) as Record<string, unknown>;
-                } catch {
-                  return {};
-                }
-              })()
-              : rawArgs;
-          const sn = parsedArgs?.skillName;
-          if (typeof sn === 'string' && sn !== '') {
-            pendingSkillBodies.push(sn);
+          const skillName = extractSkillName(part.tool_call.args);
+          if (skillName) {
+            (pendingSkillNames ??= new Set()).add(skillName);
           }
         }
       }
@@ -1087,27 +1078,29 @@ export const formatAgentMessages = (
     }
     messages.push(...formattedMessages);
 
-    /** Reconstruct HumanMessages for invoked skill bodies after their ToolMessages */
-    for (const skillName of pendingSkillBodies) {
-      const body = skills?.get(skillName);
-      if (body) {
-        messages.push(
-          new HumanMessage({
-            content: body,
-            additional_kwargs: {
-              role: 'user',
-              isMeta: true,
-              source: 'skill',
-              skillName,
-            },
-          })
-        );
+    // Capture index range BEFORE skill body injection so injected
+    // HumanMessages are excluded from the assistant's token distribution.
+    const endMessageIndex = messages.length;
+
+    if (pendingSkillNames?.size) {
+      for (const skillName of pendingSkillNames) {
+        const body = skills?.get(skillName);
+        if (body) {
+          messages.push(
+            new HumanMessage({
+              content: body,
+              additional_kwargs: {
+                role: 'user',
+                isMeta: true,
+                source: 'skill',
+                skillName,
+              },
+            })
+          );
+        }
       }
     }
 
-    // Update the index mapping for this assistant message
-    // Store all indices that were created from this original message
-    const endMessageIndex = messages.length;
     const resultIndices = [];
     for (let j = startMessageIndex; j < endMessageIndex; j++) {
       resultIndices.push(j);

--- a/src/messages/formatAgentMessages.skills.test.ts
+++ b/src/messages/formatAgentMessages.skills.test.ts
@@ -1,0 +1,334 @@
+import { HumanMessage } from '@langchain/core/messages';
+import type { TPayload } from '@/types';
+import { formatAgentMessages } from './format';
+import { ContentTypes, Constants } from '@/common';
+
+/** Helper to build a skill tool_call content part */
+function skillToolCall(
+  id: string,
+  skillName: string,
+  output = 'Skill loaded.',
+): Record<string, unknown> {
+  return {
+    type: ContentTypes.TOOL_CALL,
+    tool_call: {
+      id,
+      name: Constants.SKILL_TOOL,
+      args: JSON.stringify({ skillName }),
+      output,
+    },
+  };
+}
+
+describe('formatAgentMessages skill body reconstruction', () => {
+  const skillBodies = new Map([
+    ['pdf-analyzer', '# PDF Analyzer\nAnalyze PDF files step by step.'],
+    ['code-review', '# Code Review\nReview the code for issues.'],
+  ]);
+
+  describe('with discoveredTools (tools filtering active)', () => {
+    const tools = new Set([Constants.SKILL_TOOL, 'web_search']);
+
+    it('reconstructs HumanMessage after skill ToolMessage', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Analyze this PDF' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              [ContentTypes.TEXT]: 'I\'ll invoke the skill.',
+              tool_call_ids: ['call_1'],
+            },
+            skillToolCall('call_1', 'pdf-analyzer'),
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      // user, AI, ToolMessage, injected HumanMessage
+      expect(messages.length).toBeGreaterThanOrEqual(4);
+      const last = messages[messages.length - 1];
+      expect(last).toBeInstanceOf(HumanMessage);
+      expect(last.content).toBe('# PDF Analyzer\nAnalyze PDF files step by step.');
+      expect((last as HumanMessage).additional_kwargs.source).toBe('skill');
+      expect((last as HumanMessage).additional_kwargs.skillName).toBe('pdf-analyzer');
+      expect((last as HumanMessage).additional_kwargs.isMeta).toBe(true);
+    });
+
+    it('does NOT inject body when skill tool is not in discoveredTools', () => {
+      const restrictedTools = new Set(['web_search']); // skill NOT allowed
+      const payload: TPayload = [
+        { role: 'user', content: 'Analyze this' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'pdf-analyzer')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, restrictedTools, skillBodies);
+
+      const humanMessages = messages.filter((m) => m instanceof HumanMessage);
+      // Only the user message, no injected skill body
+      expect(humanMessages).toHaveLength(1);
+    });
+
+    it('does not inject when skill name is not in skills Map', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'unknown-skill')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const humanMessages = messages.filter((m) => m instanceof HumanMessage);
+      expect(humanMessages).toHaveLength(1); // only the user message
+    });
+  });
+
+  describe('without discoveredTools (no tools filtering)', () => {
+    it('reconstructs HumanMessage when skills Map provided', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Review my code' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'code-review')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, undefined, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(1);
+      expect(injected[0].content).toBe('# Code Review\nReview the code for issues.');
+    });
+
+    it('no injection when skills Map is undefined', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'pdf-analyzer')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, undefined, undefined);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0);
+    });
+
+    it('no injection when skills Map is empty', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'pdf-analyzer')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, undefined, new Map());
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0);
+    });
+  });
+
+  describe('extractSkillName edge cases', () => {
+    const tools = new Set([Constants.SKILL_TOOL]);
+
+    it('handles object args (not stringified)', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'call_1',
+                name: Constants.SKILL_TOOL,
+                args: { skillName: 'pdf-analyzer' }, // object, not string
+                output: 'Loaded.',
+              },
+            },
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(1);
+    });
+
+    it('gracefully skips malformed JSON args', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'call_1',
+                name: Constants.SKILL_TOOL,
+                args: '{bad json',
+                output: 'Loaded.',
+              },
+            },
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0); // gracefully skipped
+    });
+
+    it('skips empty skillName', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'call_1',
+                name: Constants.SKILL_TOOL,
+                args: JSON.stringify({ skillName: '' }),
+                output: 'Loaded.',
+              },
+            },
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0);
+    });
+  });
+
+  describe('deduplication', () => {
+    const tools = new Set([Constants.SKILL_TOOL]);
+
+    it('injects body only once when same skill invoked twice in one message', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            skillToolCall('call_1', 'pdf-analyzer'),
+            skillToolCall('call_2', 'pdf-analyzer'),
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(1);
+    });
+
+    it('injects body for each distinct skill invoked', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            skillToolCall('call_1', 'pdf-analyzer'),
+            skillToolCall('call_2', 'code-review'),
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(2);
+      const names = injected.map((m) => (m as HumanMessage).additional_kwargs.skillName);
+      expect(names).toContain('pdf-analyzer');
+      expect(names).toContain('code-review');
+    });
+  });
+
+  describe('indexTokenCountMap distribution', () => {
+    const tools = new Set([Constants.SKILL_TOOL]);
+
+    it('excludes injected HumanMessages from assistant token distribution', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Analyze this' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              [ContentTypes.TEXT]: 'Invoking skill.',
+              tool_call_ids: ['call_1'],
+            },
+            skillToolCall('call_1', 'pdf-analyzer'),
+          ],
+        },
+      ];
+
+      const inputTokenMap: Record<number, number | undefined> = {
+        0: 100, // user message
+        1: 500, // assistant message
+      };
+
+      const { messages, indexTokenCountMap } = formatAgentMessages(
+        payload,
+        inputTokenMap,
+        tools,
+        skillBodies,
+      );
+
+      // There should be messages: user, AI, ToolMessage, injected HumanMessage
+      expect(messages.length).toBeGreaterThanOrEqual(4);
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg).toBeInstanceOf(HumanMessage);
+      expect((lastMsg as HumanMessage).additional_kwargs.source).toBe('skill');
+
+      // Token map must be defined when input was provided
+      expect(indexTokenCountMap).toBeDefined();
+
+      // The injected HumanMessage's index should NOT be in the token map
+      const injectedIndex = messages.length - 1;
+      expect(indexTokenCountMap![injectedIndex]).toBeUndefined();
+
+      // The assistant's 500 tokens should be distributed only across
+      // the AI + ToolMessage, NOT the injected HumanMessage
+      let assistantTotal = 0;
+      for (const [idx, count] of Object.entries(indexTokenCountMap!)) {
+        if (Number(idx) > 0 && Number(idx) < injectedIndex) {
+          assistantTotal += count ?? 0;
+        }
+      }
+      expect(assistantTotal).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
Fixes review findings from #96:

**Critical fix**
- Capture \`endMessageIndex\` BEFORE skill body HumanMessage injection so injected messages are excluded from the assistant message's \`indexTokenCountMap\` distribution range. Previously, injected HumanMessages were included in the range, causing the assistant's token count to be split across messages with entirely new content (deflating per-message estimates).

**Review fixes:**
- Remove dead \`else if (!discoveredTools)\` branch inside \`if (discoveredTools)\` block. Revert redundant optional chaining.
- Extract \`extractSkillName()\` helper to eliminate DRY violation (identical args parsing IIFE duplicated in two locations). Fixes cryptic \`sn\` variable name.
- Use \`Set<string>\` instead of \`string[]\` for \`pendingSkillNames\` (deduplication).
-  Lazy allocation via \`??=\` (only allocated when skills are present).

All 86 existing \`formatAgentMessages\` tests pass.