### PR TITLE
feat: wire PreCompact/PostCompact hooks around summarization node

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1207,6 +1207,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             },
             runId: this.runId,
             isMultiAgent: this.isMultiAgentGraph(),
+            hookRegistry: this.hookRegistry,
             dispatchRunStep: async (runStep, nodeConfig) => {
               this.contentData.push(runStep);
               this.contentIndexMap.set(runStep.id, runStep.index);

--- a/src/hooks/__tests__/compactHooks.test.ts
+++ b/src/hooks/__tests__/compactHooks.test.ts
@@ -131,6 +131,7 @@ describe('Compaction hook integration', () => {
       expect(captured!.hook_event_name).toBe('PreCompact');
       expect(captured!.messagesBeforeCount).toBeGreaterThan(0);
       expect(captured!.runId).toBe('compact-run');
+      expect(captured!.threadId).toBe('compact-test');
       expect(captured!.trigger).toBe('default');
       expect(captured!.agentId).toBeDefined();
     });
@@ -155,7 +156,8 @@ describe('Compaction hook integration', () => {
 
       expect(captured).toBeDefined();
       expect(captured!.hook_event_name).toBe('PostCompact');
-      expect(captured!.summary).toContain('Summary');
+      expect(captured!.threadId).toBe('compact-test');
+      expect(captured!.summary).toBe(SUMMARY_RESPONSE);
       expect(captured!.messagesAfterCount).toBe(0);
       expect(captured!.agentId).toBeDefined();
     });

--- a/src/hooks/__tests__/compactHooks.test.ts
+++ b/src/hooks/__tests__/compactHooks.test.ts
@@ -1,0 +1,191 @@
+// src/hooks/__tests__/compactHooks.test.ts
+import { HumanMessage, AIMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { HookRegistry } from '../HookRegistry';
+import { Run } from '@/run';
+import * as providers from '@/llm/providers';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { createTokenCounter } from '@/utils/tokens';
+import { Providers, GraphEvents } from '@/common';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  PreCompactHookInput,
+  PreCompactHookOutput,
+  PostCompactHookInput,
+  PostCompactHookOutput,
+} from '../types';
+
+const SUMMARY_RESPONSE = '## Summary\nUser asked a question and got an answer.';
+
+const callerConfig = {
+  configurable: { thread_id: 'compact-test' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+let getChatModelClassSpy: jest.SpyInstance;
+const originalGetChatModelClass = providers.getChatModelClass;
+
+function mockSummarizationModel(): void {
+  getChatModelClassSpy = jest
+    .spyOn(providers, 'getChatModelClass')
+    .mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return class extends FakeListChatModel {
+          constructor(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            _options: any
+          ) {
+            super({ responses: [SUMMARY_RESPONSE] });
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+}
+
+function buildConversation(): t.IState {
+  const messages: import('@langchain/core/messages').BaseMessage[] = [];
+  for (let i = 0; i < 20; i++) {
+    messages.push(new HumanMessage(`Question ${i}: ` + 'padding '.repeat(50)));
+    messages.push(new AIMessage(`Answer ${i}: ` + 'response '.repeat(50)));
+  }
+  return { messages };
+}
+
+async function createCompactingRun(
+  tokenCounter: t.TokenCounter,
+  hooks?: HookRegistry,
+  runId = 'compact-run'
+): Promise<Run<t.IState>> {
+  const conversation = buildConversation();
+  const indexTokenCountMap: Record<string, number> = {};
+  for (let i = 0; i < conversation.messages.length; i++) {
+    indexTokenCountMap[String(i)] = tokenCounter(conversation.messages[i]);
+  }
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.OPENAI,
+        streaming: true,
+        streamUsage: false,
+      },
+      instructions: 'Be concise.',
+      maxContextTokens: 200,
+      summarizationEnabled: true,
+      summarizationConfig: {
+        provider: Providers.OPENAI,
+      },
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers: {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    },
+    hooks,
+    tokenCounter,
+    indexTokenCountMap,
+  });
+}
+
+describe('Compaction hook integration', () => {
+  jest.setTimeout(30_000);
+
+  let tokenCounter: t.TokenCounter;
+
+  beforeAll(async () => {
+    tokenCounter = await createTokenCounter();
+  });
+
+  beforeEach(() => {
+    mockSummarizationModel();
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  describe('PreCompact', () => {
+    it('fires with messagesBeforeCount and trigger', async () => {
+      const registry = new HookRegistry();
+      let captured: PreCompactHookInput | undefined;
+      const hook: HookCallback<'PreCompact'> = async (
+        input
+      ): Promise<PreCompactHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PreCompact', { hooks: [hook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Final answer after compaction.']);
+      const inputs = buildConversation();
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PreCompact');
+      expect(captured!.messagesBeforeCount).toBeGreaterThan(0);
+      expect(captured!.runId).toBe('compact-run');
+    });
+  });
+
+  describe('PostCompact', () => {
+    it('fires with summary text after compaction', async () => {
+      const registry = new HookRegistry();
+      let captured: PostCompactHookInput | undefined;
+      const hook: HookCallback<'PostCompact'> = async (
+        input
+      ): Promise<PostCompactHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PostCompact', { hooks: [hook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Final answer after compaction.']);
+      const inputs = buildConversation();
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PostCompact');
+      expect(captured!.summary.length).toBeGreaterThan(0);
+      expect(captured!.messagesAfterCount).toBe(0);
+    });
+  });
+
+  describe('error resilience', () => {
+    it('throwing hook does not crash compaction', async () => {
+      const registry = new HookRegistry();
+      const throwingHook: HookCallback<
+        'PreCompact'
+      > = async (): Promise<PreCompactHookOutput> => {
+        throw new Error('hook crash');
+      };
+      registry.register('PreCompact', { hooks: [throwingHook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Answer after compaction.']);
+      const inputs = buildConversation();
+
+      await expect(
+        run.processStream(inputs, callerConfig)
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('no-hooks baseline', () => {
+    it('summarization works identically without hooks', async () => {
+      const run = await createCompactingRun(tokenCounter);
+      run.Graph!.overrideTestModel(['Answer.']);
+      const inputs = buildConversation();
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/hooks/__tests__/compactHooks.test.ts
+++ b/src/hooks/__tests__/compactHooks.test.ts
@@ -131,6 +131,8 @@ describe('Compaction hook integration', () => {
       expect(captured!.hook_event_name).toBe('PreCompact');
       expect(captured!.messagesBeforeCount).toBeGreaterThan(0);
       expect(captured!.runId).toBe('compact-run');
+      expect(captured!.trigger).toBe('default');
+      expect(captured!.agentId).toBeDefined();
     });
   });
 
@@ -153,20 +155,39 @@ describe('Compaction hook integration', () => {
 
       expect(captured).toBeDefined();
       expect(captured!.hook_event_name).toBe('PostCompact');
-      expect(captured!.summary.length).toBeGreaterThan(0);
+      expect(captured!.summary).toContain('Summary');
       expect(captured!.messagesAfterCount).toBe(0);
+      expect(captured!.agentId).toBeDefined();
     });
   });
 
   describe('error resilience', () => {
-    it('throwing hook does not crash compaction', async () => {
+    it('throwing PreCompact hook does not crash compaction', async () => {
       const registry = new HookRegistry();
       const throwingHook: HookCallback<
         'PreCompact'
       > = async (): Promise<PreCompactHookOutput> => {
-        throw new Error('hook crash');
+        throw new Error('pre hook crash');
       };
       registry.register('PreCompact', { hooks: [throwingHook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Answer after compaction.']);
+      const inputs = buildConversation();
+
+      await expect(
+        run.processStream(inputs, callerConfig)
+      ).resolves.not.toThrow();
+    });
+
+    it('throwing PostCompact hook does not crash compaction', async () => {
+      const registry = new HookRegistry();
+      const throwingHook: HookCallback<
+        'PostCompact'
+      > = async (): Promise<PostCompactHookOutput> => {
+        throw new Error('post hook crash');
+      };
+      registry.register('PostCompact', { hooks: [throwingHook] });
 
       const run = await createCompactingRun(tokenCounter, registry);
       run.Graph!.overrideTestModel(['Answer after compaction.']);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,8 +2,9 @@
 //
 // Hook lifecycle system for `@librechat/agents`. Re-exported from
 // `src/index.ts` and consumed by `Run.processStream` (RunStart,
-// UserPromptSubmit, Stop, StopFailure) and `ToolNode.dispatchToolEvents`
-// (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied).
+// UserPromptSubmit, Stop, StopFailure), `ToolNode.dispatchToolEvents`
+// (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied),
+// and `createSummarizeNode` (PreCompact, PostCompact).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -139,12 +139,28 @@ export interface StopFailureHookInput extends BaseHookInput {
 export interface PreCompactHookInput extends BaseHookInput {
   hook_event_name: 'PreCompact';
   messagesBeforeCount: number;
-  trigger: 'threshold' | 'manual' | 'error';
+  /**
+   * What triggered compaction. Matches `SummarizationTrigger.type` from the
+   * agent's summarization config. `'default'` means no trigger was
+   * configured and compaction fired because messages were pruned.
+   */
+  trigger:
+    | 'token_ratio'
+    | 'remaining_tokens'
+    | 'messages_to_refine'
+    | 'default'
+    | (string & {});
 }
 
 export interface PostCompactHookInput extends BaseHookInput {
   hook_event_name: 'PostCompact';
   summary: string;
+  /**
+   * Number of messages remaining after compaction. The summarize node
+   * returns a `removeAll` signal that clears all messages from state;
+   * the summary itself is injected into the system prompt, not as a
+   * message. This is `0` at the point of hook dispatch.
+   */
   messagesAfterCount: number;
 }
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -7,18 +7,18 @@ import {
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { AgentContext } from '@/agents/AgentContext';
+import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
-import type { HookRegistry } from '@/hooks';
 import { ContentTypes, GraphEvents, StepTypes, Providers } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
-import { executeHooks } from '@/hooks';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { addCacheControl } from '@/messages/cache';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
+import { executeHooks } from '@/hooks';
 
 const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
 
@@ -534,6 +534,9 @@ async function dispatchCompletionEvents(params: {
 
   const sessionId = graph.runId ?? '';
   if (graph.hookRegistry?.hasHookFor('PostCompact', sessionId) === true) {
+    const threadId = (
+      runnableConfig?.configurable as Record<string, unknown> | undefined
+    )?.thread_id as string | undefined;
     const firstBlock = summaryBlock.content?.[0];
     const summaryText =
       firstBlock != null &&
@@ -547,6 +550,7 @@ async function dispatchCompletionEvents(params: {
       input: {
         hook_event_name: 'PostCompact',
         runId: sessionId,
+        threadId,
         agentId,
         summary: summaryText,
         messagesAfterCount: 0,
@@ -680,11 +684,15 @@ export function createSummarizeNode({
 
     const sessionId = graph.runId ?? '';
     if (graph.hookRegistry?.hasHookFor('PreCompact', sessionId) === true) {
+      const threadId = (
+        config?.configurable as Record<string, unknown> | undefined
+      )?.thread_id as string | undefined;
       await executeHooks({
         registry: graph.hookRegistry,
         input: {
           hook_event_name: 'PreCompact',
           runId: sessionId,
+          threadId,
           agentId: request.agentId,
           messagesBeforeCount: messagesToRefine.length,
           trigger: agentContext.summarizationConfig?.trigger?.type ?? 'default',

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -9,8 +9,10 @@ import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
+import type { HookRegistry } from '@/hooks';
 import { ContentTypes, GraphEvents, StepTypes, Providers } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
+import { executeHooks } from '@/hooks';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
 import { getMaxOutputTokensKey } from '@/llm/request';
@@ -530,6 +532,31 @@ async function dispatchCompletionEvents(params: {
     );
   }
 
+  const sessionId = graph.runId ?? '';
+  if (graph.hookRegistry?.hasHookFor('PostCompact', sessionId) === true) {
+    const firstBlock = summaryBlock.content?.[0];
+    const summaryText =
+      firstBlock != null &&
+      typeof firstBlock === 'object' &&
+      'text' in firstBlock &&
+      typeof firstBlock.text === 'string'
+        ? firstBlock.text
+        : '';
+    await executeHooks({
+      registry: graph.hookRegistry,
+      input: {
+        hook_event_name: 'PostCompact',
+        runId: sessionId,
+        agentId,
+        summary: summaryText,
+        messagesAfterCount: 0,
+      },
+      sessionId,
+    }).catch(() => {
+      /* PostCompact is observational — swallow errors */
+    });
+  }
+
   agentContext.rebuildTokenMapAfterSummarization({});
 }
 
@@ -545,6 +572,7 @@ interface CreateSummarizeNodeParams {
     config?: RunnableConfig;
     runId?: string;
     isMultiAgent: boolean;
+    hookRegistry?: HookRegistry;
     dispatchRunStep: (
       runStep: t.RunStep,
       config?: RunnableConfig
@@ -648,6 +676,23 @@ export function createSummarizeNode({
         } satisfies t.SummarizeStartEvent,
         runnableConfig
       );
+    }
+
+    const sessionId = graph.runId ?? '';
+    if (graph.hookRegistry?.hasHookFor('PreCompact', sessionId) === true) {
+      await executeHooks({
+        registry: graph.hookRegistry,
+        input: {
+          hook_event_name: 'PreCompact',
+          runId: sessionId,
+          agentId: request.agentId,
+          messagesBeforeCount: messagesToRefine.length,
+          trigger: agentContext.summarizationConfig?.trigger?.type ?? 'default',
+        },
+        sessionId,
+      }).catch(() => {
+        /* PreCompact is observational — swallow errors */
+      });
     }
 
     const isSelfSummarizeModel =

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -685,7 +685,7 @@ export function createSummarizeNode({
     const sessionId = graph.runId ?? '';
     if (graph.hookRegistry?.hasHookFor('PreCompact', sessionId) === true) {
       const threadId = (
-        config?.configurable as Record<string, unknown> | undefined
+        runnableConfig?.configurable as Record<string, unknown> | undefined
       )?.thread_id as string | undefined;
       await executeHooks({
         registry: graph.hookRegistry,


### PR DESCRIPTION
## Summary

Wires the last two SDK-side hook events — `PreCompact` and `PostCompact` — into the summarization node. These are auditing hooks for hosts to archive transcripts before compaction, observe summaries, or log compaction telemetry.

This completes all SDK-side hook events. The full set:
- **Run-level:** RunStart, UserPromptSubmit, Stop, StopFailure (#88)
- **Tool-level:** PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied (#90)
- **Compaction:** PreCompact, PostCompact (this PR)
- **Subagent:** SubagentStart/SubagentStop (deferred until agent-as-tool primitive is built)

### Fire points

- **PreCompact** — after `ON_SUMMARIZE_START`, before LLM call. Receives `messagesBeforeCount` and trigger type.
- **PostCompact** — after `ON_SUMMARIZE_COMPLETE`, after summary enrichment. Receives summary text and `messagesAfterCount: 0`.

Both are observational (non-blocking, errors swallowed).

### Type fix

`PreCompactHookInput.trigger` was `'threshold' | 'manual' | 'error'` (from #87) — doesn't match real trigger types. Now: `'token_ratio' | 'remaining_tokens' | 'messages_to_refine' | 'default'`.

### Files changed

| File | Change |
|---|---|
| `src/hooks/types.ts` | Fixed `trigger` type, added JSDoc for `messagesAfterCount` |
| `src/summarization/node.ts` | Import hooks, add `hookRegistry` to graph interface, fire both hooks |
| `src/graphs/Graph.ts` | Pass `hookRegistry` to `createSummarizeNode` |
| `src/hooks/__tests__/compactHooks.test.ts` | 4 new tests |

## Test plan

- [x] 4 new compaction hook tests (PreCompact fields, PostCompact summary, error resilience, no-hooks baseline)
- [x] All 108 existing hook tests still pass (112 total)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — clean