### PR TITLE
feat: add subagent-as-tool primitive for hierarchical agent delegation

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "multi-agent-chain": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-chain.ts",
     "multi-agent-sequence": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-sequence.ts",
     "multi-agent-conditional": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-conditional.ts",
+    "multi-agent-subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
     "multi-agent-supervisor": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-supervisor.ts",
     "test-handoff-preamble": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/test-handoff-preamble.ts",
     "multi-agent-list-handoff": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/test-multi-agent-list-handoff.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -55,6 +55,8 @@ export class AgentContext {
       contextPruningConfig,
       maxToolResultChars,
       toolSchemaTokens,
+      subagentConfigs,
+      maxSubagentDepth,
     } = agentConfig;
 
     const agentContext = new AgentContext({
@@ -81,6 +83,10 @@ export class AgentContext {
       contextPruningConfig,
       maxToolResultChars,
     });
+
+    agentContext._sourceInputs = agentConfig;
+    agentContext.subagentConfigs = subagentConfigs;
+    agentContext.maxSubagentDepth = maxSubagentDepth;
 
     if (initialSummary?.text != null && initialSummary.text !== '') {
       agentContext.setInitialSummary(
@@ -198,6 +204,12 @@ export class AgentContext {
   toolDefinitions?: t.LCTool[];
   /** Set of tool names discovered via tool search (to be loaded) */
   discoveredToolNames: Set<string> = new Set();
+  /** Original AgentInputs used to create this context — used for self-spawn subagent resolution. */
+  _sourceInputs?: t.AgentInputs;
+  /** Subagent configurations for hierarchical delegation. */
+  subagentConfigs?: t.SubagentConfig[];
+  /** Maximum subagent nesting depth. */
+  maxSubagentDepth?: number;
   /** Instructions for this agent */
   instructions?: string;
   /** Additional instructions for this agent */

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -686,8 +686,20 @@ export class AgentContext {
     let toolTokens = 0;
     const countedToolNames = new Set<string>();
 
-    if (this.tools && this.tools.length > 0) {
-      for (const tool of this.tools) {
+    /**
+     * Iterate both `tools` (user-provided instance tools) and `graphTools`
+     * (graph-managed tools like handoff + subagent). `graphTools` is often
+     * populated after `fromConfig()` kicks off the initial calculation, so
+     * callers that mutate `graphTools` must re-trigger this method to
+     * refresh `toolSchemaTokens`.
+     */
+    const instanceTools: t.GraphTools = [
+      ...((this.tools as t.GenericTool[] | undefined) ?? []),
+      ...((this.graphTools as t.GenericTool[] | undefined) ?? []),
+    ];
+
+    if (instanceTools.length > 0) {
+      for (const tool of instanceTools) {
         const genericTool = tool as Record<string, unknown>;
         if (
           genericTool.schema != null &&

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -186,6 +186,7 @@ export enum Constants {
   READ_FILE = 'read_file',
   BASH_TOOL = 'bash_tool',
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
+  SUBAGENT = 'subagent',
 }
 
 /** Tool names that use the code execution environment (shared session, file tracking). */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1184,6 +1184,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           parentAgentId: agentContext.agentId,
           tokenCounter: agentContext.tokenCounter,
           maxDepth: effectiveSubagentDepth,
+          createChildGraph: (input): StandardGraph => new StandardGraph(input),
         });
 
         const subagentTool = tool(async (rawInput, config) => {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { nanoid } from 'nanoid';
+import { tool } from '@langchain/core/tools';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { Runnable, RunnableConfig } from '@langchain/core/runnables';
 import { ToolMessage, AIMessageChunk } from '@langchain/core/messages';
@@ -28,6 +29,7 @@ import {
   GraphNodeKeys,
   ContentTypes,
   GraphEvents,
+  Constants,
   Providers,
   StepTypes,
 } from '@/common';
@@ -39,6 +41,7 @@ import {
   joinKeys,
   sleep,
 } from '@/utils';
+import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
@@ -1150,6 +1153,70 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const agentContext = this.agentContexts.get(agentId);
     if (!agentContext) {
       throw new Error(`Agent context not found for agentId: ${agentId}`);
+    }
+
+    if (
+      agentContext.subagentConfigs != null &&
+      agentContext.subagentConfigs.length > 0
+    ) {
+      const resolvedConfigs = resolveSubagentConfigs(
+        agentContext.subagentConfigs,
+        agentContext
+      );
+      if (resolvedConfigs.length > 0) {
+        const executor = new SubagentExecutor({
+          configs: new Map(resolvedConfigs.map((c) => [c.type, c])),
+          parentSignal: this.signal,
+          hookRegistry: this.hookRegistry,
+          parentRunId: this.runId ?? '',
+          parentAgentId: agentContext.agentId,
+          maxDepth: agentContext.maxSubagentDepth ?? 1,
+        });
+
+        const types = resolvedConfigs.map((c) => c.type);
+        const typeDescriptions = resolvedConfigs
+          .map((c) => `- "${c.type}" (${c.name}): ${c.description}`)
+          .join('\n');
+
+        const subagentTool = tool(
+          async (rawInput) => {
+            const input = rawInput as {
+              description: string;
+              subagent_type: string;
+            };
+            const result = await executor.execute({
+              description: input.description,
+              subagentType: input.subagent_type,
+            });
+            return result.content;
+          },
+          {
+            name: Constants.SUBAGENT,
+            schema: {
+              type: 'object',
+              properties: {
+                description: {
+                  type: 'string',
+                  description:
+                    'Complete task description for the subagent. This is the ONLY information it receives.',
+                },
+                subagent_type: {
+                  type: 'string',
+                  enum: types,
+                  description: `Which subagent type to delegate to. Available: ${types.join(', ')}.`,
+                },
+              },
+              required: ['description', 'subagent_type'],
+            },
+            description: `Delegate a task to a specialized subagent with isolated context. Only the final text result returns.\n\nAvailable types:\n${typeDescriptions}`,
+          }
+        );
+
+        agentContext.graphTools = [
+          ...((agentContext.graphTools as t.GenericTool[] | undefined) ?? []),
+          subagentTool as unknown as t.GenericTool,
+        ];
+      }
     }
 
     const agentNode = `${AGENT}${agentId}` as const;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1155,9 +1155,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       throw new Error(`Agent context not found for agentId: ${agentId}`);
     }
 
+    /**
+     * Depth countdown across graph boundaries: the parent's `maxSubagentDepth`
+     * becomes this executor's `maxDepth`. When the child graph is constructed,
+     * `buildChildInputs()` decrements `maxSubagentDepth` on the child's
+     * `AgentInputs` (only when `allowNested: true`; otherwise subagentConfigs
+     * are stripped entirely). The child graph's own `createAgentNode()` then
+     * reads the decremented value here and creates a narrower executor —
+     * recursion is bounded even though each graph has its own separate
+     * executor instance.
+     */
+    const effectiveSubagentDepth = agentContext.maxSubagentDepth ?? 1;
     if (
       agentContext.subagentConfigs != null &&
-      agentContext.subagentConfigs.length > 0
+      agentContext.subagentConfigs.length > 0 &&
+      effectiveSubagentDepth > 0
     ) {
       const resolvedConfigs = resolveSubagentConfigs(
         agentContext.subagentConfigs,
@@ -1171,7 +1183,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           parentRunId: this.runId ?? '',
           parentAgentId: agentContext.agentId,
           tokenCounter: agentContext.tokenCounter,
-          maxDepth: agentContext.maxSubagentDepth ?? 1,
+          maxDepth: effectiveSubagentDepth,
         });
 
         const subagentTool = tool(async (rawInput, config) => {
@@ -1199,6 +1211,30 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.graphTools = [];
         }
         (agentContext.graphTools as t.GenericTool[]).push(subagentTool);
+
+        /**
+         * Refresh toolSchemaTokens to include the subagent tool's schema.
+         * `calculateInstructionTokens()` was kicked off in `fromConfig()`
+         * before graphTools was populated, so its result did not count this
+         * tool. Without this retrigger, token-budget/pruning logic
+         * underestimates prompt overhead.
+         */
+        if (agentContext.tokenCounter) {
+          const { tokenCounter, baseIndexTokenCountMap } = agentContext;
+          agentContext.tokenCalculationPromise = agentContext
+            .calculateInstructionTokens(tokenCounter)
+            .then(() => {
+              agentContext.updateTokenMapWithInstructions(
+                baseIndexTokenCountMap
+              );
+            })
+            .catch((err) => {
+              console.error(
+                'Error recalculating instruction tokens after subagent tool injection:',
+                err
+              );
+            });
+        }
       }
     }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -29,7 +29,6 @@ import {
   GraphNodeKeys,
   ContentTypes,
   GraphEvents,
-  Constants,
   Providers,
   StepTypes,
 } from '@/common';
@@ -42,6 +41,7 @@ import {
   sleep,
 } from '@/utils';
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
+import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
@@ -1170,52 +1170,30 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           hookRegistry: this.hookRegistry,
           parentRunId: this.runId ?? '',
           parentAgentId: agentContext.agentId,
+          tokenCounter: agentContext.tokenCounter,
           maxDepth: agentContext.maxSubagentDepth ?? 1,
         });
 
-        const types = resolvedConfigs.map((c) => c.type);
-        const typeDescriptions = resolvedConfigs
-          .map((c) => `- "${c.type}" (${c.name}): ${c.description}`)
-          .join('\n');
+        const subagentTool = tool(async (rawInput, config) => {
+          const input = rawInput as {
+            description: string;
+            subagent_type: string;
+          };
+          const threadId = config.configurable?.thread_id as
+            | string
+            | undefined;
+          const result = await executor.execute({
+            description: input.description,
+            subagentType: input.subagent_type,
+            threadId,
+          });
+          return result.content;
+        }, buildSubagentToolParams(resolvedConfigs));
 
-        const subagentTool = tool(
-          async (rawInput) => {
-            const input = rawInput as {
-              description: string;
-              subagent_type: string;
-            };
-            const result = await executor.execute({
-              description: input.description,
-              subagentType: input.subagent_type,
-            });
-            return result.content;
-          },
-          {
-            name: Constants.SUBAGENT,
-            schema: {
-              type: 'object',
-              properties: {
-                description: {
-                  type: 'string',
-                  description:
-                    'Complete task description for the subagent. This is the ONLY information it receives.',
-                },
-                subagent_type: {
-                  type: 'string',
-                  enum: types,
-                  description: `Which subagent type to delegate to. Available: ${types.join(', ')}.`,
-                },
-              },
-              required: ['description', 'subagent_type'],
-            },
-            description: `Delegate a task to a specialized subagent with isolated context. Only the final text result returns.\n\nAvailable types:\n${typeDescriptions}`,
-          }
-        );
-
-        agentContext.graphTools = [
-          ...((agentContext.graphTools as t.GenericTool[] | undefined) ?? []),
-          subagentTool as unknown as t.GenericTool,
-        ];
+        if (!agentContext.graphTools) {
+          agentContext.graphTools = [];
+        }
+        (agentContext.graphTools as t.GenericTool[]).push(subagentTool);
       }
     }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1176,15 +1176,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
         const subagentTool = tool(async (rawInput, config) => {
           const input = rawInput as {
-            description: string;
-            subagent_type: string;
+            description?: string;
+            subagent_type?: string;
           };
-          const threadId = config.configurable?.thread_id as
-            | string
-            | undefined;
+          const description =
+            typeof input.description === 'string' &&
+            input.description.trim().length > 0
+              ? input.description
+              : 'No task description provided';
+          const subagentType =
+            typeof input.subagent_type === 'string' ? input.subagent_type : '';
+          const threadId = config.configurable?.thread_id as string | undefined;
           const result = await executor.execute({
-            description: input.description,
-            subagentType: input.subagent_type,
+            description,
+            subagentType,
             threadId,
           });
           return result.content;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,7 +4,8 @@
 // `src/index.ts` and consumed by `Run.processStream` (RunStart,
 // UserPromptSubmit, Stop, StopFailure), `ToolNode.dispatchToolEvents`
 // (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied),
-// and `createSummarizeNode` (PreCompact, PostCompact).
+// `createSummarizeNode` (PreCompact, PostCompact), and
+// `SubagentExecutor.execute` (SubagentStart, SubagentStop).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ export * from './tools/BashExecutor';
 export * from './tools/ProgrammaticToolCalling';
 export * from './tools/BashProgrammaticToolCalling';
 export * from './tools/SkillTool';
+export * from './tools/SubagentTool';
+export * from './tools/subagent';
 export * from './tools/ReadFile';
 export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';

--- a/src/scripts/multi-agent-subagent.ts
+++ b/src/scripts/multi-agent-subagent.ts
@@ -1,0 +1,246 @@
+import { config } from 'dotenv';
+config();
+
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { Providers, GraphEvents, Constants } from '@/common';
+import { Run } from '@/run';
+
+/**
+ * Manual verification script for the subagent primitive.
+ *
+ * Configures a supervisor agent with two subagent types (researcher, coder),
+ * sends a query, and confirms:
+ * 1. The parent agent delegates to a subagent via the `subagent` tool
+ * 2. The child executes with isolated context (fresh message history)
+ * 3. Only the filtered text result returns to the parent
+ * 4. The parent incorporates the result and responds
+ *
+ * Usage:
+ *   OPENAI_API_KEY=... npx ts-node -r tsconfig-paths/register src/scripts/multi-agent-subagent.ts
+ *
+ * Or with Anthropic:
+ *   ANTHROPIC_API_KEY=... npx ts-node -r tsconfig-paths/register src/scripts/multi-agent-subagent.ts --provider anthropic
+ */
+
+const useAnthropic =
+  process.argv.includes('--provider') &&
+  process.argv[process.argv.indexOf('--provider') + 1] === 'anthropic';
+
+const provider = useAnthropic ? Providers.ANTHROPIC : Providers.OPENAI;
+const apiKey = useAnthropic
+  ? process.env.ANTHROPIC_API_KEY
+  : process.env.OPENAI_API_KEY;
+const modelName = useAnthropic ? 'claude-sonnet-4-20250514' : 'gpt-4.1';
+
+if (!apiKey) {
+  console.error(
+    `Missing ${useAnthropic ? 'ANTHROPIC_API_KEY' : 'OPENAI_API_KEY'} environment variable`
+  );
+  process.exit(1);
+}
+
+async function testSubagentPrimitive() {
+  console.log('=== Subagent Primitive Manual Verification ===\n');
+  console.log(`Provider: ${provider}`);
+  console.log(`Model: ${modelName}\n`);
+
+  const { contentParts, aggregateContent } = createContentAggregator();
+
+  const parentAgent: t.AgentInputs = {
+    agentId: 'supervisor',
+    provider,
+    clientOptions: { modelName, apiKey },
+    instructions: `You are a supervisor agent. You have access to specialized subagents.
+
+When the user asks a research question, delegate it to the "researcher" subagent.
+When the user asks for code, delegate it to the "coder" subagent.
+
+After receiving the subagent's result, synthesize it into a clear final answer for the user.
+Always use a subagent for research or coding tasks — do not answer directly.`,
+    maxContextTokens: 16000,
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Research Specialist',
+        description:
+          'Researches topics and provides detailed summaries with sources.',
+        agentInputs: {
+          agentId: 'researcher',
+          provider,
+          clientOptions: { modelName, apiKey },
+          instructions: `You are a research specialist working in an isolated context.
+You receive a single task description and must answer it thoroughly.
+Be concise but comprehensive. Include key facts and details.`,
+          maxContextTokens: 8000,
+        },
+      },
+      {
+        type: 'coder',
+        name: 'Coding Specialist',
+        description:
+          'Writes, reviews, and explains code in any programming language.',
+        agentInputs: {
+          agentId: 'coder',
+          provider,
+          clientOptions: { modelName, apiKey },
+          instructions: `You are a coding specialist working in an isolated context.
+You receive a single task description and must provide working code.
+Include brief explanations. Use clean, idiomatic code.`,
+          maxContextTokens: 8000,
+        },
+      },
+    ],
+  };
+
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.RunStep,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.RunStep,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.RunStepDeltaEvent,
+        });
+      },
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.MessageDeltaEvent,
+        });
+      },
+    },
+  };
+
+  const run = await Run.create<t.IState>({
+    runId: `subagent-manual-${Date.now()}`,
+    graphConfig: {
+      type: 'standard',
+      agents: [parentAgent],
+    },
+    returnContent: true,
+    customHandlers,
+  });
+
+  console.log('--- Run created ---');
+  console.log(
+    `Subagent tool present: ${
+      (
+        (run.Graph as import('@/graphs/Graph').StandardGraph).agentContexts.get(
+          'supervisor'
+        )?.graphTools as t.GenericTool[] | undefined
+      )?.some((t) => 'name' in t && t.name === Constants.SUBAGENT) ?? false
+    }\n`
+  );
+
+  const conversationHistory: BaseMessage[] = [];
+
+  // Turn 1: Research question (should delegate to researcher subagent)
+  console.log('=== Turn 1: Research Question ===\n');
+  console.log(
+    'User: What are the three laws of thermodynamics? Explain briefly.\n'
+  );
+
+  const userMessage = new HumanMessage(
+    'What are the three laws of thermodynamics? Explain briefly.'
+  );
+  conversationHistory.push(userMessage);
+
+  const callerConfig = {
+    configurable: { thread_id: 'subagent-verify' },
+    streamMode: 'values' as const,
+    version: 'v2' as const,
+  };
+
+  console.log('--- Streaming response ---\n');
+  const result = await run.processStream(
+    { messages: conversationHistory },
+    callerConfig
+  );
+
+  const runMessages = run.getRunMessages();
+  console.log('\n\n--- Run Messages ---\n');
+
+  if (runMessages) {
+    for (const msg of runMessages) {
+      const type = msg._getType();
+      if (type === 'tool') {
+        const name = 'name' in msg ? msg.name : 'unknown';
+        const content =
+          typeof msg.content === 'string'
+            ? msg.content.slice(0, 200)
+            : JSON.stringify(msg.content).slice(0, 200);
+        console.log(`[ToolMessage] name=${name}`);
+        console.log(
+          `  content: ${content}${(msg.content as string).length > 200 ? '...' : ''}\n`
+        );
+      } else if (type === 'ai') {
+        const content =
+          typeof msg.content === 'string'
+            ? msg.content.slice(0, 300)
+            : JSON.stringify(msg.content).slice(0, 300);
+        const toolCalls = 'tool_calls' in msg ? msg.tool_calls : undefined;
+        console.log(`[AIMessage]`);
+        if (toolCalls && Array.isArray(toolCalls) && toolCalls.length > 0) {
+          for (const tc of toolCalls) {
+            console.log(
+              `  tool_call: ${tc.name}(${JSON.stringify(tc.args).slice(0, 100)}...)`
+            );
+          }
+        }
+        console.log(
+          `  content: ${content}${content.length >= 300 ? '...' : ''}\n`
+        );
+      }
+    }
+
+    const subagentToolMessages = runMessages.filter(
+      (msg) =>
+        msg._getType() === 'tool' &&
+        'name' in msg &&
+        msg.name === Constants.SUBAGENT
+    );
+    console.log(`\n--- Verification ---`);
+    console.log(`Subagent tool calls found: ${subagentToolMessages.length}`);
+    console.log(`Total run messages: ${runMessages.length}`);
+    console.log(`Result content parts: ${result?.length ?? 0}`);
+
+    if (subagentToolMessages.length > 0) {
+      console.log(
+        '\nSUCCESS: Subagent was invoked and returned a filtered result.'
+      );
+      console.log(
+        'The child context was isolated — only the final text came back.'
+      );
+    } else {
+      console.log('\nNOTE: No subagent tool calls detected.');
+      console.log('The LLM may have answered directly without delegating.');
+    }
+  }
+
+  console.log('\n=== Done ===');
+}
+
+testSubagentPrimitive().catch(console.error);

--- a/src/scripts/multi-agent-subagent.ts
+++ b/src/scripts/multi-agent-subagent.ts
@@ -34,7 +34,7 @@ const provider = useAnthropic ? Providers.ANTHROPIC : Providers.OPENAI;
 const apiKey = useAnthropic
   ? process.env.ANTHROPIC_API_KEY
   : process.env.OPENAI_API_KEY;
-const modelName = useAnthropic ? 'claude-sonnet-4-20250514' : 'gpt-4.1';
+const modelName = useAnthropic ? 'claude-sonnet-4-20250514' : 'gpt-5.4';
 
 if (!apiKey) {
   console.error(

--- a/src/scripts/multi-agent-subagent.ts
+++ b/src/scripts/multi-agent-subagent.ts
@@ -48,7 +48,7 @@ async function testSubagentPrimitive() {
   console.log(`Provider: ${provider}`);
   console.log(`Model: ${modelName}\n`);
 
-  const { contentParts, aggregateContent } = createContentAggregator();
+  const { aggregateContent } = createContentAggregator();
 
   const parentAgent: t.AgentInputs = {
     agentId: 'supervisor',
@@ -188,14 +188,14 @@ Include brief explanations. Use clean, idiomatic code.`,
       const type = msg._getType();
       if (type === 'tool') {
         const name = 'name' in msg ? msg.name : 'unknown';
-        const content =
+        const rawContent =
           typeof msg.content === 'string'
-            ? msg.content.slice(0, 200)
-            : JSON.stringify(msg.content).slice(0, 200);
+            ? msg.content
+            : JSON.stringify(msg.content);
+        const content = rawContent.slice(0, 200);
+        const truncated = rawContent.length > 200 ? '...' : '';
         console.log(`[ToolMessage] name=${name}`);
-        console.log(
-          `  content: ${content}${(msg.content as string).length > 200 ? '...' : ''}\n`
-        );
+        console.log(`  content: ${content}${truncated}\n`);
       } else if (type === 'ai') {
         const content =
           typeof msg.content === 'string'

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -1,0 +1,222 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { Run } from '@/run';
+import {
+  Constants,
+  GraphEvents,
+  Providers,
+  ToolEndHandler,
+  ModelEndHandler,
+  StandardGraph,
+} from '@/index';
+import * as providers from '@/llm/providers';
+
+const CHILD_RESPONSE = 'Research result: Paris is the capital of France.';
+
+const callerConfig: Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+} = {
+  configurable: { thread_id: 'subagent-test-thread' },
+  streamMode: 'values',
+  version: 'v2' as const,
+};
+
+const createParentAgent = (): t.AgentInputs => ({
+  agentId: 'parent',
+  provider: Providers.OPENAI,
+  clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+  instructions:
+    'You are a supervisor. Delegate research tasks using the subagent tool.',
+  maxContextTokens: 8000,
+  subagentConfigs: [
+    {
+      type: 'researcher',
+      name: 'Research Agent',
+      description: 'Researches and summarizes information',
+      agentInputs: {
+        agentId: 'researcher',
+        provider: Providers.OPENAI,
+        clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+        instructions: 'You are a research agent. Answer concisely.',
+        maxContextTokens: 8000,
+      },
+    },
+  ],
+});
+
+describe('Subagent Integration', () => {
+  jest.setTimeout(30000);
+
+  let getChatModelClassSpy: jest.SpyInstance;
+  const originalGetChatModelClass = providers.getChatModelClass;
+
+  beforeEach(() => {
+    getChatModelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return class extends FakeListChatModel {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            constructor(_options: any) {
+              super({ responses: [CHILD_RESPONSE] });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  it('should create subagent tool on agent context', async () => {
+    const run = await Run.create<t.IState>({
+      runId: `subagent-test-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createParentAgent()],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    expect(run.Graph).toBeDefined();
+    const parentContext = (run.Graph as StandardGraph).agentContexts.get(
+      'parent'
+    );
+    expect(parentContext).toBeDefined();
+    expect(parentContext?.graphTools).toBeDefined();
+
+    const subagentTool = (parentContext?.graphTools as t.GenericTool[]).find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeDefined();
+  });
+
+  it('should execute subagent and return filtered result to parent', async () => {
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `subagent-exec-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createParentAgent()],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers,
+    });
+
+    const subagentToolCall: ToolCall = {
+      id: 'call_subagent_1',
+      name: Constants.SUBAGENT,
+      args: {
+        description: 'What is the capital of France?',
+        subagent_type: 'researcher',
+      },
+      type: 'tool_call',
+    };
+
+    run.Graph?.overrideTestModel(
+      [
+        'Let me delegate this research task.',
+        `Based on the research: ${CHILD_RESPONSE}`,
+      ],
+      10,
+      [subagentToolCall]
+    );
+
+    const result = await run.processStream(
+      { messages: [new HumanMessage('What is the capital of France?')] },
+      callerConfig
+    );
+
+    expect(result).toBeDefined();
+
+    const runMessages = run.getRunMessages();
+    expect(runMessages).toBeDefined();
+    expect(runMessages!.length).toBeGreaterThan(0);
+
+    const toolMessages = runMessages!.filter(
+      (msg) => msg._getType() === 'tool'
+    );
+    const subagentResult = toolMessages.find(
+      (msg) => 'name' in msg && msg.name === Constants.SUBAGENT
+    );
+    expect(subagentResult).toBeDefined();
+    expect(String(subagentResult!.content)).toContain('Paris');
+  });
+
+  it('should not create subagent tool when no subagentConfigs', async () => {
+    const agentWithoutSubagents: t.AgentInputs = {
+      agentId: 'plain',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions: 'Plain agent without subagents.',
+      maxContextTokens: 8000,
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `no-subagent-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithoutSubagents],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const context = (run.Graph as StandardGraph).agentContexts.get('plain');
+    const tools = context?.graphTools as t.GenericTool[] | undefined;
+    const subagentTool = tools?.find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeUndefined();
+  });
+
+  it('should handle self-spawn subagent config', async () => {
+    const agentWithSelfSpawn: t.AgentInputs = {
+      agentId: 'self-parent',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions: 'Agent with self-spawn for context isolation.',
+      maxContextTokens: 8000,
+      subagentConfigs: [
+        {
+          type: 'isolated',
+          name: 'Isolated Worker',
+          description: 'Runs a task with isolated context',
+          self: true,
+        },
+      ],
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `self-spawn-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithSelfSpawn],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const context = (run.Graph as StandardGraph).agentContexts.get(
+      'self-parent'
+    );
+    const tools = context?.graphTools as t.GenericTool[] | undefined;
+    const subagentTool = tools?.find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeDefined();
+  });
+});

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -219,4 +219,87 @@ describe('Subagent Integration', () => {
     );
     expect(subagentTool).toBeDefined();
   });
+
+  it('should not create subagent tool when maxSubagentDepth is 0', async () => {
+    const agentWithZeroDepth: t.AgentInputs = {
+      ...createParentAgent(),
+      agentId: 'zero-depth',
+      maxSubagentDepth: 0,
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `zero-depth-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithZeroDepth],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const context = (run.Graph as StandardGraph).agentContexts.get(
+      'zero-depth'
+    );
+    const tools = context?.graphTools as t.GenericTool[] | undefined;
+    const subagentTool = tools?.find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeUndefined();
+  });
+
+  it('should account for subagent tool schema in toolSchemaTokens', async () => {
+    /** Simple char-count tokenizer — deterministic, lets us assert presence. */
+    const tokenCounter: t.TokenCounter = (message) => {
+      const content = message.content;
+      if (typeof content === 'string') return content.length;
+      if (Array.isArray(content)) return JSON.stringify(content).length;
+      return JSON.stringify(content).length;
+    };
+
+    const agentWithSubagent = createParentAgent();
+    const runWith = await Run.create<t.IState>({
+      runId: `with-sub-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithSubagent],
+      },
+      tokenCounter,
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const agentWithoutSubagent: t.AgentInputs = {
+      agentId: 'plain',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions:
+        'You are a supervisor. Delegate research tasks using the subagent tool.',
+      maxContextTokens: 8000,
+    };
+    const runWithout = await Run.create<t.IState>({
+      runId: `without-sub-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithoutSubagent],
+      },
+      tokenCounter,
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const contextWith = (runWith.Graph as StandardGraph).agentContexts.get(
+      'parent'
+    );
+    const contextWithout = (
+      runWithout.Graph as StandardGraph
+    ).agentContexts.get('plain');
+
+    await contextWith?.tokenCalculationPromise;
+    await contextWithout?.tokenCalculationPromise;
+
+    /** Subagent tool schema is ~600 chars; expect measurable difference. */
+    expect(contextWith!.toolSchemaTokens).toBeGreaterThan(
+      contextWithout!.toolSchemaTokens
+    );
+  });
 });

--- a/src/tools/SubagentTool.ts
+++ b/src/tools/SubagentTool.ts
@@ -1,6 +1,6 @@
 import { Constants } from '@/common';
 import type { SubagentConfig } from '@/types';
-import type { LCTool } from '@/types/tools';
+import type { JsonSchemaType, LCTool } from '@/types/tools';
 
 export const SubagentToolName = Constants.SUBAGENT;
 
@@ -44,12 +44,14 @@ export const SubagentToolDefinition: LCTool = {
 };
 
 /**
- * Create a SubagentTool LCTool definition with dynamic enum and description
- * populated from the available subagent configs.
+ * Build the name, schema, and description params for `tool()` from available configs.
+ * Used by `Graph.createAgentNode()` when constructing the runtime tool instance.
  */
-export function createSubagentToolDefinition(
-  configs: SubagentConfig[]
-): LCTool {
+export function buildSubagentToolParams(configs: SubagentConfig[]): {
+  name: string;
+  schema: JsonSchemaType;
+  description: string;
+} {
   const types = configs.map((c) => c.type);
   const typeDescriptions = configs
     .map((c) => `- "${c.type}" (${c.name}): ${c.description}`)
@@ -57,8 +59,7 @@ export function createSubagentToolDefinition(
 
   return {
     name: SubagentToolName,
-    description: `${SubagentToolDescription}\n\nAvailable subagent types:\n${typeDescriptions}`,
-    parameters: {
+    schema: {
       type: 'object',
       properties: {
         description: {
@@ -74,5 +75,22 @@ export function createSubagentToolDefinition(
       },
       required: ['description', 'subagent_type'],
     },
+    description: `${SubagentToolDescription}\n\nAvailable types:\n${typeDescriptions}`,
+  };
+}
+
+/**
+ * Create a SubagentTool LCTool definition with dynamic enum and description
+ * populated from the available subagent configs.
+ * Used for the tool registry in event-driven mode.
+ */
+export function createSubagentToolDefinition(
+  configs: SubagentConfig[]
+): LCTool {
+  const params = buildSubagentToolParams(configs);
+  return {
+    name: params.name,
+    description: params.description,
+    parameters: params.schema,
   };
 }

--- a/src/tools/SubagentTool.ts
+++ b/src/tools/SubagentTool.ts
@@ -20,18 +20,22 @@ CONSTRAINTS:
 - subagent_type must match one of the available types listed below.
 - The subagent cannot see your conversation history.`;
 
+const DESCRIPTION_PROP_DESCRIPTION =
+  'Complete task description for the subagent. This is the ONLY information it receives — include all necessary context, requirements, and constraints.';
+
+const SUBAGENT_TYPE_PROP_DESCRIPTION =
+  'Which subagent type to delegate to. Must be one of the available types.';
+
 export const SubagentToolSchema = {
   type: 'object',
   properties: {
     description: {
       type: 'string',
-      description:
-        'Complete task description for the subagent. This is the ONLY information it receives — include all necessary context, requirements, and constraints.',
+      description: DESCRIPTION_PROP_DESCRIPTION,
     },
     subagent_type: {
       type: 'string',
-      description:
-        'Which subagent type to delegate to. Must be one of the available types.',
+      description: SUBAGENT_TYPE_PROP_DESCRIPTION,
     },
   },
   required: ['description', 'subagent_type'] as string[],
@@ -46,6 +50,7 @@ export const SubagentToolDefinition: LCTool = {
 /**
  * Build the name, schema, and description params for `tool()` from available configs.
  * Used by `Graph.createAgentNode()` when constructing the runtime tool instance.
+ * Extends `SubagentToolSchema` by populating `subagent_type.enum` dynamically.
  */
 export function buildSubagentToolParams(configs: SubagentConfig[]): {
   name: string;
@@ -64,13 +69,12 @@ export function buildSubagentToolParams(configs: SubagentConfig[]): {
       properties: {
         description: {
           type: 'string',
-          description:
-            'Complete task description for the subagent. This is the ONLY information it receives — include all necessary context, requirements, and constraints.',
+          description: DESCRIPTION_PROP_DESCRIPTION,
         },
         subagent_type: {
           type: 'string',
           enum: types,
-          description: `Which subagent type to delegate to. Available: ${types.join(', ')}.`,
+          description: `${SUBAGENT_TYPE_PROP_DESCRIPTION} Available: ${types.join(', ')}.`,
         },
       },
       required: ['description', 'subagent_type'],

--- a/src/tools/SubagentTool.ts
+++ b/src/tools/SubagentTool.ts
@@ -1,0 +1,78 @@
+import { Constants } from '@/common';
+import type { SubagentConfig } from '@/types';
+import type { LCTool } from '@/types/tools';
+
+export const SubagentToolName = Constants.SUBAGENT;
+
+export const SubagentToolDescription = `Delegate a task to a specialized subagent that runs in an isolated context window. The subagent executes independently and returns only its final text result — all intermediate tool calls, reasoning, and context stay isolated.
+
+WHEN TO USE:
+- The task is self-contained and can be described in a single prompt.
+- You want to offload verbose or exploratory work without bloating your own context.
+- A specialized subagent is available for the task domain.
+
+WHAT HAPPENS:
+- A fresh agent is created with the task description as its only input.
+- The subagent runs to completion using its own tools and context.
+- Only the final text response is returned to you.
+
+CONSTRAINTS:
+- subagent_type must match one of the available types listed below.
+- The subagent cannot see your conversation history.`;
+
+export const SubagentToolSchema = {
+  type: 'object',
+  properties: {
+    description: {
+      type: 'string',
+      description:
+        'Complete task description for the subagent. This is the ONLY information it receives — include all necessary context, requirements, and constraints.',
+    },
+    subagent_type: {
+      type: 'string',
+      description:
+        'Which subagent type to delegate to. Must be one of the available types.',
+    },
+  },
+  required: ['description', 'subagent_type'] as string[],
+} as const;
+
+export const SubagentToolDefinition: LCTool = {
+  name: SubagentToolName,
+  description: SubagentToolDescription,
+  parameters: SubagentToolSchema,
+};
+
+/**
+ * Create a SubagentTool LCTool definition with dynamic enum and description
+ * populated from the available subagent configs.
+ */
+export function createSubagentToolDefinition(
+  configs: SubagentConfig[]
+): LCTool {
+  const types = configs.map((c) => c.type);
+  const typeDescriptions = configs
+    .map((c) => `- "${c.type}" (${c.name}): ${c.description}`)
+    .join('\n');
+
+  return {
+    name: SubagentToolName,
+    description: `${SubagentToolDescription}\n\nAvailable subagent types:\n${typeDescriptions}`,
+    parameters: {
+      type: 'object',
+      properties: {
+        description: {
+          type: 'string',
+          description:
+            'Complete task description for the subagent. This is the ONLY information it receives — include all necessary context, requirements, and constraints.',
+        },
+        subagent_type: {
+          type: 'string',
+          enum: types,
+          description: `Which subagent type to delegate to. Available: ${types.join(', ')}.`,
+        },
+      },
+      required: ['description', 'subagent_type'],
+    },
+  };
+}

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach } from '@jest/globals';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import { HookRegistry } from '@/hooks/HookRegistry';
@@ -265,6 +265,49 @@ describe('buildChildInputs', () => {
 describe('SubagentExecutor', () => {
   const config = makeConfig();
 
+  /**
+   * Build a stub `createChildGraph` factory that returns a minimal
+   * `StandardGraph`-shaped object whose `createWorkflow().invoke()`
+   * resolves to `invokeResult`. Avoids `jest.spyOn(StandardGraph)` so
+   * that SubagentExecutor does not need a runtime dep on the graphs
+   * module (circular-dep-safe).
+   */
+  function makeStubGraphFactory(
+    invokeResult: { messages: BaseMessage[] },
+    clearSpy?: jest.Mock
+  ): { factory: () => StandardGraph; clearHeavyState: jest.Mock } {
+    const mockClear = clearSpy ?? jest.fn();
+    const factory = (): StandardGraph =>
+      ({
+        createWorkflow: (): { invoke: jest.Mock } => ({
+          invoke: jest.fn().mockResolvedValue(invokeResult),
+        }),
+        clearHeavyState: mockClear,
+      }) as unknown as StandardGraph;
+    return { factory, clearHeavyState: mockClear };
+  }
+
+  function makeThrowingGraphFactory(error: Error): () => StandardGraph {
+    return (): StandardGraph =>
+      ({
+        createWorkflow: (): { invoke: jest.Mock } => ({
+          invoke: jest.fn().mockRejectedValue(error),
+        }),
+        clearHeavyState: jest.fn(),
+      }) as unknown as StandardGraph;
+  }
+
+  /** No-op factory for tests that never reach child graph construction. */
+  function makeNoopGraphFactory(): () => StandardGraph {
+    return (): StandardGraph =>
+      ({
+        createWorkflow: (): { invoke: jest.Mock } => ({
+          invoke: jest.fn().mockResolvedValue({ messages: [] }),
+        }),
+        clearHeavyState: jest.fn(),
+      }) as unknown as StandardGraph;
+  }
+
   function createExecutor(
     overrides: Partial<ConstructorParameters<typeof SubagentExecutor>[0]> = {}
   ): SubagentExecutor {
@@ -272,50 +315,10 @@ describe('SubagentExecutor', () => {
       configs: new Map([[config.type, config]]),
       parentRunId: 'test-run',
       parentAgentId: 'parent-agent',
+      createChildGraph: makeNoopGraphFactory(),
       ...overrides,
     });
   }
-
-  /** Spy handle for Graph module mock — set per test, restored in afterEach */
-  let graphSpy: jest.SpyInstance | undefined;
-
-  function mockStandardGraph(
-    invokeResult: { messages: BaseMessage[] },
-    clearSpy?: jest.Mock
-  ): { clearHeavyState: jest.Mock } {
-    const mockClear = clearSpy ?? jest.fn();
-    const GraphModule =
-      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
-    graphSpy = jest.spyOn(GraphModule, 'StandardGraph').mockImplementation(
-      () =>
-        ({
-          createWorkflow: (): { invoke: jest.Mock } => ({
-            invoke: jest.fn().mockResolvedValue(invokeResult),
-          }),
-          clearHeavyState: mockClear,
-        }) as unknown as StandardGraph
-    );
-    return { clearHeavyState: mockClear };
-  }
-
-  function mockStandardGraphError(error: Error): void {
-    const GraphModule =
-      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
-    graphSpy = jest.spyOn(GraphModule, 'StandardGraph').mockImplementation(
-      () =>
-        ({
-          createWorkflow: (): { invoke: jest.Mock } => ({
-            invoke: jest.fn().mockRejectedValue(error),
-          }),
-          clearHeavyState: jest.fn(),
-        }) as unknown as StandardGraph
-    );
-  }
-
-  afterEach(() => {
-    graphSpy?.mockRestore();
-    graphSpy = undefined;
-  });
 
   it('returns error for unknown subagent type', async () => {
     const executor = createExecutor();
@@ -340,13 +343,13 @@ describe('SubagentExecutor', () => {
   });
 
   it('executes child graph and returns filtered content', async () => {
-    const executor = createExecutor();
-    const { clearHeavyState } = mockStandardGraph({
+    const { factory, clearHeavyState } = makeStubGraphFactory({
       messages: [
         new HumanMessage('research this topic'),
         new AIMessage('Here is my research summary.'),
       ],
     });
+    const executor = createExecutor({ createChildGraph: factory });
 
     const result = await executor.execute({
       description: 'Research this topic',
@@ -359,8 +362,11 @@ describe('SubagentExecutor', () => {
   });
 
   it('returns error message when child graph throws', async () => {
-    const executor = createExecutor();
-    mockStandardGraphError(new Error('Graph recursion limit reached'));
+    const executor = createExecutor({
+      createChildGraph: makeThrowingGraphFactory(
+        new Error('Graph recursion limit reached')
+      ),
+    });
 
     const result = await executor.execute({
       description: 'Do something',
@@ -373,9 +379,10 @@ describe('SubagentExecutor', () => {
   });
 
   it('truncates long error messages to 200 chars', async () => {
-    const executor = createExecutor();
     const longMessage = 'x'.repeat(500);
-    mockStandardGraphError(new Error(longMessage));
+    const executor = createExecutor({
+      createChildGraph: makeThrowingGraphFactory(new Error(longMessage)),
+    });
 
     const result = await executor.execute({
       description: 'Do something',
@@ -393,9 +400,10 @@ describe('SubagentExecutor', () => {
   });
 
   it('does not truncate short error messages', async () => {
-    const executor = createExecutor();
     const shortMessage = 'brief error detail';
-    mockStandardGraphError(new Error(shortMessage));
+    const executor = createExecutor({
+      createChildGraph: makeThrowingGraphFactory(new Error(shortMessage)),
+    });
 
     const result = await executor.execute({
       description: 'Do something',
@@ -426,31 +434,24 @@ describe('SubagentExecutor', () => {
       },
     };
 
+    let observedChildInputs: AgentInputs | undefined;
     const executor = new SubagentExecutor({
       configs: new Map([[nestedConfig.type, nestedConfig]]),
       parentRunId: 'test-run',
       parentAgentId: 'parent',
       maxDepth: 3,
-    });
-
-    let observedChildInputs: AgentInputs | undefined;
-    const GraphModule =
-      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
-    graphSpy = jest
-      .spyOn(GraphModule, 'StandardGraph')
-      .mockImplementation(
-        (input: ConstructorParameters<typeof StandardGraph>[0]) => {
-          observedChildInputs = input.agents[0];
-          return {
-            createWorkflow: (): { invoke: jest.Mock } => ({
-              invoke: jest.fn().mockResolvedValue({
-                messages: [new AIMessage('nested done')],
-              }),
+      createChildGraph: (input): StandardGraph => {
+        observedChildInputs = input.agents[0];
+        return {
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockResolvedValue({
+              messages: [new AIMessage('nested done')],
             }),
-            clearHeavyState: jest.fn(),
-          } as unknown as StandardGraph;
-        }
-      );
+          }),
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      },
+    });
 
     await executor.execute({
       description: 'nested task',
@@ -464,25 +465,21 @@ describe('SubagentExecutor', () => {
 
   it('strips subagentConfigs from child when allowNested is not set', async () => {
     let observedChildInputs: AgentInputs | undefined;
-    const GraphModule =
-      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
-    graphSpy = jest
-      .spyOn(GraphModule, 'StandardGraph')
-      .mockImplementation(
-        (input: ConstructorParameters<typeof StandardGraph>[0]) => {
-          observedChildInputs = input.agents[0];
-          return {
-            createWorkflow: (): { invoke: jest.Mock } => ({
-              invoke: jest.fn().mockResolvedValue({
-                messages: [new AIMessage('done')],
-              }),
+    const executor = createExecutor({
+      maxDepth: 3,
+      createChildGraph: (input): StandardGraph => {
+        observedChildInputs = input.agents[0];
+        return {
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockResolvedValue({
+              messages: [new AIMessage('done')],
             }),
-            clearHeavyState: jest.fn(),
-          } as unknown as StandardGraph;
-        }
-      );
+          }),
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      },
+    });
 
-    const executor = createExecutor({ maxDepth: 3 });
     await executor.execute({
       description: 'task',
       subagentType: 'researcher',
@@ -513,8 +510,13 @@ describe('SubagentExecutor', () => {
         ],
       });
 
-      const executor = createExecutor({ hookRegistry: registry });
-      mockStandardGraph({ messages: [new AIMessage('done')] });
+      const { factory } = makeStubGraphFactory({
+        messages: [new AIMessage('done')],
+      });
+      const executor = createExecutor({
+        hookRegistry: registry,
+        createChildGraph: factory,
+      });
 
       await executor.execute({
         description: 'Test task',
@@ -539,8 +541,13 @@ describe('SubagentExecutor', () => {
         ],
       });
 
-      const executor = createExecutor({ hookRegistry: registry });
-      mockStandardGraph({ messages: [new AIMessage('done')] });
+      const { factory } = makeStubGraphFactory({
+        messages: [new AIMessage('done')],
+      });
+      const executor = createExecutor({
+        hookRegistry: registry,
+        createChildGraph: factory,
+      });
 
       await executor.execute({
         description: 'Test task',

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -115,6 +115,37 @@ describe('filterSubagentResult', () => {
     ];
     expect(filterSubagentResult(messages)).toBe('Final response');
   });
+
+  it('salvages text from an earlier AIMessage when the last has only tool_use', () => {
+    /**
+     * Scenario: subagent hit maxTurns mid-tool-call. The last AIMessage is
+     * pure tool_use with no text. Partial progress from an earlier turn
+     * should still be returned instead of "Task completed".
+     */
+    const messages: BaseMessage[] = [
+      new HumanMessage('task'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Let me search.' },
+          { type: 'tool_use', id: 'c1', name: 'search', input: {} },
+        ],
+      }),
+      new ToolMessage({ content: 'Paris.', tool_call_id: 'c1' }),
+      new AIMessage({
+        content: [{ type: 'tool_use', id: 'c2', name: 'search', input: {} }],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Let me search.');
+  });
+
+  it('salvages from earlier AIMessage when last has empty string content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage('Partial answer.'),
+      new ToolMessage({ content: 'tool out', tool_call_id: 'x' }),
+      new AIMessage(''),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Partial answer.');
+  });
 });
 
 describe('resolveSubagentConfigs', () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -9,6 +9,7 @@ import {
   SubagentExecutor,
   filterSubagentResult,
   resolveSubagentConfigs,
+  buildChildInputs,
 } from '../subagent';
 import type { StandardGraph } from '@/graphs/Graph';
 
@@ -175,6 +176,90 @@ describe('resolveSubagentConfigs', () => {
     const resolved = resolveSubagentConfigs([badConfig], parentContext);
     expect(resolved).toHaveLength(0);
   });
+
+  it('throws on duplicate subagent types', () => {
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const dup1 = makeConfig('researcher');
+    const dup2 = makeConfig('researcher');
+    expect(() => resolveSubagentConfigs([dup1, dup2], parentContext)).toThrow(
+      /Duplicate subagent type "researcher"/
+    );
+  });
+});
+
+describe('buildChildInputs', () => {
+  const parentAgentInputs: AgentInputs = {
+    agentId: 'parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test' },
+    instructions: 'parent',
+    maxContextTokens: 8000,
+    subagentConfigs: [{ type: 'researcher', name: 'R', description: 'd' }],
+    maxSubagentDepth: 3,
+  };
+
+  it('strips subagentConfigs and maxSubagentDepth when allowNested is false', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    expect(result.subagentConfigs).toBeUndefined();
+    expect(result.maxSubagentDepth).toBeUndefined();
+  });
+
+  it('decrements maxSubagentDepth when allowNested is true', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+      allowNested: true,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    expect(result.maxSubagentDepth).toBe(2);
+    expect(result.subagentConfigs).toEqual(parentAgentInputs.subagentConfigs);
+  });
+
+  it('clamps decremented depth to 0 (never negative)', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+      allowNested: true,
+    };
+    const result = buildChildInputs(config, 'child', 0);
+    expect(result.maxSubagentDepth).toBe(0);
+  });
+
+  it('always strips toolDefinitions (forces traditional mode)', () => {
+    const inputsWithToolDefs: AgentInputs = {
+      ...parentAgentInputs,
+      toolDefinitions: [{ name: 't', description: 'x' }],
+    };
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: inputsWithToolDefs,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    expect(result.toolDefinitions).toBeUndefined();
+  });
+
+  it('overrides agentId with the passed childAgentId', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+    };
+    const result = buildChildInputs(config, 'my-child', 3);
+    expect(result.agentId).toBe('my-child');
+  });
 });
 
 describe('SubagentExecutor', () => {
@@ -244,8 +329,8 @@ describe('SubagentExecutor', () => {
     expect(result.messages).toEqual([]);
   });
 
-  it('returns error when depth exceeds maxDepth', async () => {
-    const executor = createExecutor({ depth: 2, maxDepth: 2 });
+  it('returns error when maxDepth is 0 (nesting budget exhausted)', async () => {
+    const executor = createExecutor({ maxDepth: 0 });
     const result = await executor.execute({
       description: 'Do something',
       subagentType: 'researcher',
@@ -285,6 +370,108 @@ describe('SubagentExecutor', () => {
     expect(result.content).toContain('Subagent error');
     expect(result.content).toContain('Graph recursion limit reached');
     expect(result.messages).toEqual([]);
+  });
+
+  it('truncates long error messages to 200 chars', async () => {
+    const executor = createExecutor();
+    const longMessage = 'x'.repeat(500);
+    mockStandardGraphError(new Error(longMessage));
+
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+
+    expect(result.content.length).toBeLessThan(longMessage.length);
+    expect(result.content).toContain('...');
+    expect(result.content).toContain('Subagent error');
+  });
+
+  it('builds child with decremented maxSubagentDepth when allowNested=true', async () => {
+    const nestedConfig: ResolvedSubagentConfig = {
+      type: 'nested',
+      name: 'Nested',
+      description: 'allows nesting',
+      allowNested: true,
+      agentInputs: {
+        ...makeChildInputs('nested-child'),
+        subagentConfigs: [
+          {
+            type: 'nested',
+            name: 'Nested',
+            description: 'allows nesting',
+            allowNested: true,
+          },
+        ],
+        maxSubagentDepth: 3,
+      },
+    };
+
+    const executor = new SubagentExecutor({
+      configs: new Map([[nestedConfig.type, nestedConfig]]),
+      parentRunId: 'test-run',
+      parentAgentId: 'parent',
+      maxDepth: 3,
+    });
+
+    let observedChildInputs: AgentInputs | undefined;
+    const GraphModule =
+      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
+    graphSpy = jest
+      .spyOn(GraphModule, 'StandardGraph')
+      .mockImplementation(
+        (input: ConstructorParameters<typeof StandardGraph>[0]) => {
+          observedChildInputs = input.agents[0];
+          return {
+            createWorkflow: (): { invoke: jest.Mock } => ({
+              invoke: jest.fn().mockResolvedValue({
+                messages: [new AIMessage('nested done')],
+              }),
+            }),
+            clearHeavyState: jest.fn(),
+          } as unknown as StandardGraph;
+        }
+      );
+
+    await executor.execute({
+      description: 'nested task',
+      subagentType: 'nested',
+    });
+
+    expect(observedChildInputs).toBeDefined();
+    expect(observedChildInputs!.maxSubagentDepth).toBe(2);
+    expect(observedChildInputs!.subagentConfigs).toBeDefined();
+  });
+
+  it('strips subagentConfigs from child when allowNested is not set', async () => {
+    let observedChildInputs: AgentInputs | undefined;
+    const GraphModule =
+      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
+    graphSpy = jest
+      .spyOn(GraphModule, 'StandardGraph')
+      .mockImplementation(
+        (input: ConstructorParameters<typeof StandardGraph>[0]) => {
+          observedChildInputs = input.agents[0];
+          return {
+            createWorkflow: (): { invoke: jest.Mock } => ({
+              invoke: jest.fn().mockResolvedValue({
+                messages: [new AIMessage('done')],
+              }),
+            }),
+            clearHeavyState: jest.fn(),
+          } as unknown as StandardGraph;
+        }
+      );
+
+    const executor = createExecutor({ maxDepth: 3 });
+    await executor.execute({
+      description: 'task',
+      subagentType: 'researcher',
+    });
+
+    expect(observedChildInputs).toBeDefined();
+    expect(observedChildInputs!.subagentConfigs).toBeUndefined();
+    expect(observedChildInputs!.maxSubagentDepth).toBeUndefined();
   });
 
   describe('hooks', () => {
@@ -340,9 +527,6 @@ describe('SubagentExecutor', () => {
         description: 'Test task',
         subagentType: 'researcher',
       });
-
-      /** SubagentStop fires fire-and-forget; give microtask time to settle */
-      await new Promise((resolve) => setTimeout(resolve, 50));
 
       expect(capturedStop).toBeDefined();
       const input = capturedStop as Record<string, unknown>;

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -382,9 +382,28 @@ describe('SubagentExecutor', () => {
       subagentType: 'researcher',
     });
 
-    expect(result.content.length).toBeLessThan(longMessage.length);
-    expect(result.content).toContain('...');
-    expect(result.content).toContain('Subagent error');
+    /**
+     * Expected composition: "Subagent error: " (16) + 200 truncated chars + "..." (3) = 219.
+     * Assert the exact envelope to catch regressions in the truncation constant.
+     */
+    const MAX_TRUNCATED_LENGTH = 'Subagent error: '.length + 200 + '...'.length;
+    expect(result.content.length).toBe(MAX_TRUNCATED_LENGTH);
+    expect(result.content.startsWith('Subagent error: ')).toBe(true);
+    expect(result.content.endsWith('...')).toBe(true);
+  });
+
+  it('does not truncate short error messages', async () => {
+    const executor = createExecutor();
+    const shortMessage = 'brief error detail';
+    mockStandardGraphError(new Error(shortMessage));
+
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+
+    expect(result.content).toBe(`Subagent error: ${shortMessage}`);
+    expect(result.content.endsWith('...')).toBe(false);
   });
 
   it('builds child with decremented maxSubagentDepth when allowNested=true', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { HookRegistry } from '@/hooks/HookRegistry';
+import { Providers } from '@/common';
+import { AgentContext } from '@/agents/AgentContext';
+import type { AgentInputs, ResolvedSubagentConfig } from '@/types';
+import {
+  SubagentExecutor,
+  filterSubagentResult,
+  resolveSubagentConfigs,
+} from '../subagent';
+import type { StandardGraph } from '@/graphs/Graph';
+
+jest.setTimeout(15000);
+
+const makeChildInputs = (agentId = 'child-agent'): AgentInputs => ({
+  agentId,
+  provider: Providers.OPENAI,
+  clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+  instructions: 'You are a helper agent.',
+  maxContextTokens: 8000,
+});
+
+const makeConfig = (
+  type = 'researcher',
+  overrides: Partial<ResolvedSubagentConfig> = {}
+): ResolvedSubagentConfig => ({
+  type,
+  name: 'Test Researcher',
+  description: 'Researches things',
+  agentInputs: makeChildInputs(),
+  ...overrides,
+});
+
+describe('filterSubagentResult', () => {
+  it('extracts text from last AIMessage string content', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('task'),
+      new AIMessage('Here is the result'),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Here is the result');
+  });
+
+  it('extracts text blocks from array content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'First part.' },
+          { type: 'text', text: 'Second part.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('First part.\nSecond part.');
+  });
+
+  it('strips tool_use blocks from array content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'search', input: {} },
+          { type: 'text', text: 'Final answer.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Final answer.');
+  });
+
+  it('strips thinking blocks from array content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'thinking', thinking: 'Let me think...' },
+          { type: 'text', text: 'The result.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('The result.');
+  });
+
+  it('returns "Task completed" when no text blocks remain', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'do_thing', input: {} },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Task completed');
+  });
+
+  it('returns "Task completed" for empty string content', () => {
+    const messages: BaseMessage[] = [new AIMessage('')];
+    expect(filterSubagentResult(messages)).toBe('Task completed');
+  });
+
+  it('returns "Task completed" when no messages', () => {
+    expect(filterSubagentResult([])).toBe('Task completed');
+  });
+
+  it('returns "Task completed" when no AIMessage found', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('task'),
+      new ToolMessage({ content: 'result', tool_call_id: 'x' }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Task completed');
+  });
+
+  it('uses last AIMessage, not first', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage('First response'),
+      new ToolMessage({ content: 'tool output', tool_call_id: 'x' }),
+      new AIMessage('Final response'),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Final response');
+  });
+});
+
+describe('resolveSubagentConfigs', () => {
+  const parentInputs: AgentInputs = {
+    agentId: 'parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o', apiKey: 'test' },
+    instructions: 'You are a parent agent.',
+    maxContextTokens: 16000,
+  };
+
+  it('passes through configs with explicit agentInputs', () => {
+    const config = makeConfig();
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const resolved = resolveSubagentConfigs([config], parentContext);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].agentInputs.agentId).toBe('child-agent');
+  });
+
+  it('resolves self-spawn from parent _sourceInputs', () => {
+    const selfConfig = {
+      type: 'self',
+      name: 'Self Spawn',
+      description: 'Context isolation only',
+      self: true,
+    };
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const resolved = resolveSubagentConfigs([selfConfig], parentContext);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].agentInputs.provider).toBe(Providers.OPENAI);
+    expect(resolved[0].agentInputs.instructions).toBe(
+      'You are a parent agent.'
+    );
+  });
+
+  it('filters out configs with self=true when _sourceInputs is missing', () => {
+    const selfConfig = {
+      type: 'self',
+      name: 'Self Spawn',
+      description: 'Context isolation only',
+      self: true,
+    };
+    const parentContext = new AgentContext({
+      agentId: 'bare',
+      provider: Providers.OPENAI,
+      instructionTokens: 0,
+    });
+    const resolved = resolveSubagentConfigs([selfConfig], parentContext);
+    expect(resolved).toHaveLength(0);
+  });
+
+  it('filters out configs without agentInputs and self=false', () => {
+    const badConfig = {
+      type: 'broken',
+      name: 'Broken',
+      description: 'Missing inputs',
+    };
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const resolved = resolveSubagentConfigs([badConfig], parentContext);
+    expect(resolved).toHaveLength(0);
+  });
+});
+
+describe('SubagentExecutor', () => {
+  const config = makeConfig();
+
+  function createExecutor(
+    overrides: Partial<ConstructorParameters<typeof SubagentExecutor>[0]> = {}
+  ): SubagentExecutor {
+    return new SubagentExecutor({
+      configs: new Map([[config.type, config]]),
+      parentRunId: 'test-run',
+      parentAgentId: 'parent-agent',
+      ...overrides,
+    });
+  }
+
+  /** Spy handle for Graph module mock — set per test, restored in afterEach */
+  let graphSpy: jest.SpyInstance | undefined;
+
+  function mockStandardGraph(
+    invokeResult: { messages: BaseMessage[] },
+    clearSpy?: jest.Mock
+  ): { clearHeavyState: jest.Mock } {
+    const mockClear = clearSpy ?? jest.fn();
+    const GraphModule =
+      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
+    graphSpy = jest.spyOn(GraphModule, 'StandardGraph').mockImplementation(
+      () =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockResolvedValue(invokeResult),
+          }),
+          clearHeavyState: mockClear,
+        }) as unknown as StandardGraph
+    );
+    return { clearHeavyState: mockClear };
+  }
+
+  function mockStandardGraphError(error: Error): void {
+    const GraphModule =
+      jest.requireActual<typeof import('@/graphs/Graph')>('@/graphs/Graph');
+    graphSpy = jest.spyOn(GraphModule, 'StandardGraph').mockImplementation(
+      () =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockRejectedValue(error),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph
+    );
+  }
+
+  afterEach(() => {
+    graphSpy?.mockRestore();
+    graphSpy = undefined;
+  });
+
+  it('returns error for unknown subagent type', async () => {
+    const executor = createExecutor();
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'nonexistent',
+    });
+    expect(result.content).toContain('Unknown subagent type');
+    expect(result.content).toContain('nonexistent');
+    expect(result.content).toContain('researcher');
+    expect(result.messages).toEqual([]);
+  });
+
+  it('returns error when depth exceeds maxDepth', async () => {
+    const executor = createExecutor({ depth: 2, maxDepth: 2 });
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+    expect(result.content).toContain('Maximum subagent nesting depth');
+    expect(result.messages).toEqual([]);
+  });
+
+  it('executes child graph and returns filtered content', async () => {
+    const executor = createExecutor();
+    const { clearHeavyState } = mockStandardGraph({
+      messages: [
+        new HumanMessage('research this topic'),
+        new AIMessage('Here is my research summary.'),
+      ],
+    });
+
+    const result = await executor.execute({
+      description: 'Research this topic',
+      subagentType: 'researcher',
+    });
+
+    expect(result.content).toBe('Here is my research summary.');
+    expect(result.messages).toHaveLength(2);
+    expect(clearHeavyState).toHaveBeenCalled();
+  });
+
+  it('returns error message when child graph throws', async () => {
+    const executor = createExecutor();
+    mockStandardGraphError(new Error('Graph recursion limit reached'));
+
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+
+    expect(result.content).toContain('Subagent error');
+    expect(result.content).toContain('Graph recursion limit reached');
+    expect(result.messages).toEqual([]);
+  });
+
+  describe('hooks', () => {
+    let capturedStart: unknown;
+    let capturedStop: unknown;
+
+    beforeEach(() => {
+      capturedStart = undefined;
+      capturedStop = undefined;
+    });
+
+    it('fires SubagentStart before execution', async () => {
+      const registry = new HookRegistry();
+      registry.register('SubagentStart', {
+        hooks: [
+          async (input): Promise<Record<string, never>> => {
+            capturedStart = input;
+            return {};
+          },
+        ],
+      });
+
+      const executor = createExecutor({ hookRegistry: registry });
+      mockStandardGraph({ messages: [new AIMessage('done')] });
+
+      await executor.execute({
+        description: 'Test task',
+        subagentType: 'researcher',
+      });
+
+      expect(capturedStart).toBeDefined();
+      const input = capturedStart as Record<string, unknown>;
+      expect(input.hook_event_name).toBe('SubagentStart');
+      expect(input.parentAgentId).toBe('parent-agent');
+      expect(input.agentType).toBe('researcher');
+    });
+
+    it('fires SubagentStop after execution', async () => {
+      const registry = new HookRegistry();
+      registry.register('SubagentStop', {
+        hooks: [
+          async (input): Promise<Record<string, never>> => {
+            capturedStop = input;
+            return {};
+          },
+        ],
+      });
+
+      const executor = createExecutor({ hookRegistry: registry });
+      mockStandardGraph({ messages: [new AIMessage('done')] });
+
+      await executor.execute({
+        description: 'Test task',
+        subagentType: 'researcher',
+      });
+
+      /** SubagentStop fires fire-and-forget; give microtask time to settle */
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(capturedStop).toBeDefined();
+      const input = capturedStop as Record<string, unknown>;
+      expect(input.hook_event_name).toBe('SubagentStop');
+      expect(input.agentType).toBe('researcher');
+    });
+
+    it('SubagentStart deny blocks execution', async () => {
+      const registry = new HookRegistry();
+      registry.register('SubagentStart', {
+        hooks: [
+          async (): Promise<{ decision: 'deny'; reason: string }> => ({
+            decision: 'deny',
+            reason: 'Not authorized',
+          }),
+        ],
+      });
+
+      const executor = createExecutor({ hookRegistry: registry });
+      const result = await executor.execute({
+        description: 'Blocked task',
+        subagentType: 'researcher',
+      });
+
+      expect(result.content).toBe('Blocked: Not authorized');
+      expect(result.messages).toEqual([]);
+    });
+  });
+});

--- a/src/tools/__tests__/SubagentTool.test.ts
+++ b/src/tools/__tests__/SubagentTool.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from '@jest/globals';
+import { Constants } from '@/common';
+import {
+  SubagentToolName,
+  SubagentToolDescription,
+  SubagentToolDefinition,
+  SubagentToolSchema,
+  createSubagentToolDefinition,
+} from '../SubagentTool';
+import type { SubagentConfig } from '@/types';
+
+describe('SubagentTool', () => {
+  describe('schema structure', () => {
+    it('has description as required string property', () => {
+      expect(SubagentToolSchema.properties.description.type).toBe('string');
+      expect(SubagentToolSchema.required).toContain('description');
+    });
+
+    it('has subagent_type as required string property', () => {
+      expect(SubagentToolSchema.properties.subagent_type.type).toBe('string');
+      expect(SubagentToolSchema.required).toContain('subagent_type');
+    });
+
+    it('is an object type schema', () => {
+      expect(SubagentToolSchema.type).toBe('object');
+    });
+  });
+
+  describe('SubagentToolDefinition', () => {
+    it('has correct name', () => {
+      expect(SubagentToolDefinition.name).toBe(Constants.SUBAGENT);
+    });
+
+    it('references the same schema object', () => {
+      expect(SubagentToolDefinition.parameters).toBe(SubagentToolSchema);
+    });
+
+    it('has a non-empty description', () => {
+      expect(SubagentToolDefinition.description).toBe(SubagentToolDescription);
+      expect(SubagentToolDefinition.description!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SubagentToolName', () => {
+    it('equals Constants.SUBAGENT', () => {
+      expect(SubagentToolName).toBe('subagent');
+      expect(SubagentToolName).toBe(Constants.SUBAGENT);
+    });
+  });
+
+  describe('createSubagentToolDefinition', () => {
+    const configs: SubagentConfig[] = [
+      {
+        type: 'researcher',
+        name: 'Research Agent',
+        description: 'Searches and summarizes information',
+      },
+      {
+        type: 'coder',
+        name: 'Coding Agent',
+        description: 'Writes and reviews code',
+      },
+    ];
+
+    it('populates subagent_type enum from configs', () => {
+      const def = createSubagentToolDefinition(configs);
+      const schema = def.parameters as Record<string, unknown>;
+      const props = schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.subagent_type.enum).toEqual(['researcher', 'coder']);
+    });
+
+    it('includes type descriptions in tool description', () => {
+      const def = createSubagentToolDefinition(configs);
+      expect(def.description).toContain('"researcher" (Research Agent)');
+      expect(def.description).toContain('"coder" (Coding Agent)');
+      expect(def.description).toContain('Searches and summarizes information');
+      expect(def.description).toContain('Writes and reviews code');
+    });
+
+    it('has correct name', () => {
+      const def = createSubagentToolDefinition(configs);
+      expect(def.name).toBe(Constants.SUBAGENT);
+    });
+
+    it('has required description and subagent_type fields', () => {
+      const def = createSubagentToolDefinition(configs);
+      const schema = def.parameters as Record<string, unknown>;
+      expect(schema.required).toContain('description');
+      expect(schema.required).toContain('subagent_type');
+    });
+
+    it('works with single config', () => {
+      const def = createSubagentToolDefinition([configs[0]]);
+      const schema = def.parameters as Record<string, unknown>;
+      const props = schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.subagent_type.enum).toEqual(['researcher']);
+    });
+  });
+});

--- a/src/tools/__tests__/SubagentTool.test.ts
+++ b/src/tools/__tests__/SubagentTool.test.ts
@@ -6,6 +6,7 @@ import {
   SubagentToolDefinition,
   SubagentToolSchema,
   createSubagentToolDefinition,
+  buildSubagentToolParams,
 } from '../SubagentTool';
 import type { SubagentConfig } from '@/types';
 
@@ -100,6 +101,49 @@ describe('SubagentTool', () => {
         Record<string, unknown>
       >;
       expect(props.subagent_type.enum).toEqual(['researcher']);
+    });
+  });
+
+  describe('buildSubagentToolParams', () => {
+    const configs: SubagentConfig[] = [
+      {
+        type: 'researcher',
+        name: 'Research Agent',
+        description: 'Searches and summarizes information',
+      },
+      {
+        type: 'coder',
+        name: 'Coding Agent',
+        description: 'Writes and reviews code',
+      },
+    ];
+
+    it('returns name matching Constants.SUBAGENT', () => {
+      const params = buildSubagentToolParams(configs);
+      expect(params.name).toBe(Constants.SUBAGENT);
+    });
+
+    it('schema has enum populated from config types', () => {
+      const params = buildSubagentToolParams(configs);
+      const props = params.schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.subagent_type.enum).toEqual(['researcher', 'coder']);
+    });
+
+    it('description includes type listings', () => {
+      const params = buildSubagentToolParams(configs);
+      expect(params.description).toContain('"researcher" (Research Agent)');
+      expect(params.description).toContain('"coder" (Coding Agent)');
+    });
+
+    it('produces same schema as createSubagentToolDefinition', () => {
+      const params = buildSubagentToolParams(configs);
+      const def = createSubagentToolDefinition(configs);
+      expect(params.name).toBe(def.name);
+      expect(params.description).toBe(def.description);
+      expect(params.schema).toEqual(def.parameters);
     });
   });
 });

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -165,9 +165,6 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       callerConfig
     );
 
-    /** SubagentStop is fire-and-forget; give microtask time to settle */
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
     expect(captured).toBeDefined();
     expect(captured!.hook_event_name).toBe('SubagentStop');
     expect(captured!.agentType).toBe('researcher');

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1,0 +1,218 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  SubagentStartHookInput,
+  SubagentStartHookOutput,
+  SubagentStopHookInput,
+  SubagentStopHookOutput,
+} from '@/hooks/types';
+import { HookRegistry } from '@/hooks/HookRegistry';
+import { Run } from '@/run';
+import {
+  Constants,
+  GraphEvents,
+  Providers,
+  ToolEndHandler,
+  ModelEndHandler,
+} from '@/index';
+import * as providers from '@/llm/providers';
+
+const CHILD_RESPONSE = 'Hook test child response.';
+
+const callerConfig = {
+  configurable: { thread_id: 'hook-test-thread' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+const originalGetChatModelClass = providers.getChatModelClass;
+
+function makeSubagentToolCall(): ToolCall {
+  return {
+    name: Constants.SUBAGENT,
+    args: {
+      description: 'Test task for hook verification',
+      subagent_type: 'researcher',
+    },
+    id: `call_sub_${Date.now()}`,
+    type: 'tool_call',
+  };
+}
+
+function createParentAgent(): t.AgentInputs {
+  return {
+    agentId: 'hook-parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+    instructions: 'Delegate research tasks to subagents.',
+    maxContextTokens: 8000,
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Researcher',
+        description: 'Researches topics',
+        agentInputs: {
+          agentId: 'researcher-child',
+          provider: Providers.OPENAI,
+          clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+          instructions: 'Answer concisely.',
+          maxContextTokens: 8000,
+        },
+      },
+    ],
+  };
+}
+
+async function createSubagentRun(
+  hooks: HookRegistry,
+  runId = `subagent-hook-${Date.now()}`
+): Promise<Run<t.IState>> {
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      agents: [createParentAgent()],
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers: {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    },
+    hooks,
+  });
+}
+
+describe('Subagent hook integration (end-to-end via Run)', () => {
+  jest.setTimeout(15000);
+
+  let getChatModelClassSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getChatModelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return class extends FakeListChatModel {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            constructor(_options: any) {
+              super({ responses: [CHILD_RESPONSE] });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  it('SubagentStart fires with correct payload through real Run pipeline', async () => {
+    const registry = new HookRegistry();
+    let captured: SubagentStartHookInput | undefined;
+
+    const hook: HookCallback<'SubagentStart'> = async (
+      input
+    ): Promise<SubagentStartHookOutput> => {
+      captured = input;
+      return {};
+    };
+    registry.register('SubagentStart', { hooks: [hook] });
+
+    const tc = makeSubagentToolCall();
+    const run = await createSubagentRun(registry);
+    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('research something')] },
+      callerConfig
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.hook_event_name).toBe('SubagentStart');
+    expect(captured!.agentType).toBe('researcher');
+    expect(captured!.parentAgentId).toBe('hook-parent');
+    expect(captured!.threadId).toBe('hook-test-thread');
+    expect(captured!.inputs).toHaveLength(1);
+    expect(captured!.inputs[0].content).toContain(
+      'Test task for hook verification'
+    );
+  });
+
+  it('SubagentStop fires with messages from child execution', async () => {
+    const registry = new HookRegistry();
+    let captured: SubagentStopHookInput | undefined;
+
+    const hook: HookCallback<'SubagentStop'> = async (
+      input
+    ): Promise<SubagentStopHookOutput> => {
+      captured = input;
+      return {};
+    };
+    registry.register('SubagentStop', { hooks: [hook] });
+
+    const tc = makeSubagentToolCall();
+    const run = await createSubagentRun(registry);
+    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('research something')] },
+      callerConfig
+    );
+
+    /** SubagentStop is fire-and-forget; give microtask time to settle */
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(captured).toBeDefined();
+    expect(captured!.hook_event_name).toBe('SubagentStop');
+    expect(captured!.agentType).toBe('researcher');
+    expect(captured!.threadId).toBe('hook-test-thread');
+    expect(captured!.messages.length).toBeGreaterThan(0);
+  });
+
+  it('SubagentStart deny blocks subagent execution and returns blocked message', async () => {
+    const registry = new HookRegistry();
+    const denyHook: HookCallback<
+      'SubagentStart'
+    > = async (): Promise<SubagentStartHookOutput> => ({
+      decision: 'deny',
+      reason: 'policy violation',
+    });
+    registry.register('SubagentStart', {
+      pattern: '^researcher$',
+      hooks: [denyHook],
+    });
+
+    const tc = makeSubagentToolCall();
+    const run = await createSubagentRun(registry);
+    run.Graph!.overrideTestModel(
+      ['Delegating...', 'The subagent was blocked.'],
+      5,
+      [tc]
+    );
+
+    await run.processStream(
+      { messages: [new HumanMessage('research something')] },
+      callerConfig
+    );
+
+    const runMessages = run.getRunMessages();
+    expect(runMessages).toBeDefined();
+
+    const toolMessages = runMessages!.filter(
+      (msg) =>
+        msg._getType() === 'tool' &&
+        'name' in msg &&
+        msg.name === Constants.SUBAGENT
+    );
+    expect(toolMessages.length).toBe(1);
+    expect(String(toolMessages[0].content)).toContain(
+      'Blocked: policy violation'
+    );
+  });
+});

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -258,6 +258,14 @@ export function resolveSubagentConfigs(
  * `maxSubagentDepth` is decremented so that depth is consumed as the call
  * chain deepens across graph boundaries — the parent's executor-level check
  * alone cannot see into the child graph's separate executor.
+ *
+ * @remarks Advanced utility: exported primarily for testing and by
+ * {@link SubagentExecutor}. Host applications configuring subagents should
+ * not need to call this directly — it is invoked internally when a subagent
+ * tool is dispatched. The depth-countdown contract (parent's `maxDepth` in,
+ * child's decremented `maxSubagentDepth` on the returned inputs) is the
+ * mechanism that bounds nesting across graph boundaries; callers must
+ * respect it.
  */
 export function buildChildInputs(
   config: ResolvedSubagentConfig,

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -3,13 +3,14 @@ import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type {
   AgentInputs,
+  StandardGraphInput,
   ResolvedSubagentConfig,
   SubagentConfig,
   TokenCounter,
 } from '@/types';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { AgentContext } from '@/agents/AgentContext';
-import { StandardGraph } from '@/graphs/Graph';
+import type { StandardGraph } from '@/graphs/Graph';
 import { executeHooks } from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
@@ -32,6 +33,15 @@ export type SubagentExecuteResult = {
   messages: BaseMessage[];
 };
 
+/**
+ * Factory that constructs a child graph for subagent execution. Injected
+ * rather than imported so that `SubagentExecutor` does not have a runtime
+ * dependency on `StandardGraph` — this avoids a circular dependency between
+ * `src/graphs/Graph.ts` and `src/tools/subagent/` that would otherwise break
+ * Rollup's chunking under `preserveModules`.
+ */
+export type ChildGraphFactory = (input: StandardGraphInput) => StandardGraph;
+
 export type SubagentExecutorOptions = {
   configs: Map<string, ResolvedSubagentConfig>;
   parentSignal?: AbortSignal;
@@ -41,6 +51,12 @@ export type SubagentExecutorOptions = {
   tokenCounter?: TokenCounter;
   /** Remaining nesting budget. 0 or negative blocks execution. */
   maxDepth?: number;
+  /**
+   * Factory for constructing the isolated child graph. Callers pass
+   * `(input) => new StandardGraph(input)` — injected to break a circular
+   * module dependency.
+   */
+  createChildGraph: ChildGraphFactory;
 };
 
 export class SubagentExecutor {
@@ -51,6 +67,7 @@ export class SubagentExecutor {
   private readonly parentAgentId?: string;
   private readonly tokenCounter?: TokenCounter;
   private readonly maxDepth: number;
+  private readonly createChildGraph: ChildGraphFactory;
 
   constructor(options: SubagentExecutorOptions) {
     this.configs = options.configs;
@@ -60,6 +77,7 @@ export class SubagentExecutor {
     this.parentAgentId = options.parentAgentId;
     this.tokenCounter = options.tokenCounter;
     this.maxDepth = options.maxDepth ?? 1;
+    this.createChildGraph = options.createChildGraph;
   }
 
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
@@ -120,7 +138,7 @@ export class SubagentExecutor {
     const childRunId = `${this.parentRunId}_sub_${nanoid(8)}`;
     const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
 
-    const childGraph = new StandardGraph({
+    const childGraph = this.createChildGraph({
       runId: childRunId,
       signal: this.parentSignal,
       agents: [childInputs],

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -218,9 +218,14 @@ export class SubagentExecutor {
 }
 
 /**
- * Extract the last AI message's text content, stripping non-text blocks
- * (tool_use, thinking, redacted_thinking, tool_result).
- * Returns "Task completed" when no valid text content is found.
+ * Walk messages from last to first, returning the text content of the most
+ * recent AIMessage that has any. Non-text blocks (tool_use, thinking,
+ * redacted_thinking, tool_result) are stripped. If the last AIMessage is
+ * pure tool_use (e.g. the subagent hit `maxTurns` mid-tool-call), the walk
+ * continues to earlier AIMessages so partial progress is salvaged — this
+ * matches Claude Code's behavior in `agentToolUtils.finalizeAgentTool`.
+ * Returns "Task completed" only when no AIMessage in the history contains
+ * any text.
  */
 export function filterSubagentResult(messages: BaseMessage[]): string {
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -231,11 +236,12 @@ export function filterSubagentResult(messages: BaseMessage[]): string {
     const content = messages[i].content;
 
     if (typeof content === 'string') {
-      return content || 'Task completed';
+      if (content) return content;
+      continue;
     }
 
     if (!Array.isArray(content)) {
-      return 'Task completed';
+      continue;
     }
 
     const textParts: string[] = [];
@@ -247,7 +253,9 @@ export function filterSubagentResult(messages: BaseMessage[]): string {
       }
     }
 
-    return textParts.join('\n') || 'Task completed';
+    if (textParts.length > 0) {
+      return textParts.join('\n');
+    }
   }
 
   return 'Task completed';

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1,0 +1,251 @@
+import { nanoid } from 'nanoid';
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { AggregatedHookResult, HookRegistry } from '@/hooks';
+import type {
+  AgentInputs,
+  ResolvedSubagentConfig,
+  SubagentConfig,
+} from '@/types';
+import type { AgentContext } from '@/agents/AgentContext';
+import { StandardGraph } from '@/graphs/Graph';
+import { executeHooks } from '@/hooks';
+
+const DEFAULT_MAX_TURNS = 25;
+const RECURSION_MULTIPLIER = 3;
+
+const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
+  additionalContexts: [] as string[],
+  errors: [] as string[],
+});
+
+export type SubagentExecuteParams = {
+  description: string;
+  subagentType: string;
+};
+
+export type SubagentExecuteResult = {
+  content: string;
+  messages: BaseMessage[];
+};
+
+export type SubagentExecutorOptions = {
+  configs: Map<string, ResolvedSubagentConfig>;
+  parentSignal?: AbortSignal;
+  hookRegistry?: HookRegistry;
+  parentRunId: string;
+  parentAgentId?: string;
+  parentThreadId?: string;
+  depth?: number;
+  maxDepth?: number;
+};
+
+export class SubagentExecutor {
+  private readonly configs: Map<string, ResolvedSubagentConfig>;
+  private readonly parentSignal?: AbortSignal;
+  private readonly hookRegistry?: HookRegistry;
+  private readonly parentRunId: string;
+  private readonly parentAgentId?: string;
+  private readonly parentThreadId?: string;
+  private readonly depth: number;
+  private readonly maxDepth: number;
+
+  constructor(options: SubagentExecutorOptions) {
+    this.configs = options.configs;
+    this.parentSignal = options.parentSignal;
+    this.hookRegistry = options.hookRegistry;
+    this.parentRunId = options.parentRunId;
+    this.parentAgentId = options.parentAgentId;
+    this.parentThreadId = options.parentThreadId;
+    this.depth = options.depth ?? 0;
+    this.maxDepth = options.maxDepth ?? 1;
+  }
+
+  async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
+    const { description, subagentType } = params;
+    const config = this.configs.get(subagentType);
+
+    if (!config) {
+      const available = [...this.configs.keys()].join(', ');
+      return {
+        content: `Error: Unknown subagent type "${subagentType}". Available types: ${available}`,
+        messages: [],
+      };
+    }
+
+    if (this.depth >= this.maxDepth) {
+      return {
+        content: `Error: Maximum subagent nesting depth (${this.maxDepth}) exceeded.`,
+        messages: [],
+      };
+    }
+
+    const childAgentId =
+      config.agentInputs.agentId ||
+      `${this.parentAgentId ?? 'agent'}_sub_${nanoid(8)}`;
+
+    if (
+      this.hookRegistry?.hasHookFor('SubagentStart', this.parentRunId) === true
+    ) {
+      const hookResult = await executeHooks({
+        registry: this.hookRegistry,
+        input: {
+          hook_event_name: 'SubagentStart',
+          runId: this.parentRunId,
+          threadId: this.parentThreadId,
+          parentAgentId: this.parentAgentId,
+          agentId: childAgentId,
+          agentType: subagentType,
+          inputs: [new HumanMessage(description)],
+        },
+        sessionId: this.parentRunId,
+        matchQuery: subagentType,
+      }).catch((): AggregatedHookResult => HOOK_FALLBACK);
+
+      if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
+        return {
+          content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
+          messages: [],
+        };
+      }
+    }
+
+    const childInputs = buildChildInputs(config, childAgentId);
+    const childRunId = `${this.parentRunId}_sub_${nanoid(8)}`;
+    const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
+
+    const childGraph = new StandardGraph({
+      runId: childRunId,
+      signal: this.parentSignal,
+      agents: [childInputs],
+    });
+
+    let result: { messages: BaseMessage[] };
+    try {
+      const workflow = childGraph.createWorkflow();
+      result = await workflow.invoke(
+        { messages: [new HumanMessage(description)] },
+        { recursionLimit: maxTurns * RECURSION_MULTIPLIER }
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      childGraph.clearHeavyState();
+      return {
+        content: `Subagent error: ${message}`,
+        messages: [],
+      };
+    }
+
+    const filteredContent = filterSubagentResult(result.messages);
+
+    if (
+      this.hookRegistry?.hasHookFor('SubagentStop', this.parentRunId) === true
+    ) {
+      executeHooks({
+        registry: this.hookRegistry,
+        input: {
+          hook_event_name: 'SubagentStop',
+          runId: this.parentRunId,
+          threadId: this.parentThreadId,
+          agentId: childAgentId,
+          agentType: subagentType,
+          messages: result.messages,
+        },
+        sessionId: this.parentRunId,
+        matchQuery: subagentType,
+      }).catch(() => {
+        /* SubagentStop is observational — swallow errors */
+      });
+    }
+
+    childGraph.clearHeavyState();
+
+    return { content: filteredContent, messages: result.messages };
+  }
+}
+
+/**
+ * Extract the last AI message's text content, stripping non-text blocks
+ * (tool_use, thinking, redacted_thinking, tool_result).
+ * Returns "Task completed" when no valid text content is found.
+ */
+export function filterSubagentResult(messages: BaseMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]._getType() !== 'ai') {
+      continue;
+    }
+
+    const content = messages[i].content;
+
+    if (typeof content === 'string') {
+      return content || 'Task completed';
+    }
+
+    if (!Array.isArray(content)) {
+      return 'Task completed';
+    }
+
+    const textParts: string[] = [];
+    for (const block of content) {
+      if (typeof block === 'string') {
+        textParts.push(block);
+      } else if (
+        typeof block === 'object' &&
+        block != null &&
+        'type' in block &&
+        block.type === 'text' &&
+        'text' in block
+      ) {
+        textParts.push(block.text as string);
+      }
+    }
+
+    return textParts.join('\n') || 'Task completed';
+  }
+
+  return 'Task completed';
+}
+
+/**
+ * Resolve self-spawn configs by filling in agentInputs from the parent context.
+ * Returns configs with agentInputs guaranteed present.
+ */
+export function resolveSubagentConfigs(
+  configs: SubagentConfig[],
+  parentContext: AgentContext
+): ResolvedSubagentConfig[] {
+  return configs
+    .map((config) => {
+      if (config.agentInputs != null) {
+        return config as ResolvedSubagentConfig;
+      }
+      if (config.self !== true || parentContext._sourceInputs == null) {
+        return null;
+      }
+      return {
+        ...config,
+        agentInputs: { ...parentContext._sourceInputs },
+      } as ResolvedSubagentConfig;
+    })
+    .filter((c): c is ResolvedSubagentConfig => c != null);
+}
+
+/** Build child AgentInputs from a resolved config, stripping nesting and event-driven fields. */
+function buildChildInputs(
+  config: ResolvedSubagentConfig,
+  childAgentId: string
+): AgentInputs {
+  const { agentInputs } = config;
+  const childInputs: AgentInputs = {
+    ...agentInputs,
+    agentId: childAgentId,
+    toolDefinitions: undefined,
+  };
+
+  if (config.allowNested !== true) {
+    childInputs.subagentConfigs = undefined;
+    childInputs.maxSubagentDepth = undefined;
+  }
+
+  return childInputs;
+}

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1,19 +1,20 @@
 import { nanoid } from 'nanoid';
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type {
   AgentInputs,
   ResolvedSubagentConfig,
   SubagentConfig,
   TokenCounter,
 } from '@/types';
+import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { AgentContext } from '@/agents/AgentContext';
 import { StandardGraph } from '@/graphs/Graph';
 import { executeHooks } from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
 const RECURSION_MULTIPLIER = 3;
+const ERROR_MESSAGE_MAX_CHARS = 200;
 
 const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
   additionalContexts: [] as string[],
@@ -38,7 +39,7 @@ export type SubagentExecutorOptions = {
   parentRunId: string;
   parentAgentId?: string;
   tokenCounter?: TokenCounter;
-  depth?: number;
+  /** Remaining nesting budget. 0 or negative blocks execution. */
   maxDepth?: number;
 };
 
@@ -49,7 +50,6 @@ export class SubagentExecutor {
   private readonly parentRunId: string;
   private readonly parentAgentId?: string;
   private readonly tokenCounter?: TokenCounter;
-  private readonly depth: number;
   private readonly maxDepth: number;
 
   constructor(options: SubagentExecutorOptions) {
@@ -59,7 +59,6 @@ export class SubagentExecutor {
     this.parentRunId = options.parentRunId;
     this.parentAgentId = options.parentAgentId;
     this.tokenCounter = options.tokenCounter;
-    this.depth = options.depth ?? 0;
     this.maxDepth = options.maxDepth ?? 1;
   }
 
@@ -75,9 +74,9 @@ export class SubagentExecutor {
       };
     }
 
-    if (this.depth >= this.maxDepth) {
+    if (this.maxDepth <= 0) {
       return {
-        content: `Error: Maximum subagent nesting depth (${this.maxDepth}) exceeded.`,
+        content: 'Error: Maximum subagent nesting depth exceeded.',
         messages: [],
       };
     }
@@ -104,6 +103,11 @@ export class SubagentExecutor {
         matchQuery: subagentType,
       }).catch((): AggregatedHookResult => HOOK_FALLBACK);
 
+      /**
+       * `ask` is treated identically to `deny` in the subagent context:
+       * subagents are non-interactive, so there is no prompt path for `ask`.
+       * Both decisions block execution and return a "Blocked" tool result.
+       */
       if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
         return {
           content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
@@ -112,7 +116,7 @@ export class SubagentExecutor {
       }
     }
 
-    const childInputs = buildChildInputs(config, childAgentId);
+    const childInputs = buildChildInputs(config, childAgentId, this.maxDepth);
     const childRunId = `${this.parentRunId}_sub_${nanoid(8)}`;
     const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
 
@@ -134,10 +138,9 @@ export class SubagentExecutor {
         }
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
       childGraph.clearHeavyState();
       return {
-        content: `Subagent error: ${message}`,
+        content: `Subagent error: ${truncateErrorMessage(error)}`,
         messages: [],
       };
     }
@@ -147,7 +150,13 @@ export class SubagentExecutor {
     if (
       this.hookRegistry?.hasHookFor('SubagentStop', this.parentRunId) === true
     ) {
-      executeHooks({
+      /**
+       * Awaited (not fire-and-forget) for deterministic test synchronization
+       * and consistency with PostCompact. The parent is already waiting on the
+       * tool result, so the small extra latency is acceptable. Errors are
+       * swallowed — SubagentStop is observational.
+       */
+      await executeHooks({
         registry: this.hookRegistry,
         input: {
           hook_event_name: 'SubagentStop',
@@ -208,13 +217,14 @@ export function filterSubagentResult(messages: BaseMessage[]): string {
 
 /**
  * Resolve self-spawn configs by filling in agentInputs from the parent context.
- * Returns configs with agentInputs guaranteed present.
+ * Returns configs with agentInputs guaranteed present. Throws on duplicate
+ * `type` values to prevent silent config shadowing.
  */
 export function resolveSubagentConfigs(
   configs: SubagentConfig[],
   parentContext: AgentContext
 ): ResolvedSubagentConfig[] {
-  return configs
+  const resolved = configs
     .map((config) => {
       if (config.agentInputs != null) {
         return config as ResolvedSubagentConfig;
@@ -228,12 +238,31 @@ export function resolveSubagentConfigs(
       } as ResolvedSubagentConfig;
     })
     .filter((c): c is ResolvedSubagentConfig => c != null);
+
+  const seenTypes = new Set<string>();
+  for (const config of resolved) {
+    if (seenTypes.has(config.type)) {
+      throw new Error(
+        `Duplicate subagent type "${config.type}". Each SubagentConfig must have a unique "type" field.`
+      );
+    }
+    seenTypes.add(config.type);
+  }
+
+  return resolved;
 }
 
-/** Build child AgentInputs from a resolved config, stripping nesting and event-driven fields. */
-function buildChildInputs(
+/**
+ * Build child AgentInputs from a resolved config, stripping nesting and
+ * event-driven fields. When `allowNested: true`, the child's
+ * `maxSubagentDepth` is decremented so that depth is consumed as the call
+ * chain deepens across graph boundaries — the parent's executor-level check
+ * alone cannot see into the child graph's separate executor.
+ */
+export function buildChildInputs(
   config: ResolvedSubagentConfig,
-  childAgentId: string
+  childAgentId: string,
+  parentMaxDepth: number
 ): AgentInputs {
   const { agentInputs } = config;
   const childInputs: AgentInputs = {
@@ -242,10 +271,20 @@ function buildChildInputs(
     toolDefinitions: undefined,
   };
 
-  if (config.allowNested !== true) {
+  if (config.allowNested === true) {
+    childInputs.maxSubagentDepth = Math.max(0, parentMaxDepth - 1);
+  } else {
     childInputs.subagentConfigs = undefined;
     childInputs.maxSubagentDepth = undefined;
   }
 
   return childInputs;
+}
+
+function truncateErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.length <= ERROR_MESSAGE_MAX_CHARS) {
+    return message;
+  }
+  return `${message.slice(0, ERROR_MESSAGE_MAX_CHARS)}...`;
 }

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -148,11 +148,31 @@ export class SubagentExecutor {
     let result: { messages: BaseMessage[] };
     try {
       const workflow = childGraph.createWorkflow();
+      /**
+       * Detach the child invocation from the parent's callback chain.
+       * Without this, `streamEvents` in the parent's `Run.processStream`
+       * captures events from the child graph's LLM calls (e.g.
+       * `on_chat_model_stream` for the "researcher" agent) and delivers
+       * them to the parent's handlers. The parent then tries to resolve
+       * the child's agent ID in its own `agentContexts` map and throws
+       * "No agent context found for agent ID …". Setting `callbacks: []`
+       * overrides the inherited callbacks for this invoke; combined with
+       * the child's own empty `handlerRegistry`/`hookRegistry`, the child
+       * runs fully isolated.
+       *
+       * `runName` gives the child a distinct LangSmith trace root (avoids
+       * nested trace pollution).
+       */
       result = await workflow.invoke(
         { messages: [new HumanMessage(description)] },
         {
           recursionLimit: maxTurns * RECURSION_MULTIPLIER,
           signal: this.parentSignal,
+          callbacks: [],
+          runName: `subagent:${subagentType}`,
+          configurable: {
+            thread_id: childRunId,
+          },
         }
       );
     } catch (error) {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -6,6 +6,7 @@ import type {
   AgentInputs,
   ResolvedSubagentConfig,
   SubagentConfig,
+  TokenCounter,
 } from '@/types';
 import type { AgentContext } from '@/agents/AgentContext';
 import { StandardGraph } from '@/graphs/Graph';
@@ -22,6 +23,7 @@ const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
 export type SubagentExecuteParams = {
   description: string;
   subagentType: string;
+  threadId?: string;
 };
 
 export type SubagentExecuteResult = {
@@ -35,7 +37,7 @@ export type SubagentExecutorOptions = {
   hookRegistry?: HookRegistry;
   parentRunId: string;
   parentAgentId?: string;
-  parentThreadId?: string;
+  tokenCounter?: TokenCounter;
   depth?: number;
   maxDepth?: number;
 };
@@ -46,7 +48,7 @@ export class SubagentExecutor {
   private readonly hookRegistry?: HookRegistry;
   private readonly parentRunId: string;
   private readonly parentAgentId?: string;
-  private readonly parentThreadId?: string;
+  private readonly tokenCounter?: TokenCounter;
   private readonly depth: number;
   private readonly maxDepth: number;
 
@@ -56,13 +58,13 @@ export class SubagentExecutor {
     this.hookRegistry = options.hookRegistry;
     this.parentRunId = options.parentRunId;
     this.parentAgentId = options.parentAgentId;
-    this.parentThreadId = options.parentThreadId;
+    this.tokenCounter = options.tokenCounter;
     this.depth = options.depth ?? 0;
     this.maxDepth = options.maxDepth ?? 1;
   }
 
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
-    const { description, subagentType } = params;
+    const { description, subagentType, threadId } = params;
     const config = this.configs.get(subagentType);
 
     if (!config) {
@@ -92,7 +94,7 @@ export class SubagentExecutor {
         input: {
           hook_event_name: 'SubagentStart',
           runId: this.parentRunId,
-          threadId: this.parentThreadId,
+          threadId,
           parentAgentId: this.parentAgentId,
           agentId: childAgentId,
           agentType: subagentType,
@@ -118,6 +120,7 @@ export class SubagentExecutor {
       runId: childRunId,
       signal: this.parentSignal,
       agents: [childInputs],
+      tokenCounter: this.tokenCounter,
     });
 
     let result: { messages: BaseMessage[] };
@@ -125,7 +128,10 @@ export class SubagentExecutor {
       const workflow = childGraph.createWorkflow();
       result = await workflow.invoke(
         { messages: [new HumanMessage(description)] },
-        { recursionLimit: maxTurns * RECURSION_MULTIPLIER }
+        {
+          recursionLimit: maxTurns * RECURSION_MULTIPLIER,
+          signal: this.parentSignal,
+        }
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -146,7 +152,7 @@ export class SubagentExecutor {
         input: {
           hook_event_name: 'SubagentStop',
           runId: this.parentRunId,
-          threadId: this.parentThreadId,
+          threadId,
           agentId: childAgentId,
           agentType: subagentType,
           messages: result.messages,
@@ -189,13 +195,7 @@ export function filterSubagentResult(messages: BaseMessage[]): string {
     for (const block of content) {
       if (typeof block === 'string') {
         textParts.push(block);
-      } else if (
-        typeof block === 'object' &&
-        block != null &&
-        'type' in block &&
-        block.type === 'text' &&
-        'text' in block
-      ) {
+      } else if ('type' in block && block.type === 'text' && 'text' in block) {
         textParts.push(block.text as string);
       }
     }

--- a/src/tools/subagent/index.ts
+++ b/src/tools/subagent/index.ts
@@ -8,4 +8,5 @@ export type {
   SubagentExecuteParams,
   SubagentExecuteResult,
   SubagentExecutorOptions,
+  ChildGraphFactory,
 } from './SubagentExecutor';

--- a/src/tools/subagent/index.ts
+++ b/src/tools/subagent/index.ts
@@ -2,6 +2,7 @@ export {
   SubagentExecutor,
   filterSubagentResult,
   resolveSubagentConfigs,
+  buildChildInputs,
 } from './SubagentExecutor';
 export type {
   SubagentExecuteParams,

--- a/src/tools/subagent/index.ts
+++ b/src/tools/subagent/index.ts
@@ -1,0 +1,10 @@
+export {
+  SubagentExecutor,
+  filterSubagentResult,
+  resolveSubagentConfigs,
+} from './SubagentExecutor';
+export type {
+  SubagentExecuteParams,
+  SubagentExecuteResult,
+  SubagentExecutorOptions,
+} from './SubagentExecutor';

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -388,6 +388,29 @@ export type MultiAgentGraphInput = StandardGraphInput & {
   edges: GraphEdge[];
 };
 
+/** Configuration for a subagent type that can be spawned by a parent agent. */
+export type SubagentConfig = {
+  /** Identifier used in the tool's `subagent_type` enum (e.g. 'researcher', 'coder'). */
+  type: string;
+  /** Human-readable display name. */
+  name: string;
+  /** What this subagent specializes in — shown to the LLM. */
+  description: string;
+  /** Full agent config for the child graph. Omit when `self` is true. */
+  agentInputs?: AgentInputs;
+  /** When true, reuse the parent's AgentInputs (context isolation without separate config). */
+  self?: boolean;
+  /** Max AGENT→TOOLS cycles before forced stop (default: 25). */
+  maxTurns?: number;
+  /** Allow this subagent to spawn its own subagents (default: false). */
+  allowNested?: boolean;
+};
+
+/** SubagentConfig with agentInputs guaranteed present (self-spawn resolved). */
+export type ResolvedSubagentConfig = SubagentConfig & {
+  agentInputs: AgentInputs;
+};
+
 export interface AgentInputs {
   agentId: string;
   /** Human-readable name for the agent (used in handoff context). Defaults to agentId if not provided. */
@@ -431,6 +454,10 @@ export interface AgentInputs {
   maxToolResultChars?: number;
   /** Pre-computed tool schema token count (from cache). Skips recalculation when provided. */
   toolSchemaTokens?: number;
+  /** Subagent configurations for hierarchical delegation. Each defines a child agent type. */
+  subagentConfigs?: SubagentConfig[];
+  /** Maximum subagent nesting depth. Default 1 means top-level agents can spawn subagents but subagents cannot nest further. */
+  maxSubagentDepth?: number;
 }
 
 export interface ContextPruningConfig {


### PR DESCRIPTION
## Summary

Adds a `SubagentTool` that lets a parent agent delegate tasks to child agents with **isolated context windows**. This solves context window bloat: verbose tool outputs (test suites, large file reads, research results) stay in the child's context — only a filtered text summary returns to the parent.

Design synthesizes patterns from how Claude Code spawns Subagents, Langchain deep-agents' task tool, and LangGraph subgraph patterns.

### Key components

- **`SubagentConfig` type** on `AgentInputs` — declare child agent types with their own provider, instructions, tools
- **`SubagentExecutor`** — creates child `StandardGraph`, invokes with isolated state (`messages: [HumanMessage(description)]` only), filters result (strips `tool_use`/`thinking`/`redacted_thinking` blocks), fires `SubagentStart`/`SubagentStop` hooks
- **`SubagentTool`** — `LCTool` definition with dynamic enum populated from available configs
- **Graph integration** — tool created in `createAgentNode()` via `graphTools`, automatically becomes a direct tool (bypasses event-driven dispatch)
- **Self-spawn** — `self: true` reuses parent's `AgentInputs` for context isolation without separate agent config
- **Hook wiring** — `SubagentStart` (with deny/block support) and `SubagentStop` (observational) — the types existed with zero fire points, now wired
- **Manual verification script** — `src/scripts/multi-agent-subagent.ts` configures a supervisor with researcher + coder subagents

### Architecture

- **No ToolNode changes** — subagent tool is a regular `tool()` from `@langchain/core/tools` (same as handoff tools), added to `graphTools` → auto-direct-tool
- **Child isolation** — child `StandardGraph` gets no `handlerRegistry`, no `hookRegistry` → events don't leak to parent UI
- **Recursion prevention** — `maxSubagentDepth` (default: 1) + `allowNested: false` strip `subagentConfigs` from child
- **Traditional mode forced** — child strips `toolDefinitions` to avoid event-driven dispatch with no handler

## Test plan

- [x] `npx jest SubagentTool` — 12 schema tests pass
- [x] `npx jest SubagentExecutor` — 20 unit tests pass (filtering, resolve, hooks, errors, depth)
- [x] `npx jest src/specs/subagent.test` — 4 integration tests pass (tool creation, execution, no-config, self-spawn)
- [x] `npx tsc --noEmit` — clean
- [x] Full test suite — 1058 non-API tests pass, 0 regressions
- [ ] Manual: `OPENAI_API_KEY=... npx ts-node -r tsconfig-paths/register src/scripts/multi-agent-subagent.ts`