### PR TITLE
feat: add ReadFile tool definition for general-purpose file reading

### DIFF
--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -183,6 +183,7 @@ export enum Constants {
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
   SKILL_TOOL = 'skill',
+  READ_FILE = 'read_file',
   BASH_TOOL = 'bash_tool',
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from './tools/BashExecutor';
 export * from './tools/ProgrammaticToolCalling';
 export * from './tools/BashProgrammaticToolCalling';
 export * from './tools/SkillTool';
+export * from './tools/ReadFile';
 export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';
 export * from './tools/ToolNode';

--- a/src/tools/ReadFile.ts
+++ b/src/tools/ReadFile.ts
@@ -1,0 +1,39 @@
+// src/tools/ReadFile.ts
+import { Constants } from '@/common';
+
+export const ReadFileToolName = Constants.READ_FILE;
+
+export const ReadFileToolDescription = `Read the contents of a file. Returns text content with line numbers for easy reference.
+
+For skill files, use the path format: {skillName}/{filePath} (e.g. "pdf-analyzer/src/utils.py", "code-review/SKILL.md").
+
+BEHAVIOR:
+- Text files: returned with numbered lines.
+- Images (png, jpeg, gif, webp): returned as visual content the model can see.
+- PDFs: returned as document content.
+- Other binary files: metadata returned with a note to use bash for processing.
+- Large files (>256KB text, >10MB binary): metadata only.
+- SKILL.md: returns the skill's instructions directly.
+
+CONSTRAINTS:
+- Only files from invoked skills or code execution output are accessible.
+- Do not guess file paths. Use paths from the skill documentation or tool output.`;
+
+export const ReadFileToolSchema = {
+  type: 'object',
+  properties: {
+    file_path: {
+      type: 'string',
+      description:
+        'Path to the file. For skill files: "{skillName}/{path}" (e.g. "pdf-analyzer/src/utils.py"). For code execution output: the path as returned by the execution tool.',
+    },
+  },
+  required: ['file_path'],
+} as const;
+
+export const ReadFileToolDefinition = {
+  name: ReadFileToolName,
+  description: ReadFileToolDescription,
+  parameters: ReadFileToolSchema,
+  responseFormat: 'content_and_artifact' as const,
+} as const;

--- a/src/tools/__tests__/ReadFile.test.ts
+++ b/src/tools/__tests__/ReadFile.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from '@jest/globals';
+import { Constants } from '@/common';
+import {
+  ReadFileToolName,
+  ReadFileToolSchema,
+  ReadFileToolDescription,
+  ReadFileToolDefinition,
+} from '../ReadFile';
+
+describe('ReadFile', () => {
+  describe('schema structure', () => {
+    it('has file_path as required string property', () => {
+      expect(ReadFileToolSchema.properties.file_path.type).toBe('string');
+      expect(ReadFileToolSchema.required).toContain('file_path');
+    });
+
+    it('is an object type schema', () => {
+      expect(ReadFileToolSchema.type).toBe('object');
+    });
+  });
+
+  describe('ReadFileToolDefinition', () => {
+    it('has correct name', () => {
+      expect(ReadFileToolDefinition.name).toBe(Constants.READ_FILE);
+      expect(ReadFileToolDefinition.name).toBe('read_file');
+    });
+
+    it('references the same ReadFileToolSchema object', () => {
+      expect(ReadFileToolDefinition.parameters).toBe(ReadFileToolSchema);
+    });
+
+    it('has a non-empty description', () => {
+      expect(ReadFileToolDefinition.description).toBe(ReadFileToolDescription);
+      expect(ReadFileToolDefinition.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ReadFileToolName', () => {
+    it('equals Constants.READ_FILE', () => {
+      expect(ReadFileToolName).toBe('read_file');
+      expect(ReadFileToolName).toBe(Constants.READ_FILE);
+    });
+  });
+});


### PR DESCRIPTION
New \`READ_FILE\` constant and \`ReadFileToolDefinition\` for a general-purpose file reader.

Schema: \`{ file_path: string }\` — skill files use path format \`{skillName}/{path}\` (e.g. \`pdf-analyzer/src/utils.py\`).

The tool is event-driven only (host handles via \`ON_TOOL_EXECUTE\`). Works without code execution for skill files (DB/storage reads). With code env, also supports code execution output files.

**Files:**
- \`src/common/enum.ts\` — \`Constants.READ_FILE = 'read_file'\`
- \`src/tools/ReadFile.ts\` — tool definition (name, schema, description)
- \`src/tools/__tests__/ReadFile.test.ts\` — 6 tests
- \`src/index.ts\` — export