### PR TITLE
🧠 chore: Widen `AnthropicClientOptions` Thinking for Opus 4.7 Display

### DIFF
--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -45,7 +45,20 @@ export type AzureClientOptions = Partial<OpenAIChatInput> &
   } & BaseChatModelParams & {
     configuration?: OAIClientOptions;
   };
-export type ThinkingConfig = AnthropicInput['thinking'];
+/**
+ * Controls whether Claude's reasoning content is returned in adaptive
+ * thinking responses. Added for Claude Opus 4.7, which omits thinking by
+ * default unless the caller opts in with `'summarized'`.
+ * @see https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7#thinking-content-omitted-by-default
+ */
+export type ThinkingDisplay = 'summarized' | 'omitted';
+export type ThinkingConfigAdaptive = {
+  type: 'adaptive';
+  display?: ThinkingDisplay;
+};
+export type ThinkingConfig =
+  | NonNullable<AnthropicInput['thinking']>
+  | ThinkingConfigAdaptive;
 export type ChatOpenAIToolType =
   | BindToolsInput
   | OpenAIClient.ChatCompletionTool;
@@ -60,7 +73,8 @@ export type GoogleThinkingConfig = {
   thinkingLevel?: string;
 };
 export type OpenAIClientOptions = ChatOpenAIFields;
-export type AnthropicClientOptions = AnthropicInput & {
+export type AnthropicClientOptions = Omit<AnthropicInput, 'thinking'> & {
+  thinking?: ThinkingConfig;
   promptCache?: boolean;
 };
 export type MistralAIClientOptions = ChatMistralAIInput;


### PR DESCRIPTION
## Summary

I widened the `AnthropicClientOptions['thinking']` type so downstream consumers can pass Claude Opus 4.7's new adaptive-thinking `display` field without an unsafe cast. Previously the type came straight from `AnthropicInput['thinking']` in `@langchain/anthropic`, which doesn't include `{ type: 'adaptive', display?: 'summarized' | 'omitted' }`, forcing callers (e.g., LibreChat [PR #12701](https://github.com/danny-avila/LibreChat/pull/12701)) to write `adaptive as AnthropicClientOptions['thinking']`.

- Added a `ThinkingDisplay` union (`'summarized' | 'omitted'`) with a JSDoc link to the Anthropic 4.7 release notes in [src/types/llm.ts](src/types/llm.ts).
- Added a `ThinkingConfigAdaptive` type carrying the new optional `display` field.
- Extended the existing `ThinkingConfig` alias to union `NonNullable<AnthropicInput['thinking']>` with `ThinkingConfigAdaptive`, so pre-4.7 adaptive callers that omit `display` continue to type-check.
- Rewrote `AnthropicClientOptions` as `Omit<AnthropicInput, 'thinking'> & { thinking?: ThinkingConfig; promptCache?: boolean }` so the widened `thinking` takes precedence over langchain's stale definition.

Reference: https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7#thinking-content-omitted-by-default

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Ran `npx tsc --noEmit` against the full project — passes cleanly. Existing adaptive-thinking tests in [src/llm/anthropic/llm.spec.ts](src/llm/anthropic/llm.spec.ts) that construct `{ type: 'adaptive' }` still compile against the widened union. Recommend reviewers also verify the downstream LibreChat build no longer requires the `as AnthropicClientOptions['thinking']` cast after this package publishes.

### **Test Configuration**:

- Node.js 20+, TypeScript 5.5, `@langchain/anthropic ^0.3.26`, `@anthropic-ai/sdk ^0.73.0`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] Local unit tests pass with my changes