### PR TITLE
chore: add --tag dev for prerelease npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,8 +190,19 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: npm pack
 
+      - name: Determine publish tag
+        if: steps.check.outputs.skip != 'true'
+        id: publish_tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if echo "$PACKAGE_VERSION" | grep -q "-"; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish
         if: steps.check.outputs.skip != 'true'
-        run: npm publish $(ls librechat-agents-*.tgz) --access public --provenance
+        run: npm publish $(ls librechat-agents-*.tgz) --access public --provenance --tag ${{ steps.publish_tag.outputs.tag }}
         env:
           NODE_ENV: production


### PR DESCRIPTION
Adds a step to detect prerelease versions (containing `-`) and passes `--tag dev` to `npm publish`. Stable versions get `--tag latest`. Fixes `You must specify a tag when publishing a prerelease version` error on workflow_dispatch against dev.