### PR TITLE
🔍 fix: exclude deferred tools from instruction token accounting

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -664,6 +664,17 @@ export class AgentContext {
     this.indexTokenCountMap = { ...baseTokenMap };
   }
 
+  /** Tool definitions that get bound to the model (excludes deferred-and-undiscovered entries). */
+  private getActiveToolDefinitions(): t.LCTool[] {
+    if (!this.toolDefinitions) {
+      return [];
+    }
+    return this.toolDefinitions.filter(
+      (def) =>
+        def.defer_loading !== true || this.discoveredToolNames.has(def.name)
+    );
+  }
+
   /**
    * Calculate tool tokens and add to instruction tokens
    * Note: System message tokens are calculated during systemRunnable creation
@@ -697,21 +708,19 @@ export class AgentContext {
       }
     }
 
-    if (this.toolDefinitions && this.toolDefinitions.length > 0) {
-      for (const def of this.toolDefinitions) {
-        if (countedToolNames.has(def.name)) {
-          continue;
-        }
-        const schema = {
-          type: 'function',
-          function: {
-            name: def.name,
-            description: def.description ?? '',
-            parameters: def.parameters ?? {},
-          },
-        };
-        toolTokens += tokenCounter(new SystemMessage(JSON.stringify(schema)));
+    for (const def of this.getActiveToolDefinitions()) {
+      if (countedToolNames.has(def.name)) {
+        continue;
       }
+      const schema = {
+        type: 'function',
+        function: {
+          name: def.name,
+          description: def.description ?? '',
+          parameters: def.parameters ?? {},
+        },
+      };
+      toolTokens += tokenCounter(new SystemMessage(JSON.stringify(schema)));
     }
 
     const isAnthropic =
@@ -864,7 +873,7 @@ export class AgentContext {
   getTokenBudgetBreakdown(messages?: BaseMessage[]): t.TokenBudgetBreakdown {
     const maxContextTokens = this.maxContextTokens ?? 0;
     const toolCount =
-      (this.tools?.length ?? 0) + (this.toolDefinitions?.length ?? 0);
+      (this.tools?.length ?? 0) + this.getActiveToolDefinitions().length;
     const messageCount = messages?.length ?? 0;
 
     let messageTokens = 0;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -664,7 +664,7 @@ export class AgentContext {
     this.indexTokenCountMap = { ...baseTokenMap };
   }
 
-  /** Tool definitions that get bound to the model (excludes deferred-and-undiscovered entries). */
+  /** Active tool definitions for token accounting (excludes deferred-and-undiscovered entries). */
   private getActiveToolDefinitions(): t.LCTool[] {
     if (!this.toolDefinitions) {
       return [];
@@ -869,6 +869,10 @@ export class AgentContext {
   /**
    * Returns a structured breakdown of how the context token budget is consumed.
    * Useful for diagnostics when context overflow or pruning issues occur.
+   *
+   * Note: `toolCount` reflects discoveries immediately, but `toolSchemaTokens`
+   * is a snapshot taken during `calculateInstructionTokens` and is not
+   * recomputed when `markToolsAsDiscovered` is called mid-run.
    */
   getTokenBudgetBreakdown(messages?: BaseMessage[]): t.TokenBudgetBreakdown {
     const maxContextTokens = this.maxContextTokens ?? 0;

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -375,6 +375,94 @@ describe('AgentContext', () => {
 
       expect(ctx.instructionTokens).toBeGreaterThan(initialTokens);
     });
+
+    it('excludes deferred-undiscovered toolDefinitions from toolSchemaTokens', async () => {
+      const activeDef: t.LCTool = {
+        name: 'active_tool',
+        description: 'Always loaded',
+        parameters: { type: 'object', properties: {} },
+      };
+      const deferredDef: t.LCTool = {
+        name: 'deferred_tool',
+        description: 'Loaded via tool search',
+        parameters: { type: 'object', properties: {} },
+        defer_loading: true,
+      };
+
+      const ctxBase = createBasicContext({
+        agentConfig: { toolDefinitions: [activeDef] },
+        tokenCounter: mockTokenCounter,
+      });
+      const ctxWithDeferred = createBasicContext({
+        agentConfig: { toolDefinitions: [activeDef, deferredDef] },
+        tokenCounter: mockTokenCounter,
+      });
+
+      await ctxBase.tokenCalculationPromise;
+      await ctxWithDeferred.tokenCalculationPromise;
+
+      expect(ctxWithDeferred.toolSchemaTokens).toBe(ctxBase.toolSchemaTokens);
+    });
+
+    it('includes deferred toolDefinitions once discovered via discoveredTools input', async () => {
+      const toolDefinitions: t.LCTool[] = [
+        {
+          name: 'deferred_tool',
+          description: 'Loaded via tool search',
+          parameters: { type: 'object', properties: {} },
+          defer_loading: true,
+        },
+      ];
+
+      const ctxUndiscovered = createBasicContext({
+        agentConfig: { toolDefinitions },
+        tokenCounter: mockTokenCounter,
+      });
+      const ctxDiscovered = createBasicContext({
+        agentConfig: { toolDefinitions, discoveredTools: ['deferred_tool'] },
+        tokenCounter: mockTokenCounter,
+      });
+
+      await ctxUndiscovered.tokenCalculationPromise;
+      await ctxDiscovered.tokenCalculationPromise;
+
+      expect(ctxUndiscovered.toolSchemaTokens).toBe(0);
+      expect(ctxDiscovered.toolSchemaTokens).toBeGreaterThan(0);
+    });
+
+    it('getTokenBudgetBreakdown toolCount excludes deferred-undiscovered toolDefinitions', () => {
+      const toolDefinitions: t.LCTool[] = [
+        {
+          name: 'active',
+          parameters: { type: 'object', properties: {} },
+        },
+        {
+          name: 'deferred',
+          defer_loading: true,
+          parameters: { type: 'object', properties: {} },
+        },
+      ];
+
+      const ctx = createBasicContext({ agentConfig: { toolDefinitions } });
+
+      expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(1);
+    });
+
+    it('getTokenBudgetBreakdown toolCount reflects newly discovered deferred tools', () => {
+      const toolDefinitions: t.LCTool[] = [
+        {
+          name: 'deferred',
+          defer_loading: true,
+          parameters: { type: 'object', properties: {} },
+        },
+      ];
+
+      const ctx = createBasicContext({ agentConfig: { toolDefinitions } });
+
+      expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(0);
+      ctx.markToolsAsDiscovered(['deferred']);
+      expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(1);
+    });
   });
 
   describe('reset()', () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -463,6 +463,28 @@ describe('AgentContext', () => {
       ctx.markToolsAsDiscovered(['deferred']);
       expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(1);
     });
+
+    it('toolSchemaTokens snapshot does not auto-update after markToolsAsDiscovered', async () => {
+      const toolDefinitions: t.LCTool[] = [
+        {
+          name: 'deferred',
+          description: 'Loaded via tool search',
+          parameters: { type: 'object', properties: {} },
+          defer_loading: true,
+        },
+      ];
+
+      const ctx = createBasicContext({
+        agentConfig: { toolDefinitions },
+        tokenCounter: mockTokenCounter,
+      });
+
+      await ctx.tokenCalculationPromise;
+      expect(ctx.toolSchemaTokens).toBe(0);
+
+      ctx.markToolsAsDiscovered(['deferred']);
+      expect(ctx.toolSchemaTokens).toBe(0);
+    });
   });
 
   describe('reset()', () => {


### PR DESCRIPTION
## Summary

- Fixes an over-count in `AgentContext` where tool definitions with `defer_loading: true` were included in `toolSchemaTokens` and `getTokenBudgetBreakdown().toolCount` even though they are never bound to the model until discovered via `tool_search`.
- This mismatch with the `defer_loading` filter in `getEventDrivenToolsForBinding` inflated the reported instruction token count and produced spurious context-overflow errors (e.g. `292 tools` in a LibreChat MCP registry).
- Both counting paths now go through a new private `getActiveToolDefinitions()` helper that filters out `defer_loading === true` entries unless they are already present in `discoveredToolNames`.

Refs: danny-avila/LibreChat#12702

## Upgrade note for consumers

If a consumer caches `toolSchemaTokens` across runs and passes it back via `AgentInputs.toolSchemaTokens` (the fast-path added in 8e0ff93), `calculateInstructionTokens` is skipped entirely in `fromConfig`. A cached value computed before this fix will continue to reflect the inflated count. **Consumers using that cache must invalidate it when upgrading** to pick up the corrected accounting.

## Out of scope (follow-ups worth filing)

- `getActiveToolDefinitions()` does not filter on `allowed_callers` — a code_execution-only tool passed via `toolDefinitions` still contributes to `toolSchemaTokens` even though it is never bound to the model. Pre-existing; narrower fix here keeps the change focused on the issue.
- `toolSchemaTokens` is a snapshot taken during `calculateInstructionTokens` and is not recomputed on `markToolsAsDiscovered`; `toolCount` is live. The JSDoc on `getTokenBudgetBreakdown` now documents this, and a test pins the snapshot semantic.

## Test plan

- [x] `npx jest src/agents/__tests__/AgentContext.test.ts` — 54/54 pass, including 5 new cases:
  - `toolSchemaTokens` excludes deferred-undiscovered entries
  - `toolSchemaTokens` includes deferred entries pre-seeded via `discoveredTools`
  - `getTokenBudgetBreakdown().toolCount` excludes deferred-undiscovered entries
  - `getTokenBudgetBreakdown().toolCount` reflects newly discovered deferred tools
  - `toolSchemaTokens` snapshot does **not** auto-update after `markToolsAsDiscovered`
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/agents/AgentContext.ts src/agents/__tests__/AgentContext.test.ts` — clean
- [x] Full suite: only pre-existing live-API failures (missing `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`), unrelated to this change