### PR TITLE
🔊 fix: surface provider, model, and status in summarization error logs

### DIFF
--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -365,6 +365,35 @@ type LogFn = (
 ) => void;
 
 /**
+ * Extracts an HTTP status code from a thrown LLM-provider error. Returns
+ * `undefined` for non-object values (including `null` or `undefined`, both
+ * valid `throw` targets in JS) so callers never dereference a nullish
+ * value.
+ */
+function extractHttpStatus(err: unknown): number | undefined {
+  if (err == null || typeof err !== 'object') {
+    return undefined;
+  }
+  const errRecord = err as Record<string, unknown>;
+  const direct = errRecord.status;
+  if (typeof direct === 'number') {
+    return direct;
+  }
+  const statusCode = errRecord.statusCode;
+  if (typeof statusCode === 'number') {
+    return statusCode;
+  }
+  const response = errRecord.response;
+  if (response != null && typeof response === 'object') {
+    const nested = (response as Record<string, unknown>).status;
+    if (typeof nested === 'number') {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+/**
  * Formats a provider-level error for logging. Returns both a human-readable
  * suffix (safe to include in the message string so it survives any host-side
  * formatter) and a structured metadata bag for rich log backends.
@@ -386,20 +415,51 @@ function describeProviderError(
     data.errorStack = err.stack;
   }
 
-  const errObj = err as {
-    status?: number;
-    statusCode?: number;
-    response?: { status?: number };
-  };
-  const status =
-    errObj.status ?? errObj.statusCode ?? errObj.response?.status;
-  const statusSuffix = typeof status === 'number' ? ` (HTTP ${status})` : '';
-  if (typeof status === 'number') {
+  const status = extractHttpStatus(err);
+  const statusSuffix = status != null ? ` (HTTP ${status})` : '';
+  if (status != null) {
     data.status = status;
   }
 
   return {
     suffix: `[${providerLabel}]${statusSuffix}: ${errMsg}`,
+    data,
+  };
+}
+
+/**
+ * Formats an exhausted-fallback error. `tryFallbackProviders` throws the
+ * last fallback provider's error, which may be from any of the configured
+ * fallbacks — not the primary — so we label the log with the list of
+ * fallback providers attempted rather than mis-attributing to the primary.
+ */
+function describeFallbackError(
+  err: unknown,
+  fallbacks: ReadonlyArray<{ provider: string | Providers }>
+): { suffix: string; data: Record<string, unknown> } {
+  const errMsg = err instanceof Error ? err.message : String(err);
+  const providerNames = fallbacks.map((f) => String(f.provider));
+  const label =
+    providerNames.length > 0
+      ? `fallbacks=[${providerNames.join(',')}]`
+      : 'no-fallbacks';
+
+  const data: Record<string, unknown> = {
+    fallbackProviders: providerNames,
+    fallbackCount: fallbacks.length,
+  };
+  if (err instanceof Error) {
+    data.errorName = err.name;
+    data.errorStack = err.stack;
+  }
+  const status = extractHttpStatus(err);
+  const statusSuffix = status != null ? ` (HTTP ${status})` : '';
+  if (status != null) {
+    data.status = status;
+  }
+
+  return {
+    suffix: `[${label}]${statusSuffix}: ${errMsg}`,
     data,
   };
 }
@@ -500,14 +560,9 @@ async function executeSummarizationWithFallback(params: {
           );
         }
       } catch (fbErr) {
-        const fbDescribed = describeProviderError(
-          fbErr,
-          clientConfig.provider,
-          clientConfig.modelName
-        );
+        const fbDescribed = describeFallbackError(fbErr, fallbacks);
         log('warn', `Fallback providers also failed ${fbDescribed.suffix}`, {
           ...fbDescribed.data,
-          fallbackCount: fallbacks.length,
         });
       }
     }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -432,13 +432,26 @@ function describeProviderError(
  * last fallback provider's error, which may be from any of the configured
  * fallbacks — not the primary — so we label the log with the list of
  * fallback providers attempted rather than mis-attributing to the primary.
+ *
+ * Entries in `fallbacks` are normally strongly typed, but we defend against
+ * malformed runtime config (null/undefined entries, missing `provider`
+ * field) so a recoverable summarization failure is never promoted to an
+ * uncaught exception from inside the logging path.
  */
 function describeFallbackError(
   err: unknown,
-  fallbacks: ReadonlyArray<{ provider: string | Providers }>
+  fallbacks: ReadonlyArray<unknown>
 ): { suffix: string; data: Record<string, unknown> } {
   const errMsg = err instanceof Error ? err.message : String(err);
-  const providerNames = fallbacks.map((f) => String(f.provider));
+  const providerNames = fallbacks
+    .map((f) => {
+      if (f == null || typeof f !== 'object') {
+        return undefined;
+      }
+      const raw = (f as { provider?: unknown }).provider;
+      return raw != null ? String(raw) : undefined;
+    })
+    .filter((p): p is string => typeof p === 'string');
   const label =
     providerNames.length > 0
       ? `fallbacks=[${providerNames.join(',')}]`

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -440,10 +440,13 @@ function describeProviderError(
  */
 function describeFallbackError(
   err: unknown,
-  fallbacks: ReadonlyArray<unknown>
+  fallbacks: unknown
 ): { suffix: string; data: Record<string, unknown> } {
   const errMsg = err instanceof Error ? err.message : String(err);
-  const providerNames = fallbacks
+  const list: ReadonlyArray<unknown> = Array.isArray(fallbacks)
+    ? fallbacks
+    : [];
+  const providerNames = list
     .map((f) => {
       if (f == null || typeof f !== 'object') {
         return undefined;
@@ -459,7 +462,7 @@ function describeFallbackError(
 
   const data: Record<string, unknown> = {
     fallbackProviders: providerNames,
-    fallbackCount: fallbacks.length,
+    fallbackCount: list.length,
   };
   if (err instanceof Error) {
     data.errorName = err.name;
@@ -538,9 +541,10 @@ async function executeSummarizationWithFallback(params: {
       messagesToRefineCount: messages.length,
     });
 
-    const fallbacks =
-      (clientConfig.clientOptions as unknown as t.LLMConfig | undefined)
-        ?.fallbacks ?? [];
+    const rawFallbacks = (
+      clientConfig.clientOptions as unknown as t.LLMConfig | undefined
+    )?.fallbacks;
+    const fallbacks = Array.isArray(rawFallbacks) ? rawFallbacks : [];
     if (fallbacks.length > 0) {
       try {
         const onChunk = createSummarizationChunkHandler({

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -365,6 +365,46 @@ type LogFn = (
 ) => void;
 
 /**
+ * Formats a provider-level error for logging. Returns both a human-readable
+ * suffix (safe to include in the message string so it survives any host-side
+ * formatter) and a structured metadata bag for rich log backends.
+ */
+function describeProviderError(
+  err: unknown,
+  provider: string,
+  modelName?: string
+): { suffix: string; data: Record<string, unknown> } {
+  const providerLabel = `${provider}/${modelName ?? '(no-model)'}`;
+  const errMsg = err instanceof Error ? err.message : String(err);
+
+  const data: Record<string, unknown> = {
+    provider,
+    model: modelName,
+  };
+  if (err instanceof Error) {
+    data.errorName = err.name;
+    data.errorStack = err.stack;
+  }
+
+  const errObj = err as {
+    status?: number;
+    statusCode?: number;
+    response?: { status?: number };
+  };
+  const status =
+    errObj.status ?? errObj.statusCode ?? errObj.response?.status;
+  const statusSuffix = typeof status === 'number' ? ` (HTTP ${status})` : '';
+  if (typeof status === 'number') {
+    data.status = status;
+  }
+
+  return {
+    suffix: `[${providerLabel}]${statusSuffix}: ${errMsg}`,
+    data,
+  };
+}
+
+/**
  * Runs the summarization LLM call with primary + fallback providers,
  * falling back to a metadata stub when all calls fail.
  */
@@ -415,13 +455,13 @@ async function executeSummarizationWithFallback(params: {
     summaryText = result.text;
     summaryUsage = result.usage;
   } catch (primaryError) {
-    log('error', 'Summarization LLM call failed', {
-      error:
-        primaryError instanceof Error
-          ? primaryError.message
-          : String(primaryError),
-      provider: clientConfig.provider,
-      model: clientConfig.modelName,
+    const primaryDescribed = describeProviderError(
+      primaryError,
+      clientConfig.provider,
+      clientConfig.modelName
+    );
+    log('error', `Summarization LLM call failed ${primaryDescribed.suffix}`, {
+      ...primaryDescribed.data,
       messagesToRefineCount: messages.length,
     });
 
@@ -460,18 +500,26 @@ async function executeSummarizationWithFallback(params: {
           );
         }
       } catch (fbErr) {
-        log('warn', 'Fallback providers also failed', {
-          error: fbErr instanceof Error ? fbErr.message : String(fbErr),
+        const fbDescribed = describeProviderError(
+          fbErr,
+          clientConfig.provider,
+          clientConfig.modelName
+        );
+        log('warn', `Fallback providers also failed ${fbDescribed.suffix}`, {
+          ...fbDescribed.data,
+          fallbackCount: fallbacks.length,
         });
       }
     }
     if (!summaryText) {
-      log('warn', 'Summarization failed, falling back to metadata stub', {
-        error:
-          primaryError instanceof Error
-            ? primaryError.message
-            : String(primaryError),
-      });
+      log(
+        'warn',
+        `Summarization failed, falling back to metadata stub ${primaryDescribed.suffix}`,
+        {
+          ...primaryDescribed.data,
+          messagesToRefineCount: messages.length,
+        }
+      );
       summaryText = generateMetadataStub(messages);
     }
   }


### PR DESCRIPTION
## Summary

When summarization fails, host applications (e.g. LibreChat's default console formatter) frequently strip metadata from the winston `info` object — the user ends up seeing only a generic `Summarization LLM call failed` line with no indication of which provider/model misbehaved or what the underlying error actually was.

This PR folds the critical bits (provider/model label, and HTTP status when available) directly into the log message string so they survive any downstream formatter. Structured metadata stays on the event for JSON backends.

### Before

```
error: [agents:summarize] Summarization LLM call failed
warn:  [agents:summarize] Summarization failed, falling back to metadata stub
```

### After

```
error: [agents:summarize] Summarization LLM call failed [azureOpenAI/gpt-5.4-mini] (HTTP 404): The API deployment for this resource does not exist.
warn:  [agents:summarize] Summarization failed, falling back to metadata stub [azureOpenAI/gpt-5.4-mini] (HTTP 404): ...
```

### Changes

- New `describeProviderError` helper that produces a log-string suffix (`[provider/model]` + optional `(HTTP <n>)` + error message) and a structured metadata bag (`provider`, `model`, `errorName`, `errorStack`, `status`).
- Applied at all three summarization error sites: primary failure, fallback provider failure, and the final metadata-stub fallback.
- No behavior changes for the happy path — only the error/warn messages are expanded.

### Motivation

Downstream discussion: https://github.com/danny-avila/LibreChat/discussions/12733

The symptom masks at least three distinct bugs (discussion #12614, issue #12721, and the reported discussion itself). Surfacing the provider, model, and HTTP status in the log message is the single highest-leverage improvement for diagnosing the whole class.

## Test plan

- [x] `npx jest --testPathPatterns 'src/summarization/__tests__'` — all 24 existing tests pass.
- [x] `npx tsc --noEmit` — no new type errors.
- [ ] Manual repro with a bogus Azure deployment name to confirm the expanded message surfaces in LibreChat's default console output (after the companion LibreChat PR lands).