### PR TITLE
fix: resolve review findings for hooks & skills PR

### DIFF
--- a/src/hooks/__tests__/matchers.test.ts
+++ b/src/hooks/__tests__/matchers.test.ts
@@ -232,7 +232,7 @@ describe('matchesQuery', () => {
       const result = matchesQuery('(a+)+$', adversarial);
       const elapsed = Date.now() - start;
       expect(result).toBe(false);
-      expect(elapsed).toBeLessThan(50);
+      expect(elapsed).toBeLessThan(200);
     });
   });
 });

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -185,6 +185,62 @@ describe('Tool-level hook integration (event-driven mode)', () => {
       expect(toolExecuted).toBe(false);
     });
 
+    it('deny dispatches ON_RUN_STEP_COMPLETED for the blocked call', async () => {
+      const registry = new HookRegistry();
+      const denyHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'not allowed',
+      });
+      registry.register('PreToolUse', {
+        pattern: '^echo$',
+        hooks: [denyHook],
+      });
+
+      let stepCompletedData: t.ToolCompleteEvent | undefined;
+      const stepHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as { result: t.ToolCompleteEvent };
+          stepCompletedData = data.result;
+        },
+      };
+
+      const toolHandler = createToolExecuteHandler();
+      const customHandlers: Record<string, t.EventHandler> = {
+        [GraphEvents.ON_TOOL_EXECUTE]: toolHandler,
+        [GraphEvents.TOOL_END]: new ToolEndHandler(),
+        [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        [GraphEvents.ON_RUN_STEP_COMPLETED]: stepHandler,
+      };
+
+      const tc = makeToolCall('hello');
+      const run = await Run.create<t.IState>({
+        runId: 'deny-step-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef],
+          instructions: 'Use the echo tool when asked.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers,
+        hooks: registry,
+      });
+
+      run.Graph!.overrideTestModel(['calling echo'], 5, [tc]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hello')] },
+        callerConfig
+      );
+
+      expect(stepCompletedData).toBeDefined();
+      expect(stepCompletedData!.tool_call.name).toBe('echo');
+      expect(stepCompletedData!.tool_call.id).toBe(tc.id);
+      expect(stepCompletedData!.tool_call.output).toContain('Blocked:');
+    });
+
     it('ask blocks tool execution in v1 (same as deny)', async () => {
       const registry = new HookRegistry();
       let toolExecuted = false;

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -236,6 +236,7 @@ describe('Tool-level hook integration (event-driven mode)', () => {
       );
 
       expect(stepCompletedData).toBeDefined();
+      expect(stepCompletedData!.type).toBe('tool_call');
       expect(stepCompletedData!.tool_call.name).toBe('echo');
       expect(stepCompletedData!.tool_call.id).toBe(tc.id);
       expect(stepCompletedData!.tool_call.output).toContain('Blocked:');

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -349,6 +349,7 @@ export async function executeHooks(
     return freshResult();
   }
 
+  // --- SYNC CRITICAL SECTION: once-matcher removal must complete before any await ---
   const tasks: Promise<HookOutcome>[] = [];
   for (const matcher of matchers) {
     if (!matchesQuery(matcher.pattern, matchQuery)) {
@@ -363,6 +364,7 @@ export async function executeHooks(
       tasks.push(runHook(hook, input, matcherSignal, matcher));
     }
   }
+  // --- END SYNC CRITICAL SECTION ---
   if (tasks.length === 0) {
     return freshResult();
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -37,6 +37,41 @@ function isSend(value: unknown): value is Send {
   return value instanceof Send;
 }
 
+/** Merges code execution session context into the sessions map. */
+function updateCodeSession(
+  sessions: t.ToolSessionMap,
+  sessionId: string,
+  files: t.FileRefs | undefined
+): void {
+  const newFiles = files ?? [];
+  const existingSession = sessions.get(Constants.EXECUTE_CODE) as
+    | t.CodeSessionContext
+    | undefined;
+  const existingFiles = existingSession?.files ?? [];
+
+  if (newFiles.length > 0) {
+    const filesWithSession: t.FileRefs = newFiles.map((file) => ({
+      ...file,
+      session_id: sessionId,
+    }));
+    const newFileNames = new Set(filesWithSession.map((f) => f.name));
+    const filteredExisting = existingFiles.filter(
+      (f) => !newFileNames.has(f.name)
+    );
+    sessions.set(Constants.EXECUTE_CODE, {
+      session_id: sessionId,
+      files: [...filteredExisting, ...filesWithSession],
+      lastUpdated: Date.now(),
+    });
+  } else {
+    sessions.set(Constants.EXECUTE_CODE, {
+      session_id: sessionId,
+      files: existingFiles,
+      lastUpdated: Date.now(),
+    });
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private toolMap: Map<string, StructuredToolInterface | RunnableToolLike>;
@@ -320,7 +355,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   private storeCodeSessionFromResults(
     results: t.ToolExecuteResult[],
-    requests: t.ToolCallRequest[]
+    requestMap: Map<string, t.ToolCallRequest>
   ): void {
     if (!this.sessions) {
       return;
@@ -332,8 +367,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      const request = requests.find((r) => r.id === result.toolCallId);
-      if (!request?.name || (!CODE_EXECUTION_TOOLS.has(request.name) && request.name !== Constants.SKILL_TOOL)) {
+      const request = requestMap.get(result.toolCallId);
+      if (
+        !request?.name ||
+        (!CODE_EXECUTION_TOOLS.has(request.name) &&
+          request.name !== Constants.SKILL_TOOL)
+      ) {
         continue;
       }
 
@@ -342,35 +381,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      const newFiles = artifact.files ?? [];
-      const existingSession = this.sessions.get(Constants.EXECUTE_CODE) as
-        | t.CodeSessionContext
-        | undefined;
-      const existingFiles = existingSession?.files ?? [];
-
-      if (newFiles.length > 0) {
-        const filesWithSession: t.FileRefs = newFiles.map((file) => ({
-          ...file,
-          session_id: artifact.session_id,
-        }));
-
-        const newFileNames = new Set(filesWithSession.map((f) => f.name));
-        const filteredExisting = existingFiles.filter(
-          (f) => !newFileNames.has(f.name)
-        );
-
-        this.sessions.set(Constants.EXECUTE_CODE, {
-          session_id: artifact.session_id,
-          files: [...filteredExisting, ...filesWithSession],
-          lastUpdated: Date.now(),
-        });
-      } else {
-        this.sessions.set(Constants.EXECUTE_CODE, {
-          session_id: artifact.session_id,
-          files: existingFiles,
-          lastUpdated: Date.now(),
-        });
-      }
+      updateCodeSession(this.sessions, artifact.session_id!, artifact.files);
     }
   }
 
@@ -406,39 +417,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      // Store code session context from tool results
       if (this.sessions && CODE_EXECUTION_TOOLS.has(call.name)) {
         const artifact = toolMessage.artifact as
           | t.CodeExecutionArtifact
           | undefined;
         if (artifact?.session_id != null && artifact.session_id !== '') {
-          const newFiles = artifact.files ?? [];
-          const existingSession = this.sessions.get(Constants.EXECUTE_CODE) as
-            | t.CodeSessionContext
-            | undefined;
-          const existingFiles = existingSession?.files ?? [];
-
-          if (newFiles.length > 0) {
-            const filesWithSession: t.FileRefs = newFiles.map((file) => ({
-              ...file,
-              session_id: artifact.session_id,
-            }));
-            const newFileNames = new Set(filesWithSession.map((f) => f.name));
-            const filteredExisting = existingFiles.filter(
-              (f) => !newFileNames.has(f.name)
-            );
-            this.sessions.set(Constants.EXECUTE_CODE, {
-              session_id: artifact.session_id,
-              files: [...filteredExisting, ...filesWithSession],
-              lastUpdated: Date.now(),
-            });
-          } else {
-            this.sessions.set(Constants.EXECUTE_CODE, {
-              session_id: artifact.session_id,
-              files: existingFiles,
-              lastUpdated: Date.now(),
-            });
-          }
+          updateCodeSession(this.sessions, artifact.session_id, artifact.files);
         }
       }
 
@@ -604,7 +588,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           turn,
         };
 
-        if (CODE_EXECUTION_TOOLS.has(entry.call.name) || entry.call.name === Constants.SKILL_TOOL) {
+        if (
+          CODE_EXECUTION_TOOLS.has(entry.call.name) ||
+          entry.call.name === Constants.SKILL_TOOL
+        ) {
           request.codeSessionContext = this.getCodeSessionContext();
         }
 
@@ -635,7 +622,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
       );
 
-      this.storeCodeSessionFromResults(results, requests);
+      this.storeCodeSessionFromResults(results, requestMap);
 
       const hasPostHook =
         this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -104,13 +104,23 @@ function fitNamesOnly(
   entries: { name: string }[],
   budgetChars: number
 ): string {
-  const namesOnly = entries.map((s) => ({ name: s.name, description: '' }));
-  const full = formatEntries(namesOnly);
-  if (full.length <= budgetChars) return full;
+  // Format: "HEADER\n\n- name1\n- name2\n..."
+  // Running sum avoids O(n²) repeated string construction.
+  const prefix = HEADER.length + 2; // "HEADER\n\n"
+  const entryOverhead = 2; // "- "
+  let total = prefix;
+  let fitCount = 0;
 
-  for (let count = namesOnly.length - 1; count > 0; count--) {
-    const trimmed = formatEntries(namesOnly.slice(0, count));
-    if (trimmed.length <= budgetChars) return trimmed;
+  for (let i = 0; i < entries.length; i++) {
+    const added = (i > 0 ? 1 : 0) + entryOverhead + entries[i].name.length;
+    if (total + added > budgetChars) break;
+    total += added;
+    fitCount = i + 1;
   }
-  return '';
+
+  if (fitCount === 0) return '';
+  const namesOnly = entries
+    .slice(0, fitCount)
+    .map((s) => ({ name: s.name, description: '' }));
+  return formatEntries(namesOnly);
 }

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -117,7 +117,8 @@ export type RunConfig = {
   /**
    * Pre-constructed hook registry for this run. Hooks fire at lifecycle
    * points in `processStream` (RunStart, UserPromptSubmit, Stop,
-   * StopFailure) and — once the tool-hook PR lands — around tool calls.
+   * StopFailure) and around tool calls (PreToolUse, PostToolUse,
+   * PostToolUseFailure, PermissionDenied).
    *
    * Pass `undefined` (the default) to skip all hook dispatch. When a
    * registry is provided, the run attaches it to the `Graph` so internal


### PR DESCRIPTION
## Summary

Resolves all 7 findings from the code review of the hooks & skills PR:

- **Stale JSDoc** (`src/types/run.ts`): Replaced self-referential "once the tool-hook PR lands" with concrete event names
- **Array.find → Map.get** (`src/tools/ToolNode.ts`): `storeCodeSessionFromResults` now accepts the existing `requestMap` for O(1) lookups per AGENTS.md guidelines
- **DRY session storage** (`src/tools/ToolNode.ts`): Extracted shared `updateCodeSession` helper eliminating duplicated file-dedup + session-merge logic between `storeCodeSessionFromResults` and `handleRunToolCompletions`
- **Sync critical section markers** (`src/hooks/executeHooks.ts`): Added boundary comments around the once-matcher removal loop to prevent future contributors from inserting an `await` that would break atomicity
- **O(n²) → O(n) fitNamesOnly** (`src/tools/skillCatalog.ts`): Replaced repeated `formatEntries(slice())` calls with a running character sum
- **CI-safe timing assertion** (`src/hooks/__tests__/matchers.test.ts`): Widened ReDoS test bound from 50ms to 200ms
- **Missing test coverage** (`src/hooks/__tests__/toolHooks.test.ts`): Added test verifying `ON_RUN_STEP_COMPLETED` dispatches for denied tool calls

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all modified files — clean (1 pre-existing warning)
- [x] All 134 tests pass across 7 affected suites (matchers, executeHooks, toolHooks, skillCatalog, SkillTool, HookRegistry, integration)