### PR TITLE
fix(summarization): log and recover from model init errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -190,8 +190,19 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: npm pack
 
+      - name: Determine publish tag
+        if: steps.check.outputs.skip != 'true'
+        id: publish_tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if echo "$PACKAGE_VERSION" | grep -q "-"; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish
         if: steps.check.outputs.skip != 'true'
-        run: npm publish $(ls librechat-agents-*.tgz) --access public --provenance
+        run: npm publish $(ls librechat-agents-*.tgz) --access public --provenance --tag ${{ steps.publish_tag.outputs.tag }}
         env:
           NODE_ENV: production

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,7 @@
 {
   "name": "@librechat/agents",
   "version": "3.1.67",
+  "version": "3.1.66-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.67",
-  "version": "3.1.66-dev.0",
+  "version": "3.1.67-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.67",
+      "version": "3.1.67-dev.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.67",
+  "version": "3.1.66-dev.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.67-dev.0",
+  "version": "3.1.67-dev.4",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",
@@ -61,6 +61,9 @@
     "tool": "node --trace-warnings -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tools.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
     "search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/search.ts --provider 'bedrock' --name 'Jo' --location 'New York, NY'",
     "tool_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/tool_search.ts",
+    "subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
+    "subagent:events": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-event-driven-debug.ts",
+    "subagent:tools": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-tools-debug.ts",
     "programmatic_exec": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/programmatic_exec.ts",
     "code_exec_ptc": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/code_exec_ptc.ts --provider 'openAI' --name 'Jo' --location 'New York, NY'",
     "programmatic_exec_agent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/programmatic_exec_agent.ts --provider 'openAI' --name 'Jo' --location 'New York, NY'",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "multi-agent-chain": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-chain.ts",
     "multi-agent-sequence": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-sequence.ts",
     "multi-agent-conditional": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-conditional.ts",
+    "multi-agent-subagent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-subagent.ts",
     "multi-agent-supervisor": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/multi-agent-supervisor.ts",
     "test-handoff-preamble": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/test-handoff-preamble.ts",
     "multi-agent-list-handoff": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/test-multi-agent-list-handoff.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.66-dev.0",
+  "version": "3.1.67-dev.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -55,6 +55,8 @@ export class AgentContext {
       contextPruningConfig,
       maxToolResultChars,
       toolSchemaTokens,
+      subagentConfigs,
+      maxSubagentDepth,
     } = agentConfig;
 
     const agentContext = new AgentContext({
@@ -81,6 +83,10 @@ export class AgentContext {
       contextPruningConfig,
       maxToolResultChars,
     });
+
+    agentContext._sourceInputs = agentConfig;
+    agentContext.subagentConfigs = subagentConfigs;
+    agentContext.maxSubagentDepth = maxSubagentDepth;
 
     if (initialSummary?.text != null && initialSummary.text !== '') {
       agentContext.setInitialSummary(
@@ -198,6 +204,12 @@ export class AgentContext {
   toolDefinitions?: t.LCTool[];
   /** Set of tool names discovered via tool search (to be loaded) */
   discoveredToolNames: Set<string> = new Set();
+  /** Original AgentInputs used to create this context — used for self-spawn subagent resolution. */
+  _sourceInputs?: t.AgentInputs;
+  /** Subagent configurations for hierarchical delegation. */
+  subagentConfigs?: t.SubagentConfig[];
+  /** Maximum subagent nesting depth. */
+  maxSubagentDepth?: number;
   /** Instructions for this agent */
   instructions?: string;
   /** Additional instructions for this agent */
@@ -685,8 +697,20 @@ export class AgentContext {
     let toolTokens = 0;
     const countedToolNames = new Set<string>();
 
-    if (this.tools && this.tools.length > 0) {
-      for (const tool of this.tools) {
+    /**
+     * Iterate both `tools` (user-provided instance tools) and `graphTools`
+     * (graph-managed tools like handoff + subagent). `graphTools` is often
+     * populated after `fromConfig()` kicks off the initial calculation, so
+     * callers that mutate `graphTools` must re-trigger this method to
+     * refresh `toolSchemaTokens`.
+     */
+    const instanceTools: t.GraphTools = [
+      ...((this.tools as t.GenericTool[] | undefined) ?? []),
+      ...((this.graphTools as t.GenericTool[] | undefined) ?? []),
+    ];
+
+    if (instanceTools.length > 0) {
+      for (const tool of instanceTools) {
         const genericTool = tool as Record<string, unknown>;
         if (
           genericTool.schema != null &&

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -186,6 +186,7 @@ export enum Constants {
   READ_FILE = 'read_file',
   BASH_TOOL = 'bash_tool',
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
+  SUBAGENT = 'subagent',
 }
 
 /** Tool names that use the code execution environment (shared session, file tracking). */

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -183,6 +183,8 @@ export enum Constants {
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
   SKILL_TOOL = 'skill',
+  EXECUTE_BASH = 'execute_bash',
+  BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
 }
 
 export enum TitleMethod {

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -183,7 +183,7 @@ export enum Constants {
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
   SKILL_TOOL = 'skill',
-  EXECUTE_BASH = 'execute_bash',
+  BASH_TOOL = 'bash_tool',
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
 }
 

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -183,6 +183,7 @@ export enum Constants {
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
   SKILL_TOOL = 'skill',
+  READ_FILE = 'read_file',
   BASH_TOOL = 'bash_tool',
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
 }

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -182,6 +182,7 @@ export enum Constants {
   MCP_DELIMITER = '_mcp_',
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
+  SKILL_TOOL = 'skill',
 }
 
 export enum TitleMethod {

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -187,6 +187,14 @@ export enum Constants {
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',
 }
 
+/** Tool names that use the code execution environment (shared session, file tracking). */
+export const CODE_EXECUTION_TOOLS: ReadonlySet<string> = new Set([
+  Constants.EXECUTE_CODE,
+  Constants.BASH_TOOL,
+  Constants.PROGRAMMATIC_TOOL_CALLING,
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+]);
+
 export enum TitleMethod {
   STRUCTURED = 'structured',
   FUNCTIONS = 'functions',

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -27,6 +27,8 @@ export enum GraphEvents {
   ON_SUMMARIZE_DELTA = 'on_summarize_delta',
   /** [Custom] Emitted when the summarize node completes with the final summary */
   ON_SUMMARIZE_COMPLETE = 'on_summarize_complete',
+  /** [Custom] Progress update from a running subagent (wraps child-graph events so hosts can display activity separately from parent). */
+  ON_SUBAGENT_UPDATE = 'on_subagent_update',
   /** [Custom] Diagnostic logging event for context management observability */
   ON_AGENT_LOG = 'on_agent_log',
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { nanoid } from 'nanoid';
+import { tool } from '@langchain/core/tools';
 import { ToolNode } from '@langchain/langgraph/prebuilt';
 import { Runnable, RunnableConfig } from '@langchain/core/runnables';
 import { ToolMessage, AIMessageChunk } from '@langchain/core/messages';
@@ -39,6 +40,8 @@ import {
   joinKeys,
   sleep,
 } from '@/utils';
+import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
+import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
@@ -1150,6 +1153,90 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const agentContext = this.agentContexts.get(agentId);
     if (!agentContext) {
       throw new Error(`Agent context not found for agentId: ${agentId}`);
+    }
+
+    /**
+     * Depth countdown across graph boundaries: the parent's `maxSubagentDepth`
+     * becomes this executor's `maxDepth`. When the child graph is constructed,
+     * `buildChildInputs()` decrements `maxSubagentDepth` on the child's
+     * `AgentInputs` (only when `allowNested: true`; otherwise subagentConfigs
+     * are stripped entirely). The child graph's own `createAgentNode()` then
+     * reads the decremented value here and creates a narrower executor —
+     * recursion is bounded even though each graph has its own separate
+     * executor instance.
+     */
+    const effectiveSubagentDepth = agentContext.maxSubagentDepth ?? 1;
+    if (
+      agentContext.subagentConfigs != null &&
+      agentContext.subagentConfigs.length > 0 &&
+      effectiveSubagentDepth > 0
+    ) {
+      const resolvedConfigs = resolveSubagentConfigs(
+        agentContext.subagentConfigs,
+        agentContext
+      );
+      if (resolvedConfigs.length > 0) {
+        const executor = new SubagentExecutor({
+          configs: new Map(resolvedConfigs.map((c) => [c.type, c])),
+          parentSignal: this.signal,
+          hookRegistry: this.hookRegistry,
+          parentRunId: this.runId ?? '',
+          parentAgentId: agentContext.agentId,
+          tokenCounter: agentContext.tokenCounter,
+          maxDepth: effectiveSubagentDepth,
+          createChildGraph: (input): StandardGraph => new StandardGraph(input),
+        });
+
+        const subagentTool = tool(async (rawInput, config) => {
+          const input = rawInput as {
+            description?: string;
+            subagent_type?: string;
+          };
+          const description =
+            typeof input.description === 'string' &&
+            input.description.trim().length > 0
+              ? input.description
+              : 'No task description provided';
+          const subagentType =
+            typeof input.subagent_type === 'string' ? input.subagent_type : '';
+          const threadId = config.configurable?.thread_id as string | undefined;
+          const result = await executor.execute({
+            description,
+            subagentType,
+            threadId,
+          });
+          return result.content;
+        }, buildSubagentToolParams(resolvedConfigs));
+
+        if (!agentContext.graphTools) {
+          agentContext.graphTools = [];
+        }
+        (agentContext.graphTools as t.GenericTool[]).push(subagentTool);
+
+        /**
+         * Refresh toolSchemaTokens to include the subagent tool's schema.
+         * `calculateInstructionTokens()` was kicked off in `fromConfig()`
+         * before graphTools was populated, so its result did not count this
+         * tool. Without this retrigger, token-budget/pruning logic
+         * underestimates prompt overhead.
+         */
+        if (agentContext.tokenCounter) {
+          const { tokenCounter, baseIndexTokenCountMap } = agentContext;
+          agentContext.tokenCalculationPromise = agentContext
+            .calculateInstructionTokens(tokenCounter)
+            .then(() => {
+              agentContext.updateTokenMapWithInstructions(
+                baseIndexTokenCountMap
+              );
+            })
+            .catch((err) => {
+              console.error(
+                'Error recalculating instruction tokens after subagent tool injection:',
+                err
+              );
+            });
+        }
+      }
     }
 
     const agentNode = `${AGENT}${agentId}` as const;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -53,6 +53,7 @@ import { isThinkingEnabled } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
 import { ChatOpenAI } from '@/llm/openai';
+import type { HookRegistry } from '@/hooks';
 
 const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 
@@ -123,6 +124,7 @@ export abstract class Graph<
   /** Set of invoked tool call IDs from non-message run steps completed mid-run, if any */
   invokedToolIds?: Set<string>;
   handlerRegistry: HandlerRegistry | undefined;
+  hookRegistry: HookRegistry | undefined;
   /**
    * Tool session contexts for automatic state persistence across tool invocations.
    * Keyed by tool name (e.g., Constants.EXECUTE_CODE).
@@ -147,6 +149,7 @@ export abstract class Graph<
     this.prelimMessageIdsByStepKey = new Map();
     this.invokedToolIds = undefined;
     this.handlerRegistry = undefined;
+    this.hookRegistry = undefined;
     this.sessions.clear();
   }
 }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1207,6 +1207,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             },
             runId: this.runId,
             isMultiAgent: this.isMultiAgentGraph(),
+            hookRegistry: this.hookRegistry,
             dispatchRunStep: async (runStep, nodeConfig) => {
               this.contentData.push(runStep);
               this.contentIndexMap.set(runStep.id, runStep.index);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -509,6 +509,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentId: agentContext?.agentId,
         toolCallStepIds: this.toolCallStepIds,
         toolRegistry: agentContext?.toolRegistry,
+        hookRegistry: this.hookRegistry,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,
         maxToolResultChars: agentContext?.maxToolResultChars,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1176,10 +1176,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentContext
       );
       if (resolvedConfigs.length > 0) {
+        const getParentHandlerRegistry = (): HandlerRegistry | undefined =>
+          this.handlerRegistry;
         const executor = new SubagentExecutor({
           configs: new Map(resolvedConfigs.map((c) => [c.type, c])),
           parentSignal: this.signal,
           hookRegistry: this.hookRegistry,
+          /** Lazy — Run wires the registry onto the graph AFTER
+           *  `createWorkflow()` runs, so a direct capture here would be
+           *  `undefined` at construction time. */
+          parentHandlerRegistry: getParentHandlerRegistry,
           parentRunId: this.runId ?? '',
           parentAgentId: agentContext.agentId,
           tokenCounter: agentContext.tokenCounter,
@@ -1200,10 +1206,25 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const subagentType =
             typeof input.subagent_type === 'string' ? input.subagent_type : '';
           const threadId = config.configurable?.thread_id as string | undefined;
+          /**
+           * When the tool is dispatched from an LLM's `tool_call`, LangChain
+           * threads the originating `ToolCall` onto the RunnableConfig as
+           * `config.toolCall` (see `ToolRunnableConfig` in
+           * `@langchain/core/tools` — internal but stable since ≥0.3.x).
+           * Surfacing its id lets hosts correlate `SubagentUpdateEvent`s
+           * back to the parent's `tool_call_id` deterministically — no
+           * temporal heuristics needed. If a future LangChain version
+           * changes the threading, the type-guarded read falls back to
+           * `undefined` and the correlation degrades gracefully.
+           */
+          const toolCall = (config as { toolCall?: { id?: string } }).toolCall;
+          const parentToolCallId =
+            typeof toolCall?.id === 'string' ? toolCall.id : undefined;
           const result = await executor.execute({
             description,
             subagentType,
             threadId,
+            parentToolCallId,
           });
           return result.content;
         }, buildSubagentToolParams(resolvedConfigs));

--- a/src/hooks/HookRegistry.ts
+++ b/src/hooks/HookRegistry.ts
@@ -1,0 +1,208 @@
+// src/hooks/HookRegistry.ts
+import type { HookEvent, HookMatcher } from './types';
+
+/**
+ * Internal matcher storage type.
+ *
+ * Matchers registered via the public `register<E>` API are strictly typed
+ * to a single `E`, but the storage needs one uniform slot type per event.
+ * We store them as `HookMatcher<HookEvent>` and cast once at the variance
+ * boundary — see `ensureList` and `snapshot` below. The invariant (every
+ * matcher in `bucket[event]` was registered with that exact event) is
+ * enforced by the public API; breaking it requires bypassing the types.
+ */
+type MatcherBucket = Partial<Record<HookEvent, HookMatcher<HookEvent>[]>>;
+
+/**
+ * Run-scoped storage for hook matchers with an additional layer for
+ * session-scoped matchers that should be cleaned up between sessions.
+ *
+ * Hosts construct one registry per `Run` (mirroring how `HandlerRegistry` is
+ * scoped) and register global matchers + per-session matchers against it.
+ * Registration is strictly additive — nothing in this class mutates a
+ * matcher's callbacks or flags after insertion.
+ *
+ * ## Why `Map<sessionId, MatcherBucket>` and not `Record`
+ *
+ * LibreChat runs thousands of parallel sessions in one Node process, and
+ * hook registration happens inside hot paths (tool loading, agent spawning).
+ * A `Record<sessionId, ...>` has to be spread on every insertion, which is
+ * O(n) per call and O(n²) total for a batch of parallel registrations. A
+ * Map mutates in place, keeping insertions O(1). This mirrors the reasoning
+ * Claude Code documents at `utils/hooks/sessionHooks.ts:62`.
+ */
+export class HookRegistry {
+  private readonly global: MatcherBucket = {};
+  private readonly sessions: Map<string, MatcherBucket> = new Map();
+
+  /**
+   * Register a matcher for the lifetime of this registry (= one Run).
+   * Returns an unregister function that removes the matcher by reference.
+   */
+  register<E extends HookEvent>(event: E, matcher: HookMatcher<E>): () => void {
+    const list = ensureList(this.global, event);
+    list.push(widen(matcher));
+    return () => {
+      removeFromList(list, matcher);
+    };
+  }
+
+  /**
+   * Register a matcher for a specific session. Cleared automatically when
+   * `clearSession(sessionId)` is called, or can be removed directly via the
+   * returned unregister function.
+   */
+  registerSession<E extends HookEvent>(
+    sessionId: string,
+    event: E,
+    matcher: HookMatcher<E>
+  ): () => void {
+    const bucket = this.ensureSessionBucket(sessionId);
+    const list = ensureList(bucket, event);
+    list.push(widen(matcher));
+    return () => {
+      removeFromList(list, matcher);
+    };
+  }
+
+  /**
+   * Returns all matchers registered for `event`, concatenating global first
+   * and then session-specific (when `sessionId` is supplied). The caller
+   * receives a fresh array, so iterating it is safe even if a matcher is
+   * removed mid-iteration (e.g. via `once: true`).
+   */
+  getMatchers<E extends HookEvent>(
+    event: E,
+    sessionId?: string
+  ): HookMatcher<E>[] {
+    const globalList = readList(this.global, event);
+    if (sessionId === undefined) {
+      return snapshot<E>(globalList);
+    }
+    const bucket = this.sessions.get(sessionId);
+    if (bucket === undefined) {
+      return snapshot<E>(globalList);
+    }
+    const sessionList = readList(bucket, event);
+    if (globalList.length === 0) {
+      return snapshot<E>(sessionList);
+    }
+    if (sessionList.length === 0) {
+      return snapshot<E>(globalList);
+    }
+    return snapshot<E>([...globalList, ...sessionList]);
+  }
+
+  /**
+   * Removes `matcher` by reference from global storage first, falling back
+   * to the session bucket when `sessionId` is supplied. Used by
+   * `executeHooks` to drop `once: true` matchers after they fire.
+   */
+  removeMatcher<E extends HookEvent>(
+    event: E,
+    matcher: HookMatcher<E>,
+    sessionId?: string
+  ): boolean {
+    if (removeFromList(readList(this.global, event), matcher)) {
+      return true;
+    }
+    if (sessionId === undefined) {
+      return false;
+    }
+    const bucket = this.sessions.get(sessionId);
+    if (bucket === undefined) {
+      return false;
+    }
+    return removeFromList(readList(bucket, event), matcher);
+  }
+
+  /**
+   * Drops every session-scoped matcher for `sessionId`. Call this in the
+   * `finally` block around a Run so a `once: true` hook that never fired
+   * cannot leak into the next session on the same registry.
+   */
+  clearSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  /** True if at least one matcher exists for `event` (global + session). */
+  hasHookFor(event: HookEvent, sessionId?: string): boolean {
+    if (readList(this.global, event).length > 0) {
+      return true;
+    }
+    if (sessionId === undefined) {
+      return false;
+    }
+    const bucket = this.sessions.get(sessionId);
+    if (bucket === undefined) {
+      return false;
+    }
+    return readList(bucket, event).length > 0;
+  }
+
+  private ensureSessionBucket(sessionId: string): MatcherBucket {
+    const existing = this.sessions.get(sessionId);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const fresh: MatcherBucket = {};
+    this.sessions.set(sessionId, fresh);
+    return fresh;
+  }
+}
+
+function ensureList(
+  bucket: MatcherBucket,
+  event: HookEvent
+): HookMatcher<HookEvent>[] {
+  const existing = bucket[event];
+  if (existing !== undefined) {
+    return existing;
+  }
+  const fresh: HookMatcher<HookEvent>[] = [];
+  bucket[event] = fresh;
+  return fresh;
+}
+
+function readList(
+  bucket: MatcherBucket,
+  event: HookEvent
+): HookMatcher<HookEvent>[] {
+  return bucket[event] ?? [];
+}
+
+function removeFromList<E extends HookEvent>(
+  list: HookMatcher<HookEvent>[],
+  matcher: HookMatcher<E>
+): boolean {
+  const idx = list.indexOf(widen(matcher));
+  if (idx < 0) {
+    return false;
+  }
+  list.splice(idx, 1);
+  return true;
+}
+
+/**
+ * Widen a per-event matcher to the storage's uniform slot type. Unsound at
+ * the type level (function parameters are contravariant) but safe by
+ * construction: `HookRegistry.register<E>` only ever puts matchers into the
+ * bucket slot for their own event, and reads go through `snapshot<E>`
+ * which is only called with the same `E`.
+ */
+function widen<E extends HookEvent>(
+  matcher: HookMatcher<E>
+): HookMatcher<HookEvent> {
+  return matcher as unknown as HookMatcher<HookEvent>;
+}
+
+/**
+ * Narrow a storage list back to a per-event matcher list on the way out.
+ * Sound counterpart to `widen`: the list only contains matchers that were
+ * registered against `E`, because the public API enforces it on insert.
+ */
+function snapshot<E extends HookEvent>(
+  list: readonly HookMatcher<HookEvent>[]
+): HookMatcher<E>[] {
+  return list.slice() as unknown as HookMatcher<E>[];
+}

--- a/src/hooks/__tests__/HookRegistry.test.ts
+++ b/src/hooks/__tests__/HookRegistry.test.ts
@@ -1,0 +1,190 @@
+// src/hooks/__tests__/HookRegistry.test.ts
+import { HookRegistry } from '../HookRegistry';
+import type {
+  HookMatcher,
+  HookCallback,
+  PreToolUseHookOutput,
+  PostToolUseHookOutput,
+} from '../types';
+
+const noop: HookCallback<
+  'PreToolUse'
+> = async (): Promise<PreToolUseHookOutput> => ({});
+const noopPost: HookCallback<
+  'PostToolUse'
+> = async (): Promise<PostToolUseHookOutput> => ({});
+
+function makePreToolUseMatcher(pattern?: string): HookMatcher<'PreToolUse'> {
+  return {
+    pattern,
+    hooks: [noop],
+  };
+}
+
+function makePostToolUseMatcher(): HookMatcher<'PostToolUse'> {
+  return {
+    hooks: [noopPost],
+  };
+}
+
+describe('HookRegistry', () => {
+  describe('global registration', () => {
+    it('stores a matcher and returns it via getMatchers', () => {
+      const registry = new HookRegistry();
+      const matcher = makePreToolUseMatcher('Bash');
+      registry.register('PreToolUse', matcher);
+      const matchers = registry.getMatchers('PreToolUse');
+      expect(matchers).toHaveLength(1);
+      expect(matchers[0]).toBe(matcher);
+    });
+
+    it('keeps registrations isolated across events', () => {
+      const registry = new HookRegistry();
+      const pre = makePreToolUseMatcher('Bash');
+      const post = makePostToolUseMatcher();
+      registry.register('PreToolUse', pre);
+      registry.register('PostToolUse', post);
+      expect(registry.getMatchers('PreToolUse')).toEqual([pre]);
+      expect(registry.getMatchers('PostToolUse')).toEqual([post]);
+      expect(registry.getMatchers('Stop')).toEqual([]);
+    });
+
+    it('unregister removes the matcher from the registry', () => {
+      const registry = new HookRegistry();
+      const matcher = makePreToolUseMatcher();
+      const unregister = registry.register('PreToolUse', matcher);
+      expect(registry.getMatchers('PreToolUse')).toHaveLength(1);
+      unregister();
+      expect(registry.getMatchers('PreToolUse')).toHaveLength(0);
+    });
+
+    it('hasHookFor reflects registration state', () => {
+      const registry = new HookRegistry();
+      expect(registry.hasHookFor('PreToolUse')).toBe(false);
+      registry.register('PreToolUse', makePreToolUseMatcher());
+      expect(registry.hasHookFor('PreToolUse')).toBe(true);
+      expect(registry.hasHookFor('PostToolUse')).toBe(false);
+    });
+
+    it('supports multiple matchers on the same event', () => {
+      const registry = new HookRegistry();
+      const a = makePreToolUseMatcher('Bash');
+      const b = makePreToolUseMatcher('Edit');
+      registry.register('PreToolUse', a);
+      registry.register('PreToolUse', b);
+      const matchers = registry.getMatchers('PreToolUse');
+      expect(matchers).toHaveLength(2);
+      expect(matchers).toContain(a);
+      expect(matchers).toContain(b);
+    });
+
+    it('returns a fresh array on each getMatchers call', () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', makePreToolUseMatcher());
+      const first = registry.getMatchers('PreToolUse');
+      const second = registry.getMatchers('PreToolUse');
+      expect(first).not.toBe(second);
+      first.length = 0;
+      expect(registry.getMatchers('PreToolUse')).toHaveLength(1);
+    });
+  });
+
+  describe('session registration', () => {
+    it('scopes matchers to a single session', () => {
+      const registry = new HookRegistry();
+      const sessionA = makePreToolUseMatcher('Bash');
+      const sessionB = makePreToolUseMatcher('Edit');
+      registry.registerSession('run-a', 'PreToolUse', sessionA);
+      registry.registerSession('run-b', 'PreToolUse', sessionB);
+
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([sessionA]);
+      expect(registry.getMatchers('PreToolUse', 'run-b')).toEqual([sessionB]);
+      expect(registry.getMatchers('PreToolUse')).toEqual([]);
+    });
+
+    it('merges global matchers in front of session matchers', () => {
+      const registry = new HookRegistry();
+      const global = makePreToolUseMatcher('global');
+      const session = makePreToolUseMatcher('session');
+      registry.register('PreToolUse', global);
+      registry.registerSession('run-a', 'PreToolUse', session);
+
+      const matchers = registry.getMatchers('PreToolUse', 'run-a');
+      expect(matchers).toEqual([global, session]);
+    });
+
+    it('clearSession drops only the given session', () => {
+      const registry = new HookRegistry();
+      const a = makePreToolUseMatcher('a');
+      const b = makePreToolUseMatcher('b');
+      registry.registerSession('run-a', 'PreToolUse', a);
+      registry.registerSession('run-b', 'PreToolUse', b);
+
+      registry.clearSession('run-a');
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([]);
+      expect(registry.getMatchers('PreToolUse', 'run-b')).toEqual([b]);
+    });
+
+    it('removeMatcher removes from the correct scope', () => {
+      const registry = new HookRegistry();
+      const global = makePreToolUseMatcher('global');
+      const session = makePreToolUseMatcher('session');
+      registry.register('PreToolUse', global);
+      registry.registerSession('run-a', 'PreToolUse', session);
+
+      expect(registry.removeMatcher('PreToolUse', session, 'run-a')).toBe(true);
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([global]);
+
+      expect(registry.removeMatcher('PreToolUse', global)).toBe(true);
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([]);
+    });
+
+    it('removeMatcher returns false when the matcher is not found', () => {
+      const registry = new HookRegistry();
+      const orphan = makePreToolUseMatcher('orphan');
+      expect(registry.removeMatcher('PreToolUse', orphan)).toBe(false);
+      expect(registry.removeMatcher('PreToolUse', orphan, 'run-a')).toBe(false);
+    });
+
+    it('session unregister function removes only that matcher', () => {
+      const registry = new HookRegistry();
+      const a = makePreToolUseMatcher('a');
+      const b = makePreToolUseMatcher('b');
+      const unregisterA = registry.registerSession('run-a', 'PreToolUse', a);
+      registry.registerSession('run-a', 'PreToolUse', b);
+
+      unregisterA();
+      expect(registry.getMatchers('PreToolUse', 'run-a')).toEqual([b]);
+    });
+
+    it('hasHookFor honours the sessionId parameter', () => {
+      const registry = new HookRegistry();
+      registry.registerSession('run-a', 'PreToolUse', makePreToolUseMatcher());
+      expect(registry.hasHookFor('PreToolUse')).toBe(false);
+      expect(registry.hasHookFor('PreToolUse', 'run-a')).toBe(true);
+      expect(registry.hasHookFor('PreToolUse', 'run-b')).toBe(false);
+    });
+  });
+
+  describe('session isolation under parallel registration', () => {
+    it('does not leak matchers between sessions registered in parallel', async () => {
+      const registry = new HookRegistry();
+      const sessions = Array.from({ length: 50 }, (_, i) => `run-${i}`);
+      await Promise.all(
+        sessions.map(async (sid): Promise<void> => {
+          registry.registerSession(
+            sid,
+            'PreToolUse',
+            makePreToolUseMatcher(sid)
+          );
+        })
+      );
+
+      for (const sid of sessions) {
+        const matchers = registry.getMatchers('PreToolUse', sid);
+        expect(matchers).toHaveLength(1);
+        expect(matchers[0]?.pattern).toBe(sid);
+      }
+    });
+  });
+});

--- a/src/hooks/__tests__/compactHooks.test.ts
+++ b/src/hooks/__tests__/compactHooks.test.ts
@@ -1,0 +1,214 @@
+// src/hooks/__tests__/compactHooks.test.ts
+import { HumanMessage, AIMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import { HookRegistry } from '../HookRegistry';
+import { Run } from '@/run';
+import * as providers from '@/llm/providers';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { createTokenCounter } from '@/utils/tokens';
+import { Providers, GraphEvents } from '@/common';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  PreCompactHookInput,
+  PreCompactHookOutput,
+  PostCompactHookInput,
+  PostCompactHookOutput,
+} from '../types';
+
+const SUMMARY_RESPONSE = '## Summary\nUser asked a question and got an answer.';
+
+const callerConfig = {
+  configurable: { thread_id: 'compact-test' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+let getChatModelClassSpy: jest.SpyInstance;
+const originalGetChatModelClass = providers.getChatModelClass;
+
+function mockSummarizationModel(): void {
+  getChatModelClassSpy = jest
+    .spyOn(providers, 'getChatModelClass')
+    .mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return class extends FakeListChatModel {
+          constructor(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            _options: any
+          ) {
+            super({ responses: [SUMMARY_RESPONSE] });
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+}
+
+function buildConversation(): t.IState {
+  const messages: import('@langchain/core/messages').BaseMessage[] = [];
+  for (let i = 0; i < 20; i++) {
+    messages.push(new HumanMessage(`Question ${i}: ` + 'padding '.repeat(50)));
+    messages.push(new AIMessage(`Answer ${i}: ` + 'response '.repeat(50)));
+  }
+  return { messages };
+}
+
+async function createCompactingRun(
+  tokenCounter: t.TokenCounter,
+  hooks?: HookRegistry,
+  runId = 'compact-run'
+): Promise<Run<t.IState>> {
+  const conversation = buildConversation();
+  const indexTokenCountMap: Record<string, number> = {};
+  for (let i = 0; i < conversation.messages.length; i++) {
+    indexTokenCountMap[String(i)] = tokenCounter(conversation.messages[i]);
+  }
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.OPENAI,
+        streaming: true,
+        streamUsage: false,
+      },
+      instructions: 'Be concise.',
+      maxContextTokens: 200,
+      summarizationEnabled: true,
+      summarizationConfig: {
+        provider: Providers.OPENAI,
+      },
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers: {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    },
+    hooks,
+    tokenCounter,
+    indexTokenCountMap,
+  });
+}
+
+describe('Compaction hook integration', () => {
+  jest.setTimeout(30_000);
+
+  let tokenCounter: t.TokenCounter;
+
+  beforeAll(async () => {
+    tokenCounter = await createTokenCounter();
+  });
+
+  beforeEach(() => {
+    mockSummarizationModel();
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  describe('PreCompact', () => {
+    it('fires with messagesBeforeCount and trigger', async () => {
+      const registry = new HookRegistry();
+      let captured: PreCompactHookInput | undefined;
+      const hook: HookCallback<'PreCompact'> = async (
+        input
+      ): Promise<PreCompactHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PreCompact', { hooks: [hook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Final answer after compaction.']);
+      const inputs = buildConversation();
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PreCompact');
+      expect(captured!.messagesBeforeCount).toBeGreaterThan(0);
+      expect(captured!.runId).toBe('compact-run');
+      expect(captured!.threadId).toBe('compact-test');
+      expect(captured!.trigger).toBe('default');
+      expect(captured!.agentId).toBeDefined();
+    });
+  });
+
+  describe('PostCompact', () => {
+    it('fires with summary text after compaction', async () => {
+      const registry = new HookRegistry();
+      let captured: PostCompactHookInput | undefined;
+      const hook: HookCallback<'PostCompact'> = async (
+        input
+      ): Promise<PostCompactHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PostCompact', { hooks: [hook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Final answer after compaction.']);
+      const inputs = buildConversation();
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PostCompact');
+      expect(captured!.threadId).toBe('compact-test');
+      expect(captured!.summary).toBe(SUMMARY_RESPONSE);
+      expect(captured!.messagesAfterCount).toBe(0);
+      expect(captured!.agentId).toBeDefined();
+    });
+  });
+
+  describe('error resilience', () => {
+    it('throwing PreCompact hook does not crash compaction', async () => {
+      const registry = new HookRegistry();
+      const throwingHook: HookCallback<
+        'PreCompact'
+      > = async (): Promise<PreCompactHookOutput> => {
+        throw new Error('pre hook crash');
+      };
+      registry.register('PreCompact', { hooks: [throwingHook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Answer after compaction.']);
+      const inputs = buildConversation();
+
+      await expect(
+        run.processStream(inputs, callerConfig)
+      ).resolves.not.toThrow();
+    });
+
+    it('throwing PostCompact hook does not crash compaction', async () => {
+      const registry = new HookRegistry();
+      const throwingHook: HookCallback<
+        'PostCompact'
+      > = async (): Promise<PostCompactHookOutput> => {
+        throw new Error('post hook crash');
+      };
+      registry.register('PostCompact', { hooks: [throwingHook] });
+
+      const run = await createCompactingRun(tokenCounter, registry);
+      run.Graph!.overrideTestModel(['Answer after compaction.']);
+      const inputs = buildConversation();
+
+      await expect(
+        run.processStream(inputs, callerConfig)
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('no-hooks baseline', () => {
+    it('summarization works identically without hooks', async () => {
+      const run = await createCompactingRun(tokenCounter);
+      run.Graph!.overrideTestModel(['Answer.']);
+      const inputs = buildConversation();
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -1,0 +1,1013 @@
+// src/hooks/__tests__/executeHooks.test.ts
+import { HookRegistry } from '../HookRegistry';
+import { executeHooks } from '../executeHooks';
+import { clearMatcherCache } from '../matchers';
+import type {
+  HookCallback,
+  HookMatcher,
+  RunStartHookInput,
+  RunStartHookOutput,
+  StopHookInput,
+  StopHookOutput,
+  PreToolUseHookInput,
+  PreToolUseHookOutput,
+  PostToolUseHookInput,
+  PostToolUseHookOutput,
+} from '../types';
+
+function preToolUseInput(
+  toolName: string,
+  overrides: Partial<PreToolUseHookInput> = {}
+): PreToolUseHookInput {
+  return {
+    hook_event_name: 'PreToolUse',
+    runId: 'run-1',
+    threadId: 'thread-1',
+    toolName,
+    toolInput: { cmd: 'ls' },
+    toolUseId: 'tool-call-1',
+    ...overrides,
+  };
+}
+
+function postToolUseInput(
+  toolName: string,
+  overrides: Partial<PostToolUseHookInput> = {}
+): PostToolUseHookInput {
+  return {
+    hook_event_name: 'PostToolUse',
+    runId: 'run-1',
+    toolName,
+    toolInput: {},
+    toolOutput: null,
+    toolUseId: 'tc-1',
+    ...overrides,
+  };
+}
+
+function stopInput(overrides: Partial<StopHookInput> = {}): StopHookInput {
+  return {
+    hook_event_name: 'Stop',
+    runId: 'run-1',
+    messages: [],
+    stopHookActive: false,
+    ...overrides,
+  };
+}
+
+function runStartInput(): RunStartHookInput {
+  return {
+    hook_event_name: 'RunStart',
+    runId: 'run-1',
+    messages: [],
+  };
+}
+
+function preToolHook(
+  fn: HookCallback<'PreToolUse'>
+): HookCallback<'PreToolUse'> {
+  return fn;
+}
+
+function postToolHook(
+  fn: HookCallback<'PostToolUse'>
+): HookCallback<'PostToolUse'> {
+  return fn;
+}
+
+function runStartHook(fn: HookCallback<'RunStart'>): HookCallback<'RunStart'> {
+  return fn;
+}
+
+function stopHook(fn: HookCallback<'Stop'>): HookCallback<'Stop'> {
+  return fn;
+}
+
+const emptyPreOutput: PreToolUseHookOutput = {};
+const emptyRunStartOutput: RunStartHookOutput = {};
+
+const noopPreHook = preToolHook(
+  async (): Promise<PreToolUseHookOutput> => emptyPreOutput
+);
+const noopRunStartHook = runStartHook(
+  async (): Promise<RunStartHookOutput> => emptyRunStartOutput
+);
+
+describe('executeHooks', () => {
+  let consoleWarnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    clearMatcherCache();
+    consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation((): void => {
+        /* silence expected warnings */
+      });
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('empty matcher set', () => {
+    it('returns an empty aggregated result when no matchers are registered', async () => {
+      const registry = new HookRegistry();
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result).toEqual({ additionalContexts: [], errors: [] });
+    });
+
+    it('returns an empty result when no matcher pattern matches the query', async () => {
+      const registry = new HookRegistry();
+      let called = false;
+      registry.register('PreToolUse', {
+        pattern: '^Edit$',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            called = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(called).toBe(false);
+      expect(result).toEqual({ additionalContexts: [], errors: [] });
+    });
+  });
+
+  describe('matcher regex filtering', () => {
+    it('fires hooks whose matcher regex matches the query', async () => {
+      const registry = new HookRegistry();
+      const calls: string[] = [];
+      registry.register('PreToolUse', {
+        pattern: '^Bash$',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            calls.push('bash-only');
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      registry.register('PreToolUse', {
+        pattern: 'Bash|Edit',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            calls.push('bash-or-edit');
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      registry.register('PreToolUse', {
+        pattern: '^Edit$',
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            calls.push('edit-only');
+            return emptyPreOutput;
+          }),
+        ],
+      });
+
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(calls.sort()).toEqual(['bash-only', 'bash-or-edit']);
+    });
+
+    it('fires matchers with no pattern regardless of query', async () => {
+      const registry = new HookRegistry();
+      let fired = false;
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            fired = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(fired).toBe(true);
+    });
+  });
+
+  describe('decision precedence (deny > ask > allow)', () => {
+    it('deny beats allow', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'allow',
+              reason: 'all good',
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'deny',
+              reason: 'forbidden',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toBe('forbidden');
+    });
+
+    it('deny beats ask', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'ask',
+              reason: 'needs prompt',
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'deny',
+              reason: 'forbidden',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('deny');
+      expect(result.reason).toBe('forbidden');
+    });
+
+    it('ask beats allow but not deny', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({ decision: 'allow' })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'ask',
+              reason: 'please confirm',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('ask');
+      expect(result.reason).toBe('please confirm');
+    });
+
+    it('allow is the default when any hook returned allow and none denied or asked', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              decision: 'allow',
+              reason: 'ok',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBe('allow');
+      expect(result.reason).toBe('ok');
+    });
+
+    it('no decision is set when no hook returns one', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [noopPreHook],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.decision).toBeUndefined();
+    });
+  });
+
+  describe('stop decision folding', () => {
+    it('any block wins over continue', async () => {
+      const registry = new HookRegistry();
+      registry.register('Stop', {
+        hooks: [
+          stopHook(
+            async (): Promise<StopHookOutput> => ({ decision: 'continue' })
+          ),
+        ],
+      });
+      registry.register('Stop', {
+        hooks: [
+          stopHook(
+            async (): Promise<StopHookOutput> => ({
+              decision: 'block',
+              reason: 'more work to do',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({ registry, input: stopInput() });
+      expect(result.stopDecision).toBe('block');
+      expect(result.reason).toBe('more work to do');
+    });
+
+    it('continue is the aggregated result when no hook blocks', async () => {
+      const registry = new HookRegistry();
+      registry.register('Stop', {
+        hooks: [
+          stopHook(
+            async (): Promise<StopHookOutput> => ({ decision: 'continue' })
+          ),
+        ],
+      });
+      const result = await executeHooks({ registry, input: stopInput() });
+      expect(result.stopDecision).toBe('continue');
+    });
+  });
+
+  describe('additionalContext accumulation', () => {
+    it('accumulates non-empty additionalContext from every hook', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              additionalContext: 'context one',
+            })
+          ),
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              additionalContext: '',
+            })
+          ),
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              additionalContext: 'context two',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.additionalContexts.sort()).toEqual([
+        'context one',
+        'context two',
+      ]);
+    });
+  });
+
+  describe('updatedInput handling', () => {
+    it('last-writer-wins on updatedInput follows registration order', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'first' },
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'second' },
+            })
+          ),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'third' },
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedInput).toEqual({ cmd: 'third' });
+    });
+
+    it('last-writer-wins within a single matcher follows hook array order', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'inner-first' },
+            })
+          ),
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> => ({
+              updatedInput: { cmd: 'inner-second' },
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedInput).toEqual({ cmd: 'inner-second' });
+    });
+  });
+
+  describe('updatedOutput handling', () => {
+    it('flows updatedOutput through the aggregated result', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              updatedOutput: 'redacted',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedOutput).toBe('redacted');
+    });
+
+    it('last-writer-wins on updatedOutput follows registration order', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              updatedOutput: { tag: 'first' },
+            })
+          ),
+        ],
+      });
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              updatedOutput: { tag: 'second' },
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedOutput).toEqual({ tag: 'second' });
+    });
+
+    it('leaves updatedOutput undefined when no hook sets it', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [postToolHook(async (): Promise<PostToolUseHookOutput> => ({}))],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.updatedOutput).toBeUndefined();
+    });
+  });
+
+  describe('preventContinuation', () => {
+    it('propagates preventContinuation and stopReason', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+              stopReason: 'budget exhausted',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.preventContinuation).toBe(true);
+      expect(result.stopReason).toBe('budget exhausted');
+    });
+
+    it('keeps the first stopReason when multiple hooks set preventContinuation', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+              stopReason: 'first writer',
+            })
+          ),
+        ],
+      });
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+              stopReason: 'second writer',
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.preventContinuation).toBe(true);
+      expect(result.stopReason).toBe('first writer');
+    });
+
+    it('sets preventContinuation even if only the flag, no reason, is present', async () => {
+      const registry = new HookRegistry();
+      registry.register('PostToolUse', {
+        hooks: [
+          postToolHook(
+            async (): Promise<PostToolUseHookOutput> => ({
+              preventContinuation: true,
+            })
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: postToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.preventContinuation).toBe(true);
+      expect(result.stopReason).toBeUndefined();
+    });
+  });
+
+  describe('session scoping', () => {
+    it('runs session matchers only when sessionId is supplied', async () => {
+      const registry = new HookRegistry();
+      let globalFired = false;
+      let sessionFired = false;
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            globalFired = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+      registry.registerSession('run-1', 'PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            sessionFired = true;
+            return emptyPreOutput;
+          }),
+        ],
+      });
+
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(globalFired).toBe(true);
+      expect(sessionFired).toBe(false);
+
+      globalFired = false;
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        sessionId: 'run-1',
+      });
+      expect(globalFired).toBe(true);
+      expect(sessionFired).toBe(true);
+    });
+  });
+
+  describe('once: true self-removal', () => {
+    it('removes the matcher after a successful fire', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            calls++;
+            return emptyRunStartOutput;
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      await executeHooks({ registry, input: runStartInput() });
+      expect(calls).toBe(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+
+      await executeHooks({ registry, input: runStartInput() });
+      expect(calls).toBe(1);
+    });
+
+    it('removes the matcher even when every hook in it throws (at-most-once dispatch)', async () => {
+      const registry = new HookRegistry();
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            throw new Error('hook failed');
+          }),
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            throw new Error('hook also failed');
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      const result = await executeHooks({ registry, input: runStartInput() });
+      expect(result.errors).toHaveLength(2);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+    });
+
+    it('removes the matcher when at least one hook succeeds', async () => {
+      const registry = new HookRegistry();
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            throw new Error('boom');
+          }),
+          noopRunStartHook,
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      const result = await executeHooks({ registry, input: runStartInput() });
+      expect(result.errors).toHaveLength(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+    });
+
+    it('removes once-matchers registered for a session from the session scope', async () => {
+      const registry = new HookRegistry();
+      const matcher: HookMatcher<'PreToolUse'> = {
+        once: true,
+        hooks: [noopPreHook],
+      };
+      registry.registerSession('run-1', 'PreToolUse', matcher);
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        sessionId: 'run-1',
+      });
+      expect(registry.getMatchers('PreToolUse', 'run-1')).toHaveLength(0);
+    });
+
+    it('fires exactly once across concurrent executeHooks calls (atomic claim)', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            calls++;
+            return emptyRunStartOutput;
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      await Promise.all([
+        executeHooks({ registry, input: runStartInput() }),
+        executeHooks({ registry, input: runStartInput() }),
+        executeHooks({ registry, input: runStartInput() }),
+      ]);
+
+      expect(calls).toBe(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+    });
+
+    it('fires exactly once across concurrent dispatch even when hooks are slow', async () => {
+      const registry = new HookRegistry();
+      let calls = 0;
+      const matcher: HookMatcher<'RunStart'> = {
+        once: true,
+        hooks: [
+          runStartHook(async (): Promise<RunStartHookOutput> => {
+            calls++;
+            await new Promise<void>((resolve): void => {
+              setTimeout(resolve, 10);
+            });
+            return emptyRunStartOutput;
+          }),
+        ],
+      };
+      registry.register('RunStart', matcher);
+
+      await Promise.all(
+        Array.from({ length: 8 }, () =>
+          executeHooks({ registry, input: runStartInput() })
+        )
+      );
+
+      expect(calls).toBe(1);
+      expect(registry.getMatchers('RunStart')).toHaveLength(0);
+    });
+  });
+
+  describe('timeout enforcement', () => {
+    it('aborts hooks that exceed the matcher timeout', async () => {
+      const registry = new HookRegistry();
+      registry.register('RunStart', {
+        timeout: 20,
+        hooks: [
+          runStartHook(
+            (_input, signal): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((_resolve, reject) => {
+                const id = setTimeout((): void => {
+                  reject(new Error('hook should have been aborted'));
+                }, 500);
+                signal.addEventListener('abort', (): void => {
+                  clearTimeout(id);
+                  reject(new Error('aborted'));
+                });
+              })
+          ),
+        ],
+      });
+
+      const start = Date.now();
+      const result = await executeHooks({ registry, input: runStartInput() });
+      const elapsed = Date.now() - start;
+
+      expect(result.errors).toHaveLength(1);
+      expect(elapsed).toBeLessThan(400);
+    });
+
+    it('times out hooks that ignore the signal and surfaces an abort-shaped error', async () => {
+      const registry = new HookRegistry();
+      const pendingTimers: NodeJS.Timeout[] = [];
+      registry.register('RunStart', {
+        timeout: 15,
+        hooks: [
+          runStartHook(
+            (): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((resolve): void => {
+                const id = setTimeout(
+                  (): void => resolve(emptyRunStartOutput),
+                  500
+                );
+                pendingTimers.push(id);
+              })
+          ),
+        ],
+      });
+
+      const start = Date.now();
+      const result = await executeHooks({ registry, input: runStartInput() });
+      const elapsed = Date.now() - start;
+
+      for (const id of pendingTimers) {
+        clearTimeout(id);
+      }
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.toLowerCase()).toMatch(
+        /timeout|timed out|abort/
+      );
+      expect(elapsed).toBeLessThan(400);
+    });
+
+    it('honours the batch timeoutMs default when the matcher does not set its own', async () => {
+      const registry = new HookRegistry();
+      registry.register('RunStart', {
+        hooks: [
+          runStartHook(
+            (_input, signal): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((_resolve, reject) => {
+                signal.addEventListener('abort', (): void =>
+                  reject(new Error('aborted'))
+                );
+              })
+          ),
+        ],
+      });
+
+      const start = Date.now();
+      const result = await executeHooks({
+        registry,
+        input: runStartInput(),
+        timeoutMs: 25,
+      });
+      const elapsed = Date.now() - start;
+
+      expect(result.errors).toHaveLength(1);
+      expect(elapsed).toBeLessThan(400);
+    });
+  });
+
+  describe('error non-fatality', () => {
+    it('swallows synchronous throws into the errors array and keeps going', async () => {
+      const registry = new HookRegistry();
+      let otherRan = false;
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook((): Promise<PreToolUseHookOutput> => {
+            throw new Error('sync boom');
+          }),
+        ],
+      });
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(async (): Promise<PreToolUseHookOutput> => {
+            otherRan = true;
+            return { additionalContext: 'still ran' };
+          }),
+        ],
+      });
+
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(otherRan).toBe(true);
+      expect(result.additionalContexts).toEqual(['still ran']);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('sync boom');
+    });
+
+    it('swallows async rejections', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('async boom'))
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('async boom');
+    });
+
+    it('excludes internal matcher errors from the errors array', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        internal: true,
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('internal failure'))
+          ),
+        ],
+      });
+      const result = await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('routes non-internal errors through an optional logger instead of console', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('oops'))
+          ),
+        ],
+      });
+      const warnings: string[] = [];
+      const fakeLogger = {
+        warn: (msg: string): void => {
+          warnings.push(msg);
+        },
+      } as unknown as import('winston').Logger;
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+        logger: fakeLogger,
+      });
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('oops');
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to console.warn when no logger is supplied', async () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          preToolHook(
+            async (): Promise<PreToolUseHookOutput> =>
+              Promise.reject(new Error('fallback'))
+          ),
+        ],
+      });
+      await executeHooks({
+        registry,
+        input: preToolUseInput('Bash'),
+        matchQuery: 'Bash',
+      });
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      const firstCall = consoleWarnSpy.mock.calls[0] as unknown[];
+      expect(String(firstCall[0])).toContain('fallback');
+    });
+  });
+
+  describe('parent AbortSignal combination', () => {
+    it('aborts hooks when the caller signal fires', async () => {
+      const registry = new HookRegistry();
+      registry.register('RunStart', {
+        hooks: [
+          runStartHook(
+            (_input, signal): Promise<RunStartHookOutput> =>
+              new Promise<RunStartHookOutput>((_resolve, reject) => {
+                signal.addEventListener('abort', (): void =>
+                  reject(new Error('aborted'))
+                );
+              })
+          ),
+        ],
+      });
+
+      const controller = new AbortController();
+      setTimeout((): void => controller.abort(), 20);
+
+      const start = Date.now();
+      const result = await executeHooks({
+        registry,
+        input: runStartInput(),
+        signal: controller.signal,
+        timeoutMs: 5_000,
+      });
+      const elapsed = Date.now() - start;
+
+      expect(result.errors).toHaveLength(1);
+      expect(elapsed).toBeLessThan(400);
+    });
+  });
+});

--- a/src/hooks/__tests__/integration.test.ts
+++ b/src/hooks/__tests__/integration.test.ts
@@ -1,0 +1,337 @@
+// src/hooks/__tests__/integration.test.ts
+import { HumanMessage } from '@langchain/core/messages';
+import { HookRegistry } from '../HookRegistry';
+import { Run } from '@/run';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  RunStartHookInput,
+  RunStartHookOutput,
+  UserPromptSubmitHookOutput,
+  StopHookInput,
+  StopHookOutput,
+  StopFailureHookOutput,
+} from '../types';
+import { Providers } from '@/common';
+
+const llmConfig: t.LLMConfig = {
+  provider: Providers.OPENAI,
+  streaming: true,
+  streamUsage: false,
+};
+
+const callerConfig = {
+  configurable: { thread_id: 'test-thread' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+function createRun(
+  hooks: HookRegistry,
+  runId = 'test-run'
+): Promise<Run<t.IState>> {
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: { type: 'standard', llmConfig },
+    returnContent: true,
+    skipCleanup: true,
+    hooks,
+  });
+}
+
+describe('Run-level hook integration', () => {
+  jest.setTimeout(15000);
+
+  describe('RunStart', () => {
+    it('fires with runId, threadId, and messages before the stream', async () => {
+      const registry = new HookRegistry();
+      let captured: RunStartHookInput | undefined;
+      const hook: HookCallback<'RunStart'> = async (
+        input
+      ): Promise<RunStartHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('RunStart', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['hello']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('RunStart');
+      expect(captured!.runId).toBe('test-run');
+      expect(captured!.threadId).toBe('test-thread');
+      expect(captured!.messages).toHaveLength(1);
+    });
+  });
+
+  describe('UserPromptSubmit', () => {
+    it('extracts prompt text from the last human message', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt = '';
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['response']);
+      const inputs = { messages: [new HumanMessage('hello world')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(capturedPrompt).toBe('hello world');
+    });
+
+    it('extracts prompt from multi-part content (text + non-text blocks)', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt = '';
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['ok']);
+      const msg = new HumanMessage({
+        content: [
+          { type: 'text', text: 'hello' },
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,...' },
+          },
+          { type: 'text', text: 'world' },
+        ],
+      });
+      await run.processStream({ messages: [msg] }, callerConfig);
+
+      expect(capturedPrompt).toBe('hello\nworld');
+    });
+
+    it('yields empty prompt for image-only content', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt: string | undefined;
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['ok']);
+      const msg = new HumanMessage({
+        content: [
+          {
+            type: 'image_url',
+            image_url: { url: 'data:image/png;base64,...' },
+          },
+        ],
+      });
+      await run.processStream({ messages: [msg] }, callerConfig);
+
+      expect(capturedPrompt).toBe('');
+    });
+
+    it('fires with empty prompt when human message has no text blocks', async () => {
+      const registry = new HookRegistry();
+      let capturedPrompt: string | undefined;
+      const hook: HookCallback<'UserPromptSubmit'> = async (
+        input
+      ): Promise<UserPromptSubmitHookOutput> => {
+        capturedPrompt = input.prompt;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['ok']);
+      const msg = new HumanMessage({ content: [] });
+      await run.processStream({ messages: [msg] }, callerConfig);
+
+      expect(capturedPrompt).toBe('');
+    });
+
+    it('aborts the run when hook returns deny', async () => {
+      const registry = new HookRegistry();
+      let stopFired = false;
+      const denyHook: HookCallback<
+        'UserPromptSubmit'
+      > = async (): Promise<UserPromptSubmitHookOutput> => ({
+        decision: 'deny',
+        reason: 'blocked by policy',
+      });
+      const stopHook: HookCallback<
+        'Stop'
+      > = async (): Promise<StopHookOutput> => {
+        stopFired = true;
+        return {};
+      };
+      registry.register('UserPromptSubmit', { hooks: [denyHook] });
+      registry.register('Stop', { hooks: [stopHook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['should not reach']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeUndefined();
+      expect(stopFired).toBe(false);
+    });
+
+    it('aborts the run when hook returns ask (v1 — no interactive flow)', async () => {
+      const registry = new HookRegistry();
+      const askHook: HookCallback<
+        'UserPromptSubmit'
+      > = async (): Promise<UserPromptSubmitHookOutput> => ({
+        decision: 'ask',
+        reason: 'needs confirmation',
+      });
+      registry.register('UserPromptSubmit', { hooks: [askHook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['should not reach']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('Stop', () => {
+    it('fires after a successful stream with accumulated messages', async () => {
+      const registry = new HookRegistry();
+      let captured: StopHookInput | undefined;
+      const hook: HookCallback<'Stop'> = async (
+        input
+      ): Promise<StopHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('Stop', { hooks: [hook] });
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['agent reply']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('Stop');
+      expect(captured!.runId).toBe('test-run');
+      expect(captured!.stopHookActive).toBe(false);
+      expect(captured!.messages.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('does not fire when the stream throws an error', async () => {
+      const registry = new HookRegistry();
+      let stopFired = false;
+      const hook: HookCallback<'Stop'> = async (): Promise<StopHookOutput> => {
+        stopFired = true;
+        return {};
+      };
+      registry.register('Stop', { hooks: [hook] });
+
+      const run = await createRun(registry, 'error-run');
+      run.Graph!.overrideTestModel([]);
+
+      const inputs = { messages: [new HumanMessage('hi')] };
+      try {
+        await run.processStream(inputs, callerConfig);
+      } catch {
+        /* expected */
+      }
+
+      expect(stopFired).toBe(false);
+    });
+  });
+
+  describe('StopFailure', () => {
+    it('fires when the stream throws and preserves the original error', async () => {
+      const registry = new HookRegistry();
+      let capturedError = '';
+      const hook: HookCallback<'StopFailure'> = async (
+        input
+      ): Promise<StopFailureHookOutput> => {
+        capturedError = input.error;
+        return {};
+      };
+      registry.register('StopFailure', { hooks: [hook] });
+
+      const run = await createRun(registry, 'fail-run');
+      run.Graph!.overrideTestModel([]);
+
+      const inputs = { messages: [new HumanMessage('hi')] };
+      let thrownError: Error | undefined;
+      try {
+        await run.processStream(inputs, callerConfig);
+      } catch (err) {
+        thrownError = err instanceof Error ? err : new Error(String(err));
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(typeof capturedError).toBe('string');
+      expect(capturedError.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('session teardown', () => {
+    it('clears session matchers after processStream completes', async () => {
+      const registry = new HookRegistry();
+      registry.registerSession('test-run', 'RunStart', {
+        hooks: [async (): Promise<RunStartHookOutput> => ({})],
+      });
+      expect(registry.getMatchers('RunStart', 'test-run')).toHaveLength(1);
+
+      const run = await createRun(registry);
+      run.Graph!.overrideTestModel(['done']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      await run.processStream(inputs, callerConfig);
+
+      expect(registry.getMatchers('RunStart', 'test-run')).toHaveLength(0);
+    });
+
+    it('clears session even when the stream errors', async () => {
+      const registry = new HookRegistry();
+      registry.registerSession('error-run', 'RunStart', {
+        hooks: [async (): Promise<RunStartHookOutput> => ({})],
+      });
+
+      const run = await createRun(registry, 'error-run');
+      run.Graph!.overrideTestModel([]);
+
+      const inputs = { messages: [new HumanMessage('hi')] };
+      try {
+        await run.processStream(inputs, callerConfig);
+      } catch {
+        /* expected */
+      }
+
+      expect(registry.getMatchers('RunStart', 'error-run')).toHaveLength(0);
+    });
+  });
+
+  describe('no-hooks baseline', () => {
+    it('works identically when no hooks registry is provided', async () => {
+      const run = await Run.create<t.IState>({
+        runId: 'no-hooks-run',
+        graphConfig: { type: 'standard', llmConfig },
+        returnContent: true,
+        skipCleanup: true,
+      });
+      run.Graph!.overrideTestModel(['response']);
+      const inputs = { messages: [new HumanMessage('hi')] };
+      const result = await run.processStream(inputs, callerConfig);
+
+      expect(result).toBeDefined();
+      expect(result!.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/hooks/__tests__/matchers.test.ts
+++ b/src/hooks/__tests__/matchers.test.ts
@@ -232,7 +232,7 @@ describe('matchesQuery', () => {
       const result = matchesQuery('(a+)+$', adversarial);
       const elapsed = Date.now() - start;
       expect(result).toBe(false);
-      expect(elapsed).toBeLessThan(50);
+      expect(elapsed).toBeLessThan(200);
     });
   });
 });

--- a/src/hooks/__tests__/matchers.test.ts
+++ b/src/hooks/__tests__/matchers.test.ts
@@ -1,0 +1,238 @@
+// src/hooks/__tests__/matchers.test.ts
+import {
+  matchesQuery,
+  clearMatcherCache,
+  getMatcherCacheSize,
+  hasNestedQuantifier,
+  MAX_PATTERN_LENGTH,
+  MAX_CACHE_SIZE,
+} from '../matchers';
+
+describe('matchesQuery', () => {
+  beforeEach(() => {
+    clearMatcherCache();
+  });
+
+  it('treats undefined pattern as a wildcard match', () => {
+    expect(matchesQuery(undefined, 'Bash')).toBe(true);
+    expect(matchesQuery(undefined, '')).toBe(true);
+    expect(matchesQuery(undefined, undefined)).toBe(true);
+  });
+
+  it('treats empty-string pattern as a wildcard match', () => {
+    expect(matchesQuery('', 'Bash')).toBe(true);
+    expect(matchesQuery('', undefined)).toBe(true);
+  });
+
+  it('returns false when the pattern is set but the query is absent', () => {
+    expect(matchesQuery('Bash', undefined)).toBe(false);
+    expect(matchesQuery('Bash', '')).toBe(false);
+  });
+
+  it('runs the pattern as a regex against the query', () => {
+    expect(matchesQuery('Bash', 'Bash')).toBe(true);
+    expect(matchesQuery('^Bash$', 'Bash')).toBe(true);
+    expect(matchesQuery('^Bash$', 'BashExtra')).toBe(false);
+    expect(matchesQuery('Bash|Shell', 'Shell')).toBe(true);
+    expect(matchesQuery('mcp_.*_search', 'mcp_github_search')).toBe(true);
+  });
+
+  it('does not throw on invalid regex and returns false instead', () => {
+    expect(() => matchesQuery('[unclosed', 'anything')).not.toThrow();
+    expect(matchesQuery('[unclosed', 'anything')).toBe(false);
+  });
+
+  describe('pattern length bound', () => {
+    it('rejects patterns longer than MAX_PATTERN_LENGTH', () => {
+      const tooLong = 'a'.repeat(MAX_PATTERN_LENGTH + 1);
+      expect(matchesQuery(tooLong, 'aaa')).toBe(false);
+    });
+
+    it('accepts patterns exactly at MAX_PATTERN_LENGTH', () => {
+      const atLimit = 'a'.repeat(MAX_PATTERN_LENGTH);
+      expect(matchesQuery(atLimit, 'a'.repeat(MAX_PATTERN_LENGTH))).toBe(true);
+    });
+  });
+
+  describe('compilation cache', () => {
+    it('caches successful compiles so the same RegExp object is reused', () => {
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('^Bash$', 'Bash');
+        matchesQuery('^Bash$', 'Edit');
+        matchesQuery('^Bash$', 'Bash');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('caches failed compiles so invalid patterns do not re-enter the compiler', () => {
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('[unclosed', 'any');
+        matchesQuery('[unclosed', 'any');
+        matchesQuery('[unclosed', 'other');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('clearMatcherCache drops cached compiles', () => {
+      matchesQuery('^Bash$', 'Bash');
+      clearMatcherCache();
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('^Bash$', 'Bash');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('evicts the oldest entry once the cache is full (LRU)', () => {
+      for (let i = 0; i < MAX_CACHE_SIZE; i++) {
+        matchesQuery(`^pattern${i}$`, `pattern${i}`);
+      }
+      expect(getMatcherCacheSize()).toBe(MAX_CACHE_SIZE);
+
+      matchesQuery('^overflow$', 'overflow');
+      expect(getMatcherCacheSize()).toBe(MAX_CACHE_SIZE);
+
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery('^pattern0$', 'pattern0');
+        expect(spy).toHaveBeenCalledTimes(1);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('refreshes LRU position on hit so hot patterns are not evicted', () => {
+      const hotPattern = '^hot$';
+      matchesQuery(hotPattern, 'hot');
+      for (let i = 0; i < MAX_CACHE_SIZE - 1; i++) {
+        matchesQuery(`^cold${i}$`, `cold${i}`);
+      }
+      matchesQuery(hotPattern, 'hot');
+
+      matchesQuery('^overflow$', 'overflow');
+
+      const spy = jest.spyOn(global, 'RegExp');
+      try {
+        matchesQuery(hotPattern, 'hot');
+        expect(spy).not.toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe('hasNestedQuantifier', () => {
+    it('detects the classic (a+)+ shape', () => {
+      expect(hasNestedQuantifier('(a+)+')).toBe(true);
+      expect(hasNestedQuantifier('(a+)+$')).toBe(true);
+    });
+
+    it('detects (.*)* and (.+)+', () => {
+      expect(hasNestedQuantifier('(.*)*')).toBe(true);
+      expect(hasNestedQuantifier('(.+)+')).toBe(true);
+    });
+
+    it('detects nested quantifier with ? outside', () => {
+      expect(hasNestedQuantifier('(a+)?')).toBe(true);
+    });
+
+    it('detects nested quantifier with {n,} outside', () => {
+      expect(hasNestedQuantifier('(a+){2,}')).toBe(true);
+    });
+
+    it('detects nested quantifier inside deeper groups', () => {
+      expect(hasNestedQuantifier('((a+)+)')).toBe(true);
+      expect(hasNestedQuantifier('prefix(\\w+)+suffix')).toBe(true);
+    });
+
+    it('allows quantifiers that are not nested', () => {
+      expect(hasNestedQuantifier('a+')).toBe(false);
+      expect(hasNestedQuantifier('^Bash$')).toBe(false);
+      expect(hasNestedQuantifier('(a)(b)')).toBe(false);
+      expect(hasNestedQuantifier('(a)+(b)')).toBe(false);
+      expect(hasNestedQuantifier('(ab)+')).toBe(false);
+      expect(hasNestedQuantifier('mcp_\\w+_search')).toBe(false);
+    });
+
+    it('ignores quantifier-looking chars inside character classes', () => {
+      expect(hasNestedQuantifier('([a+b])+')).toBe(false);
+      expect(hasNestedQuantifier('[*+?]+')).toBe(false);
+    });
+
+    it('ignores escaped quantifier characters', () => {
+      expect(hasNestedQuantifier('(\\+)+')).toBe(false);
+      expect(hasNestedQuantifier('(a\\*)+')).toBe(false);
+    });
+
+    describe('group-syntax prefixes are not misread as quantifiers', () => {
+      it('allows non-capturing groups with optional quantifier', () => {
+        expect(hasNestedQuantifier('(?:pre_)?tool_name')).toBe(false);
+        expect(hasNestedQuantifier('(?:ab)?')).toBe(false);
+      });
+
+      it('allows non-capturing groups with + or * quantifier', () => {
+        expect(hasNestedQuantifier('(?:Bash|Shell)+')).toBe(false);
+        expect(hasNestedQuantifier('(?:ab)*')).toBe(false);
+        expect(hasNestedQuantifier('(?:ab){2,5}')).toBe(false);
+      });
+
+      it('allows lookahead and negative lookahead', () => {
+        expect(hasNestedQuantifier('(?=foo)bar')).toBe(false);
+        expect(hasNestedQuantifier('(?!foo)bar')).toBe(false);
+        expect(hasNestedQuantifier('(?=\\w+)bar')).toBe(false);
+      });
+
+      it('allows lookbehind and negative lookbehind', () => {
+        expect(hasNestedQuantifier('(?<=\\s)\\w+')).toBe(false);
+        expect(hasNestedQuantifier('(?<!^)\\w+')).toBe(false);
+      });
+
+      it('allows named capture groups with trailing quantifier', () => {
+        expect(hasNestedQuantifier('(?<name>\\d+)')).toBe(false);
+        expect(hasNestedQuantifier('(?<digits>\\d)+')).toBe(false);
+      });
+    });
+
+    describe('risk propagation across non-capturing wrappers', () => {
+      it('flags (?:(a+))+ — outer quantifier over a wrapped quantified group', () => {
+        expect(hasNestedQuantifier('(?:(a+))+')).toBe(true);
+      });
+
+      it('flags (?:a+)+ — non-capturing group with internal quantifier', () => {
+        expect(hasNestedQuantifier('(?:a+)+')).toBe(true);
+      });
+
+      it('does not flag (?:(ab))+ — quantified wrapper, no inner quantifier', () => {
+        expect(hasNestedQuantifier('(?:(ab))+')).toBe(false);
+      });
+
+      it('flags ((ab)+)+ — multiply-wrapped but contains quantified subgroup', () => {
+        expect(hasNestedQuantifier('((ab)+)+')).toBe(true);
+      });
+    });
+  });
+
+  describe('ReDoS mitigation via matchesQuery', () => {
+    it('rejects nested-quantifier patterns as never-matching', () => {
+      expect(matchesQuery('(a+)+', 'aaaaaaaaaa')).toBe(false);
+      expect(matchesQuery('(.*)*', 'hello')).toBe(false);
+    });
+
+    it('does not stall on an adversarial input that would backtrack', () => {
+      const adversarial = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!';
+      const start = Date.now();
+      const result = matchesQuery('(a+)+$', adversarial);
+      const elapsed = Date.now() - start;
+      expect(result).toBe(false);
+      expect(elapsed).toBeLessThan(50);
+    });
+  });
+});

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -1,0 +1,612 @@
+// src/hooks/__tests__/toolHooks.test.ts
+import { ToolCall } from '@langchain/core/messages/tool';
+import { HumanMessage } from '@langchain/core/messages';
+import { HookRegistry } from '../HookRegistry';
+import { Run } from '@/run';
+import {
+  GraphEvents,
+  Providers,
+  ToolEndHandler,
+  ModelEndHandler,
+} from '@/index';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  PreToolUseHookOutput,
+  PostToolUseHookOutput,
+  PostToolUseFailureHookOutput,
+  PermissionDeniedHookInput,
+  PermissionDeniedHookOutput,
+  PreToolUseHookInput,
+  PostToolUseHookInput,
+  PostToolUseFailureHookInput,
+} from '../types';
+
+const llmConfig: t.LLMConfig = {
+  provider: Providers.OPENAI,
+  streaming: true,
+  streamUsage: false,
+};
+
+const callerConfig = {
+  configurable: { thread_id: 'test-thread' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+const echoToolDef: t.LCTool = {
+  name: 'echo',
+  description: 'Echoes input',
+  parameters: {
+    type: 'object' as const,
+    properties: { text: { type: 'string' } },
+    required: ['text'],
+  },
+};
+
+let callCounter = 0;
+
+function makeToolCall(text = 'hello', name = 'echo'): ToolCall {
+  return {
+    name,
+    args: { text },
+    id: `call_${++callCounter}`,
+    type: 'tool_call',
+  };
+}
+
+function createToolExecuteHandler(): t.EventHandler {
+  return {
+    handle: async (_event: string, rawData: unknown): Promise<void> => {
+      const data = rawData as t.ToolExecuteBatchRequest;
+      const results: t.ToolExecuteResult[] = data.toolCalls.map(
+        (tc: t.ToolCallRequest) => ({
+          toolCallId: tc.id,
+          content: `echo: ${(tc.args as Record<string, string>).text}`,
+          status: 'success' as const,
+        })
+      );
+      data.resolve(results);
+    },
+  };
+}
+
+function createErrorToolExecuteHandler(): t.EventHandler {
+  return {
+    handle: async (_event: string, rawData: unknown): Promise<void> => {
+      const data = rawData as t.ToolExecuteBatchRequest;
+      const results: t.ToolExecuteResult[] = data.toolCalls.map(
+        (tc: t.ToolCallRequest) => ({
+          toolCallId: tc.id,
+          content: '',
+          status: 'error' as const,
+          errorMessage: `tool ${tc.name} failed deliberately`,
+        })
+      );
+      data.resolve(results);
+    },
+  };
+}
+
+async function createEventDrivenRun(
+  hooks: HookRegistry,
+  toolHandler: t.EventHandler = createToolExecuteHandler(),
+  runId = 'tool-hook-run'
+): Promise<Run<t.IState>> {
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.ON_TOOL_EXECUTE]: toolHandler,
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+  };
+
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig,
+      toolDefinitions: [echoToolDef],
+      instructions: 'Use the echo tool when asked.',
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers,
+    hooks,
+  });
+}
+
+describe('Tool-level hook integration (event-driven mode)', () => {
+  beforeEach(() => {
+    callCounter = 0;
+  });
+  jest.setTimeout(15000);
+
+  describe('PreToolUse', () => {
+    it('fires with toolName, toolInput, and toolUseId', async () => {
+      const registry = new HookRegistry();
+      let captured: PreToolUseHookInput | undefined;
+      const hook: HookCallback<'PreToolUse'> = async (
+        input
+      ): Promise<PreToolUseHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PreToolUse', { hooks: [hook] });
+
+      const tc = makeToolCall('world');
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [tc]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo world')] },
+        callerConfig
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PreToolUse');
+      expect(captured!.toolName).toBe('echo');
+      expect(captured!.toolInput).toEqual({ text: 'world' });
+      expect(captured!.toolUseId).toBe(tc.id);
+    });
+
+    it('deny blocks tool execution and produces error ToolMessage', async () => {
+      const registry = new HookRegistry();
+      let toolExecuted = false;
+      const denyHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'not allowed',
+      });
+      registry.register('PreToolUse', {
+        pattern: '^echo$',
+        hooks: [denyHook],
+      });
+
+      const spyHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          toolExecuted = true;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: 'should not reach',
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, spyHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hello')] },
+        callerConfig
+      );
+
+      expect(toolExecuted).toBe(false);
+    });
+
+    it('ask blocks tool execution in v1 (same as deny)', async () => {
+      const registry = new HookRegistry();
+      let toolExecuted = false;
+      const askHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'ask',
+        reason: 'needs confirmation',
+      });
+      registry.register('PreToolUse', { hooks: [askHook] });
+
+      const spyHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          toolExecuted = true;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: 'x',
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, spyHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hello')] },
+        callerConfig
+      );
+
+      expect(toolExecuted).toBe(false);
+    });
+
+    it('updatedInput rewrites tool args before dispatch', async () => {
+      const registry = new HookRegistry();
+      let receivedArgs: Record<string, unknown> | undefined;
+      const rewriteHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        updatedInput: { text: 'sanitized' },
+      });
+      registry.register('PreToolUse', { hooks: [rewriteHook] });
+
+      const captureHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          receivedArgs = data.toolCalls[0]?.args;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: `echo: ${(tc.args as Record<string, string>).text}`,
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, captureHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [
+        makeToolCall('dangerous'),
+      ]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      expect(receivedArgs).toEqual({ text: 'sanitized' });
+    });
+
+    it('hook errors are non-fatal — tool still executes', async () => {
+      const registry = new HookRegistry();
+      let toolExecuted = false;
+      const throwingHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => {
+        throw new Error('hook crash');
+      };
+      registry.register('PreToolUse', { hooks: [throwingHook] });
+
+      const spyHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          toolExecuted = true;
+          data.resolve(
+            data.toolCalls.map((tc: t.ToolCallRequest) => ({
+              toolCallId: tc.id,
+              content: 'ok',
+              status: 'success' as const,
+            }))
+          );
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, spyHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      expect(toolExecuted).toBe(true);
+    });
+  });
+
+  describe('PermissionDenied', () => {
+    it('fires after PreToolUse deny with the reason', async () => {
+      const registry = new HookRegistry();
+      let pdResolve: () => void;
+      const pdDone = new Promise<void>((r) => {
+        pdResolve = r;
+      });
+      let captured: PermissionDeniedHookInput | undefined;
+      const denyHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'security policy',
+      });
+      const pdHook: HookCallback<'PermissionDenied'> = async (
+        input
+      ): Promise<PermissionDeniedHookOutput> => {
+        captured = input;
+        pdResolve();
+        return {};
+      };
+      registry.register('PreToolUse', { hooks: [denyHook] });
+      registry.register('PermissionDenied', { hooks: [pdHook] });
+
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      await pdDone;
+      expect(captured).toBeDefined();
+      expect(captured!.reason).toBe('security policy');
+      expect(captured!.toolName).toBe('echo');
+    });
+  });
+
+  describe('PostToolUse', () => {
+    it('fires after successful tool execution with output', async () => {
+      const registry = new HookRegistry();
+      let captured: PostToolUseHookInput | undefined;
+      const hook: HookCallback<'PostToolUse'> = async (
+        input
+      ): Promise<PostToolUseHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PostToolUse', { hooks: [hook] });
+
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall('hi')]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hi')] },
+        callerConfig
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PostToolUse');
+      expect(captured!.toolName).toBe('echo');
+      expect(captured!.toolOutput).toBe('echo: hi');
+    });
+
+    it('updatedOutput replaces the ToolMessage content', async () => {
+      const registry = new HookRegistry();
+      const replaceHook: HookCallback<
+        'PostToolUse'
+      > = async (): Promise<PostToolUseHookOutput> => ({
+        updatedOutput: 'REDACTED',
+      });
+      registry.register('PostToolUse', { hooks: [replaceHook] });
+
+      let resolvedContent: string | undefined;
+      const captureHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          const results = data.toolCalls.map(
+            (tc: t.ToolCallRequest): t.ToolExecuteResult => ({
+              toolCallId: tc.id,
+              content: 'original secret output',
+              status: 'success' as const,
+            })
+          );
+          data.resolve(results);
+        },
+      };
+
+      const run = await createEventDrivenRun(registry, captureHandler);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      const messages = run.Graph!.getRunMessages() ?? [];
+      const toolMsg = messages.find((m) => m.getType() === 'tool');
+      expect(toolMsg).toBeDefined();
+      if (toolMsg != null) {
+        resolvedContent =
+          typeof toolMsg.content === 'string'
+            ? toolMsg.content
+            : JSON.stringify(toolMsg.content);
+      }
+
+      expect(resolvedContent).toBe('REDACTED');
+    });
+  });
+
+  describe('PostToolUseFailure', () => {
+    it('fires when tool execution returns an error', async () => {
+      const registry = new HookRegistry();
+      let captured: PostToolUseFailureHookInput | undefined;
+      const hook: HookCallback<'PostToolUseFailure'> = async (
+        input
+      ): Promise<PostToolUseFailureHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PostToolUseFailure', { hooks: [hook] });
+
+      const run = await createEventDrivenRun(
+        registry,
+        createErrorToolExecuteHandler()
+      );
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall()]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo')] },
+        callerConfig
+      );
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PostToolUseFailure');
+      expect(captured!.toolName).toBe('echo');
+      expect(captured!.error).toContain('failed deliberately');
+    });
+  });
+
+  describe('multi-call batch', () => {
+    const mathToolDef: t.LCTool = {
+      name: 'math',
+      description: 'Does math',
+      parameters: {
+        type: 'object' as const,
+        properties: { expr: { type: 'string' } },
+        required: ['expr'],
+      },
+    };
+
+    function createMultiToolRun(
+      hooks: HookRegistry,
+      runId = 'multi-run'
+    ): Promise<Run<t.IState>> {
+      const handler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as t.ToolExecuteBatchRequest;
+          data.resolve(
+            data.toolCalls.map(
+              (tc: t.ToolCallRequest): t.ToolExecuteResult => ({
+                toolCallId: tc.id,
+                content: `${tc.name}: ok`,
+                status: 'success' as const,
+              })
+            )
+          );
+        },
+      };
+      return Run.create<t.IState>({
+        runId,
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef, mathToolDef],
+          instructions: 'Use tools.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: handler,
+          [GraphEvents.TOOL_END]: new ToolEndHandler(),
+          [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        },
+        hooks,
+      });
+    }
+
+    it('partial deny: denied call produces error, approved call executes, order preserved', async () => {
+      const registry = new HookRegistry();
+      const denyEcho: HookCallback<'PreToolUse'> = async (
+        input
+      ): Promise<PreToolUseHookOutput> =>
+        input.toolName === 'echo'
+          ? { decision: 'deny', reason: 'echo blocked' }
+          : {};
+      registry.register('PreToolUse', { hooks: [denyEcho] });
+
+      const echoCall = makeToolCall('hi', 'echo');
+      const mathCall = makeToolCall('1+1', 'math');
+      const run = await createMultiToolRun(registry);
+      run.Graph!.overrideTestModel(['calling tools'], 5, [echoCall, mathCall]);
+      await run.processStream(
+        { messages: [new HumanMessage('do both')] },
+        callerConfig
+      );
+
+      const messages = run.Graph!.getRunMessages() ?? [];
+      const toolMsgs = messages.filter((m) => m.getType() === 'tool');
+
+      expect(toolMsgs).toHaveLength(2);
+      const first = toolMsgs[0];
+      const second = toolMsgs[1];
+      expect(first.content).toContain('Blocked');
+      expect(second.content).toContain('math: ok');
+    });
+
+    it('all denied: no ON_TOOL_EXECUTE dispatch, all error messages', async () => {
+      const registry = new HookRegistry();
+      let handlerCalled = false;
+      const denyAll: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'all blocked',
+      });
+      registry.register('PreToolUse', { hooks: [denyAll] });
+
+      const handler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          handlerCalled = true;
+          const data = rawData as t.ToolExecuteBatchRequest;
+          data.resolve([]);
+        },
+      };
+
+      const run = await Run.create<t.IState>({
+        runId: 'all-denied-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef, mathToolDef],
+          instructions: 'Use tools.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: handler,
+          [GraphEvents.TOOL_END]: new ToolEndHandler(),
+          [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        },
+        hooks: registry,
+      });
+      run.Graph!.overrideTestModel(['calling tools'], 5, [
+        makeToolCall('a', 'echo'),
+        makeToolCall('b', 'math'),
+      ]);
+      await run.processStream(
+        { messages: [new HumanMessage('do both')] },
+        callerConfig
+      );
+
+      expect(handlerCalled).toBe(false);
+    });
+  });
+
+  describe('PostToolUse error resilience', () => {
+    it('PostToolUse hook errors are non-fatal — original output preserved', async () => {
+      const registry = new HookRegistry();
+      const throwingHook: HookCallback<
+        'PostToolUse'
+      > = async (): Promise<PostToolUseHookOutput> => {
+        throw new Error('post hook crash');
+      };
+      registry.register('PostToolUse', { hooks: [throwingHook] });
+
+      const run = await createEventDrivenRun(registry);
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall('hi')]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hi')] },
+        callerConfig
+      );
+
+      const messages = run.Graph!.getRunMessages() ?? [];
+      const toolMsg = messages.find((m) => m.getType() === 'tool');
+      expect(toolMsg).toBeDefined();
+      const content =
+        typeof toolMsg!.content === 'string'
+          ? toolMsg!.content
+          : JSON.stringify(toolMsg!.content);
+      expect(content).toContain('echo: hi');
+    });
+  });
+
+  describe('no-hooks baseline', () => {
+    it('event-driven tool execution works identically without hooks', async () => {
+      const run = await Run.create<t.IState>({
+        runId: 'no-hooks-tool-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef],
+          instructions: 'Use echo.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: createToolExecuteHandler(),
+          [GraphEvents.TOOL_END]: new ToolEndHandler(),
+          [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        },
+      });
+      run.Graph!.overrideTestModel(['calling echo'], 5, [makeToolCall('test')]);
+      const result = await run.processStream(
+        { messages: [new HumanMessage('echo test')] },
+        callerConfig
+      );
+
+      expect(result).toBeDefined();
+    });
+  });
+});

--- a/src/hooks/__tests__/toolHooks.test.ts
+++ b/src/hooks/__tests__/toolHooks.test.ts
@@ -185,6 +185,63 @@ describe('Tool-level hook integration (event-driven mode)', () => {
       expect(toolExecuted).toBe(false);
     });
 
+    it('deny dispatches ON_RUN_STEP_COMPLETED for the blocked call', async () => {
+      const registry = new HookRegistry();
+      const denyHook: HookCallback<
+        'PreToolUse'
+      > = async (): Promise<PreToolUseHookOutput> => ({
+        decision: 'deny',
+        reason: 'not allowed',
+      });
+      registry.register('PreToolUse', {
+        pattern: '^echo$',
+        hooks: [denyHook],
+      });
+
+      let stepCompletedData: t.ToolCompleteEvent | undefined;
+      const stepHandler: t.EventHandler = {
+        handle: async (_event: string, rawData: unknown): Promise<void> => {
+          const data = rawData as { result: t.ToolCompleteEvent };
+          stepCompletedData = data.result;
+        },
+      };
+
+      const toolHandler = createToolExecuteHandler();
+      const customHandlers: Record<string, t.EventHandler> = {
+        [GraphEvents.ON_TOOL_EXECUTE]: toolHandler,
+        [GraphEvents.TOOL_END]: new ToolEndHandler(),
+        [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        [GraphEvents.ON_RUN_STEP_COMPLETED]: stepHandler,
+      };
+
+      const tc = makeToolCall('hello');
+      const run = await Run.create<t.IState>({
+        runId: 'deny-step-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig,
+          toolDefinitions: [echoToolDef],
+          instructions: 'Use the echo tool when asked.',
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers,
+        hooks: registry,
+      });
+
+      run.Graph!.overrideTestModel(['calling echo'], 5, [tc]);
+      await run.processStream(
+        { messages: [new HumanMessage('echo hello')] },
+        callerConfig
+      );
+
+      expect(stepCompletedData).toBeDefined();
+      expect(stepCompletedData!.type).toBe('tool_call');
+      expect(stepCompletedData!.tool_call.name).toBe('echo');
+      expect(stepCompletedData!.tool_call.id).toBe(tc.id);
+      expect(stepCompletedData!.tool_call.output).toContain('Blocked:');
+    });
+
     it('ask blocks tool execution in v1 (same as deny)', async () => {
       const registry = new HookRegistry();
       let toolExecuted = false;

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -349,6 +349,7 @@ export async function executeHooks(
     return freshResult();
   }
 
+  // --- SYNC CRITICAL SECTION: once-matcher removal must complete before any await ---
   const tasks: Promise<HookOutcome>[] = [];
   for (const matcher of matchers) {
     if (!matchesQuery(matcher.pattern, matchQuery)) {
@@ -363,6 +364,7 @@ export async function executeHooks(
       tasks.push(runHook(hook, input, matcherSignal, matcher));
     }
   }
+  // --- END SYNC CRITICAL SECTION ---
   if (tasks.length === 0) {
     return freshResult();
   }

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -1,0 +1,373 @@
+// src/hooks/executeHooks.ts
+import type { Logger } from 'winston';
+import type { HookRegistry } from './HookRegistry';
+import type {
+  HookInput,
+  HookEvent,
+  HookOutput,
+  HookMatcher,
+  ToolDecision,
+  StopDecision,
+  HookCallback,
+  AggregatedHookResult,
+} from './types';
+import { matchesQuery } from './matchers';
+
+/** Default per-hook timeout when a matcher doesn't set its own. */
+export const DEFAULT_HOOK_TIMEOUT_MS = 30_000;
+
+/**
+ * Options for a single `executeHooks` call. The `input` drives everything —
+ * the event name is read from `input.hook_event_name`, matchers are looked
+ * up against that event, and each hook receives `input` directly.
+ */
+export interface ExecuteHooksOptions {
+  registry: HookRegistry;
+  input: HookInput;
+  /** Scope lookup to this session (in addition to global matchers). */
+  sessionId?: string;
+  /** Query string matched against each matcher's pattern (tool name, etc.). */
+  matchQuery?: string;
+  /** Parent AbortSignal — combined with per-hook timeout into the hook signal. */
+  signal?: AbortSignal;
+  /** Default per-hook timeout; overridden by `matcher.timeout` when present. */
+  timeoutMs?: number;
+  /** Optional winston logger for non-internal hook errors. */
+  logger?: Logger;
+}
+
+type WideMatcher = HookMatcher<HookEvent>;
+type WideCallback = HookCallback<HookEvent>;
+
+interface HookOutcome {
+  matcher: WideMatcher;
+  output: HookOutput | null;
+  error: string | null;
+  timedOut: boolean;
+}
+
+function freshResult(): AggregatedHookResult {
+  return {
+    additionalContexts: [],
+    errors: [],
+  };
+}
+
+function combineSignals(
+  parent: AbortSignal | undefined,
+  timeoutMs: number
+): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  if (parent === undefined) {
+    return timeoutSignal;
+  }
+  return AbortSignal.any([parent, timeoutSignal]);
+}
+
+function isTimeout(err: unknown): boolean {
+  if (err instanceof Error) {
+    return err.name === 'TimeoutError' || err.name === 'AbortError';
+  }
+  return false;
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message !== '' ? err.message : err.name;
+  }
+  return String(err);
+}
+
+function makeAbortPromise(signal: AbortSignal): {
+  promise: Promise<never>;
+  cleanup: () => void;
+} {
+  let onAbort: (() => void) | undefined;
+  const promise = new Promise<never>((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(
+        signal.reason instanceof Error ? signal.reason : new Error('aborted')
+      );
+      return;
+    }
+    onAbort = (): void => {
+      reject(
+        signal.reason instanceof Error ? signal.reason : new Error('aborted')
+      );
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  const cleanup = (): void => {
+    if (onAbort !== undefined) {
+      signal.removeEventListener('abort', onAbort);
+      onAbort = undefined;
+    }
+  };
+  return { promise, cleanup };
+}
+
+async function runHook(
+  hook: WideCallback,
+  input: HookInput,
+  signal: AbortSignal,
+  matcher: WideMatcher
+): Promise<HookOutcome> {
+  const hookPromise = Promise.resolve().then(() => hook(input, signal));
+  const { promise: abortPromise, cleanup } = makeAbortPromise(signal);
+  try {
+    const output = await Promise.race([hookPromise, abortPromise]);
+    return { matcher, output, error: null, timedOut: false };
+  } catch (err) {
+    return {
+      matcher,
+      output: null,
+      error: describeError(err),
+      timedOut: isTimeout(err),
+    };
+  } finally {
+    cleanup();
+  }
+}
+
+function reportErrors(
+  outcomes: readonly HookOutcome[],
+  event: HookEvent,
+  logger: Logger | undefined
+): void {
+  for (const outcome of outcomes) {
+    if (outcome.error === null) {
+      continue;
+    }
+    if (outcome.matcher.internal === true) {
+      continue;
+    }
+    const label = outcome.timedOut ? 'timed out' : 'threw an error';
+    const message = `Hook for ${event} ${label}: ${outcome.error}`;
+    if (logger !== undefined) {
+      logger.warn(message);
+      continue;
+    }
+    // eslint-disable-next-line no-console
+    console.warn(message);
+  }
+}
+
+function applyToolDecision(
+  agg: AggregatedHookResult,
+  decision: ToolDecision,
+  reason: string | undefined
+): void {
+  if (decision === 'deny') {
+    if (agg.decision === 'deny') {
+      return;
+    }
+    agg.decision = 'deny';
+    agg.reason = reason;
+    return;
+  }
+  if (decision === 'ask') {
+    if (agg.decision === 'deny' || agg.decision === 'ask') {
+      return;
+    }
+    agg.decision = 'ask';
+    agg.reason = reason;
+    return;
+  }
+  if (agg.decision === undefined) {
+    agg.decision = 'allow';
+    agg.reason = reason;
+  }
+}
+
+function applyStopDecision(
+  agg: AggregatedHookResult,
+  decision: StopDecision,
+  reason: string | undefined
+): void {
+  if (decision === 'block') {
+    if (agg.stopDecision === 'block') {
+      return;
+    }
+    agg.stopDecision = 'block';
+    agg.reason = reason;
+    return;
+  }
+  if (agg.stopDecision === undefined) {
+    agg.stopDecision = 'continue';
+    if (agg.reason === undefined) {
+      agg.reason = reason;
+    }
+  }
+}
+
+function applyDecision(agg: AggregatedHookResult, output: HookOutput): void {
+  if (!('decision' in output) || output.decision === undefined) {
+    return;
+  }
+  const decision = output.decision;
+  const reason =
+    'reason' in output && typeof output.reason === 'string'
+      ? output.reason
+      : undefined;
+  if (decision === 'deny' || decision === 'ask' || decision === 'allow') {
+    applyToolDecision(agg, decision, reason);
+    return;
+  }
+  applyStopDecision(agg, decision, reason);
+}
+
+function applyContext(agg: AggregatedHookResult, output: HookOutput): void {
+  if (
+    typeof output.additionalContext === 'string' &&
+    output.additionalContext.length > 0
+  ) {
+    agg.additionalContexts.push(output.additionalContext);
+  }
+}
+
+function applyStopFlag(agg: AggregatedHookResult, output: HookOutput): void {
+  if (output.preventContinuation !== true) {
+    return;
+  }
+  agg.preventContinuation = true;
+  if (typeof output.stopReason === 'string' && agg.stopReason === undefined) {
+    agg.stopReason = output.stopReason;
+  }
+}
+
+function applyUpdatedInput(
+  agg: AggregatedHookResult,
+  output: HookOutput
+): void {
+  if (!('updatedInput' in output) || output.updatedInput === undefined) {
+    return;
+  }
+  agg.updatedInput = output.updatedInput;
+}
+
+function applyUpdatedOutput(
+  agg: AggregatedHookResult,
+  output: HookOutput
+): void {
+  if (!('updatedOutput' in output) || output.updatedOutput === undefined) {
+    return;
+  }
+  agg.updatedOutput = output.updatedOutput;
+}
+
+function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
+  const agg = freshResult();
+  for (const outcome of outcomes) {
+    if (outcome.error !== null) {
+      if (outcome.matcher.internal !== true) {
+        agg.errors.push(outcome.error);
+      }
+      continue;
+    }
+    const output = outcome.output;
+    if (output === null) {
+      continue;
+    }
+    applyContext(agg, output);
+    applyStopFlag(agg, output);
+    applyDecision(agg, output);
+    applyUpdatedInput(agg, output);
+    applyUpdatedOutput(agg, output);
+  }
+  return agg;
+}
+
+/**
+ * Fires every matcher registered against `input.hook_event_name`, folding
+ * their results per `deny > ask > allow` precedence and accumulating
+ * context/errors.
+ *
+ * ## Parallelism and determinism
+ *
+ * All matching hooks fire simultaneously and are awaited via `Promise.all`,
+ * which preserves input-array order in its returned results. The fold
+ * therefore iterates outcomes in **registration order** — outer loop over
+ * matchers as they sit in the registry (global first, then session), inner
+ * loop over each matcher's `hooks` array. Last-writer-wins fields
+ * (`updatedInput`, `updatedOutput`) are deterministic in that order, even
+ * though hooks may complete in arbitrary wall-clock order.
+ *
+ * Consumers that need a single authoritative rewrite should still scope
+ * `updatedInput`/`updatedOutput` to one hook per matcher to avoid subtle
+ * precedence bugs when matchers are added in a different order than
+ * expected.
+ *
+ * ## Timeouts and cancellation
+ *
+ * Each matcher receives **one shared `AbortSignal`** derived from the
+ * caller's parent signal combined with `matcher.timeout` (falling back to
+ * `opts.timeoutMs`, default {@link DEFAULT_HOOK_TIMEOUT_MS}). Sharing the
+ * signal across hooks in a matcher collapses N timer allocations into
+ * one, which matters on the PreToolUse hot path where a matcher with
+ * several hooks fires on every tool call. Each hook call is raced
+ * against the shared signal, so even a hook that ignores the signal is
+ * force-unblocked when the timeout fires. Timeout/abort errors are
+ * swallowed into the aggregated result's `errors` array (non-fatal by
+ * default).
+ *
+ * ## Internal matchers
+ *
+ * A matcher with `internal: true` is excluded from both the `errors` array
+ * and the logger output. Use it for infrastructure hooks whose failures
+ * should not pollute user-visible diagnostics.
+ *
+ * ## Once semantics — atomic at-most-once
+ *
+ * A matcher with `once: true` is removed from the registry **before any
+ * hook runs**, inside the synchronous prefix of `executeHooks` (between
+ * `getMatchers` and the first `await`). Because Node's event loop serialises
+ * sync work, two concurrent `executeHooks` calls can never both observe
+ * and dispatch the same `once` matcher — whichever call runs its sync
+ * prefix first consumes it, and the loser sees an empty bucket.
+ *
+ * Trade-off: if every hook in a `once` matcher throws, the matcher is
+ * still gone. "Once" here means "at most one dispatch, ever", not "at
+ * most one successful execution with retry on failure". Hosts that need
+ * retry semantics should register a normal matcher and self-unregister
+ * via the `unregister` callback returned from `registry.register`.
+ */
+export async function executeHooks(
+  opts: ExecuteHooksOptions
+): Promise<AggregatedHookResult> {
+  const {
+    registry,
+    input,
+    sessionId,
+    matchQuery,
+    signal,
+    timeoutMs = DEFAULT_HOOK_TIMEOUT_MS,
+    logger,
+  } = opts;
+  const event = input.hook_event_name;
+  const matchers = registry.getMatchers(event, sessionId);
+  if (matchers.length === 0) {
+    return freshResult();
+  }
+
+  const tasks: Promise<HookOutcome>[] = [];
+  for (const matcher of matchers) {
+    if (!matchesQuery(matcher.pattern, matchQuery)) {
+      continue;
+    }
+    if (matcher.once === true) {
+      registry.removeMatcher(event, matcher, sessionId);
+    }
+    const perHookTimeout = matcher.timeout ?? timeoutMs;
+    const matcherSignal = combineSignals(signal, perHookTimeout);
+    for (const hook of matcher.hooks) {
+      tasks.push(runHook(hook, input, matcherSignal, matcher));
+    }
+  }
+  if (tasks.length === 0) {
+    return freshResult();
+  }
+
+  const outcomes = await Promise.all(tasks);
+  reportErrors(outcomes, event, logger);
+  return fold(outcomes);
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,8 +2,9 @@
 //
 // Hook lifecycle system for `@librechat/agents`. Re-exported from
 // `src/index.ts` and consumed by `Run.processStream` (RunStart,
-// UserPromptSubmit, Stop, StopFailure) and `ToolNode.dispatchToolEvents`
-// (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied).
+// UserPromptSubmit, Stop, StopFailure), `ToolNode.dispatchToolEvents`
+// (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied),
+// and `createSummarizeNode` (PreCompact, PostCompact).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,56 @@
+// src/hooks/index.ts
+//
+// Phase 1 PR 1: this directory is purely additive and is NOT re-exported
+// from `src/index.ts`. The types and classes below are consumed internally
+// in subsequent PRs that wire the registry into `Run`, `Graph`, and
+// `ToolNode`. Leaving it unexported keeps the public API surface frozen
+// until the integration layer is in place.
+export { HookRegistry } from './HookRegistry';
+export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
+export {
+  matchesQuery,
+  hasNestedQuantifier,
+  MAX_PATTERN_LENGTH,
+  MAX_CACHE_SIZE,
+} from './matchers';
+export { HOOK_EVENTS } from './types';
+export type {
+  HookEvent,
+  HookInput,
+  HookOutput,
+  HookCallback,
+  HookMatcher,
+  HooksByEvent,
+  HookInputByEvent,
+  HookOutputByEvent,
+  BaseHookInput,
+  BaseHookOutput,
+  ToolDecision,
+  StopDecision,
+  AggregatedHookResult,
+  RunStartHookInput,
+  UserPromptSubmitHookInput,
+  PreToolUseHookInput,
+  PostToolUseHookInput,
+  PostToolUseFailureHookInput,
+  PermissionDeniedHookInput,
+  SubagentStartHookInput,
+  SubagentStopHookInput,
+  StopHookInput,
+  StopFailureHookInput,
+  PreCompactHookInput,
+  PostCompactHookInput,
+  RunStartHookOutput,
+  UserPromptSubmitHookOutput,
+  PreToolUseHookOutput,
+  PostToolUseHookOutput,
+  PostToolUseFailureHookOutput,
+  PermissionDeniedHookOutput,
+  SubagentStartHookOutput,
+  SubagentStopHookOutput,
+  StopHookOutput,
+  StopFailureHookOutput,
+  PreCompactHookOutput,
+  PostCompactHookOutput,
+} from './types';
+export type { ExecuteHooksOptions } from './executeHooks';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,7 +4,8 @@
 // `src/index.ts` and consumed by `Run.processStream` (RunStart,
 // UserPromptSubmit, Stop, StopFailure), `ToolNode.dispatchToolEvents`
 // (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied),
-// and `createSummarizeNode` (PreCompact, PostCompact).
+// `createSummarizeNode` (PreCompact, PostCompact), and
+// `SubagentExecutor.execute` (SubagentStart, SubagentStop).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,10 +1,9 @@
 // src/hooks/index.ts
 //
-// Phase 1 PR 1: this directory is purely additive and is NOT re-exported
-// from `src/index.ts`. The types and classes below are consumed internally
-// in subsequent PRs that wire the registry into `Run`, `Graph`, and
-// `ToolNode`. Leaving it unexported keeps the public API surface frozen
-// until the integration layer is in place.
+// Hook lifecycle system for `@librechat/agents`. Re-exported from
+// `src/index.ts` and consumed by `Run.processStream` (RunStart,
+// UserPromptSubmit, Stop, StopFailure) and — once the tool-hook PR
+// lands — by `ToolNode` (PreToolUse, PostToolUse, etc.).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,8 +2,8 @@
 //
 // Hook lifecycle system for `@librechat/agents`. Re-exported from
 // `src/index.ts` and consumed by `Run.processStream` (RunStart,
-// UserPromptSubmit, Stop, StopFailure) and — once the tool-hook PR
-// lands — by `ToolNode` (PreToolUse, PostToolUse, etc.).
+// UserPromptSubmit, Stop, StopFailure) and `ToolNode.dispatchToolEvents`
+// (PreToolUse, PostToolUse, PostToolUseFailure, PermissionDenied).
 export { HookRegistry } from './HookRegistry';
 export { executeHooks, DEFAULT_HOOK_TIMEOUT_MS } from './executeHooks';
 export {

--- a/src/hooks/matchers.ts
+++ b/src/hooks/matchers.ts
@@ -1,0 +1,280 @@
+// src/hooks/matchers.ts
+
+/**
+ * Upper bound on hook-matcher pattern length. Patterns longer than this
+ * are rejected outright — the goal is a cheap cap on pathological inputs
+ * (repeated quantifiers, huge alternation groups) without pulling in a
+ * safe-regex dependency.
+ *
+ * Legitimate matchers are almost always under 50 characters (tool names,
+ * short alternations, simple prefix anchors); 512 leaves generous
+ * headroom while preventing 10KB regexes.
+ */
+export const MAX_PATTERN_LENGTH = 512;
+
+/**
+ * Upper bound on the compilation cache. Chosen to comfortably hold every
+ * distinct pattern a single multi-tenant run is likely to see (tools,
+ * agent types, basename filters) without growing without bound.
+ *
+ * Under hosts that register unique patterns per tenant, LRU eviction
+ * keeps the working set bounded — cold patterns are re-compiled on next
+ * use, which is the correct cost trade-off for long-running processes
+ * that must not leak memory.
+ */
+export const MAX_CACHE_SIZE = 256;
+
+interface CacheEntry {
+  regex: RegExp | null;
+}
+
+/**
+ * Module-level LRU cache keyed by pattern string. Map iteration order is
+ * insertion order in ECMAScript, so refreshing an entry's position means
+ * "delete then re-set". On overflow we evict the first key (least
+ * recently used).
+ *
+ * Failed compiles are cached as `{ regex: null }` so a malformed pattern
+ * does not re-enter the compiler — and so a tenant spamming bad patterns
+ * doesn't burn CPU on every call.
+ */
+const patternCache: Map<string, CacheEntry> = new Map();
+
+/**
+ * Threshold above which `touchCacheEntry` actually performs the LRU
+ * refresh. Below this watermark the cache has zero eviction pressure, so
+ * the delete+set on every hit would be pure overhead. Above it we refresh
+ * properly so hot patterns survive evictions. 75% of capacity is the
+ * standard sweet spot.
+ */
+const LRU_REFRESH_THRESHOLD = Math.floor((MAX_CACHE_SIZE * 3) / 4);
+
+function touchCacheEntry(pattern: string, entry: CacheEntry): void {
+  if (patternCache.size < LRU_REFRESH_THRESHOLD) {
+    return;
+  }
+  patternCache.delete(pattern);
+  patternCache.set(pattern, entry);
+}
+
+function setCacheEntry(pattern: string, entry: CacheEntry): void {
+  if (patternCache.size >= MAX_CACHE_SIZE) {
+    const oldestKey = patternCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      patternCache.delete(oldestKey);
+    }
+  }
+  patternCache.set(pattern, entry);
+}
+
+interface QuantifierFrame {
+  hasBacktrackRisk: boolean;
+}
+
+function skipGroupSyntaxPrefix(pattern: string, start: number): number {
+  if (start >= pattern.length || pattern[start] !== '?') {
+    return start;
+  }
+  let i = start + 1;
+  if (i >= pattern.length) {
+    return i;
+  }
+  const modifier = pattern[i];
+  if (modifier === ':' || modifier === '=' || modifier === '!') {
+    return i + 1;
+  }
+  if (modifier !== '<') {
+    return i;
+  }
+  i++;
+  if (i < pattern.length && (pattern[i] === '=' || pattern[i] === '!')) {
+    return i + 1;
+  }
+  while (i < pattern.length && pattern[i] !== '>') {
+    i++;
+  }
+  if (i < pattern.length) {
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Cheap syntactic detector for the most common catastrophic-backtracking
+ * shape: a quantified group that contains another quantifier (e.g.
+ * `(a+)+`, `(.*)*`, `(\w+)+$`, `(?:(a+))+`). This is the "nested
+ * quantifier" class of ReDoS — runs in polynomial-or-worse time on
+ * adversarial inputs.
+ *
+ * The scan walks the pattern linearly using an explicit stack of group
+ * frames. For each group it tracks whether the group's contents include
+ * "backtrack risk" — meaning a direct quantifier OR a nested group that
+ * carries risk up. When a group closes with a trailing quantifier AND its
+ * frame carries backtrack risk, the pattern is flagged. Risk propagates
+ * to the enclosing frame when a child group closes (whether the child
+ * itself was quantified or not), so `(?:(a+))+` — equivalent to `(a+)+`
+ * — is flagged correctly even though the outer non-capturing wrapper is
+ * one level removed from the inner quantifier.
+ *
+ * ## Group-syntax prefixes
+ *
+ * Non-capturing groups (`(?:`), lookaheads (`(?=`, `(?!`), lookbehinds
+ * (`(?<=`, `(?<!`), and named groups (`(?<name>`) are skipped over at
+ * the `(` so their `?` is not misread as a quantifier. Without this,
+ * `(?:pre_)?tool_name` would be incorrectly rejected because the scanner
+ * would see the group-syntax `?` as a quantifier at depth 1.
+ *
+ * ## Heuristic, not a proof
+ *
+ * This catches the common forms but not all. Ambiguous-alternation ReDoS
+ * like `(a|a)+` is not detected. Pathologically long patterns are also
+ * caught by {@link MAX_PATTERN_LENGTH}. Hosts that accept user-supplied
+ * patterns must still validate upstream.
+ */
+export function hasNestedQuantifier(pattern: string): boolean {
+  const stack: QuantifierFrame[] = [];
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === '[') {
+      i = findCharClassEnd(pattern, i) + 1;
+      continue;
+    }
+    if (ch === '(') {
+      stack.push({ hasBacktrackRisk: false });
+      i = skipGroupSyntaxPrefix(pattern, i + 1);
+      continue;
+    }
+    if (ch === ')') {
+      const frame = stack.pop();
+      if (frame === undefined) {
+        i++;
+        continue;
+      }
+      const next = pattern[i + 1];
+      const isQuantifier =
+        next === '*' || next === '+' || next === '?' || next === '{';
+      if (isQuantifier && frame.hasBacktrackRisk) {
+        return true;
+      }
+      if (stack.length > 0 && (frame.hasBacktrackRisk || isQuantifier)) {
+        stack[stack.length - 1].hasBacktrackRisk = true;
+      }
+      i++;
+      continue;
+    }
+    if (ch === '*' || ch === '+' || ch === '?' || ch === '{') {
+      if (stack.length > 0) {
+        stack[stack.length - 1].hasBacktrackRisk = true;
+      }
+    }
+    i++;
+  }
+  return false;
+}
+
+function findCharClassEnd(pattern: string, start: number): number {
+  let i = start + 1;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === ']') {
+      return i;
+    }
+    i++;
+  }
+  return pattern.length - 1;
+}
+
+function compile(pattern: string): RegExp | null {
+  const cached = patternCache.get(pattern);
+  if (cached !== undefined) {
+    touchCacheEntry(pattern, cached);
+    return cached.regex;
+  }
+  if (pattern.length > MAX_PATTERN_LENGTH) {
+    setCacheEntry(pattern, { regex: null });
+    return null;
+  }
+  if (hasNestedQuantifier(pattern)) {
+    setCacheEntry(pattern, { regex: null });
+    return null;
+  }
+  try {
+    const regex = new RegExp(pattern);
+    setCacheEntry(pattern, { regex });
+    return regex;
+  } catch {
+    setCacheEntry(pattern, { regex: null });
+    return null;
+  }
+}
+
+/**
+ * Tests whether a hook matcher pattern matches the given query string.
+ *
+ * ## Semantics
+ *
+ * - `undefined` or empty `pattern` matches any query (wildcard). This is
+ *   the intended shape for events that do not supply a query string at
+ *   all (`RunStart`, `Stop`, etc.) — register such matchers without a
+ *   pattern.
+ * - `undefined` or empty `query` with a non-empty `pattern` never matches.
+ *   Setting a pattern on a query-less event is therefore inert: the
+ *   matcher will simply never fire. This is intentional — it keeps
+ *   query-based filtering out of event types where "query" has no meaning,
+ *   and is documented on `HookMatcher.pattern`.
+ * - Otherwise, the pattern is compiled once (via a bounded LRU cache) and
+ *   tested against the query.
+ * - Invalid regex patterns never throw — a failed compile is cached as
+ *   "never matches" so a single malformed pattern cannot take out a whole
+ *   `executeHooks` batch.
+ *
+ * ## ReDoS mitigations
+ *
+ * Patterns compile through three cheap gates before reaching `new RegExp`:
+ *
+ * 1. {@link MAX_PATTERN_LENGTH} length cap rejects oversized inputs.
+ * 2. {@link hasNestedQuantifier} rejects the most common catastrophic-
+ *    backtracking shape (quantified group containing a quantifier).
+ * 3. Successful compiles are cached in a bounded LRU so repeated calls
+ *    never re-enter the regex compiler.
+ *
+ * These are a floor, not a ceiling. Hosts that accept user-supplied
+ * patterns should still validate upstream. The design report §3.8 routes
+ * persistable hooks through a host-side compiler before they reach this
+ * module.
+ */
+export function matchesQuery(
+  pattern: string | undefined,
+  query: string | undefined
+): boolean {
+  if (pattern === undefined || pattern === '') {
+    return true;
+  }
+  if (query === undefined || query === '') {
+    return false;
+  }
+  const regex = compile(pattern);
+  if (regex === null) {
+    return false;
+  }
+  return regex.test(query);
+}
+
+/** Clears the regex compilation cache. Intended for test isolation. */
+export function clearMatcherCache(): void {
+  patternCache.clear();
+}
+
+/** Returns the current size of the compilation cache. Intended for tests. */
+export function getMatcherCacheSize(): number {
+  return patternCache.size;
+}

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,0 +1,382 @@
+// src/hooks/types.ts
+import type { BaseMessage } from '@langchain/core/messages';
+
+/**
+ * Closed set of hook lifecycle events supported by the hooks system.
+ *
+ * These mirror the subset of Claude Code's event surface that makes sense
+ * for a library context (no filesystem/CLI-specific events). See
+ * `docs/hooks-design-report.md` §3.2 for the mapping to existing
+ * `@librechat/agents` emission points.
+ */
+export const HOOK_EVENTS = [
+  'RunStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'PostToolUseFailure',
+  'PermissionDenied',
+  'SubagentStart',
+  'SubagentStop',
+  'Stop',
+  'StopFailure',
+  'PreCompact',
+  'PostCompact',
+] as const;
+
+export type HookEvent = (typeof HOOK_EVENTS)[number];
+
+/** Tool-gating decision; executeHooks folds with `deny > ask > allow` precedence. */
+export type ToolDecision = 'allow' | 'deny' | 'ask';
+
+/** Stop-loop decision; `block` means "do not stop, run another turn". Any `block` wins. */
+export type StopDecision = 'continue' | 'block';
+
+/**
+ * Fields shared by every `HookInput`. Discriminated by `hook_event_name`.
+ *
+ * - `runId` identifies the current agent run and is always present.
+ * - `threadId` identifies the conversation thread when the host has one.
+ * - `agentId` is only set when the hook fires inside a subagent scope.
+ */
+export interface BaseHookInput {
+  runId: string;
+  threadId?: string;
+  agentId?: string;
+}
+
+export interface RunStartHookInput extends BaseHookInput {
+  hook_event_name: 'RunStart';
+  messages: BaseMessage[];
+}
+
+export interface UserPromptSubmitHookInput extends BaseHookInput {
+  hook_event_name: 'UserPromptSubmit';
+  prompt: string;
+  attachments?: BaseMessage[];
+}
+
+/**
+ * Fires before a tool is invoked. Hook may return `deny`/`ask`/`allow` and/or
+ * an `updatedInput` that replaces the tool arguments before invocation.
+ *
+ * `toolInput` is intentionally typed as `Record<string, unknown>` because the
+ * SDK is tool-agnostic — concrete tool argument shapes are only known at the
+ * call site and are narrowed by the host. This is the one escape hatch in
+ * the hook type system.
+ */
+export interface PreToolUseHookInput extends BaseHookInput {
+  hook_event_name: 'PreToolUse';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId: string;
+  stepId?: string;
+  turn?: number;
+}
+
+export interface PostToolUseHookInput extends BaseHookInput {
+  hook_event_name: 'PostToolUse';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolOutput: unknown;
+  toolUseId: string;
+  stepId?: string;
+  turn?: number;
+}
+
+export interface PostToolUseFailureHookInput extends BaseHookInput {
+  hook_event_name: 'PostToolUseFailure';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId: string;
+  error: string;
+  stepId?: string;
+  turn?: number;
+}
+
+export interface PermissionDeniedHookInput extends BaseHookInput {
+  hook_event_name: 'PermissionDenied';
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  toolUseId: string;
+  reason: string;
+}
+
+export interface SubagentStartHookInput extends BaseHookInput {
+  hook_event_name: 'SubagentStart';
+  parentAgentId?: string;
+  agentId: string;
+  agentType: string;
+  inputs: BaseMessage[];
+}
+
+export interface SubagentStopHookInput extends BaseHookInput {
+  hook_event_name: 'SubagentStop';
+  agentId: string;
+  agentType: string;
+  messages: BaseMessage[];
+}
+
+export interface StopHookInput extends BaseHookInput {
+  hook_event_name: 'Stop';
+  messages: BaseMessage[];
+  stopReason?: string;
+  stopHookActive: boolean;
+}
+
+export interface StopFailureHookInput extends BaseHookInput {
+  hook_event_name: 'StopFailure';
+  error: string;
+  lastAssistantMessage?: BaseMessage;
+}
+
+export interface PreCompactHookInput extends BaseHookInput {
+  hook_event_name: 'PreCompact';
+  messagesBeforeCount: number;
+  trigger: 'threshold' | 'manual' | 'error';
+}
+
+export interface PostCompactHookInput extends BaseHookInput {
+  hook_event_name: 'PostCompact';
+  summary: string;
+  messagesAfterCount: number;
+}
+
+/** Discriminated union of every hook input shape. */
+export type HookInput =
+  | RunStartHookInput
+  | UserPromptSubmitHookInput
+  | PreToolUseHookInput
+  | PostToolUseHookInput
+  | PostToolUseFailureHookInput
+  | PermissionDeniedHookInput
+  | SubagentStartHookInput
+  | SubagentStopHookInput
+  | StopHookInput
+  | StopFailureHookInput
+  | PreCompactHookInput
+  | PostCompactHookInput;
+
+/** Compile-time map from event name to its input shape. */
+export type HookInputByEvent = {
+  RunStart: RunStartHookInput;
+  UserPromptSubmit: UserPromptSubmitHookInput;
+  PreToolUse: PreToolUseHookInput;
+  PostToolUse: PostToolUseHookInput;
+  PostToolUseFailure: PostToolUseFailureHookInput;
+  PermissionDenied: PermissionDeniedHookInput;
+  SubagentStart: SubagentStartHookInput;
+  SubagentStop: SubagentStopHookInput;
+  Stop: StopHookInput;
+  StopFailure: StopFailureHookInput;
+  PreCompact: PreCompactHookInput;
+  PostCompact: PostCompactHookInput;
+};
+
+/**
+ * Fields common to every hook output. Hooks that have nothing to say simply
+ * return `{}` (or omit the fields below).
+ */
+export interface BaseHookOutput {
+  /** Context string to inject into the conversation. Accumulated across hooks. */
+  additionalContext?: string;
+  /** True to prevent the next model turn. Any hook can set this. */
+  preventContinuation?: boolean;
+  /** Reason reported alongside `preventContinuation`. */
+  stopReason?: string;
+}
+
+export type RunStartHookOutput = BaseHookOutput;
+
+export interface UserPromptSubmitHookOutput extends BaseHookOutput {
+  decision?: ToolDecision;
+  reason?: string;
+}
+
+export interface PreToolUseHookOutput extends BaseHookOutput {
+  decision?: ToolDecision;
+  reason?: string;
+  /**
+   * Replacement tool input. Merged into the pending tool call by the host.
+   *
+   * When multiple hooks set `updatedInput` within a single `executeHooks`
+   * call, the last writer in registration order wins (outer loop: matcher
+   * registration order; inner loop: hook position within the matcher). The
+   * winner is deterministic — `Promise.all` preserves input-array order.
+   * Consumers that need a single authoritative rewrite should still scope
+   * `updatedInput` to one hook per matcher to avoid confusing precedence.
+   */
+  updatedInput?: Record<string, unknown>;
+}
+
+export interface PostToolUseHookOutput extends BaseHookOutput {
+  /**
+   * Replacement tool output. Flows through the aggregated result so the
+   * host can substitute it before appending the tool result message.
+   * Ordering semantics match `PreToolUseHookOutput.updatedInput`:
+   * last-writer-wins in registration order.
+   */
+  updatedOutput?: unknown;
+}
+
+export type PostToolUseFailureHookOutput = BaseHookOutput;
+
+export type PermissionDeniedHookOutput = BaseHookOutput;
+
+export interface SubagentStartHookOutput extends BaseHookOutput {
+  decision?: ToolDecision;
+  reason?: string;
+}
+
+export type SubagentStopHookOutput = BaseHookOutput;
+
+export interface StopHookOutput extends BaseHookOutput {
+  decision?: StopDecision;
+  reason?: string;
+}
+
+export type StopFailureHookOutput = BaseHookOutput;
+
+export type PreCompactHookOutput = BaseHookOutput;
+
+export type PostCompactHookOutput = BaseHookOutput;
+
+/** Compile-time map from event name to its output shape. */
+export type HookOutputByEvent = {
+  RunStart: RunStartHookOutput;
+  UserPromptSubmit: UserPromptSubmitHookOutput;
+  PreToolUse: PreToolUseHookOutput;
+  PostToolUse: PostToolUseHookOutput;
+  PostToolUseFailure: PostToolUseFailureHookOutput;
+  PermissionDenied: PermissionDeniedHookOutput;
+  SubagentStart: SubagentStartHookOutput;
+  SubagentStop: SubagentStopHookOutput;
+  Stop: StopHookOutput;
+  StopFailure: StopFailureHookOutput;
+  PreCompact: PreCompactHookOutput;
+  PostCompact: PostCompactHookOutput;
+};
+
+/** Superset output shape used by the executor's fold loop. */
+export type HookOutput =
+  | RunStartHookOutput
+  | UserPromptSubmitHookOutput
+  | PreToolUseHookOutput
+  | PostToolUseHookOutput
+  | PostToolUseFailureHookOutput
+  | PermissionDeniedHookOutput
+  | SubagentStartHookOutput
+  | SubagentStopHookOutput
+  | StopHookOutput
+  | StopFailureHookOutput
+  | PreCompactHookOutput
+  | PostCompactHookOutput;
+
+/**
+ * A hook callback is a plain async function registered against a specific
+ * event. The `signal` is always supplied by `executeHooks` and combines the
+ * batch's parent signal with the per-hook timeout — callbacks that perform
+ * long-running work should observe it.
+ */
+export type HookCallback<E extends HookEvent = HookEvent> = (
+  input: HookInputByEvent[E],
+  signal: AbortSignal
+) => HookOutputByEvent[E] | Promise<HookOutputByEvent[E]>;
+
+/**
+ * A matcher groups one or more callbacks under a shared regex filter and
+ * shared timeout/once/internal flags. The generic `E` ties the callback
+ * types to the event the matcher is registered against.
+ */
+export interface HookMatcher<E extends HookEvent = HookEvent> {
+  /**
+   * Regex pattern matched against the event's primary query string (e.g.
+   * the tool name for `PreToolUse`, the agent type for `SubagentStart`).
+   *
+   * Omitted or empty means "always match". For events that do not supply a
+   * query string (`RunStart`, `Stop`, etc.), only wildcard matchers fire —
+   * a non-empty pattern on such events will never match.
+   *
+   * Patterns are treated as trusted input: `executeHooks` compiles them
+   * with `new RegExp(pattern)` without any sandbox, and a pathological
+   * pattern can block the event loop. Host registration code is expected
+   * to validate or length-bound patterns that originate from user input.
+   */
+  pattern?: string;
+  /** Callbacks that fire when the matcher hits. Executed in parallel. */
+  hooks: HookCallback<E>[];
+  /** Per-matcher timeout in ms. Defaults to the executor's batch timeout. */
+  timeout?: number;
+  /**
+   * Atomically remove the matcher before its first dispatch.
+   *
+   * `executeHooks` claims `once: true` matchers synchronously — between
+   * `getMatchers` and its first `await` — so two concurrent calls cannot
+   * both dispatch the same matcher. Whichever call runs its sync prefix
+   * first wins the matcher; the other sees an empty bucket.
+   *
+   * Semantics are "at most one dispatch, ever" — if every hook in the
+   * matcher throws, the matcher is still gone. Use `once` for
+   * fire-and-forget bootstrapping (registration, telemetry, setup). Hosts
+   * that need retry semantics should register a normal matcher and
+   * self-unregister via the callback returned from `registry.register`.
+   */
+  once?: boolean;
+  /** Internal hooks are excluded from telemetry and non-fatal error logging. */
+  internal?: boolean;
+}
+
+/**
+ * Storage shape for matchers keyed by event. Each event's matcher list is
+ * a generic array parameterized by that event type, so lookup via
+ * `HooksByEvent[E]` preserves type-safe callback signatures.
+ */
+export type HooksByEvent = {
+  [E in HookEvent]?: HookMatcher<E>[];
+};
+
+/**
+ * Aggregated result of a single `executeHooks` call. Fields are populated
+ * according to the fold rules in `executeHooks.ts`.
+ */
+export interface AggregatedHookResult {
+  /** Folded tool-gating decision; `deny > ask > allow`. */
+  decision?: ToolDecision;
+  /** Folded stop decision; any `block` wins. */
+  stopDecision?: StopDecision;
+  /** Reason from the hook that set the winning decision. */
+  reason?: string;
+  /**
+   * Replacement tool input from a `PreToolUse` hook.
+   *
+   * Last-writer-wins in **registration order**: `executeHooks` uses
+   * `Promise.all`, which preserves input-array order, so the fold iterates
+   * outcomes in the same order they were pushed — outer loop over matchers
+   * as they sit in the registry, inner loop over each matcher's `hooks`
+   * array. The winner is therefore deterministic but may not match the
+   * order in which hooks actually completed. Consumers that want a single
+   * authoritative rewrite should still register one `updatedInput`-setting
+   * hook per matcher to avoid subtle precedence bugs.
+   */
+  updatedInput?: Record<string, unknown>;
+  /**
+   * Replacement tool output from a `PostToolUse` hook.
+   *
+   * Same last-writer-wins-in-registration-order semantics as
+   * `updatedInput`. Present only when at least one hook set it; `undefined`
+   * means "use the original tool output".
+   */
+  updatedOutput?: unknown;
+  /** Accumulated `additionalContext` strings from every hook, in order. */
+  additionalContexts: string[];
+  /** True if any hook returned `preventContinuation`. */
+  preventContinuation?: boolean;
+  /**
+   * Reason recorded alongside `preventContinuation`. First winner wins:
+   * once a hook sets both flags, later hooks that also set
+   * `preventContinuation` do not overwrite the reason.
+   */
+  stopReason?: string;
+  /** Error messages from hooks that threw; always present (possibly empty). */
+  errors: string[];
+}

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -139,12 +139,28 @@ export interface StopFailureHookInput extends BaseHookInput {
 export interface PreCompactHookInput extends BaseHookInput {
   hook_event_name: 'PreCompact';
   messagesBeforeCount: number;
-  trigger: 'threshold' | 'manual' | 'error';
+  /**
+   * What triggered compaction. Matches `SummarizationTrigger.type` from the
+   * agent's summarization config. `'default'` means no trigger was
+   * configured and compaction fired because messages were pruned.
+   */
+  trigger:
+    | 'token_ratio'
+    | 'remaining_tokens'
+    | 'messages_to_refine'
+    | 'default'
+    | (string & {});
 }
 
 export interface PostCompactHookInput extends BaseHookInput {
   hook_event_name: 'PostCompact';
   summary: string;
+  /**
+   * Number of messages remaining after compaction. The summarize node
+   * returns a `removeAll` signal that clears all messages from state;
+   * the summary itself is injected into the system prompt, not as a
+   * message. This is `0` at the point of hook dispatch.
+   */
   messagesAfterCount: number;
 }
 

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -71,6 +71,12 @@ export interface PreToolUseHookInput extends BaseHookInput {
   toolInput: Record<string, unknown>;
   toolUseId: string;
   stepId?: string;
+  /**
+   * Number of times this tool has been invoked in prior batches within the
+   * current run. Within a single batch of parallel calls, all calls to the
+   * same tool share the same turn value — per-call discrimination within a
+   * batch is not supported in v1.
+   */
   turn?: number;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export * from './tools/search';
 export * from './common';
 export * from './utils';
 
+/* Hooks */
+export * from './hooks';
+
 /* Types */
 export type * from './types';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export * from './summarization';
 export * from './tools/Calculator';
 export * from './tools/CodeExecutor';
 export * from './tools/ProgrammaticToolCalling';
+export * from './tools/SkillTool';
+export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';
 export * from './tools/ToolNode';
 export * from './tools/schema';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ export * from './tools/BashExecutor';
 export * from './tools/ProgrammaticToolCalling';
 export * from './tools/BashProgrammaticToolCalling';
 export * from './tools/SkillTool';
+export * from './tools/SubagentTool';
+export * from './tools/subagent';
 export * from './tools/ReadFile';
 export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from './tools/BashExecutor';
 export * from './tools/ProgrammaticToolCalling';
 export * from './tools/BashProgrammaticToolCalling';
 export * from './tools/SkillTool';
+export * from './tools/ReadFile';
 export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';
 export * from './tools/ToolNode';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ export * from './summarization';
 /* Tools */
 export * from './tools/Calculator';
 export * from './tools/CodeExecutor';
+export * from './tools/BashExecutor';
 export * from './tools/ProgrammaticToolCalling';
+export * from './tools/BashProgrammaticToolCalling';
 export * from './tools/SkillTool';
 export * from './tools/skillCatalog';
 export * from './tools/ToolSearch';

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -808,7 +808,11 @@ function contentPartCharLength(part: MessageContentComplex): number {
 export const formatAgentMessages = (
   payload: TPayload,
   indexTokenCountMap?: Record<number, number | undefined>,
-  tools?: Set<string>
+  tools?: Set<string>,
+  /** Pre-resolved skill bodies keyed by skill name. When present, HumanMessages
+   *  are reconstructed after skill ToolMessages to restore skill instructions
+   *  that were only in LangGraph state during the original run. */
+  skills?: Map<string, string>
 ): {
   messages: Array<HumanMessage | AIMessage | SystemMessage | ToolMessage>;
   indexTokenCountMap?: Record<number, number>;
@@ -902,6 +906,7 @@ export const formatAgentMessages = (
      * - Dynamically expand the set when tool_search results are encountered
      */
     let processedMessage = message;
+    const pendingSkillBodies: string[] = [];
     if (discoveredTools) {
       const content = message.content;
       if (content != null && Array.isArray(content)) {
@@ -949,8 +954,28 @@ export const formatAgentMessages = (
             }
           }
 
-          if (discoveredTools.has(toolName)) {
+          if (discoveredTools?.has(toolName)) {
             /** Valid tool - keep it */
+            filteredContent.push(part);
+            /** Collect invoked skill names for body reconstruction (only for allowed calls) */
+            if (toolName === Constants.SKILL_TOOL && skills?.size) {
+              const rawArgs = part.tool_call.args;
+              const parsedArgs =
+                typeof rawArgs === 'string'
+                  ? (() => {
+                    try {
+                      return JSON.parse(rawArgs) as Record<string, unknown>;
+                    } catch {
+                      return {};
+                    }
+                  })()
+                  : rawArgs;
+              const sn = parsedArgs?.skillName;
+              if (typeof sn === 'string' && sn !== '') {
+                pendingSkillBodies.push(sn);
+              }
+            }
+          } else if (!discoveredTools) {
             filteredContent.push(part);
           } else {
             /** Invalid tool - convert to string for context preservation */
@@ -1027,6 +1052,33 @@ export const formatAgentMessages = (
       }
     }
 
+    /** When tools filtering is off, still detect skill tool_calls for body reconstruction */
+    if (!discoveredTools && skills?.size) {
+      const content = processedMessage.content;
+      if (Array.isArray(content)) {
+        for (const part of content) {
+          if (part.type !== ContentTypes.TOOL_CALL || part.tool_call?.name !== Constants.SKILL_TOOL) {
+            continue;
+          }
+          const rawArgs = part.tool_call.args;
+          const parsedArgs =
+            typeof rawArgs === 'string'
+              ? (() => {
+                try {
+                  return JSON.parse(rawArgs) as Record<string, unknown>;
+                } catch {
+                  return {};
+                }
+              })()
+              : rawArgs;
+          const sn = parsedArgs?.skillName;
+          if (typeof sn === 'string' && sn !== '') {
+            pendingSkillBodies.push(sn);
+          }
+        }
+      }
+    }
+
     const formattedMessages = formatAssistantMessage(processedMessage);
     if (sourceMessageId != null && sourceMessageId !== '') {
       for (const formattedMessage of formattedMessages) {
@@ -1034,6 +1086,24 @@ export const formatAgentMessages = (
       }
     }
     messages.push(...formattedMessages);
+
+    /** Reconstruct HumanMessages for invoked skill bodies after their ToolMessages */
+    for (const skillName of pendingSkillBodies) {
+      const body = skills?.get(skillName);
+      if (body) {
+        messages.push(
+          new HumanMessage({
+            content: body,
+            additional_kwargs: {
+              role: 'user',
+              isMeta: true,
+              source: 'skill',
+              skillName,
+            },
+          })
+        );
+      }
+    }
 
     // Update the index mapping for this assistant message
     // Store all indices that were created from this original message

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -797,12 +797,29 @@ function contentPartCharLength(part: MessageContentComplex): number {
   return len;
 }
 
+/** Extracts the skillName from a skill tool_call's args (string or object). */
+function extractSkillName(args: unknown): string | undefined {
+  let parsed: Record<string, unknown> | undefined;
+  if (typeof args === 'string') {
+    try {
+      parsed = JSON.parse(args) as Record<string, unknown>;
+    } catch {
+      /* malformed args — skip */
+    }
+  } else {
+    parsed = args as Record<string, unknown> | undefined;
+  }
+  const name = parsed?.skillName;
+  return typeof name === 'string' && name !== '' ? name : undefined;
+}
+
 /**
  * Formats an array of messages for LangChain, handling tool calls and creating ToolMessage instances.
  *
  * @param payload - The array of messages to format.
  * @param indexTokenCountMap - Optional map of message indices to token counts.
  * @param tools - Optional set of tool names that are allowed in the request.
+ * @param skills - Optional map of skill name to body for reconstructing skill HumanMessages.
  * @returns - Object containing formatted messages and updated indexTokenCountMap if provided.
  */
 export const formatAgentMessages = (
@@ -906,7 +923,7 @@ export const formatAgentMessages = (
      * - Dynamically expand the set when tool_search results are encountered
      */
     let processedMessage = message;
-    const pendingSkillBodies: string[] = [];
+    let pendingSkillNames: Set<string> | undefined;
     if (discoveredTools) {
       const content = message.content;
       if (content != null && Array.isArray(content)) {
@@ -954,29 +971,14 @@ export const formatAgentMessages = (
             }
           }
 
-          if (discoveredTools?.has(toolName)) {
-            /** Valid tool - keep it */
+          if (discoveredTools.has(toolName)) {
             filteredContent.push(part);
-            /** Collect invoked skill names for body reconstruction (only for allowed calls) */
             if (toolName === Constants.SKILL_TOOL && skills?.size) {
-              const rawArgs = part.tool_call.args;
-              const parsedArgs =
-                typeof rawArgs === 'string'
-                  ? (() => {
-                    try {
-                      return JSON.parse(rawArgs) as Record<string, unknown>;
-                    } catch {
-                      return {};
-                    }
-                  })()
-                  : rawArgs;
-              const sn = parsedArgs?.skillName;
-              if (typeof sn === 'string' && sn !== '') {
-                pendingSkillBodies.push(sn);
+              const skillName = extractSkillName(part.tool_call.args);
+              if (skillName) {
+                (pendingSkillNames ??= new Set()).add(skillName);
               }
             }
-          } else if (!discoveredTools) {
-            filteredContent.push(part);
           } else {
             /** Invalid tool - convert to string for context preservation */
             if (
@@ -1060,20 +1062,9 @@ export const formatAgentMessages = (
           if (part.type !== ContentTypes.TOOL_CALL || part.tool_call?.name !== Constants.SKILL_TOOL) {
             continue;
           }
-          const rawArgs = part.tool_call.args;
-          const parsedArgs =
-            typeof rawArgs === 'string'
-              ? (() => {
-                try {
-                  return JSON.parse(rawArgs) as Record<string, unknown>;
-                } catch {
-                  return {};
-                }
-              })()
-              : rawArgs;
-          const sn = parsedArgs?.skillName;
-          if (typeof sn === 'string' && sn !== '') {
-            pendingSkillBodies.push(sn);
+          const skillName = extractSkillName(part.tool_call.args);
+          if (skillName) {
+            (pendingSkillNames ??= new Set()).add(skillName);
           }
         }
       }
@@ -1087,27 +1078,29 @@ export const formatAgentMessages = (
     }
     messages.push(...formattedMessages);
 
-    /** Reconstruct HumanMessages for invoked skill bodies after their ToolMessages */
-    for (const skillName of pendingSkillBodies) {
-      const body = skills?.get(skillName);
-      if (body) {
-        messages.push(
-          new HumanMessage({
-            content: body,
-            additional_kwargs: {
-              role: 'user',
-              isMeta: true,
-              source: 'skill',
-              skillName,
-            },
-          })
-        );
+    // Capture index range BEFORE skill body injection so injected
+    // HumanMessages are excluded from the assistant's token distribution.
+    const endMessageIndex = messages.length;
+
+    if (pendingSkillNames?.size) {
+      for (const skillName of pendingSkillNames) {
+        const body = skills?.get(skillName);
+        if (body) {
+          messages.push(
+            new HumanMessage({
+              content: body,
+              additional_kwargs: {
+                role: 'user',
+                isMeta: true,
+                source: 'skill',
+                skillName,
+              },
+            })
+          );
+        }
       }
     }
 
-    // Update the index mapping for this assistant message
-    // Store all indices that were created from this original message
-    const endMessageIndex = messages.length;
     const resultIndices = [];
     for (let j = startMessageIndex; j < endMessageIndex; j++) {
       resultIndices.push(j);

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -973,8 +973,12 @@ export const formatAgentMessages = (
 
           if (discoveredTools.has(toolName)) {
             filteredContent.push(part);
-            if (toolName === Constants.SKILL_TOOL && skills?.size) {
-              const skillName = extractSkillName(part.tool_call.args);
+            if (
+              toolName === Constants.SKILL_TOOL &&
+              skills?.size != null &&
+              skills.size > 0
+            ) {
+              const skillName = extractSkillName(part.tool_call.args) ?? '';
               if (skillName) {
                 (pendingSkillNames ??= new Set()).add(skillName);
               }
@@ -1055,14 +1059,17 @@ export const formatAgentMessages = (
     }
 
     /** When tools filtering is off, still detect skill tool_calls for body reconstruction */
-    if (!discoveredTools && skills?.size) {
+    if (!discoveredTools && skills?.size != null && skills.size > 0) {
       const content = processedMessage.content;
       if (Array.isArray(content)) {
         for (const part of content) {
-          if (part.type !== ContentTypes.TOOL_CALL || part.tool_call?.name !== Constants.SKILL_TOOL) {
+          if (
+            part.type !== ContentTypes.TOOL_CALL ||
+            part.tool_call?.name !== Constants.SKILL_TOOL
+          ) {
             continue;
           }
-          const skillName = extractSkillName(part.tool_call.args);
+          const skillName = extractSkillName(part.tool_call.args) ?? '';
           if (skillName) {
             (pendingSkillNames ??= new Set()).add(skillName);
           }
@@ -1082,9 +1089,9 @@ export const formatAgentMessages = (
     // HumanMessages are excluded from the assistant's token distribution.
     const endMessageIndex = messages.length;
 
-    if (pendingSkillNames?.size) {
+    if (pendingSkillNames?.size != null && pendingSkillNames.size > 0) {
       for (const skillName of pendingSkillNames) {
-        const body = skills?.get(skillName);
+        const body = skills?.get(skillName) ?? '';
         if (body) {
           messages.push(
             new HumanMessage({

--- a/src/messages/formatAgentMessages.skills.test.ts
+++ b/src/messages/formatAgentMessages.skills.test.ts
@@ -1,0 +1,334 @@
+import { HumanMessage } from '@langchain/core/messages';
+import type { TPayload } from '@/types';
+import { formatAgentMessages } from './format';
+import { ContentTypes, Constants } from '@/common';
+
+/** Helper to build a skill tool_call content part */
+function skillToolCall(
+  id: string,
+  skillName: string,
+  output = 'Skill loaded.',
+): Record<string, unknown> {
+  return {
+    type: ContentTypes.TOOL_CALL,
+    tool_call: {
+      id,
+      name: Constants.SKILL_TOOL,
+      args: JSON.stringify({ skillName }),
+      output,
+    },
+  };
+}
+
+describe('formatAgentMessages skill body reconstruction', () => {
+  const skillBodies = new Map([
+    ['pdf-analyzer', '# PDF Analyzer\nAnalyze PDF files step by step.'],
+    ['code-review', '# Code Review\nReview the code for issues.'],
+  ]);
+
+  describe('with discoveredTools (tools filtering active)', () => {
+    const tools = new Set([Constants.SKILL_TOOL, 'web_search']);
+
+    it('reconstructs HumanMessage after skill ToolMessage', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Analyze this PDF' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              [ContentTypes.TEXT]: 'I\'ll invoke the skill.',
+              tool_call_ids: ['call_1'],
+            },
+            skillToolCall('call_1', 'pdf-analyzer'),
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      // user, AI, ToolMessage, injected HumanMessage
+      expect(messages.length).toBeGreaterThanOrEqual(4);
+      const last = messages[messages.length - 1];
+      expect(last).toBeInstanceOf(HumanMessage);
+      expect(last.content).toBe('# PDF Analyzer\nAnalyze PDF files step by step.');
+      expect((last as HumanMessage).additional_kwargs.source).toBe('skill');
+      expect((last as HumanMessage).additional_kwargs.skillName).toBe('pdf-analyzer');
+      expect((last as HumanMessage).additional_kwargs.isMeta).toBe(true);
+    });
+
+    it('does NOT inject body when skill tool is not in discoveredTools', () => {
+      const restrictedTools = new Set(['web_search']); // skill NOT allowed
+      const payload: TPayload = [
+        { role: 'user', content: 'Analyze this' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'pdf-analyzer')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, restrictedTools, skillBodies);
+
+      const humanMessages = messages.filter((m) => m instanceof HumanMessage);
+      // Only the user message, no injected skill body
+      expect(humanMessages).toHaveLength(1);
+    });
+
+    it('does not inject when skill name is not in skills Map', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'unknown-skill')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const humanMessages = messages.filter((m) => m instanceof HumanMessage);
+      expect(humanMessages).toHaveLength(1); // only the user message
+    });
+  });
+
+  describe('without discoveredTools (no tools filtering)', () => {
+    it('reconstructs HumanMessage when skills Map provided', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Review my code' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'code-review')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, undefined, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(1);
+      expect(injected[0].content).toBe('# Code Review\nReview the code for issues.');
+    });
+
+    it('no injection when skills Map is undefined', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'pdf-analyzer')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, undefined, undefined);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0);
+    });
+
+    it('no injection when skills Map is empty', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: [skillToolCall('call_1', 'pdf-analyzer')],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, undefined, new Map());
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0);
+    });
+  });
+
+  describe('extractSkillName edge cases', () => {
+    const tools = new Set([Constants.SKILL_TOOL]);
+
+    it('handles object args (not stringified)', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'call_1',
+                name: Constants.SKILL_TOOL,
+                args: { skillName: 'pdf-analyzer' }, // object, not string
+                output: 'Loaded.',
+              },
+            },
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(1);
+    });
+
+    it('gracefully skips malformed JSON args', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'call_1',
+                name: Constants.SKILL_TOOL,
+                args: '{bad json',
+                output: 'Loaded.',
+              },
+            },
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0); // gracefully skipped
+    });
+
+    it('skips empty skillName', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TOOL_CALL,
+              tool_call: {
+                id: 'call_1',
+                name: Constants.SKILL_TOOL,
+                args: JSON.stringify({ skillName: '' }),
+                output: 'Loaded.',
+              },
+            },
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(0);
+    });
+  });
+
+  describe('deduplication', () => {
+    const tools = new Set([Constants.SKILL_TOOL]);
+
+    it('injects body only once when same skill invoked twice in one message', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            skillToolCall('call_1', 'pdf-analyzer'),
+            skillToolCall('call_2', 'pdf-analyzer'),
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(1);
+    });
+
+    it('injects body for each distinct skill invoked', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Go' },
+        {
+          role: 'assistant',
+          content: [
+            skillToolCall('call_1', 'pdf-analyzer'),
+            skillToolCall('call_2', 'code-review'),
+          ],
+        },
+      ];
+
+      const { messages } = formatAgentMessages(payload, undefined, tools, skillBodies);
+
+      const injected = messages.filter(
+        (m) => m instanceof HumanMessage && (m as HumanMessage).additional_kwargs?.source === 'skill',
+      );
+      expect(injected).toHaveLength(2);
+      const names = injected.map((m) => (m as HumanMessage).additional_kwargs.skillName);
+      expect(names).toContain('pdf-analyzer');
+      expect(names).toContain('code-review');
+    });
+  });
+
+  describe('indexTokenCountMap distribution', () => {
+    const tools = new Set([Constants.SKILL_TOOL]);
+
+    it('excludes injected HumanMessages from assistant token distribution', () => {
+      const payload: TPayload = [
+        { role: 'user', content: 'Analyze this' },
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              [ContentTypes.TEXT]: 'Invoking skill.',
+              tool_call_ids: ['call_1'],
+            },
+            skillToolCall('call_1', 'pdf-analyzer'),
+          ],
+        },
+      ];
+
+      const inputTokenMap: Record<number, number | undefined> = {
+        0: 100, // user message
+        1: 500, // assistant message
+      };
+
+      const { messages, indexTokenCountMap } = formatAgentMessages(
+        payload,
+        inputTokenMap,
+        tools,
+        skillBodies,
+      );
+
+      // There should be messages: user, AI, ToolMessage, injected HumanMessage
+      expect(messages.length).toBeGreaterThanOrEqual(4);
+      const lastMsg = messages[messages.length - 1];
+      expect(lastMsg).toBeInstanceOf(HumanMessage);
+      expect((lastMsg as HumanMessage).additional_kwargs.source).toBe('skill');
+
+      // Token map must be defined when input was provided
+      expect(indexTokenCountMap).toBeDefined();
+
+      // The injected HumanMessage's index should NOT be in the token map
+      const injectedIndex = messages.length - 1;
+      expect(indexTokenCountMap![injectedIndex]).toBeUndefined();
+
+      // The assistant's 500 tokens should be distributed only across
+      // the AI + ToolMessage, NOT the injected HumanMessage
+      let assistantTotal = 0;
+      for (const [idx, count] of Object.entries(indexTokenCountMap!)) {
+        if (Number(idx) > 0 && Number(idx) < injectedIndex) {
+          assistantTotal += count ?? 0;
+        }
+      }
+      expect(assistantTotal).toBe(500);
+    });
+  });
+});

--- a/src/run.ts
+++ b/src/run.ts
@@ -22,8 +22,10 @@ import { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import { StandardGraph } from '@/graphs/Graph';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
+import { executeHooks } from '@/hooks';
 import { isOpenAILike } from '@/utils/llm';
 import { isPresent } from '@/utils/misc';
+import type { HookRegistry } from '@/hooks';
 
 export const defaultOmitOptions = new Set([
   'stream',
@@ -42,6 +44,7 @@ export class Run<_T extends t.BaseGraphState> {
   id: string;
   private tokenCounter?: t.TokenCounter;
   private handlerRegistry?: HandlerRegistry;
+  private hookRegistry?: HookRegistry;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   graphRunnable?: t.CompiledStateWorkflow;
@@ -74,6 +77,7 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     this.handlerRegistry = handlerRegistry;
+    this.hookRegistry = config.hooks;
 
     if (!config.graphConfig) {
       throw new Error('Graph config not provided');
@@ -84,6 +88,7 @@ export class Run<_T extends t.BaseGraphState> {
       this.graphRunnable = this.createMultiAgentGraph(config.graphConfig);
       if (this.Graph) {
         this.Graph.handlerRegistry = handlerRegistry;
+        this.Graph.hookRegistry = this.hookRegistry;
       }
     } else {
       /** Default to legacy graph for 'standard' or undefined type */
@@ -92,6 +97,7 @@ export class Run<_T extends t.BaseGraphState> {
         this.Graph.compileOptions =
           config.graphConfig.compileOptions ?? this.Graph.compileOptions;
         this.Graph.handlerRegistry = handlerRegistry;
+        this.Graph.hookRegistry = this.hookRegistry;
       }
     }
 
@@ -332,6 +338,47 @@ export class Run<_T extends t.BaseGraphState> {
       run_id: this.id,
     });
 
+    const threadId = config.configurable.thread_id as string | undefined;
+
+    if (this.hookRegistry != null) {
+      await executeHooks({
+        registry: this.hookRegistry,
+        input: {
+          hook_event_name: 'RunStart',
+          runId: this.id,
+          threadId,
+          agentId: this.Graph.defaultAgentId,
+          messages: inputs.messages,
+        },
+        sessionId: this.id,
+      });
+
+      const lastHuman = findLastMessageOfType(inputs.messages, 'human');
+      if (lastHuman != null) {
+        const promptResult = await executeHooks({
+          registry: this.hookRegistry,
+          input: {
+            hook_event_name: 'UserPromptSubmit',
+            runId: this.id,
+            threadId,
+            agentId: this.Graph.defaultAgentId,
+            prompt: extractPromptText(lastHuman),
+            // attachments: not yet wired — Phase 2 will extract
+            // non-text content blocks (images, files) from messages
+          },
+          sessionId: this.id,
+        });
+        if (
+          promptResult.decision === 'deny' ||
+          promptResult.decision === 'ask'
+        ) {
+          this.hookRegistry.clearSession(this.id);
+          config.callbacks = undefined;
+          return undefined;
+        }
+      }
+    }
+
     const stream = this.graphRunnable.streamEvents(inputs, config, {
       raiseError: true,
       /**
@@ -361,7 +408,45 @@ export class Run<_T extends t.BaseGraphState> {
           await handler.handle(eventName, data, metadata, this.Graph);
         }
       }
+
+      if (this.hookRegistry?.hasHookFor('Stop', this.id) === true) {
+        await executeHooks({
+          registry: this.hookRegistry,
+          input: {
+            hook_event_name: 'Stop',
+            runId: this.id,
+            threadId,
+            agentId: this.Graph.defaultAgentId,
+            messages: this.Graph.getRunMessages() ?? inputs.messages,
+            stopHookActive: false, // will be true when stop is triggered by a hook (Phase 2)
+          },
+          sessionId: this.id,
+        }).catch(() => {
+          /* Stop hook errors must not masquerade as stream failures */
+        });
+      }
+    } catch (err) {
+      if (this.hookRegistry?.hasHookFor('StopFailure', this.id) === true) {
+        const runMessages = this.Graph.getRunMessages() ?? [];
+        await executeHooks({
+          registry: this.hookRegistry,
+          input: {
+            hook_event_name: 'StopFailure',
+            runId: this.id,
+            threadId,
+            agentId: this.Graph.defaultAgentId,
+            error: err instanceof Error ? err.message : String(err),
+            lastAssistantMessage: findLastMessageOfType(runMessages, 'ai'),
+          },
+          sessionId: this.id,
+        }).catch(() => {
+          /* swallow hook errors — the original error must propagate */
+        });
+      }
+      throw err;
     } finally {
+      this.hookRegistry?.clearSession(this.id);
+
       /**
        * Break the reference chain that keeps heavy data alive via
        * LangGraph's internal `__pregel_scratchpad.currentTaskInput` →
@@ -556,4 +641,39 @@ export class Run<_T extends t.BaseGraphState> {
       );
     }
   }
+}
+
+function findLastMessageOfType(
+  messages: BaseMessage[],
+  type: string
+): BaseMessage | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].getType() === type) {
+      return messages[i];
+    }
+  }
+  return undefined;
+}
+
+function extractPromptText(message: BaseMessage): string {
+  const content = message.content;
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return String(content);
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    if (
+      typeof block === 'object' &&
+      'type' in block &&
+      block.type === 'text' &&
+      'text' in block &&
+      typeof block.text === 'string'
+    ) {
+      parts.push(block.text);
+    }
+  }
+  return parts.join('\n');
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -99,6 +99,12 @@ export class Run<_T extends t.BaseGraphState> {
       }
     }
 
+    if (config.initialSessions && this.Graph) {
+      for (const [key, value] of config.initialSessions) {
+        this.Graph.sessions.set(key, value);
+      }
+    }
+
     this.returnContent = config.returnContent ?? false;
     this.skipCleanup = config.skipCleanup ?? false;
   }

--- a/src/run.ts
+++ b/src/run.ts
@@ -88,7 +88,6 @@ export class Run<_T extends t.BaseGraphState> {
       this.graphRunnable = this.createMultiAgentGraph(config.graphConfig);
       if (this.Graph) {
         this.Graph.handlerRegistry = handlerRegistry;
-        this.Graph.hookRegistry = this.hookRegistry;
       }
     } else {
       /** Default to legacy graph for 'standard' or undefined type */
@@ -97,7 +96,6 @@ export class Run<_T extends t.BaseGraphState> {
         this.Graph.compileOptions =
           config.graphConfig.compileOptions ?? this.Graph.compileOptions;
         this.Graph.handlerRegistry = handlerRegistry;
-        this.Graph.hookRegistry = this.hookRegistry;
       }
     }
 
@@ -149,6 +147,7 @@ export class Run<_T extends t.BaseGraphState> {
     });
     /** Propagate compile options from graph config */
     standardGraph.compileOptions = config.compileOptions;
+    standardGraph.hookRegistry = this.hookRegistry;
     this.Graph = standardGraph;
     return standardGraph.createWorkflow();
   }
@@ -171,6 +170,7 @@ export class Run<_T extends t.BaseGraphState> {
       multiAgentGraph.compileOptions = compileOptions;
     }
 
+    multiAgentGraph.hookRegistry = this.hookRegistry;
     this.Graph = multiAgentGraph;
     return multiAgentGraph.createWorkflow();
   }

--- a/src/scripts/multi-agent-subagent.ts
+++ b/src/scripts/multi-agent-subagent.ts
@@ -1,0 +1,246 @@
+import { config } from 'dotenv';
+config();
+
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { Providers, GraphEvents, Constants } from '@/common';
+import { Run } from '@/run';
+
+/**
+ * Manual verification script for the subagent primitive.
+ *
+ * Configures a supervisor agent with two subagent types (researcher, coder),
+ * sends a query, and confirms:
+ * 1. The parent agent delegates to a subagent via the `subagent` tool
+ * 2. The child executes with isolated context (fresh message history)
+ * 3. Only the filtered text result returns to the parent
+ * 4. The parent incorporates the result and responds
+ *
+ * Usage:
+ *   OPENAI_API_KEY=... npx ts-node -r tsconfig-paths/register src/scripts/multi-agent-subagent.ts
+ *
+ * Or with Anthropic:
+ *   ANTHROPIC_API_KEY=... npx ts-node -r tsconfig-paths/register src/scripts/multi-agent-subagent.ts --provider anthropic
+ */
+
+const useAnthropic =
+  process.argv.includes('--provider') &&
+  process.argv[process.argv.indexOf('--provider') + 1] === 'anthropic';
+
+const provider = useAnthropic ? Providers.ANTHROPIC : Providers.OPENAI;
+const apiKey = useAnthropic
+  ? process.env.ANTHROPIC_API_KEY
+  : process.env.OPENAI_API_KEY;
+const modelName = useAnthropic ? 'claude-sonnet-4-20250514' : 'gpt-5.4';
+
+if (!apiKey) {
+  console.error(
+    `Missing ${useAnthropic ? 'ANTHROPIC_API_KEY' : 'OPENAI_API_KEY'} environment variable`
+  );
+  process.exit(1);
+}
+
+async function testSubagentPrimitive() {
+  console.log('=== Subagent Primitive Manual Verification ===\n');
+  console.log(`Provider: ${provider}`);
+  console.log(`Model: ${modelName}\n`);
+
+  const { aggregateContent } = createContentAggregator();
+
+  const parentAgent: t.AgentInputs = {
+    agentId: 'supervisor',
+    provider,
+    clientOptions: { modelName, apiKey },
+    instructions: `You are a supervisor agent. You have access to specialized subagents.
+
+When the user asks a research question, delegate it to the "researcher" subagent.
+When the user asks for code, delegate it to the "coder" subagent.
+
+After receiving the subagent's result, synthesize it into a clear final answer for the user.
+Always use a subagent for research or coding tasks — do not answer directly.`,
+    maxContextTokens: 16000,
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Research Specialist',
+        description:
+          'Researches topics and provides detailed summaries with sources.',
+        agentInputs: {
+          agentId: 'researcher',
+          provider,
+          clientOptions: { modelName, apiKey },
+          instructions: `You are a research specialist working in an isolated context.
+You receive a single task description and must answer it thoroughly.
+Be concise but comprehensive. Include key facts and details.`,
+          maxContextTokens: 8000,
+        },
+      },
+      {
+        type: 'coder',
+        name: 'Coding Specialist',
+        description:
+          'Writes, reviews, and explains code in any programming language.',
+        agentInputs: {
+          agentId: 'coder',
+          provider,
+          clientOptions: { modelName, apiKey },
+          instructions: `You are a coding specialist working in an isolated context.
+You receive a single task description and must provide working code.
+Include brief explanations. Use clean, idiomatic code.`,
+          maxContextTokens: 8000,
+        },
+      },
+    ],
+  };
+
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.RunStep,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.RunStep,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.RunStepDeltaEvent,
+        });
+      },
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        aggregateContent({
+          event: event as GraphEvents,
+          data: data as t.MessageDeltaEvent,
+        });
+      },
+    },
+  };
+
+  const run = await Run.create<t.IState>({
+    runId: `subagent-manual-${Date.now()}`,
+    graphConfig: {
+      type: 'standard',
+      agents: [parentAgent],
+    },
+    returnContent: true,
+    customHandlers,
+  });
+
+  console.log('--- Run created ---');
+  console.log(
+    `Subagent tool present: ${
+      (
+        (run.Graph as import('@/graphs/Graph').StandardGraph).agentContexts.get(
+          'supervisor'
+        )?.graphTools as t.GenericTool[] | undefined
+      )?.some((t) => 'name' in t && t.name === Constants.SUBAGENT) ?? false
+    }\n`
+  );
+
+  const conversationHistory: BaseMessage[] = [];
+
+  // Turn 1: Research question (should delegate to researcher subagent)
+  console.log('=== Turn 1: Research Question ===\n');
+  console.log(
+    'User: What are the three laws of thermodynamics? Explain briefly.\n'
+  );
+
+  const userMessage = new HumanMessage(
+    'What are the three laws of thermodynamics? Explain briefly.'
+  );
+  conversationHistory.push(userMessage);
+
+  const callerConfig = {
+    configurable: { thread_id: 'subagent-verify' },
+    streamMode: 'values' as const,
+    version: 'v2' as const,
+  };
+
+  console.log('--- Streaming response ---\n');
+  const result = await run.processStream(
+    { messages: conversationHistory },
+    callerConfig
+  );
+
+  const runMessages = run.getRunMessages();
+  console.log('\n\n--- Run Messages ---\n');
+
+  if (runMessages) {
+    for (const msg of runMessages) {
+      const type = msg._getType();
+      if (type === 'tool') {
+        const name = 'name' in msg ? msg.name : 'unknown';
+        const rawContent =
+          typeof msg.content === 'string'
+            ? msg.content
+            : JSON.stringify(msg.content);
+        const content = rawContent.slice(0, 200);
+        const truncated = rawContent.length > 200 ? '...' : '';
+        console.log(`[ToolMessage] name=${name}`);
+        console.log(`  content: ${content}${truncated}\n`);
+      } else if (type === 'ai') {
+        const content =
+          typeof msg.content === 'string'
+            ? msg.content.slice(0, 300)
+            : JSON.stringify(msg.content).slice(0, 300);
+        const toolCalls = 'tool_calls' in msg ? msg.tool_calls : undefined;
+        console.log(`[AIMessage]`);
+        if (toolCalls && Array.isArray(toolCalls) && toolCalls.length > 0) {
+          for (const tc of toolCalls) {
+            console.log(
+              `  tool_call: ${tc.name}(${JSON.stringify(tc.args).slice(0, 100)}...)`
+            );
+          }
+        }
+        console.log(
+          `  content: ${content}${content.length >= 300 ? '...' : ''}\n`
+        );
+      }
+    }
+
+    const subagentToolMessages = runMessages.filter(
+      (msg) =>
+        msg._getType() === 'tool' &&
+        'name' in msg &&
+        msg.name === Constants.SUBAGENT
+    );
+    console.log(`\n--- Verification ---`);
+    console.log(`Subagent tool calls found: ${subagentToolMessages.length}`);
+    console.log(`Total run messages: ${runMessages.length}`);
+    console.log(`Result content parts: ${result?.length ?? 0}`);
+
+    if (subagentToolMessages.length > 0) {
+      console.log(
+        '\nSUCCESS: Subagent was invoked and returned a filtered result.'
+      );
+      console.log(
+        'The child context was isolated — only the final text came back.'
+      );
+    } else {
+      console.log('\nNOTE: No subagent tool calls detected.');
+      console.log('The LLM may have answered directly without delegating.');
+    }
+  }
+
+  console.log('\n=== Done ===');
+}
+
+testSubagentPrimitive().catch(console.error);

--- a/src/scripts/subagent-event-driven-debug.ts
+++ b/src/scripts/subagent-event-driven-debug.ts
@@ -1,0 +1,190 @@
+import { config } from 'dotenv';
+config();
+
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { ChatModelStreamHandler } from '@/stream';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { Providers, GraphEvents, Constants } from '@/common';
+import { Run } from '@/run';
+
+/**
+ * Repro for LibreChat's actual setup: event-driven tools via `toolDefinitions`
+ * + an ON_TOOL_EXECUTE handler that runs the tool. Self-spawn subagent must
+ * be able to drive the SAME tool pipeline.
+ */
+const apiKey = process.env.OPENAI_API_KEY!;
+if (!apiKey) {
+  console.error('Missing OPENAI_API_KEY');
+  process.exit(1);
+}
+
+// Simulate LibreChat: tool definitions only, execution routed via event.
+const calculatorDef: t.LCTool = {
+  name: 'calculator',
+  description: 'Evaluate a math expression. Use for any arithmetic.',
+  parameters: {
+    type: 'object',
+    properties: {
+      expression: {
+        type: 'string',
+        description: "A JS math expression, e.g. '42 * 58'",
+      },
+    },
+    required: ['expression'],
+  },
+};
+
+async function main() {
+  console.log('=== Subagent Event-Driven Tool Diagnostic ===\n');
+
+  const parentAgent: t.AgentInputs = {
+    agentId: 'supervisor',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey },
+    instructions: `You have calculator AND can spawn a "self" subagent in an isolated context.
+For any arithmetic question, spawn the "self" subagent with the math task.
+The subagent MUST use the calculator tool — never estimate.`,
+    maxContextTokens: 8000,
+    toolDefinitions: [calculatorDef],
+    subagentConfigs: [
+      {
+        type: 'self',
+        self: true,
+        name: 'supervisor',
+        description:
+          'Spawn a copy of this agent in an isolated context for a focused math subtask.',
+      },
+    ],
+  };
+
+  let toolCallCount = 0;
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    [GraphEvents.ON_TOOL_EXECUTE]: {
+      handle: (_event, rawData): void => {
+        const data = rawData as t.ToolExecuteBatchRequest;
+        console.log(
+          `[PARENT ON_TOOL_EXECUTE] agentId=${data.agentId} calls=${data.toolCalls
+            .map((c) => c.name)
+            .join(',')}`
+        );
+        const results: t.ToolExecuteResult[] = data.toolCalls.map((call) => {
+          toolCallCount += 1;
+          const args = call.args as { expression?: string };
+          const expression = args.expression ?? '';
+          let content: string;
+          try {
+            // eslint-disable-next-line no-eval
+            const result = eval(expression);
+            content = `${expression} = ${result}`;
+          } catch (err) {
+            content = `Error: ${String(err)}`;
+          }
+          return {
+            toolCallId: call.id!,
+            status: 'success',
+            content,
+          };
+        });
+        data.resolve(results);
+      },
+    },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event, data): void => {
+        const d = data as { type?: string; runId?: string; agentId?: string };
+        console.log(
+          `[PARENT ${event}] type=${d.type} agentId=${d.agentId ?? '-'} runId=${d.runId ?? '-'}`
+        );
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (event, data): void => {
+        const r = (
+          data as { result: { type: string; tool_call?: { name?: string } } }
+        ).result;
+        console.log(
+          `[PARENT ${event}] type=${r.type} tool=${r.tool_call?.name ?? '-'}`
+        );
+      },
+    },
+    [GraphEvents.ON_SUBAGENT_UPDATE]: {
+      handle: (_event, rawData): void => {
+        const d = rawData as t.SubagentUpdateEvent;
+        console.log(
+          `[SUBAGENT ${d.phase}] [${d.subagentType}] tool_call_id=${d.parentToolCallId ?? '-'} ${d.label ?? ''}`
+        );
+      },
+    },
+  };
+
+  const run = await Run.create<t.IState>({
+    runId: `sub-evt-${Date.now()}`,
+    graphConfig: { type: 'standard', agents: [parentAgent] },
+    customHandlers,
+  });
+
+  const question = new HumanMessage(
+    'Compute (42 * 58) + (13 ** 3). Use the self subagent, and have it use the calculator.'
+  );
+
+  console.log('User:', question.content, '\n');
+
+  await run.processStream(
+    { messages: [question] },
+    {
+      configurable: { thread_id: `sub-evt` },
+      version: 'v2' as const,
+    }
+  );
+
+  const msgs = (run.getRunMessages() ?? []) as BaseMessage[];
+  console.log('\n--- Run messages ---\n');
+  for (const msg of msgs) {
+    const type = msg._getType();
+    const name = 'name' in msg ? (msg as { name?: string }).name : undefined;
+    const content =
+      typeof msg.content === 'string'
+        ? msg.content.slice(0, 400)
+        : JSON.stringify(msg.content).slice(0, 400);
+    const toolCalls =
+      'tool_calls' in msg
+        ? (msg as { tool_calls?: Array<{ name: string; args: unknown }> })
+            .tool_calls
+        : undefined;
+    console.log(`[${type}]${name ? ` name=${name}` : ''}`);
+    if (toolCalls?.length) {
+      for (const tc of toolCalls) {
+        console.log(
+          `  tool_call: ${tc.name}(${JSON.stringify(tc.args).slice(0, 150)})`
+        );
+      }
+    }
+    console.log(`  content: ${content}\n`);
+  }
+
+  const subagentMsgs = msgs.filter(
+    (m) =>
+      m._getType() === 'tool' &&
+      (m as { name?: string }).name === Constants.SUBAGENT
+  );
+
+  console.log('--- Verification ---');
+  console.log(`subagent tool calls seen (parent): ${subagentMsgs.length}`);
+  console.log(
+    `ON_TOOL_EXECUTE dispatched (parent saw): ${toolCallCount} (expected >= 1 if subagent used calculator)`
+  );
+  if (subagentMsgs[0]) {
+    console.log(
+      `\nsubagent result:\n${(subagentMsgs[0].content as string).slice(0, 600)}`
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error('Script error:', err);
+  process.exit(1);
+});

--- a/src/scripts/subagent-tools-debug.ts
+++ b/src/scripts/subagent-tools-debug.ts
@@ -1,0 +1,160 @@
+import { config } from 'dotenv';
+config();
+
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import type * as t from '@/types';
+import { ChatModelStreamHandler } from '@/stream';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { Providers, GraphEvents, Constants } from '@/common';
+import { Run } from '@/run';
+
+/**
+ * Diagnostic: verify a self-spawned subagent can call parent's real tools.
+ * Expected before-fix: parent delegates to self; child cannot invoke calculator.
+ */
+const apiKey = process.env.OPENAI_API_KEY!;
+if (!apiKey) {
+  console.error('Missing OPENAI_API_KEY');
+  process.exit(1);
+}
+
+const calculator = tool(
+  async ({ expression }) => {
+    const result = eval(expression); // don't do this in prod
+    return `${expression} = ${result}`;
+  },
+  {
+    name: 'calculator',
+    description: 'Evaluate a math expression. Use for any arithmetic.',
+    schema: z.object({
+      expression: z.string().describe("A JS math expression, e.g. '42 * 58'"),
+    }),
+  }
+);
+
+async function main() {
+  console.log('=== Subagent Tool-Access Diagnostic ===\n');
+
+  const parentAgent: t.AgentInputs = {
+    agentId: 'supervisor',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey },
+    instructions: `You have calculator AND can spawn a "self" subagent in an isolated context.
+For any arithmetic question that would bloat your context, spawn the "self" subagent with the math task.
+The subagent must use the calculator tool — never estimate.`,
+    maxContextTokens: 8000,
+    tools: [calculator],
+    subagentConfigs: [
+      {
+        type: 'self',
+        self: true,
+        name: 'supervisor',
+        description:
+          'Spawn a copy of this agent in an isolated context for a focused math subtask.',
+      },
+    ],
+  };
+
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event, data): void => {
+        console.log(
+          `[PARENT EVENT] ${event}`,
+          JSON.stringify(data).slice(0, 200)
+        );
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (event, data): void => {
+        console.log(
+          `[PARENT EVENT] ${event}`,
+          JSON.stringify(data).slice(0, 200)
+        );
+      },
+    },
+  };
+
+  const run = await Run.create<t.IState>({
+    runId: `subagent-debug-${Date.now()}`,
+    graphConfig: { type: 'standard', agents: [parentAgent] },
+    customHandlers,
+  });
+
+  const question = new HumanMessage(
+    'Compute (42 * 58) + (13 ^ 3). Spawn the self subagent to do this, and have IT use calculator.'
+  );
+
+  console.log('User:', question.content, '\n');
+
+  await run.processStream(
+    { messages: [question] },
+    {
+      configurable: { thread_id: `subagent-debug` },
+      version: 'v2' as const,
+    }
+  );
+
+  const msgs = (run.getRunMessages() ?? []) as BaseMessage[];
+  console.log('\n--- Run messages ---\n');
+  for (const msg of msgs) {
+    const type = msg._getType();
+    const name = 'name' in msg ? (msg as { name?: string }).name : undefined;
+    const content =
+      typeof msg.content === 'string'
+        ? msg.content.slice(0, 400)
+        : JSON.stringify(msg.content).slice(0, 400);
+    const toolCalls =
+      'tool_calls' in msg
+        ? (msg as { tool_calls?: Array<{ name: string; args: unknown }> })
+            .tool_calls
+        : undefined;
+    console.log(`[${type}]${name ? ` name=${name}` : ''}`);
+    if (toolCalls?.length) {
+      for (const tc of toolCalls) {
+        console.log(
+          `  tool_call: ${tc.name}(${JSON.stringify(tc.args).slice(0, 150)})`
+        );
+      }
+    }
+    console.log(`  content: ${content}\n`);
+  }
+
+  const subagentCalls = msgs.filter(
+    (m) =>
+      m._getType() === 'tool' &&
+      'name' in m &&
+      (m as { name?: string }).name === Constants.SUBAGENT
+  );
+  const calculatorCalls = msgs.filter(
+    (m) =>
+      m._getType() === 'tool' &&
+      'name' in m &&
+      (m as { name?: string }).name === 'calculator'
+  );
+
+  console.log('--- Verification ---');
+  console.log(`subagent tool calls seen (parent): ${subagentCalls.length}`);
+  console.log(
+    `calculator tool calls seen (parent): ${calculatorCalls.length} (expected: 0 if subagent did the math)`
+  );
+  if (subagentCalls.length > 0) {
+    const subResult = subagentCalls[0].content as string;
+    console.log(`\nsubagent result snippet:\n${subResult.slice(0, 600)}\n`);
+    if (/\berror\b/i.test(subResult) && /tool/i.test(subResult)) {
+      console.log('⚠️  BUG CONFIRMED: subagent result mentions tool error');
+    } else if (!/\d/.test(subResult)) {
+      console.log('⚠️  POSSIBLY BUGGY: subagent result has no numbers');
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error('Script error:', err);
+  process.exit(1);
+});

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -1,0 +1,305 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { Run } from '@/run';
+import {
+  Constants,
+  GraphEvents,
+  Providers,
+  ToolEndHandler,
+  ModelEndHandler,
+  StandardGraph,
+} from '@/index';
+import * as providers from '@/llm/providers';
+
+const CHILD_RESPONSE = 'Research result: Paris is the capital of France.';
+
+const callerConfig: Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+} = {
+  configurable: { thread_id: 'subagent-test-thread' },
+  streamMode: 'values',
+  version: 'v2' as const,
+};
+
+const createParentAgent = (): t.AgentInputs => ({
+  agentId: 'parent',
+  provider: Providers.OPENAI,
+  clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+  instructions:
+    'You are a supervisor. Delegate research tasks using the subagent tool.',
+  maxContextTokens: 8000,
+  subagentConfigs: [
+    {
+      type: 'researcher',
+      name: 'Research Agent',
+      description: 'Researches and summarizes information',
+      agentInputs: {
+        agentId: 'researcher',
+        provider: Providers.OPENAI,
+        clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+        instructions: 'You are a research agent. Answer concisely.',
+        maxContextTokens: 8000,
+      },
+    },
+  ],
+});
+
+describe('Subagent Integration', () => {
+  jest.setTimeout(30000);
+
+  let getChatModelClassSpy: jest.SpyInstance;
+  const originalGetChatModelClass = providers.getChatModelClass;
+
+  beforeEach(() => {
+    getChatModelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return class extends FakeListChatModel {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            constructor(_options: any) {
+              super({ responses: [CHILD_RESPONSE] });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  it('should create subagent tool on agent context', async () => {
+    const run = await Run.create<t.IState>({
+      runId: `subagent-test-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createParentAgent()],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    expect(run.Graph).toBeDefined();
+    const parentContext = (run.Graph as StandardGraph).agentContexts.get(
+      'parent'
+    );
+    expect(parentContext).toBeDefined();
+    expect(parentContext?.graphTools).toBeDefined();
+
+    const subagentTool = (parentContext?.graphTools as t.GenericTool[]).find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeDefined();
+  });
+
+  it('should execute subagent and return filtered result to parent', async () => {
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `subagent-exec-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createParentAgent()],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers,
+    });
+
+    const subagentToolCall: ToolCall = {
+      id: 'call_subagent_1',
+      name: Constants.SUBAGENT,
+      args: {
+        description: 'What is the capital of France?',
+        subagent_type: 'researcher',
+      },
+      type: 'tool_call',
+    };
+
+    run.Graph?.overrideTestModel(
+      [
+        'Let me delegate this research task.',
+        `Based on the research: ${CHILD_RESPONSE}`,
+      ],
+      10,
+      [subagentToolCall]
+    );
+
+    const result = await run.processStream(
+      { messages: [new HumanMessage('What is the capital of France?')] },
+      callerConfig
+    );
+
+    expect(result).toBeDefined();
+
+    const runMessages = run.getRunMessages();
+    expect(runMessages).toBeDefined();
+    expect(runMessages!.length).toBeGreaterThan(0);
+
+    const toolMessages = runMessages!.filter(
+      (msg) => msg._getType() === 'tool'
+    );
+    const subagentResult = toolMessages.find(
+      (msg) => 'name' in msg && msg.name === Constants.SUBAGENT
+    );
+    expect(subagentResult).toBeDefined();
+    expect(String(subagentResult!.content)).toContain('Paris');
+  });
+
+  it('should not create subagent tool when no subagentConfigs', async () => {
+    const agentWithoutSubagents: t.AgentInputs = {
+      agentId: 'plain',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions: 'Plain agent without subagents.',
+      maxContextTokens: 8000,
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `no-subagent-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithoutSubagents],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const context = (run.Graph as StandardGraph).agentContexts.get('plain');
+    const tools = context?.graphTools as t.GenericTool[] | undefined;
+    const subagentTool = tools?.find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeUndefined();
+  });
+
+  it('should handle self-spawn subagent config', async () => {
+    const agentWithSelfSpawn: t.AgentInputs = {
+      agentId: 'self-parent',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions: 'Agent with self-spawn for context isolation.',
+      maxContextTokens: 8000,
+      subagentConfigs: [
+        {
+          type: 'isolated',
+          name: 'Isolated Worker',
+          description: 'Runs a task with isolated context',
+          self: true,
+        },
+      ],
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `self-spawn-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithSelfSpawn],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const context = (run.Graph as StandardGraph).agentContexts.get(
+      'self-parent'
+    );
+    const tools = context?.graphTools as t.GenericTool[] | undefined;
+    const subagentTool = tools?.find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeDefined();
+  });
+
+  it('should not create subagent tool when maxSubagentDepth is 0', async () => {
+    const agentWithZeroDepth: t.AgentInputs = {
+      ...createParentAgent(),
+      agentId: 'zero-depth',
+      maxSubagentDepth: 0,
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `zero-depth-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithZeroDepth],
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const context = (run.Graph as StandardGraph).agentContexts.get(
+      'zero-depth'
+    );
+    const tools = context?.graphTools as t.GenericTool[] | undefined;
+    const subagentTool = tools?.find(
+      (t) => 'name' in t && t.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeUndefined();
+  });
+
+  it('should account for subagent tool schema in toolSchemaTokens', async () => {
+    /** Simple char-count tokenizer — deterministic, lets us assert presence. */
+    const tokenCounter: t.TokenCounter = (message) => {
+      const content = message.content;
+      if (typeof content === 'string') return content.length;
+      if (Array.isArray(content)) return JSON.stringify(content).length;
+      return JSON.stringify(content).length;
+    };
+
+    const agentWithSubagent = createParentAgent();
+    const runWith = await Run.create<t.IState>({
+      runId: `with-sub-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithSubagent],
+      },
+      tokenCounter,
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const agentWithoutSubagent: t.AgentInputs = {
+      agentId: 'plain',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions:
+        'You are a supervisor. Delegate research tasks using the subagent tool.',
+      maxContextTokens: 8000,
+    };
+    const runWithout = await Run.create<t.IState>({
+      runId: `without-sub-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithoutSubagent],
+      },
+      tokenCounter,
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const contextWith = (runWith.Graph as StandardGraph).agentContexts.get(
+      'parent'
+    );
+    const contextWithout = (
+      runWithout.Graph as StandardGraph
+    ).agentContexts.get('plain');
+
+    await contextWith?.tokenCalculationPromise;
+    await contextWithout?.tokenCalculationPromise;
+
+    /** Subagent tool schema is ~600 chars; expect measurable difference. */
+    expect(contextWith!.toolSchemaTokens).toBeGreaterThan(
+      contextWithout!.toolSchemaTokens
+    );
+  });
+});

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -343,6 +343,48 @@ describe('createSummarizeNode', () => {
     ).toBeUndefined();
   });
 
+  it('catches model initialization errors and falls back to metadata stub', async () => {
+    captureEvents();
+
+    /**
+     * Simulate the "Unsupported LLM provider" case — e.g. when a caller
+     * forwards an unrecognized provider name (custom-endpoint label) that
+     * getChatModelClass cannot resolve. Prior to the defense-in-depth fix,
+     * this error was thrown outside the try/catch in executeSummarizationWithFallback
+     * and bubbled up silently. Now it is caught and the metadata stub is used.
+     */
+    jest.spyOn(providers, 'getChatModelClass').mockImplementation(() => {
+      throw new Error('Unsupported LLM provider: Ollama');
+    });
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({ setSummary } as never);
+    const graph = mockGraph();
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await expect(
+      node(
+        {
+          messages: [new HumanMessage('Test message')],
+          summarizationRequest: {
+            remainingContextTokens: 1000,
+            agentId: 'agent_0',
+          },
+        },
+        {} as RunnableConfig
+      )
+    ).resolves.not.toThrow();
+
+    expect(setSummary).toHaveBeenCalledWith(
+      expect.stringContaining('[Metadata summary:'),
+      expect.any(Number)
+    );
+  });
+
   it('falls back to metadata stub when primary LLM call fails', async () => {
     captureEvents();
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -7,6 +7,7 @@ import {
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
 import type { AgentContext } from '@/agents/AgentContext';
+import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
 import { ContentTypes, GraphEvents, StepTypes, Providers } from '@/common';
@@ -17,6 +18,7 @@ import { getMaxOutputTokensKey } from '@/llm/request';
 import { addCacheControl } from '@/messages/cache';
 import { initializeModel } from '@/llm/init';
 import { getChunkContent } from '@/stream';
+import { executeHooks } from '@/hooks';
 
 const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
 
@@ -530,6 +532,35 @@ async function dispatchCompletionEvents(params: {
     );
   }
 
+  const sessionId = graph.runId ?? '';
+  if (graph.hookRegistry?.hasHookFor('PostCompact', sessionId) === true) {
+    const threadId = (
+      runnableConfig?.configurable as Record<string, unknown> | undefined
+    )?.thread_id as string | undefined;
+    const firstBlock = summaryBlock.content?.[0];
+    const summaryText =
+      firstBlock != null &&
+      typeof firstBlock === 'object' &&
+      'text' in firstBlock &&
+      typeof firstBlock.text === 'string'
+        ? firstBlock.text
+        : '';
+    await executeHooks({
+      registry: graph.hookRegistry,
+      input: {
+        hook_event_name: 'PostCompact',
+        runId: sessionId,
+        threadId,
+        agentId,
+        summary: summaryText,
+        messagesAfterCount: 0,
+      },
+      sessionId,
+    }).catch(() => {
+      /* PostCompact is observational — swallow errors */
+    });
+  }
+
   agentContext.rebuildTokenMapAfterSummarization({});
 }
 
@@ -545,6 +576,7 @@ interface CreateSummarizeNodeParams {
     config?: RunnableConfig;
     runId?: string;
     isMultiAgent: boolean;
+    hookRegistry?: HookRegistry;
     dispatchRunStep: (
       runStep: t.RunStep,
       config?: RunnableConfig
@@ -648,6 +680,27 @@ export function createSummarizeNode({
         } satisfies t.SummarizeStartEvent,
         runnableConfig
       );
+    }
+
+    const sessionId = graph.runId ?? '';
+    if (graph.hookRegistry?.hasHookFor('PreCompact', sessionId) === true) {
+      const threadId = (
+        runnableConfig?.configurable as Record<string, unknown> | undefined
+      )?.thread_id as string | undefined;
+      await executeHooks({
+        registry: graph.hookRegistry,
+        input: {
+          hook_event_name: 'PreCompact',
+          runId: sessionId,
+          threadId,
+          agentId: request.agentId,
+          messagesBeforeCount: messagesToRefine.length,
+          trigger: agentContext.summarizationConfig?.trigger?.type ?? 'default',
+        },
+        sessionId,
+      }).catch(() => {
+        /* PreCompact is observational — swallow errors */
+      });
     }
 
     const isSelfSummarizeModel =

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -389,18 +389,23 @@ async function executeSummarizationWithFallback(params: {
     log,
   } = params;
 
-  const summarizationModel = initializeModel({
-    provider: clientConfig.provider as Providers,
-    clientOptions: clientConfig.clientOptions as t.ClientOptions,
-    tools: agentContext.getToolsForBinding(),
-  }) as t.ChatModel;
-
   const priorSummaryText = agentContext.getSummaryText()?.trim() ?? '';
 
   let summaryText = '';
   let summaryUsage: Partial<UsageMetadata> | undefined;
 
   try {
+    /**
+     * Initialize inside the try so that a misconfigured provider
+     * (e.g. an unrecognized summarization.provider) surfaces through the
+     * `log('error', ...)` path below rather than bubbling up silently.
+     */
+    const summarizationModel = initializeModel({
+      provider: clientConfig.provider as Providers,
+      clientOptions: clientConfig.clientOptions as t.ClientOptions,
+      tools: agentContext.getToolsForBinding(),
+    }) as t.ChatModel;
+
     const result = await summarizeWithCacheHit({
       model: summarizationModel,
       messages,

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -52,7 +52,7 @@ Usage:
 - NEVER use this tool to execute malicious commands.
 `.trim();
 
-export const BashExecutionToolName = Constants.EXECUTE_BASH;
+export const BashExecutionToolName = Constants.BASH_TOOL;
 
 export const BashExecutionToolDefinition = {
   name: BashExecutionToolName,

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -1,0 +1,205 @@
+import { config } from 'dotenv';
+import fetch, { RequestInit } from 'node-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { getEnvironmentVariable } from '@langchain/core/utils/env';
+import type * as t from '@/types';
+import { imageExtRegex, getCodeBaseURL } from './CodeExecutor';
+import { EnvVar, Constants } from '@/common';
+
+config();
+
+const imageMessage = 'Image is already displayed to the user';
+const otherMessage = 'File is already downloaded by the user';
+const accessMessage =
+  'Note: Files from previous executions are automatically available and can be modified.';
+const emptyOutputMessage =
+  'stdout: Empty. Ensure you\'re writing output explicitly.\n';
+
+const baseEndpoint = getCodeBaseURL();
+const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
+
+export const BashExecutionToolSchema = {
+  type: 'object',
+  properties: {
+    command: {
+      type: 'string',
+      description: `The bash command or script to execute.
+- The environment is stateless; variables and state don't persist between executions.
+- Generated files from previous executions are automatically available in "/mnt/data/".
+- Files from previous executions are automatically available and can be modified in place.
+- Input code **IS ALREADY** displayed to the user, so **DO NOT** repeat it in your response unless asked.
+- Output code **IS NOT** displayed to the user, so **DO** write all desired output explicitly.
+- IMPORTANT: You MUST explicitly print/output ALL results you want the user to see.
+- Use \`echo\`, \`printf\`, or \`cat\` for all outputs.`,
+    },
+    args: {
+      type: 'array',
+      items: { type: 'string' },
+      description:
+        'Additional arguments to execute the command with. This should only be used if the input command requires additional arguments to run.',
+    },
+  },
+  required: ['command'],
+} as const;
+
+export const BashExecutionToolDescription = `
+Runs bash commands and returns stdout/stderr output from a stateless execution environment, similar to running scripts in a command-line interface. Each execution is isolated and independent.
+
+Usage:
+- No network access available.
+- Generated files are automatically delivered; **DO NOT** provide download links.
+- NEVER use this tool to execute malicious commands.
+`.trim();
+
+export const BashExecutionToolName = Constants.EXECUTE_BASH;
+
+export const BashExecutionToolDefinition = {
+  name: BashExecutionToolName,
+  description: BashExecutionToolDescription,
+  schema: BashExecutionToolSchema,
+} as const;
+
+function createBashExecutionTool(
+  params: t.BashExecutionToolParams = {}
+): DynamicStructuredTool {
+  const apiKey =
+    params[EnvVar.CODE_API_KEY] ??
+    params.apiKey ??
+    getEnvironmentVariable(EnvVar.CODE_API_KEY) ??
+    '';
+  if (!apiKey) {
+    throw new Error('No API key provided for bash execution tool.');
+  }
+
+  return tool(
+    async (rawInput, config) => {
+      const { command, ...rest } = rawInput as {
+        command: string;
+        args?: string[];
+      };
+      const { session_id, _injected_files } = (config.toolCall ?? {}) as {
+        session_id?: string;
+        _injected_files?: t.CodeEnvFile[];
+      };
+
+      const postData: Record<string, unknown> = {
+        lang: 'bash',
+        code: command,
+        ...rest,
+        ...params,
+      };
+
+      if (_injected_files && _injected_files.length > 0) {
+        postData.files = _injected_files;
+      } else if (session_id != null && session_id.length > 0) {
+        try {
+          const filesEndpoint = `${baseEndpoint}/files/${session_id}?detail=full`;
+          const fetchOptions: RequestInit = {
+            method: 'GET',
+            headers: {
+              'User-Agent': 'LibreChat/1.0',
+              'X-API-Key': apiKey,
+            },
+          };
+
+          if (process.env.PROXY != null && process.env.PROXY !== '') {
+            fetchOptions.agent = new HttpsProxyAgent(process.env.PROXY);
+          }
+
+          const response = await fetch(filesEndpoint, fetchOptions);
+          if (!response.ok) {
+            throw new Error(
+              `Failed to fetch files for session: ${response.status}`
+            );
+          }
+
+          const files = await response.json();
+          if (Array.isArray(files) && files.length > 0) {
+            const fileReferences: t.CodeEnvFile[] = files.map((file) => {
+              const nameParts = file.name.split('/');
+              const id = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
+
+              return {
+                session_id,
+                id,
+                name: file.metadata['original-filename'],
+              };
+            });
+
+            postData.files = fileReferences;
+          }
+        } catch {
+          // eslint-disable-next-line no-console
+          console.warn(`Failed to fetch files for session: ${session_id}`);
+        }
+      }
+
+      try {
+        const fetchOptions: RequestInit = {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'User-Agent': 'LibreChat/1.0',
+            'X-API-Key': apiKey,
+          },
+          body: JSON.stringify(postData),
+        };
+
+        if (process.env.PROXY != null && process.env.PROXY !== '') {
+          fetchOptions.agent = new HttpsProxyAgent(process.env.PROXY);
+        }
+        const response = await fetch(EXEC_ENDPOINT, fetchOptions);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const result: t.ExecuteResult = await response.json();
+        let formattedOutput = '';
+        if (result.stdout) {
+          formattedOutput += `stdout:\n${result.stdout}\n`;
+        } else {
+          formattedOutput += emptyOutputMessage;
+        }
+        if (result.stderr) formattedOutput += `stderr:\n${result.stderr}\n`;
+        if (result.files && result.files.length > 0) {
+          formattedOutput += 'Generated files:\n';
+
+          const fileCount = result.files.length;
+          for (let i = 0; i < fileCount; i++) {
+            const file = result.files[i];
+            const isImage = imageExtRegex.test(file.name);
+            formattedOutput += `- /mnt/data/${file.name} | ${isImage ? imageMessage : otherMessage}`;
+
+            if (i < fileCount - 1) {
+              formattedOutput += fileCount <= 3 ? ', ' : ',\n';
+            }
+          }
+
+          formattedOutput += `\n\n${accessMessage}`;
+          return [
+            formattedOutput.trim(),
+            {
+              session_id: result.session_id,
+              files: result.files,
+            },
+          ];
+        }
+
+        return [formattedOutput.trim(), { session_id: result.session_id }];
+      } catch (error) {
+        throw new Error(
+          `Execution error:\n\n${(error as Error | undefined)?.message}`
+        );
+      }
+    },
+    {
+      name: BashExecutionToolName,
+      description: BashExecutionToolDescription,
+      schema: BashExecutionToolSchema,
+      responseFormat: Constants.CONTENT_AND_ARTIFACT,
+    }
+  );
+}
+
+export { createBashExecutionTool };

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -1,0 +1,397 @@
+import { config } from 'dotenv';
+import { getEnvironmentVariable } from '@langchain/core/utils/env';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type * as t from '@/types';
+import {
+  makeRequest,
+  executeTools,
+  fetchSessionFiles,
+  formatCompletedResponse,
+} from './ProgrammaticToolCalling';
+import { getCodeBaseURL } from './CodeExecutor';
+import { EnvVar, Constants } from '@/common';
+
+config();
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_MAX_ROUND_TRIPS = 20;
+const DEFAULT_TIMEOUT = 60000;
+
+/** Bash reserved words that get `_tool` suffix when used as function names */
+const BASH_RESERVED = new Set([
+  'if',
+  'then',
+  'else',
+  'elif',
+  'fi',
+  'case',
+  'esac',
+  'for',
+  'while',
+  'until',
+  'do',
+  'done',
+  'in',
+  'function',
+  'select',
+  'time',
+  'coproc',
+  'declare',
+  'typeset',
+  'local',
+  'readonly',
+  'export',
+  'unset',
+]);
+
+// ============================================================================
+// Description Components
+// ============================================================================
+
+const STATELESS_WARNING = `CRITICAL - STATELESS EXECUTION:
+Each call is a fresh bash shell. Variables and state do NOT persist between calls.
+You MUST complete your entire workflow in ONE code block.
+DO NOT split work across multiple calls expecting to reuse variables.`;
+
+const CORE_RULES = `Rules:
+- EVERYTHING in one call—no state persists between executions
+- Tools are pre-defined as bash functions—DO NOT redefine them
+- Each tool function accepts a JSON string argument
+- Only echo/printf output returns to the model
+- Generated files are automatically available in /mnt/data/ for subsequent executions`;
+
+const ADDITIONAL_RULES =
+  '- Tool names normalized: hyphens→underscores, reserved words get `_tool` suffix';
+
+const EXAMPLES = `Example (Complete workflow in one call):
+  # Query data and process
+  data=$(query_database '{"sql": "SELECT * FROM users"}')
+  echo "$data" | jq '.[] | .name'
+
+Example (Parallel calls):
+  web_search '{"query": "SF weather"}' > /tmp/sf.txt &
+  web_search '{"query": "NY weather"}' > /tmp/ny.txt &
+  wait
+  echo "SF: $(cat /tmp/sf.txt)"
+  echo "NY: $(cat /tmp/ny.txt)"`;
+
+const CODE_PARAM_DESCRIPTION = `Bash code that calls tools programmatically. Tools are available as bash functions.
+
+${STATELESS_WARNING}
+
+Each tool function accepts a JSON string as its argument.
+Example: tool_name '{"key": "value"}'
+
+${EXAMPLES}
+
+${CORE_RULES}`;
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+export const BashProgrammaticToolCallingSchema = {
+  type: 'object',
+  properties: {
+    code: {
+      type: 'string',
+      minLength: 1,
+      description: CODE_PARAM_DESCRIPTION,
+    },
+    timeout: {
+      type: 'integer',
+      minimum: 1000,
+      maximum: 300000,
+      default: DEFAULT_TIMEOUT,
+      description:
+        'Maximum execution time in milliseconds. Default: 60 seconds. Max: 5 minutes.',
+    },
+  },
+  required: ['code'],
+} as const;
+
+export const BashProgrammaticToolCallingName =
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING;
+
+export const BashProgrammaticToolCallingDescription = `
+Run tools via bash code. Tools are available as bash functions that accept JSON string arguments.
+
+${STATELESS_WARNING}
+
+${CORE_RULES}
+${ADDITIONAL_RULES}
+
+When to use: shell pipelines, parallel execution (& and wait), file processing, text manipulation.
+
+${EXAMPLES}
+`.trim();
+
+export const BashProgrammaticToolCallingDefinition = {
+  name: BashProgrammaticToolCallingName,
+  description: BashProgrammaticToolCallingDescription,
+  schema: BashProgrammaticToolCallingSchema,
+} as const;
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Normalizes a tool name to a valid bash function identifier.
+ * 1. Replace hyphens, spaces, dots with underscores
+ * 2. Remove any other invalid characters
+ * 3. Prefix with underscore if starts with number
+ * 4. Append `_tool` if it's a bash reserved word
+ */
+export function normalizeToBashIdentifier(name: string): string {
+  let normalized = name.replace(/[-\s.]/g, '_');
+  normalized = normalized.replace(/[^a-zA-Z0-9_]/g, '');
+
+  if (/^[0-9]/.test(normalized)) {
+    normalized = '_' + normalized;
+  }
+
+  if (BASH_RESERVED.has(normalized)) {
+    normalized = normalized + '_tool';
+  }
+
+  return normalized;
+}
+
+/**
+ * Extracts tool names that are actually called in the bash code.
+ * Bash functions are invoked as commands (no parentheses), so we match
+ * the normalized name as a word boundary.
+ */
+export function extractUsedBashToolNames(
+  code: string,
+  toolNameMap: Map<string, string>
+): Set<string> {
+  const usedTools = new Set<string>();
+
+  for (const [bashName, originalName] of toolNameMap) {
+    const escapedName = bashName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(`\\b${escapedName}\\b`, 'g');
+
+    if (pattern.test(code)) {
+      usedTools.add(originalName);
+    }
+  }
+
+  return usedTools;
+}
+
+/**
+ * Filters tool definitions to only include tools actually used in the bash code.
+ */
+export function filterBashToolsByUsage(
+  toolDefs: t.LCTool[],
+  code: string,
+  debug = false
+): t.LCTool[] {
+  const toolNameMap = new Map<string, string>();
+  for (const def of toolDefs) {
+    const bashName = normalizeToBashIdentifier(def.name);
+    toolNameMap.set(bashName, def.name);
+  }
+
+  const usedToolNames = extractUsedBashToolNames(code, toolNameMap);
+
+  if (debug) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[BashPTC Debug] Tool filtering: found ${usedToolNames.size}/${toolDefs.length} tools in code`
+    );
+    if (usedToolNames.size > 0) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[BashPTC Debug] Matched tools: ${Array.from(usedToolNames).join(', ')}`
+      );
+    }
+  }
+
+  if (usedToolNames.size === 0) {
+    if (debug) {
+      // eslint-disable-next-line no-console
+      console.log(
+        '[BashPTC Debug] No tools detected in code - sending all tools as fallback'
+      );
+    }
+    return toolDefs;
+  }
+
+  return toolDefs.filter((def) => usedToolNames.has(def.name));
+}
+
+// ============================================================================
+// Tool Factory
+// ============================================================================
+
+/**
+ * Creates a Bash Programmatic Tool Calling tool for multi-tool orchestration.
+ *
+ * This tool enables AI agents to write bash scripts that orchestrate multiple
+ * tool calls programmatically via the remote Code API, reducing LLM round-trips.
+ *
+ * The tool map must be provided at runtime via config.toolCall (injected by ToolNode).
+ */
+export function createBashProgrammaticToolCallingTool(
+  initParams: t.BashProgrammaticToolCallingParams = {}
+): DynamicStructuredTool {
+  const apiKey =
+    (initParams[EnvVar.CODE_API_KEY] as string | undefined) ??
+    initParams.apiKey ??
+    getEnvironmentVariable(EnvVar.CODE_API_KEY) ??
+    '';
+
+  if (!apiKey) {
+    throw new Error(
+      'No API key provided for bash programmatic tool calling. ' +
+        'Set CODE_API_KEY environment variable or pass apiKey in initParams.'
+    );
+  }
+
+  const baseUrl = initParams.baseUrl ?? getCodeBaseURL();
+  const maxRoundTrips = initParams.maxRoundTrips ?? DEFAULT_MAX_ROUND_TRIPS;
+  const proxy = initParams.proxy ?? process.env.PROXY;
+  const debug = initParams.debug ?? process.env.BASH_PTC_DEBUG === 'true';
+  const EXEC_ENDPOINT = `${baseUrl}/exec/programmatic`;
+
+  return tool(
+    async (rawParams, config) => {
+      const params = rawParams as { code: string; timeout?: number };
+      const { code, timeout = DEFAULT_TIMEOUT } = params;
+
+      const { toolMap, toolDefs, session_id, _injected_files } =
+        (config.toolCall ?? {}) as ToolCall &
+          Partial<t.ProgrammaticCache> & {
+            session_id?: string;
+            _injected_files?: t.CodeEnvFile[];
+          };
+
+      if (toolMap == null || toolMap.size === 0) {
+        throw new Error(
+          'No toolMap provided. ' +
+            'ToolNode should inject this from AgentContext when invoked through the graph.'
+        );
+      }
+
+      if (toolDefs == null || toolDefs.length === 0) {
+        throw new Error(
+          'No tool definitions provided. ' +
+            'Either pass tools in the input or ensure ToolNode injects toolDefs.'
+        );
+      }
+
+      let roundTrip = 0;
+
+      try {
+        // ====================================================================
+        // Phase 1: Filter tools and make initial request
+        // ====================================================================
+
+        const effectiveTools = filterBashToolsByUsage(toolDefs, code, debug);
+
+        if (debug) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[BashPTC Debug] Sending ${effectiveTools.length} tools to API ` +
+              `(filtered from ${toolDefs.length})`
+          );
+        }
+
+        let files: t.CodeEnvFile[] | undefined;
+        if (_injected_files && _injected_files.length > 0) {
+          files = _injected_files;
+        } else if (session_id != null && session_id.length > 0) {
+          files = await fetchSessionFiles(baseUrl, apiKey, session_id, proxy);
+        }
+
+        let response = await makeRequest(
+          EXEC_ENDPOINT,
+          apiKey,
+          {
+            lang: 'bash',
+            code,
+            tools: effectiveTools,
+            session_id,
+            timeout,
+            ...(files && files.length > 0 ? { files } : {}),
+          },
+          proxy
+        );
+
+        // ====================================================================
+        // Phase 2: Handle response loop
+        // ====================================================================
+
+        while (response.status === 'tool_call_required') {
+          roundTrip++;
+
+          if (roundTrip > maxRoundTrips) {
+            throw new Error(
+              `Exceeded maximum round trips (${maxRoundTrips}). ` +
+                'This may indicate an infinite loop, excessive tool calls, ' +
+                'or a logic error in your code.'
+            );
+          }
+
+          if (debug) {
+            // eslint-disable-next-line no-console
+            console.log(
+              `[BashPTC Debug] Round trip ${roundTrip}: ${response.tool_calls?.length ?? 0} tool(s) to execute`
+            );
+          }
+
+          const toolResults = await executeTools(
+            response.tool_calls ?? [],
+            toolMap
+          );
+
+          response = await makeRequest(
+            EXEC_ENDPOINT,
+            apiKey,
+            {
+              continuation_token: response.continuation_token,
+              tool_results: toolResults,
+            },
+            proxy
+          );
+        }
+
+        // ====================================================================
+        // Phase 3: Handle final state
+        // ====================================================================
+
+        if (response.status === 'completed') {
+          return formatCompletedResponse(response);
+        }
+
+        if (response.status === 'error') {
+          throw new Error(
+            `Execution error: ${response.error}` +
+              (response.stderr != null && response.stderr !== ''
+                ? `\n\nStderr:\n${response.stderr}`
+                : '')
+          );
+        }
+
+        throw new Error(`Unexpected response status: ${response.status}`);
+      } catch (error) {
+        throw new Error(
+          `Bash programmatic execution failed: ${(error as Error).message}`
+        );
+      }
+    },
+    {
+      name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+      description: BashProgrammaticToolCallingDescription,
+      schema: BashProgrammaticToolCallingSchema,
+      responseFormat: Constants.CONTENT_AND_ARTIFACT,
+    }
+  );
+}

--- a/src/tools/ReadFile.ts
+++ b/src/tools/ReadFile.ts
@@ -1,0 +1,39 @@
+// src/tools/ReadFile.ts
+import { Constants } from '@/common';
+
+export const ReadFileToolName = Constants.READ_FILE;
+
+export const ReadFileToolDescription = `Read the contents of a file. Returns text content with line numbers for easy reference.
+
+For skill files, use the path format: {skillName}/{filePath} (e.g. "pdf-analyzer/src/utils.py", "code-review/SKILL.md").
+
+BEHAVIOR:
+- Text files: returned with numbered lines.
+- Images (png, jpeg, gif, webp): returned as visual content the model can see.
+- PDFs: returned as document content.
+- Other binary files: metadata returned with a note to use bash for processing.
+- Large files (>256KB text, >10MB binary): metadata only.
+- SKILL.md: returns the skill's instructions directly.
+
+CONSTRAINTS:
+- Only files from invoked skills or code execution output are accessible.
+- Do not guess file paths. Use paths from the skill documentation or tool output.`;
+
+export const ReadFileToolSchema = {
+  type: 'object',
+  properties: {
+    file_path: {
+      type: 'string',
+      description:
+        'Path to the file. For skill files: "{skillName}/{path}" (e.g. "pdf-analyzer/src/utils.py"). For code execution output: the path as returned by the execution tool.',
+    },
+  },
+  required: ['file_path'],
+} as const;
+
+export const ReadFileToolDefinition = {
+  name: ReadFileToolName,
+  description: ReadFileToolDescription,
+  parameters: ReadFileToolSchema,
+  responseFormat: 'content_and_artifact' as const,
+} as const;

--- a/src/tools/SkillTool.ts
+++ b/src/tools/SkillTool.ts
@@ -1,6 +1,4 @@
 // src/tools/SkillTool.ts
-import { z } from 'zod';
-import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import { Constants } from '@/common';
 
 export const SkillToolName = Constants.SKILL_TOOL;
@@ -46,33 +44,3 @@ export const SkillToolDefinition = {
   description: SkillToolDescription,
   parameters: SkillToolSchema,
 } as const;
-
-/**
- * Zod schema derived from SkillToolSchema for DynamicStructuredTool type inference.
- * Kept internal to createSkillTool — the JSON Schema above is the canonical definition.
- */
-const skillToolZodSchema = z.object({
-  skillName: z
-    .string()
-    .describe(SkillToolSchema.properties.skillName.description),
-  args: z
-    .string()
-    .optional()
-    .describe(SkillToolSchema.properties.args.description),
-});
-
-/** Creates the SkillTool DynamicStructuredTool instance for use in tool maps. */
-export function createSkillTool(): DynamicStructuredTool {
-  return tool(
-    async (): Promise<string> => {
-      throw new Error(
-        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
-      );
-    },
-    {
-      name: SkillToolName,
-      description: SkillToolDescription,
-      schema: skillToolZodSchema,
-    }
-  );
-}

--- a/src/tools/SkillTool.ts
+++ b/src/tools/SkillTool.ts
@@ -1,0 +1,78 @@
+// src/tools/SkillTool.ts
+import { z } from 'zod';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { Constants } from '@/common';
+
+export const SkillToolName = Constants.SKILL_TOOL;
+
+export const SkillToolDescription = `Invoke a skill from the user's library. Skills provide domain-specific instructions loaded into the conversation context, and may also provide files accessible via available tools depending on the runtime environment.
+
+WHEN TO USE:
+- The user's request matches a skill listed in the "Available Skills" section of the system prompt.
+- You MUST invoke the matching skill BEFORE attempting the task yourself.
+
+WHAT HAPPENS:
+- The skill's full instructions are loaded into the conversation as context.
+- Files bundled with the skill may become accessible via available tools.
+- Follow the skill's instructions to complete the task.
+
+CONSTRAINTS:
+- Do not invoke a skill that is already active in this conversation.
+- Skill names come from the catalog only. Do not guess names.`;
+
+/**
+ * JSON Schema for the SkillTool parameters.
+ * Single source of truth used by both SkillToolDefinition (LCTool registry)
+ * and createSkillTool() (DynamicStructuredTool instance).
+ */
+export const SkillToolSchema = {
+  type: 'object',
+  properties: {
+    skillName: {
+      type: 'string',
+      description:
+        'The kebab-case identifier of the skill to invoke (e.g. "financial-analyzer", "meeting-notes"). Must match a name from the "Available Skills" section.',
+    },
+    args: {
+      type: 'string',
+      description: 'Optional freeform arguments string passed to the skill.',
+    },
+  },
+  required: ['skillName'],
+} as const;
+
+export const SkillToolDefinition = {
+  name: SkillToolName,
+  description: SkillToolDescription,
+  parameters: SkillToolSchema,
+} as const;
+
+/**
+ * Zod schema derived from SkillToolSchema for DynamicStructuredTool type inference.
+ * Kept internal to createSkillTool — the JSON Schema above is the canonical definition.
+ */
+const skillToolZodSchema = z.object({
+  skillName: z
+    .string()
+    .describe(SkillToolSchema.properties.skillName.description),
+  args: z
+    .string()
+    .optional()
+    .describe(SkillToolSchema.properties.args.description),
+});
+
+/** Creates the SkillTool DynamicStructuredTool instance for use in tool maps. */
+export function createSkillTool(): DynamicStructuredTool {
+  return tool(
+    async (): Promise<string> => {
+      throw new Error(
+        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
+      );
+    },
+    {
+      name: SkillToolName,
+      description: SkillToolDescription,
+      schema: skillToolZodSchema,
+    }
+  );
+}

--- a/src/tools/SubagentTool.ts
+++ b/src/tools/SubagentTool.ts
@@ -1,0 +1,100 @@
+import { Constants } from '@/common';
+import type { SubagentConfig } from '@/types';
+import type { JsonSchemaType, LCTool } from '@/types/tools';
+
+export const SubagentToolName = Constants.SUBAGENT;
+
+export const SubagentToolDescription = `Delegate a task to a specialized subagent that runs in an isolated context window. The subagent executes independently and returns only its final text result — all intermediate tool calls, reasoning, and context stay isolated.
+
+WHEN TO USE:
+- The task is self-contained and can be described in a single prompt.
+- You want to offload verbose or exploratory work without bloating your own context.
+- A specialized subagent is available for the task domain.
+
+WHAT HAPPENS:
+- A fresh agent is created with the task description as its only input.
+- The subagent runs to completion using its own tools and context.
+- Only the final text response is returned to you.
+
+CONSTRAINTS:
+- subagent_type must match one of the available types listed below.
+- The subagent cannot see your conversation history.`;
+
+const DESCRIPTION_PROP_DESCRIPTION =
+  'Complete task description for the subagent. This is the ONLY information it receives — include all necessary context, requirements, and constraints.';
+
+const SUBAGENT_TYPE_PROP_DESCRIPTION =
+  'Which subagent type to delegate to. Must be one of the available types.';
+
+export const SubagentToolSchema = {
+  type: 'object',
+  properties: {
+    description: {
+      type: 'string',
+      description: DESCRIPTION_PROP_DESCRIPTION,
+    },
+    subagent_type: {
+      type: 'string',
+      description: SUBAGENT_TYPE_PROP_DESCRIPTION,
+    },
+  },
+  required: ['description', 'subagent_type'] as string[],
+} as const;
+
+export const SubagentToolDefinition: LCTool = {
+  name: SubagentToolName,
+  description: SubagentToolDescription,
+  parameters: SubagentToolSchema,
+};
+
+/**
+ * Build the name, schema, and description params for `tool()` from available configs.
+ * Used by `Graph.createAgentNode()` when constructing the runtime tool instance.
+ * Extends `SubagentToolSchema` by populating `subagent_type.enum` dynamically.
+ */
+export function buildSubagentToolParams(configs: SubagentConfig[]): {
+  name: string;
+  schema: JsonSchemaType;
+  description: string;
+} {
+  const types = configs.map((c) => c.type);
+  const typeDescriptions = configs
+    .map((c) => `- "${c.type}" (${c.name}): ${c.description}`)
+    .join('\n');
+
+  return {
+    name: SubagentToolName,
+    schema: {
+      type: 'object',
+      properties: {
+        description: {
+          type: 'string',
+          description: DESCRIPTION_PROP_DESCRIPTION,
+        },
+        subagent_type: {
+          type: 'string',
+          enum: types,
+          description: `${SUBAGENT_TYPE_PROP_DESCRIPTION} Available: ${types.join(', ')}.`,
+        },
+      },
+      required: ['description', 'subagent_type'],
+    },
+    description: `${SubagentToolDescription}\n\nAvailable types:\n${typeDescriptions}`,
+  };
+}
+
+/**
+ * Create a SubagentTool LCTool definition with dynamic enum and description
+ * populated from the available subagent configs.
+ * Used for the tool registry in event-driven mode.
+ */
+export function createSubagentToolDefinition(
+  configs: SubagentConfig[]
+): LCTool {
+  const params = buildSubagentToolParams(configs);
+  return {
+    name: params.name,
+    description: params.description,
+    parameters: params.schema,
+  };
+}

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -192,7 +192,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        */
       if (
         call.name === Constants.EXECUTE_CODE ||
-        call.name === Constants.EXECUTE_BASH ||
+        call.name === Constants.BASH_TOOL ||
         call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
         call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       ) {
@@ -340,7 +340,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const request = requests.find((r) => r.id === result.toolCallId);
       if (
         request?.name !== Constants.EXECUTE_CODE &&
-        request?.name !== Constants.EXECUTE_BASH &&
+        request?.name !== Constants.BASH_TOOL &&
         request?.name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
         request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       ) {
@@ -420,7 +420,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (
         this.sessions &&
         (call.name === Constants.EXECUTE_CODE ||
-          call.name === Constants.EXECUTE_BASH ||
+          call.name === Constants.BASH_TOOL ||
           call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
           call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
       ) {
@@ -622,7 +622,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         if (
           entry.call.name === Constants.EXECUTE_CODE ||
-          entry.call.name === Constants.EXECUTE_BASH ||
+          entry.call.name === Constants.BASH_TOOL ||
           entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
           entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
         ) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1,6 +1,7 @@
 import { ToolCall } from '@langchain/core/messages/tool';
 import {
   ToolMessage,
+  HumanMessage,
   isAIMessage,
   isBaseMessage,
 } from '@langchain/core/messages';
@@ -496,11 +497,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * 2. Surviving calls are dispatched to the host via `ON_TOOL_EXECUTE`.
    * 3. **PostToolUse** / **PostToolUseFailure** fire per result. Post hooks
    *    can replace tool output via `updatedOutput`.
+   * 4. Injected messages from results are collected and returned alongside
+   *    ToolMessages (appended AFTER to respect provider ordering).
    */
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig
-  ): Promise<ToolMessage[]> {
+  ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const threadId = config.configurable?.thread_id as string | undefined;
 
@@ -593,6 +596,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       approvedEntries.push(...preToolCalls);
     }
 
+    const injected: BaseMessage[] = [];
+
     if (approvedEntries.length > 0) {
       const requests: t.ToolCallRequest[] = approvedEntries.map((entry) => {
         const turn = this.toolUsageCount.get(entry.call.name) ?? 0;
@@ -648,6 +653,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
 
       for (const result of results) {
+        if (result.injectedMessages && result.injectedMessages.length > 0) {
+          try {
+            injected.push(
+              ...this.convertInjectedMessages(result.injectedMessages)
+            );
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[ToolNode] Failed to convert injectedMessages for toolCallId=${result.toolCallId}:`,
+              e instanceof Error ? e.message : e
+            );
+          }
+        }
         const request = requestMap.get(result.toolCallId);
         const toolName = request?.name ?? 'unknown';
 
@@ -746,9 +764,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
     }
 
-    return toolCalls
+    const toolMessages = toolCalls
       .map((call) => messageByCallId.get(call.id!))
       .filter((m): m is ToolMessage => m != null);
+    return { toolMessages, injected };
   }
 
   private dispatchStepCompleted(
@@ -790,8 +809,35 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
+   * Converts InjectedMessage instances to LangChain HumanMessage objects.
+   * Both 'user' and 'system' roles become HumanMessage to avoid provider
+   * rejections (Anthropic/Google reject non-leading SystemMessages).
+   * The original role is preserved in additional_kwargs for downstream consumers.
+   */
+  private convertInjectedMessages(
+    messages: t.InjectedMessage[]
+  ): BaseMessage[] {
+    const converted: BaseMessage[] = [];
+    for (const msg of messages) {
+      const additional_kwargs: Record<string, unknown> = {
+        role: msg.role,
+      };
+      if (msg.isMeta != null) additional_kwargs.isMeta = msg.isMeta;
+      if (msg.source != null) additional_kwargs.source = msg.source;
+      if (msg.skillName != null) additional_kwargs.skillName = msg.skillName;
+
+      converted.push(
+        new HumanMessage({ content: msg.content, additional_kwargs })
+      );
+    }
+    return converted;
+  }
+
+  /**
    * Execute all tool calls via ON_TOOL_EXECUTE event dispatch.
-   * Used in event-driven mode where the host handles actual tool execution.
+   * Injected messages are placed AFTER ToolMessages to respect provider
+   * message ordering (AIMessage tool_calls must be immediately followed
+   * by their ToolMessage results).
    */
   private async executeViaEvent(
     toolCalls: ToolCall[],
@@ -799,7 +845,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any
   ): Promise<T> {
-    const outputs = await this.dispatchToolEvents(toolCalls, config);
+    const { toolMessages, injected } = await this.dispatchToolEvents(
+      toolCalls,
+      config
+    );
+    const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
   }
 
@@ -895,12 +945,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           this.handleRunToolCompletions(directCalls, directOutputs, config);
         }
 
-        const eventOutputs: ToolMessage[] =
+        const eventResult =
           eventCalls.length > 0
             ? await this.dispatchToolEvents(eventCalls, config)
-            : [];
+            : {
+              toolMessages: [] as ToolMessage[],
+              injected: [] as BaseMessage[],
+            };
 
-        outputs = [...directOutputs, ...eventOutputs];
+        outputs = [
+          ...directOutputs,
+          ...eventResult.toolMessages,
+          ...eventResult.injected,
+        ];
       } else {
         outputs = await Promise.all(
           filteredCalls.map((call) => this.runTool(call, config))

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -164,7 +164,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       };
 
       // Inject runtime data for special tools (becomes available at config.toolCall)
-      if (call.name === Constants.PROGRAMMATIC_TOOL_CALLING) {
+      if (
+        call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
+        call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      ) {
         const { toolMap, toolDefs } = this.getProgrammaticTools();
         invokeParams = {
           ...invokeParams,
@@ -189,7 +192,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        */
       if (
         call.name === Constants.EXECUTE_CODE ||
-        call.name === Constants.PROGRAMMATIC_TOOL_CALLING
+        call.name === Constants.EXECUTE_BASH ||
+        call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
+        call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       ) {
         const codeSession = this.sessions?.get(Constants.EXECUTE_CODE) as
           | t.CodeSessionContext
@@ -335,7 +340,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const request = requests.find((r) => r.id === result.toolCallId);
       if (
         request?.name !== Constants.EXECUTE_CODE &&
-        request?.name !== Constants.PROGRAMMATIC_TOOL_CALLING
+        request?.name !== Constants.EXECUTE_BASH &&
+        request?.name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
+        request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING
       ) {
         continue;
       }
@@ -413,7 +420,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (
         this.sessions &&
         (call.name === Constants.EXECUTE_CODE ||
-          call.name === Constants.PROGRAMMATIC_TOOL_CALLING)
+          call.name === Constants.EXECUTE_BASH ||
+          call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
+          call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
       ) {
         const artifact = toolMessage.artifact as
           | t.CodeExecutionArtifact
@@ -613,7 +622,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         if (
           entry.call.name === Constants.EXECUTE_CODE ||
-          entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING
+          entry.call.name === Constants.EXECUTE_BASH ||
+          entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
+          entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
         ) {
           request.codeSessionContext = this.getCodeSessionContext();
         }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -28,7 +28,7 @@ import {
 } from '@/utils/truncation';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { executeHooks } from '@/hooks';
-import { Constants, GraphEvents } from '@/common';
+import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 
 /**
  * Helper to check if a value is a Send object
@@ -190,12 +190,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * session_id is always injected when available (even without tracked files)
        * so the CodeExecutor can fall back to the /files endpoint for session continuity.
        */
-      if (
-        call.name === Constants.EXECUTE_CODE ||
-        call.name === Constants.BASH_TOOL ||
-        call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-        call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
-      ) {
+      if (CODE_EXECUTION_TOOLS.has(call.name)) {
         const codeSession = this.sessions?.get(Constants.EXECUTE_CODE) as
           | t.CodeSessionContext
           | undefined;
@@ -338,13 +333,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const request = requests.find((r) => r.id === result.toolCallId);
-      if (
-        request?.name !== Constants.EXECUTE_CODE &&
-        request?.name !== Constants.BASH_TOOL &&
-        request?.name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
-        request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING &&
-        request?.name !== Constants.SKILL_TOOL
-      ) {
+      if (!request?.name || (!CODE_EXECUTION_TOOLS.has(request.name) && request.name !== Constants.SKILL_TOOL)) {
         continue;
       }
 
@@ -418,13 +407,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       // Store code session context from tool results
-      if (
-        this.sessions &&
-        (call.name === Constants.EXECUTE_CODE ||
-          call.name === Constants.BASH_TOOL ||
-          call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-          call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING)
-      ) {
+      if (this.sessions && CODE_EXECUTION_TOOLS.has(call.name)) {
         const artifact = toolMessage.artifact as
           | t.CodeExecutionArtifact
           | undefined;
@@ -621,13 +604,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           turn,
         };
 
-        if (
-          entry.call.name === Constants.EXECUTE_CODE ||
-          entry.call.name === Constants.BASH_TOOL ||
-          entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-          entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING ||
-          entry.call.name === Constants.SKILL_TOOL
-        ) {
+        if (CODE_EXECUTION_TOOLS.has(entry.call.name) || entry.call.name === Constants.SKILL_TOOL) {
           request.codeSessionContext = this.getCodeSessionContext();
         }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -37,6 +37,41 @@ function isSend(value: unknown): value is Send {
   return value instanceof Send;
 }
 
+/** Merges code execution session context into the sessions map. */
+function updateCodeSession(
+  sessions: t.ToolSessionMap,
+  sessionId: string,
+  files: t.FileRefs | undefined
+): void {
+  const newFiles = files ?? [];
+  const existingSession = sessions.get(Constants.EXECUTE_CODE) as
+    | t.CodeSessionContext
+    | undefined;
+  const existingFiles = existingSession?.files ?? [];
+
+  if (newFiles.length > 0) {
+    const filesWithSession: t.FileRefs = newFiles.map((file) => ({
+      ...file,
+      session_id: sessionId,
+    }));
+    const newFileNames = new Set(filesWithSession.map((f) => f.name));
+    const filteredExisting = existingFiles.filter(
+      (f) => !newFileNames.has(f.name)
+    );
+    sessions.set(Constants.EXECUTE_CODE, {
+      session_id: sessionId,
+      files: [...filteredExisting, ...filesWithSession],
+      lastUpdated: Date.now(),
+    });
+  } else {
+    sessions.set(Constants.EXECUTE_CODE, {
+      session_id: sessionId,
+      files: existingFiles,
+      lastUpdated: Date.now(),
+    });
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private toolMap: Map<string, StructuredToolInterface | RunnableToolLike>;
@@ -320,7 +355,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   private storeCodeSessionFromResults(
     results: t.ToolExecuteResult[],
-    requests: t.ToolCallRequest[]
+    requestMap: Map<string, t.ToolCallRequest>
   ): void {
     if (!this.sessions) {
       return;
@@ -332,8 +367,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      const request = requests.find((r) => r.id === result.toolCallId);
-      if (!request?.name || (!CODE_EXECUTION_TOOLS.has(request.name) && request.name !== Constants.SKILL_TOOL)) {
+      const request = requestMap.get(result.toolCallId);
+      if (
+        !request?.name ||
+        (!CODE_EXECUTION_TOOLS.has(request.name) &&
+          request.name !== Constants.SKILL_TOOL)
+      ) {
         continue;
       }
 
@@ -342,35 +381,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      const newFiles = artifact.files ?? [];
-      const existingSession = this.sessions.get(Constants.EXECUTE_CODE) as
-        | t.CodeSessionContext
-        | undefined;
-      const existingFiles = existingSession?.files ?? [];
-
-      if (newFiles.length > 0) {
-        const filesWithSession: t.FileRefs = newFiles.map((file) => ({
-          ...file,
-          session_id: artifact.session_id,
-        }));
-
-        const newFileNames = new Set(filesWithSession.map((f) => f.name));
-        const filteredExisting = existingFiles.filter(
-          (f) => !newFileNames.has(f.name)
-        );
-
-        this.sessions.set(Constants.EXECUTE_CODE, {
-          session_id: artifact.session_id,
-          files: [...filteredExisting, ...filesWithSession],
-          lastUpdated: Date.now(),
-        });
-      } else {
-        this.sessions.set(Constants.EXECUTE_CODE, {
-          session_id: artifact.session_id,
-          files: existingFiles,
-          lastUpdated: Date.now(),
-        });
-      }
+      updateCodeSession(this.sessions, artifact.session_id!, artifact.files);
     }
   }
 
@@ -406,39 +417,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      // Store code session context from tool results
       if (this.sessions && CODE_EXECUTION_TOOLS.has(call.name)) {
         const artifact = toolMessage.artifact as
           | t.CodeExecutionArtifact
           | undefined;
         if (artifact?.session_id != null && artifact.session_id !== '') {
-          const newFiles = artifact.files ?? [];
-          const existingSession = this.sessions.get(Constants.EXECUTE_CODE) as
-            | t.CodeSessionContext
-            | undefined;
-          const existingFiles = existingSession?.files ?? [];
-
-          if (newFiles.length > 0) {
-            const filesWithSession: t.FileRefs = newFiles.map((file) => ({
-              ...file,
-              session_id: artifact.session_id,
-            }));
-            const newFileNames = new Set(filesWithSession.map((f) => f.name));
-            const filteredExisting = existingFiles.filter(
-              (f) => !newFileNames.has(f.name)
-            );
-            this.sessions.set(Constants.EXECUTE_CODE, {
-              session_id: artifact.session_id,
-              files: [...filteredExisting, ...filesWithSession],
-              lastUpdated: Date.now(),
-            });
-          } else {
-            this.sessions.set(Constants.EXECUTE_CODE, {
-              session_id: artifact.session_id,
-              files: existingFiles,
-              lastUpdated: Date.now(),
-            });
-          }
+          updateCodeSession(this.sessions, artifact.session_id, artifact.files);
         }
       }
 
@@ -604,7 +588,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           turn,
         };
 
-        if (CODE_EXECUTION_TOOLS.has(entry.call.name) || entry.call.name === Constants.SKILL_TOOL) {
+        if (
+          CODE_EXECUTION_TOOLS.has(entry.call.name) ||
+          entry.call.name === Constants.SKILL_TOOL
+        ) {
           request.codeSessionContext = this.getCodeSessionContext();
         }
 
@@ -635,7 +622,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
       );
 
-      this.storeCodeSessionFromResults(results, requests);
+      this.storeCodeSessionFromResults(results, requestMap);
 
       const hasPostHook =
         this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -19,12 +19,14 @@ import type {
 import type { BaseMessage, AIMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
+import type { HookRegistry, AggregatedHookResult } from '@/hooks';
 import { RunnableCallable } from '@/utils';
 import {
   calculateMaxToolResultChars,
   truncateToolResultContent,
 } from '@/utils/truncation';
 import { safeDispatchCustomEvent } from '@/utils/events';
+import { executeHooks } from '@/hooks';
 import { Constants, GraphEvents } from '@/common';
 
 /**
@@ -59,6 +61,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private directToolNames?: Set<string>;
   /** Maximum characters allowed in a single tool result before truncation. */
   private maxToolResultChars: number;
+  /** Hook registry for PreToolUse/PostToolUse lifecycle hooks */
+  private hookRegistry?: HookRegistry;
 
   constructor({
     tools,
@@ -76,6 +80,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     directToolNames,
     maxContextTokens,
     maxToolResultChars,
+    hookRegistry,
   }: t.ToolNodeConstructorParams) {
     super({ name, tags, func: (input, config) => this.run(input, config) });
     this.toolMap = toolMap ?? new Map(tools.map((tool) => [tool.name, tool]));
@@ -91,6 +96,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.directToolNames = directToolNames;
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
+    this.hookRegistry = hookRegistry;
   }
 
   /**
@@ -482,123 +488,305 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   /**
    * Dispatches tool calls to the host via ON_TOOL_EXECUTE event and returns raw ToolMessages.
    * Core logic for event-driven execution, separated from output shaping.
+   *
+   * Hook lifecycle (when `hookRegistry` is set):
+   * 1. **PreToolUse** fires per call in parallel before dispatch. Denied
+   *    calls produce error ToolMessages and fire **PermissionDenied**;
+   *    surviving calls proceed with optional `updatedInput`.
+   * 2. Surviving calls are dispatched to the host via `ON_TOOL_EXECUTE`.
+   * 3. **PostToolUse** / **PostToolUseFailure** fire per result. Post hooks
+   *    can replace tool output via `updatedOutput`.
    */
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig
   ): Promise<ToolMessage[]> {
-    const requests: t.ToolCallRequest[] = toolCalls.map((call) => {
-      const turn = this.toolUsageCount.get(call.name) ?? 0;
-      this.toolUsageCount.set(call.name, turn + 1);
+    const runId = (config.configurable?.run_id as string | undefined) ?? '';
+    const threadId = config.configurable?.thread_id as string | undefined;
 
-      const request: t.ToolCallRequest = {
-        id: call.id!,
-        name: call.name,
-        args: call.args as Record<string, unknown>,
-        stepId: this.toolCallStepIds?.get(call.id!),
-        turn,
-      };
+    const preToolCalls = toolCalls.map((call) => ({
+      call,
+      stepId: this.toolCallStepIds?.get(call.id!) ?? '',
+      args: call.args as Record<string, unknown>,
+    }));
 
-      if (
-        call.name === Constants.EXECUTE_CODE ||
-        call.name === Constants.PROGRAMMATIC_TOOL_CALLING
-      ) {
-        request.codeSessionContext = this.getCodeSessionContext();
-      }
-
-      return request;
+    const messageByCallId = new Map<string, ToolMessage>();
+    const approvedEntries: typeof preToolCalls = [];
+    const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
+      additionalContexts: [] as string[],
+      errors: [] as string[],
     });
 
-    const results = await new Promise<t.ToolExecuteResult[]>(
-      (resolve, reject) => {
-        const request: t.ToolExecuteBatchRequest = {
-          toolCalls: requests,
-          userId: config.configurable?.user_id as string | undefined,
-          agentId: this.agentId,
-          configurable: config.configurable as
-            | Record<string, unknown>
-            | undefined,
-          metadata: config.metadata as Record<string, unknown> | undefined,
-          resolve,
-          reject,
-        };
-
-        safeDispatchCustomEvent(GraphEvents.ON_TOOL_EXECUTE, request, config);
-      }
-    );
-
-    this.storeCodeSessionFromResults(results, requests);
-
-    return results.map((result) => {
-      const request = requests.find((r) => r.id === result.toolCallId);
-      const toolName = request?.name ?? 'unknown';
-      const stepId = this.toolCallStepIds?.get(result.toolCallId) ?? '';
-      if (!stepId) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[ToolNode] toolCallStepIds missing entry for toolCallId=${result.toolCallId} (tool=${toolName}). ` +
-            'This indicates a race between the stream consumer and graph execution. ' +
-            `Map size: ${this.toolCallStepIds?.size ?? 0}`
-        );
-      }
-
-      let toolMessage: ToolMessage;
-      let contentString: string;
-
-      if (result.status === 'error') {
-        contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
-        toolMessage = new ToolMessage({
-          status: 'error',
-          content: contentString,
-          name: toolName,
-          tool_call_id: result.toolCallId,
-        });
-      } else {
-        const rawContent =
-          typeof result.content === 'string'
-            ? result.content
-            : JSON.stringify(result.content);
-        contentString = truncateToolResultContent(
-          rawContent,
-          this.maxToolResultChars
-        );
-        toolMessage = new ToolMessage({
-          status: 'success',
-          name: toolName,
-          content: contentString,
-          artifact: result.artifact,
-          tool_call_id: result.toolCallId,
-        });
-      }
-
-      const tool_call: t.ProcessedToolCall = {
-        args:
-          typeof request?.args === 'string'
-            ? request.args
-            : JSON.stringify(request?.args ?? {}),
-        name: toolName,
-        id: result.toolCallId,
-        output: contentString,
-        progress: 1,
-      };
-
-      const runStepCompletedData = {
-        result: {
-          id: stepId,
-          index: request?.turn ?? 0,
-          type: 'tool_call' as const,
-          tool_call,
-        },
-      };
-
-      safeDispatchCustomEvent(
-        GraphEvents.ON_RUN_STEP_COMPLETED,
-        runStepCompletedData,
-        config
+    if (this.hookRegistry?.hasHookFor('PreToolUse', runId) === true) {
+      const preResults = await Promise.all(
+        preToolCalls.map((entry) =>
+          executeHooks({
+            registry: this.hookRegistry!,
+            input: {
+              hook_event_name: 'PreToolUse',
+              runId,
+              threadId,
+              agentId: this.agentId,
+              toolName: entry.call.name,
+              toolInput: entry.args,
+              toolUseId: entry.call.id!,
+              stepId: entry.stepId,
+              turn: this.toolUsageCount.get(entry.call.name) ?? 0,
+            },
+            sessionId: runId,
+            matchQuery: entry.call.name,
+          }).catch((): AggregatedHookResult => HOOK_FALLBACK)
+        )
       );
 
-      return toolMessage;
-    });
+      for (let i = 0; i < preToolCalls.length; i++) {
+        const hookResult = preResults[i];
+        const entry = preToolCalls[i];
+        const isDenied =
+          hookResult.decision === 'deny' || hookResult.decision === 'ask';
+        if (isDenied) {
+          const reason = hookResult.reason ?? 'Blocked by hook';
+          const contentString = `Blocked: ${reason}`;
+          messageByCallId.set(
+            entry.call.id!,
+            new ToolMessage({
+              status: 'error',
+              content: contentString,
+              name: entry.call.name,
+              tool_call_id: entry.call.id!,
+            })
+          );
+          this.dispatchStepCompleted(
+            entry.call.id!,
+            entry.call.name,
+            entry.args,
+            contentString,
+            config
+          );
+          if (this.hookRegistry.hasHookFor('PermissionDenied', runId)) {
+            executeHooks({
+              registry: this.hookRegistry,
+              input: {
+                hook_event_name: 'PermissionDenied',
+                runId,
+                threadId,
+                agentId: this.agentId,
+                toolName: entry.call.name,
+                toolInput: entry.args,
+                toolUseId: entry.call.id!,
+                reason,
+              },
+              sessionId: runId,
+              matchQuery: entry.call.name,
+            }).catch(() => {
+              /* PermissionDenied is observational — swallow errors */
+            });
+          }
+          continue;
+        }
+        if (hookResult.updatedInput != null) {
+          entry.args = hookResult.updatedInput;
+        }
+        approvedEntries.push(entry);
+      }
+    } else {
+      approvedEntries.push(...preToolCalls);
+    }
+
+    if (approvedEntries.length > 0) {
+      const requests: t.ToolCallRequest[] = approvedEntries.map((entry) => {
+        const turn = this.toolUsageCount.get(entry.call.name) ?? 0;
+        this.toolUsageCount.set(entry.call.name, turn + 1);
+
+        const request: t.ToolCallRequest = {
+          id: entry.call.id!,
+          name: entry.call.name,
+          args: entry.args,
+          stepId: entry.stepId,
+          turn,
+        };
+
+        if (
+          entry.call.name === Constants.EXECUTE_CODE ||
+          entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING
+        ) {
+          request.codeSessionContext = this.getCodeSessionContext();
+        }
+
+        return request;
+      });
+
+      const requestMap = new Map(requests.map((r) => [r.id, r]));
+
+      const results = await new Promise<t.ToolExecuteResult[]>(
+        (resolve, reject) => {
+          const batchRequest: t.ToolExecuteBatchRequest = {
+            toolCalls: requests,
+            userId: config.configurable?.user_id as string | undefined,
+            agentId: this.agentId,
+            configurable: config.configurable as
+              | Record<string, unknown>
+              | undefined,
+            metadata: config.metadata as Record<string, unknown> | undefined,
+            resolve,
+            reject,
+          };
+
+          safeDispatchCustomEvent(
+            GraphEvents.ON_TOOL_EXECUTE,
+            batchRequest,
+            config
+          );
+        }
+      );
+
+      this.storeCodeSessionFromResults(results, requests);
+
+      const hasPostHook =
+        this.hookRegistry?.hasHookFor('PostToolUse', runId) === true;
+      const hasFailureHook =
+        this.hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
+
+      for (const result of results) {
+        const request = requestMap.get(result.toolCallId);
+        const toolName = request?.name ?? 'unknown';
+
+        let contentString: string;
+        let toolMessage: ToolMessage;
+
+        if (result.status === 'error') {
+          contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
+          toolMessage = new ToolMessage({
+            status: 'error',
+            content: contentString,
+            name: toolName,
+            tool_call_id: result.toolCallId,
+          });
+
+          if (hasFailureHook) {
+            await executeHooks({
+              registry: this.hookRegistry!,
+              input: {
+                hook_event_name: 'PostToolUseFailure',
+                runId,
+                threadId,
+                agentId: this.agentId,
+                toolName,
+                toolInput: request?.args ?? {},
+                toolUseId: result.toolCallId,
+                error: result.errorMessage ?? 'Unknown error',
+                stepId: request?.stepId,
+                turn: request?.turn,
+              },
+              sessionId: runId,
+              matchQuery: toolName,
+            }).catch(() => {
+              /* PostToolUseFailure is observational — swallow errors */
+            });
+          }
+        } else {
+          const rawContent =
+            typeof result.content === 'string'
+              ? result.content
+              : JSON.stringify(result.content);
+          contentString = truncateToolResultContent(
+            rawContent,
+            this.maxToolResultChars
+          );
+
+          if (hasPostHook) {
+            const hookResult = await executeHooks({
+              registry: this.hookRegistry!,
+              input: {
+                hook_event_name: 'PostToolUse',
+                runId,
+                threadId,
+                agentId: this.agentId,
+                toolName,
+                toolInput: request?.args ?? {},
+                toolOutput: result.content,
+                toolUseId: result.toolCallId,
+                stepId: request?.stepId,
+                turn: request?.turn,
+              },
+              sessionId: runId,
+              matchQuery: toolName,
+            }).catch((): undefined => undefined);
+            if (hookResult?.updatedOutput != null) {
+              const replaced =
+                typeof hookResult.updatedOutput === 'string'
+                  ? hookResult.updatedOutput
+                  : JSON.stringify(hookResult.updatedOutput);
+              contentString = truncateToolResultContent(
+                replaced,
+                this.maxToolResultChars
+              );
+            }
+          }
+
+          toolMessage = new ToolMessage({
+            status: 'success',
+            name: toolName,
+            content: contentString,
+            artifact: result.artifact,
+            tool_call_id: result.toolCallId,
+          });
+        }
+
+        this.dispatchStepCompleted(
+          result.toolCallId,
+          toolName,
+          request?.args ?? {},
+          contentString,
+          config,
+          request?.turn
+        );
+
+        messageByCallId.set(result.toolCallId, toolMessage);
+      }
+    }
+
+    return toolCalls
+      .map((call) => messageByCallId.get(call.id!))
+      .filter((m): m is ToolMessage => m != null);
+  }
+
+  private dispatchStepCompleted(
+    toolCallId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    output: string,
+    config: RunnableConfig,
+    turn?: number
+  ): void {
+    const stepId = this.toolCallStepIds?.get(toolCallId) ?? '';
+    if (!stepId) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[ToolNode] toolCallStepIds missing entry for toolCallId=${toolCallId} (tool=${toolName}). ` +
+          'This indicates a race between the stream consumer and graph execution. ' +
+          `Map size: ${this.toolCallStepIds?.size ?? 0}`
+      );
+    }
+
+    safeDispatchCustomEvent(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: stepId,
+          index: turn ?? this.toolUsageCount.get(toolName) ?? 0,
+          type: 'tool_call' as const,
+          tool_call: {
+            args: JSON.stringify(args),
+            name: toolName,
+            id: toolCallId,
+            output,
+            progress: 1,
+          } as t.ProcessedToolCall,
+        },
+      },
+      config
+    );
   }
 
   /**

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -342,7 +342,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         request?.name !== Constants.EXECUTE_CODE &&
         request?.name !== Constants.BASH_TOOL &&
         request?.name !== Constants.PROGRAMMATIC_TOOL_CALLING &&
-        request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+        request?.name !== Constants.BASH_PROGRAMMATIC_TOOL_CALLING &&
+        request?.name !== Constants.SKILL_TOOL
       ) {
         continue;
       }
@@ -624,7 +625,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           entry.call.name === Constants.EXECUTE_CODE ||
           entry.call.name === Constants.BASH_TOOL ||
           entry.call.name === Constants.PROGRAMMATIC_TOOL_CALLING ||
-          entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+          entry.call.name === Constants.BASH_PROGRAMMATIC_TOOL_CALLING ||
+          entry.call.name === Constants.SKILL_TOOL
         ) {
           request.codeSessionContext = this.getCodeSessionContext();
         }

--- a/src/tools/__tests__/ReadFile.test.ts
+++ b/src/tools/__tests__/ReadFile.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from '@jest/globals';
+import { Constants } from '@/common';
+import {
+  ReadFileToolName,
+  ReadFileToolSchema,
+  ReadFileToolDescription,
+  ReadFileToolDefinition,
+} from '../ReadFile';
+
+describe('ReadFile', () => {
+  describe('schema structure', () => {
+    it('has file_path as required string property', () => {
+      expect(ReadFileToolSchema.properties.file_path.type).toBe('string');
+      expect(ReadFileToolSchema.required).toContain('file_path');
+    });
+
+    it('is an object type schema', () => {
+      expect(ReadFileToolSchema.type).toBe('object');
+    });
+  });
+
+  describe('ReadFileToolDefinition', () => {
+    it('has correct name', () => {
+      expect(ReadFileToolDefinition.name).toBe(Constants.READ_FILE);
+      expect(ReadFileToolDefinition.name).toBe('read_file');
+    });
+
+    it('references the same ReadFileToolSchema object', () => {
+      expect(ReadFileToolDefinition.parameters).toBe(ReadFileToolSchema);
+    });
+
+    it('has a non-empty description', () => {
+      expect(ReadFileToolDefinition.description).toBe(ReadFileToolDescription);
+      expect(ReadFileToolDefinition.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ReadFileToolName', () => {
+    it('equals Constants.READ_FILE', () => {
+      expect(ReadFileToolName).toBe('read_file');
+      expect(ReadFileToolName).toBe(Constants.READ_FILE);
+    });
+  });
+});

--- a/src/tools/__tests__/SkillTool.test.ts
+++ b/src/tools/__tests__/SkillTool.test.ts
@@ -9,11 +9,10 @@ import * as events from '@/utils/events';
 import { ToolNode } from '../ToolNode';
 import { Constants } from '@/common';
 import {
-  SkillToolName,
-  SkillToolSchema,
   SkillToolDescription,
   SkillToolDefinition,
-  createSkillTool,
+  SkillToolSchema,
+  SkillToolName,
 } from '../SkillTool';
 
 describe('SkillTool', () => {
@@ -30,25 +29,6 @@ describe('SkillTool', () => {
 
     it('is an object type schema', () => {
       expect(SkillToolSchema.type).toBe('object');
-    });
-  });
-
-  describe('createSkillTool', () => {
-    it('throws on direct invocation', async () => {
-      const skillTool = createSkillTool();
-      await expect(skillTool.invoke({ skillName: 'test' })).rejects.toThrow(
-        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
-      );
-    });
-
-    it('has correct name', () => {
-      const skillTool = createSkillTool();
-      expect(skillTool.name).toBe('skill');
-    });
-
-    it('validates skillName is required', async () => {
-      const skillTool = createSkillTool();
-      await expect(skillTool.invoke({})).rejects.toThrow();
     });
   });
 

--- a/src/tools/__tests__/SkillTool.test.ts
+++ b/src/tools/__tests__/SkillTool.test.ts
@@ -1,0 +1,462 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { describe, it, expect } from '@jest/globals';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import * as events from '@/utils/events';
+import { ToolNode } from '../ToolNode';
+import { Constants } from '@/common';
+import {
+  SkillToolName,
+  SkillToolSchema,
+  SkillToolDescription,
+  SkillToolDefinition,
+  createSkillTool,
+} from '../SkillTool';
+
+describe('SkillTool', () => {
+  describe('schema structure', () => {
+    it('has skillName as required string property', () => {
+      expect(SkillToolSchema.properties.skillName.type).toBe('string');
+      expect(SkillToolSchema.required).toContain('skillName');
+    });
+
+    it('has args as optional string property', () => {
+      expect(SkillToolSchema.properties.args.type).toBe('string');
+      expect(SkillToolSchema.required).not.toContain('args');
+    });
+
+    it('is an object type schema', () => {
+      expect(SkillToolSchema.type).toBe('object');
+    });
+  });
+
+  describe('createSkillTool', () => {
+    it('throws on direct invocation', async () => {
+      const skillTool = createSkillTool();
+      await expect(skillTool.invoke({ skillName: 'test' })).rejects.toThrow(
+        'SkillTool requires event-driven execution mode (ON_TOOL_EXECUTE). Direct invocation is not supported.'
+      );
+    });
+
+    it('has correct name', () => {
+      const skillTool = createSkillTool();
+      expect(skillTool.name).toBe('skill');
+    });
+
+    it('validates skillName is required', async () => {
+      const skillTool = createSkillTool();
+      await expect(skillTool.invoke({})).rejects.toThrow();
+    });
+  });
+
+  describe('SkillToolDefinition', () => {
+    it('has correct name', () => {
+      expect(SkillToolDefinition.name).toBe(Constants.SKILL_TOOL);
+    });
+
+    it('references the same SkillToolSchema object (no duplication)', () => {
+      expect(SkillToolDefinition.parameters).toBe(SkillToolSchema);
+    });
+
+    it('has a non-empty description', () => {
+      expect(SkillToolDefinition.description).toBe(SkillToolDescription);
+      expect(SkillToolDefinition.description.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SkillToolName', () => {
+    it('equals Constants.SKILL_TOOL', () => {
+      expect(SkillToolName).toBe('skill');
+      expect(SkillToolName).toBe(Constants.SKILL_TOOL);
+    });
+  });
+
+  describe('InjectedMessage type-check', () => {
+    it('constructs a valid ToolExecuteResult with injectedMessages', () => {
+      const result: t.ToolExecuteResult = {
+        toolCallId: 'call_1',
+        content: 'Skill loaded successfully.',
+        status: 'success',
+        injectedMessages: [
+          {
+            role: 'user',
+            content: '# PDF Processor Instructions\n\nFollow these steps...',
+            isMeta: true,
+            source: 'skill',
+            skillName: 'pdf-processor',
+          },
+          {
+            role: 'system',
+            content: 'Skill files are available at /skills/pdf-processor/',
+            source: 'skill',
+            skillName: 'pdf-processor',
+          },
+        ],
+      };
+
+      expect(result.injectedMessages).toHaveLength(2);
+      expect(result.injectedMessages![0].role).toBe('user');
+      expect(result.injectedMessages![1].role).toBe('system');
+    });
+
+    it('accepts MessageContentComplex[] content', () => {
+      const result: t.ToolExecuteResult = {
+        toolCallId: 'call_1',
+        content: '',
+        status: 'success',
+        injectedMessages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Skill instructions here' },
+              { type: 'image_url', image_url: { url: 'data:image/png;...' } },
+            ],
+            isMeta: true,
+            source: 'skill',
+            skillName: 'visual-skill',
+          },
+        ],
+      };
+
+      expect(Array.isArray(result.injectedMessages![0].content)).toBe(true);
+    });
+  });
+
+  describe('ToolNode injectedMessages plumbing (event-driven)', () => {
+    const createDummyTool = (name = 'dummy'): StructuredToolInterface =>
+      tool(async () => 'dummy', {
+        name,
+        description: 'dummy',
+        schema: z.object({ x: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+    function mockEventDispatch(
+      mockResults: t.ToolExecuteResult[]
+    ): jest.SpyInstance {
+      return jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (_event, data) => {
+          const request = data as Record<string, unknown>;
+          if (typeof request.resolve === 'function') {
+            (request.resolve as (r: t.ToolExecuteResult[]) => void)(
+              mockResults
+            );
+          }
+        });
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('appends injected messages AFTER ToolMessages in output', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_1', 'step_1']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_1', name: 'dummy', args: { x: 'hello' } }],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_1',
+          content: 'Tool result text',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected skill body content',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'test-skill',
+            },
+            {
+              role: 'system',
+              content: 'System context hint',
+              source: 'system',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(3);
+
+      // ToolMessage comes FIRST (preserves AIMessage -> ToolMessage adjacency)
+      expect(messages[0]._getType()).toBe('tool');
+
+      // Injected messages come AFTER
+      const second = messages[1] as HumanMessage;
+      expect(second).toBeInstanceOf(HumanMessage);
+      expect(second.content).toBe('Injected skill body content');
+      expect(second.additional_kwargs.role).toBe('user');
+      expect(second.additional_kwargs.isMeta).toBe(true);
+      expect(second.additional_kwargs.source).toBe('skill');
+      expect(second.additional_kwargs.skillName).toBe('test-skill');
+
+      // role: 'system' also becomes HumanMessage (avoids provider rejections)
+      const third = messages[2] as HumanMessage;
+      expect(third).toBeInstanceOf(HumanMessage);
+      expect(third.content).toBe('System context hint');
+      expect(third.additional_kwargs.role).toBe('system');
+      expect(third.additional_kwargs.source).toBe('system');
+    });
+
+    it('returns only ToolMessages when no injectedMessages present', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_2', 'step_2']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_2', name: 'dummy', args: { x: 'test' } }],
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'call_2', content: 'Normal result', status: 'success' },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0]._getType()).toBe('tool');
+    });
+
+    it('passes MessageContentComplex[] content through without stringifying', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_3', 'step_3']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_3', name: 'dummy', args: { x: 'test' } }],
+      });
+
+      const complexContent = [
+        { type: 'text', text: 'Multi-part skill instructions' },
+        { type: 'text', text: 'Second part of instructions' },
+      ];
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_3',
+          content: '',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user' as const,
+              content: complexContent,
+              isMeta: true,
+              source: 'skill' as const,
+              skillName: 'complex-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(2);
+      // ToolMessage first
+      expect(messages[0]._getType()).toBe('tool');
+      // Injected message second with array content preserved (not stringified)
+      const injected = messages[1] as HumanMessage;
+      expect(injected).toBeInstanceOf(HumanMessage);
+      expect(Array.isArray(injected.content)).toBe(true);
+      expect(injected.content).toEqual(complexContent);
+    });
+
+    it('aggregates injected messages from multiple tool calls', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool('tool_a'), createDummyTool('tool_b')],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([
+          ['call_a', 'step_a'],
+          ['call_b', 'step_b'],
+        ]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'call_a', name: 'tool_a', args: { x: 'a' } },
+          { id: 'call_b', name: 'tool_b', args: { x: 'b' } },
+        ],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_a',
+          content: 'Result A',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected from A',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'skill-a',
+            },
+          ],
+        },
+        {
+          toolCallId: 'call_b',
+          content: 'Result B',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Injected from B',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'skill-b',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      // 2 ToolMessages + 2 injected messages
+      expect(messages).toHaveLength(4);
+      // ToolMessages come first
+      expect(messages[0]._getType()).toBe('tool');
+      expect(messages[1]._getType()).toBe('tool');
+      // Injected messages come after all ToolMessages
+      expect(messages[2]).toBeInstanceOf(HumanMessage);
+      expect((messages[2] as HumanMessage).content).toBe('Injected from A');
+      expect(messages[3]).toBeInstanceOf(HumanMessage);
+      expect((messages[3] as HumanMessage).content).toBe('Injected from B');
+    });
+
+    it('handles mixed mode: direct tools + event-driven with injected messages', async () => {
+      const directTool = tool(async () => 'direct result', {
+        name: 'handoff_tool',
+        description: 'A direct tool',
+        schema: z.object({ target: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      const eventTool = createDummyTool('event_tool');
+
+      const toolNode = new ToolNode({
+        tools: [directTool, eventTool],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        directToolNames: new Set(['handoff_tool']),
+        toolCallStepIds: new Map([
+          ['call_direct', 'step_direct'],
+          ['call_event', 'step_event'],
+        ]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_direct',
+            name: 'handoff_tool',
+            args: { target: 'agent-2' },
+          },
+          { id: 'call_event', name: 'event_tool', args: { x: 'hello' } },
+        ],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_event',
+          content: 'Event result',
+          status: 'success',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Skill body from event tool',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'my-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      // directOutputs first, then eventResult.toolMessages, then eventResult.injected
+      expect(messages.length).toBeGreaterThanOrEqual(3);
+      // Direct tool result (ToolMessage from runTool)
+      expect(messages[0]._getType()).toBe('tool');
+      // Event tool result (ToolMessage from dispatchToolEvents)
+      expect(messages[1]._getType()).toBe('tool');
+      // Injected message last
+      const last = messages[messages.length - 1] as HumanMessage;
+      expect(last).toBeInstanceOf(HumanMessage);
+      expect(last.content).toBe('Skill body from event tool');
+      expect(last.additional_kwargs.skillName).toBe('my-skill');
+    });
+
+    it('includes injected messages even when tool result has error status', async () => {
+      const toolNode = new ToolNode({
+        tools: [createDummyTool()],
+        eventDrivenMode: true,
+        agentId: 'test-agent',
+        toolCallStepIds: new Map([['call_err', 'step_err']]),
+      });
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call_err', name: 'dummy', args: { x: 'fail' } }],
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'call_err',
+          content: '',
+          status: 'error',
+          errorMessage: 'Skill not found',
+          injectedMessages: [
+            {
+              role: 'user',
+              content: 'Partial context before failure',
+              isMeta: true,
+              source: 'skill',
+              skillName: 'broken-skill',
+            },
+          ],
+        },
+      ]);
+
+      const result = await toolNode.invoke({ messages: [aiMsg] });
+      const messages = (result as { messages: BaseMessage[] }).messages;
+
+      expect(messages).toHaveLength(2);
+      // Error ToolMessage first
+      expect(messages[0]._getType()).toBe('tool');
+      expect(String(messages[0].content)).toContain('Skill not found');
+      // Injected message still included
+      const injected = messages[1] as HumanMessage;
+      expect(injected).toBeInstanceOf(HumanMessage);
+      expect(injected.content).toBe('Partial context before failure');
+      expect(injected.additional_kwargs.skillName).toBe('broken-skill');
+    });
+  });
+});

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach } from '@jest/globals';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import { HookRegistry } from '@/hooks/HookRegistry';
-import { Providers } from '@/common';
+import { Providers, GraphEvents } from '@/common';
+import { HandlerRegistry } from '@/events';
 import { AgentContext } from '@/agents/AgentContext';
 import type { AgentInputs, ResolvedSubagentConfig } from '@/types';
 import {
@@ -10,6 +11,7 @@ import {
   filterSubagentResult,
   resolveSubagentConfigs,
   buildChildInputs,
+  summarizeEvent,
 } from '../subagent';
 import type { StandardGraph } from '@/graphs/Graph';
 
@@ -279,6 +281,29 @@ describe('buildChildInputs', () => {
     };
     const result = buildChildInputs(config, 'child', 3);
     expect(result.toolDefinitions).toBeUndefined();
+  });
+
+  it('strips parent-run-scoped initialSummary and discoveredTools from child inputs', () => {
+    /**
+     * Codex P1: a child inheriting `initialSummary` or `discoveredTools` from
+     * the parent's shallow-spread AgentInputs leaks unrelated conversation
+     * context / prior tool-search state into an isolated subagent run,
+     * defeating the context-isolation contract. Both fields must be cleared.
+     */
+    const inputsWithRunContext: AgentInputs = {
+      ...parentAgentInputs,
+      initialSummary: { text: 'prior conversation summary', tokenCount: 42 },
+      discoveredTools: ['prior_tool_a', 'prior_tool_b'],
+    };
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: inputsWithRunContext,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    expect(result.initialSummary).toBeUndefined();
+    expect(result.discoveredTools).toBeUndefined();
   });
 
   it('overrides agentId with the passed childAgentId', () => {
@@ -611,5 +636,513 @@ describe('SubagentExecutor', () => {
       expect(result.content).toBe('Blocked: Not authorized');
       expect(result.messages).toEqual([]);
     });
+  });
+
+  describe('event forwarding', () => {
+    it('emits start/stop ON_SUBAGENT_UPDATE envelopes when parentHandlerRegistry is provided', async () => {
+      const events: unknown[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, data): void => {
+          events.push(data);
+        },
+      });
+
+      const { factory } = makeStubGraphFactory({
+        messages: [new AIMessage('done')],
+      });
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Test task',
+        subagentType: 'researcher',
+      });
+
+      const phases = events.map((e) => (e as { phase: string }).phase);
+      expect(phases[0]).toBe('start');
+      expect(phases[phases.length - 1]).toBe('stop');
+    });
+
+    it('keeps toolDefinitions on child when registry has ON_TOOL_EXECUTE handler', async () => {
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_TOOL_EXECUTE, {
+        handle: (): void => {},
+      });
+      let observedChildInputs: AgentInputs | undefined;
+      const configWithDefs: ResolvedSubagentConfig = {
+        type: 'researcher',
+        name: 'Research Specialist',
+        description: 'Researches topics',
+        agentInputs: {
+          agentId: 'researcher',
+          provider: Providers.OPENAI,
+          toolDefinitions: [
+            { name: 'web', description: 'search', parameters: {} },
+          ],
+        } as AgentInputs,
+      };
+
+      const executor = new SubagentExecutor({
+        configs: new Map([[configWithDefs.type, configWithDefs]]),
+        parentRunId: 'run',
+        parentAgentId: 'parent',
+        parentHandlerRegistry: registry,
+        createChildGraph: (input): StandardGraph => {
+          observedChildInputs = input.agents[0];
+          return {
+            createWorkflow: (): { invoke: jest.Mock } => ({
+              invoke: jest.fn().mockResolvedValue({
+                messages: [new AIMessage('ok')],
+              }),
+            }),
+            clearHeavyState: jest.fn(),
+          } as unknown as StandardGraph;
+        },
+      });
+
+      await executor.execute({
+        description: 'find weather',
+        subagentType: 'researcher',
+      });
+
+      expect(observedChildInputs?.toolDefinitions).toHaveLength(1);
+      expect(observedChildInputs?.toolDefinitions?.[0]?.name).toBe('web');
+    });
+
+    it('strips toolDefinitions when registry is present but ON_TOOL_EXECUTE handler is absent', async () => {
+      const registry = new HandlerRegistry();
+      let observedChildInputs: AgentInputs | undefined;
+      const configWithDefs: ResolvedSubagentConfig = {
+        type: 'researcher',
+        name: 'Research Specialist',
+        description: 'Researches topics',
+        agentInputs: {
+          agentId: 'researcher',
+          provider: Providers.OPENAI,
+          toolDefinitions: [
+            { name: 'web', description: 'search', parameters: {} },
+          ],
+        } as AgentInputs,
+      };
+
+      const executor = new SubagentExecutor({
+        configs: new Map([[configWithDefs.type, configWithDefs]]),
+        parentRunId: 'run',
+        parentAgentId: 'parent',
+        parentHandlerRegistry: registry,
+        createChildGraph: (input): StandardGraph => {
+          observedChildInputs = input.agents[0];
+          return {
+            createWorkflow: (): { invoke: jest.Mock } => ({
+              invoke: jest.fn().mockResolvedValue({
+                messages: [new AIMessage('ok')],
+              }),
+            }),
+            clearHeavyState: jest.fn(),
+          } as unknown as StandardGraph;
+        },
+      });
+
+      await executor.execute({
+        description: 'find weather',
+        subagentType: 'researcher',
+      });
+
+      expect(observedChildInputs?.toolDefinitions).toBeUndefined();
+    });
+
+    it('forwards parentToolCallId from execute params to SubagentUpdateEvent envelopes', async () => {
+      const events: unknown[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, data): void => {
+          events.push(data);
+        },
+      });
+
+      const { factory } = makeStubGraphFactory({
+        messages: [new AIMessage('done')],
+      });
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_abc123',
+      });
+
+      expect(events.length).toBeGreaterThan(0);
+      for (const e of events) {
+        expect((e as { parentToolCallId?: string }).parentToolCallId).toBe(
+          'call_abc123'
+        );
+      }
+    });
+
+    it('still strips toolDefinitions when no parentHandlerRegistry is provided (legacy isolation)', async () => {
+      let observedChildInputs: AgentInputs | undefined;
+      const configWithDefs: ResolvedSubagentConfig = {
+        type: 'researcher',
+        name: 'Research Specialist',
+        description: 'Researches topics',
+        agentInputs: {
+          agentId: 'researcher',
+          provider: Providers.OPENAI,
+          toolDefinitions: [
+            { name: 'web', description: 'search', parameters: {} },
+          ],
+        } as AgentInputs,
+      };
+
+      const executor = new SubagentExecutor({
+        configs: new Map([[configWithDefs.type, configWithDefs]]),
+        parentRunId: 'run',
+        parentAgentId: 'parent',
+        createChildGraph: (input): StandardGraph => {
+          observedChildInputs = input.agents[0];
+          return {
+            createWorkflow: (): { invoke: jest.Mock } => ({
+              invoke: jest.fn().mockResolvedValue({
+                messages: [new AIMessage('ok')],
+              }),
+            }),
+            clearHeavyState: jest.fn(),
+          } as unknown as StandardGraph;
+        },
+      });
+
+      await executor.execute({
+        description: 'find weather',
+        subagentType: 'researcher',
+      });
+
+      expect(observedChildInputs?.toolDefinitions).toBeUndefined();
+    });
+
+    it('accepts parentHandlerRegistry as a lazy getter', async () => {
+      const lazyHolder: { registry?: InstanceType<typeof HandlerRegistry> } =
+        {};
+      const events: unknown[] = [];
+      const { factory } = makeStubGraphFactory({
+        messages: [new AIMessage('done')],
+      });
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: () => lazyHolder.registry,
+      });
+
+      lazyHolder.registry = new HandlerRegistry();
+      lazyHolder.registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, data): void => {
+          events.push(data);
+        },
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+      });
+
+      expect(events.length).toBeGreaterThan(0);
+      expect((events[0] as { phase: string }).phase).toBe('start');
+    });
+
+    it('routes child ON_TOOL_EXECUTE dispatches through the parent registry', async () => {
+      /**
+       * Drives the forwarder callback the executor installs on the child's
+       * `workflow.invoke({ callbacks: [forwarder] })`. We capture that
+       * callback when the child workflow runs, then synthesize the same
+       * `handleCustomEvent` call that a real `ToolNode` would make when
+       * the child LLM emits a tool_call. If the forwarder routes correctly,
+       * the parent's `ON_TOOL_EXECUTE` handler receives the batch and
+       * resolves the promise with our canned results.
+       */
+
+      const parentToolHandler = jest.fn(
+        async (_event: string, rawData: unknown): Promise<void> => {
+          const req = rawData as {
+            toolCalls: Array<{ id: string; name: string }>;
+            resolve: (results: unknown[]) => void;
+          };
+          req.resolve(
+            req.toolCalls.map((tc) => ({
+              toolCallId: tc.id,
+              status: 'success',
+              content: `ran ${tc.name}`,
+            }))
+          );
+        }
+      );
+
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_TOOL_EXECUTE, {
+        handle: parentToolHandler,
+      });
+
+      let capturedInvokeOptions: unknown;
+      const factory: () => StandardGraph = (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(async (_state, options) => {
+              capturedInvokeOptions = options;
+              return { messages: [new AIMessage('ok')] };
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_parent_123',
+      });
+
+      const opts = capturedInvokeOptions as
+        | { callbacks?: unknown[] }
+        | undefined;
+      expect(opts?.callbacks).toBeDefined();
+      const forwarder = (opts?.callbacks ?? [])[0] as {
+        handleCustomEvent?: (
+          eventName: string,
+          data: unknown,
+          runId: string,
+          tags?: string[],
+          metadata?: Record<string, unknown>
+        ) => Promise<void> | void;
+      };
+      expect(typeof forwarder.handleCustomEvent).toBe('function');
+
+      /** Simulate the child's ToolNode emitting a real batch request. */
+      const resolvePromise = new Promise<
+        Array<{ toolCallId: string; status: string; content: string }>
+      >((resolve, reject) => {
+        const batchRequest = {
+          toolCalls: [{ id: 'call_child_xyz', name: 'calculator', args: {} }],
+          agentId: 'researcher',
+          resolve,
+          reject,
+        };
+        forwarder.handleCustomEvent?.(
+          GraphEvents.ON_TOOL_EXECUTE,
+          batchRequest,
+          'child-run-id'
+        );
+      });
+
+      const results = await resolvePromise;
+      expect(parentToolHandler).toHaveBeenCalledTimes(1);
+      expect(results).toEqual([
+        {
+          toolCallId: 'call_child_xyz',
+          status: 'success',
+          content: 'ran calculator',
+        },
+      ]);
+    });
+
+    it('does NOT forward ON_TOOL_EXECUTE when the parent registry has no handler (safe fallback)', async () => {
+      /**
+       * The executor strips `toolDefinitions` when the parent registry has
+       * no `ON_TOOL_EXECUTE` handler (see the companion strip-on-no-handler
+       * test). Defence-in-depth: if the LLM somehow still dispatches a tool
+       * call, the forwarder must not silently consume it without resolving;
+       * reject would be better than hang. This test confirms no handler
+       * is invoked on the parent side so it's clear a forwarded request
+       * would need separate treatment.
+       */
+
+      const registry = new HandlerRegistry();
+      /** Only ON_SUBAGENT_UPDATE registered — no ON_TOOL_EXECUTE. */
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, { handle: jest.fn() });
+
+      let capturedInvokeOptions: unknown;
+      const factory: () => StandardGraph = (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(async (_state, options) => {
+              capturedInvokeOptions = options;
+              return { messages: [new AIMessage('ok')] };
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+      });
+
+      const opts = capturedInvokeOptions as { callbacks?: unknown[] };
+      const forwarder = (opts.callbacks ?? [])[0] as {
+        handleCustomEvent?: (
+          eventName: string,
+          data: unknown
+        ) => Promise<void> | void;
+      };
+
+      let resolved = false;
+      const batchRequest = {
+        toolCalls: [{ id: 'call_x', name: 'calculator', args: {} }],
+        agentId: 'researcher',
+        resolve: (): void => {
+          resolved = true;
+        },
+        reject: (): void => {},
+      };
+      await forwarder.handleCustomEvent?.(
+        GraphEvents.ON_TOOL_EXECUTE,
+        batchRequest
+      );
+
+      /** No handler exists → nothing resolves the promise. This is the
+       *  state that justifies the `keepToolDefinitions` gate: without the
+       *  gate we'd deadlock here. The gate ensures the LLM never sees
+       *  tools in the first place, making this scenario unreachable in
+       *  practice — the test just documents the fallback. */
+      expect(resolved).toBe(false);
+    });
+
+    it('emits an `error` phase envelope when the child graph throws', async () => {
+      const events: unknown[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, data): void => {
+          events.push(data);
+        },
+      });
+
+      const executor = createExecutor({
+        createChildGraph: makeThrowingGraphFactory(
+          new Error('recursion limit')
+        ),
+        parentHandlerRegistry: registry,
+      });
+
+      const result = await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_err',
+      });
+
+      expect(result.content).toContain('Subagent error: recursion limit');
+      const phases = events.map((e) => (e as { phase: string }).phase);
+      expect(phases).toContain('start');
+      expect(phases).toContain('error');
+      const errEvent = events.find(
+        (e) => (e as { phase: string }).phase === 'error'
+      ) as { data?: { message?: string }; parentToolCallId?: string };
+      expect(errEvent.data?.message).toContain('recursion limit');
+      expect(errEvent.parentToolCallId).toBe('call_err');
+    });
+  });
+});
+
+describe('summarizeEvent', () => {
+  it('labels a run step tool_calls stepDetails by tool name', () => {
+    const label = summarizeEvent(GraphEvents.ON_RUN_STEP, {
+      stepDetails: {
+        type: 'tool_calls',
+        tool_calls: [{ name: 'calculator', id: 'c1' }],
+      },
+    });
+    expect(label).toBe('Using tool: calculator');
+  });
+
+  it('joins multiple tool names on a single run step', () => {
+    const label = summarizeEvent(GraphEvents.ON_RUN_STEP, {
+      stepDetails: {
+        type: 'tool_calls',
+        tool_calls: [{ name: 'web' }, { name: 'calculator' }],
+      },
+    });
+    expect(label).toBe('Using tool: web, calculator');
+  });
+
+  it('falls back to "Planning tool call" when tool_calls is empty', () => {
+    const label = summarizeEvent(GraphEvents.ON_RUN_STEP, {
+      stepDetails: { type: 'tool_calls', tool_calls: [] },
+    });
+    expect(label).toBe('Planning tool call');
+  });
+
+  it('labels message_creation steps as "Thinking…"', () => {
+    const label = summarizeEvent(GraphEvents.ON_RUN_STEP, {
+      stepDetails: { type: 'message_creation' },
+    });
+    expect(label).toBe('Thinking…');
+  });
+
+  it('labels ON_TOOL_EXECUTE with the batch of tool names', () => {
+    const label = summarizeEvent(GraphEvents.ON_TOOL_EXECUTE, {
+      toolCalls: [{ name: 'web' }, { name: 'calculator' }],
+    });
+    expect(label).toBe('Calling web, calculator');
+  });
+
+  it('falls back to a generic "Calling tool" when toolCalls is empty', () => {
+    const label = summarizeEvent(GraphEvents.ON_TOOL_EXECUTE, {
+      toolCalls: [],
+    });
+    expect(label).toBe('Calling tool');
+  });
+
+  it('labels completed run steps by completed tool name', () => {
+    const label = summarizeEvent(GraphEvents.ON_RUN_STEP_COMPLETED, {
+      result: { type: 'tool_call', tool_call: { name: 'calculator' } },
+    });
+    expect(label).toBe('Tool calculator complete');
+  });
+
+  it('labels completed steps without a tool name as "Step complete"', () => {
+    const label = summarizeEvent(GraphEvents.ON_RUN_STEP_COMPLETED, {
+      result: { type: 'message_creation' },
+    });
+    expect(label).toBe('Step complete');
+  });
+
+  it('labels ON_MESSAGE_DELTA as "Streaming…"', () => {
+    expect(summarizeEvent(GraphEvents.ON_MESSAGE_DELTA, {})).toBe('Streaming…');
+  });
+
+  it('falls back to top-level `step.type` when `stepDetails` is absent', () => {
+    /**
+     * Covers the `step.stepDetails?.type ?? step.type ?? 'step'` chain
+     * when the payload uses the top-level form (no `stepDetails` wrapper).
+     * Exercises the second clause of the fallback so future changes to
+     * the resolution order fail fast.
+     */
+    expect(
+      summarizeEvent(GraphEvents.ON_RUN_STEP, { type: 'tool_calls' })
+    ).toBe('Planning tool call');
+    expect(
+      summarizeEvent(GraphEvents.ON_RUN_STEP, { type: 'message_creation' })
+    ).toBe('Thinking…');
+  });
+
+  it('falls back to "Step: step" when neither `stepDetails.type` nor `step.type` is present', () => {
+    /** Exercises the final `?? 'step'` default plus the generic
+     *  `Step: <detailType>` branch when a run step arrives with an
+     *  unrecognized shape. */
+    expect(summarizeEvent(GraphEvents.ON_RUN_STEP, {})).toBe('Step: step');
+  });
+
+  it('returns the event name for unknown events', () => {
+    expect(summarizeEvent('on_unknown_event', {})).toBe('on_unknown_event');
   });
 });

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1,0 +1,615 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { HookRegistry } from '@/hooks/HookRegistry';
+import { Providers } from '@/common';
+import { AgentContext } from '@/agents/AgentContext';
+import type { AgentInputs, ResolvedSubagentConfig } from '@/types';
+import {
+  SubagentExecutor,
+  filterSubagentResult,
+  resolveSubagentConfigs,
+  buildChildInputs,
+} from '../subagent';
+import type { StandardGraph } from '@/graphs/Graph';
+
+jest.setTimeout(15000);
+
+const makeChildInputs = (agentId = 'child-agent'): AgentInputs => ({
+  agentId,
+  provider: Providers.OPENAI,
+  clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+  instructions: 'You are a helper agent.',
+  maxContextTokens: 8000,
+});
+
+const makeConfig = (
+  type = 'researcher',
+  overrides: Partial<ResolvedSubagentConfig> = {}
+): ResolvedSubagentConfig => ({
+  type,
+  name: 'Test Researcher',
+  description: 'Researches things',
+  agentInputs: makeChildInputs(),
+  ...overrides,
+});
+
+describe('filterSubagentResult', () => {
+  it('extracts text from last AIMessage string content', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('task'),
+      new AIMessage('Here is the result'),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Here is the result');
+  });
+
+  it('extracts text blocks from array content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'First part.' },
+          { type: 'text', text: 'Second part.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('First part.\nSecond part.');
+  });
+
+  it('strips tool_use blocks from array content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'search', input: {} },
+          { type: 'text', text: 'Final answer.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Final answer.');
+  });
+
+  it('strips thinking blocks from array content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'thinking', thinking: 'Let me think...' },
+          { type: 'text', text: 'The result.' },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('The result.');
+  });
+
+  it('returns "Task completed" when no text blocks remain', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage({
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'do_thing', input: {} },
+        ],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Task completed');
+  });
+
+  it('returns "Task completed" for empty string content', () => {
+    const messages: BaseMessage[] = [new AIMessage('')];
+    expect(filterSubagentResult(messages)).toBe('Task completed');
+  });
+
+  it('returns "Task completed" when no messages', () => {
+    expect(filterSubagentResult([])).toBe('Task completed');
+  });
+
+  it('returns "Task completed" when no AIMessage found', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('task'),
+      new ToolMessage({ content: 'result', tool_call_id: 'x' }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Task completed');
+  });
+
+  it('uses last AIMessage, not first', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage('First response'),
+      new ToolMessage({ content: 'tool output', tool_call_id: 'x' }),
+      new AIMessage('Final response'),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Final response');
+  });
+
+  it('salvages text from an earlier AIMessage when the last has only tool_use', () => {
+    /**
+     * Scenario: subagent hit maxTurns mid-tool-call. The last AIMessage is
+     * pure tool_use with no text. Partial progress from an earlier turn
+     * should still be returned instead of "Task completed".
+     */
+    const messages: BaseMessage[] = [
+      new HumanMessage('task'),
+      new AIMessage({
+        content: [
+          { type: 'text', text: 'Let me search.' },
+          { type: 'tool_use', id: 'c1', name: 'search', input: {} },
+        ],
+      }),
+      new ToolMessage({ content: 'Paris.', tool_call_id: 'c1' }),
+      new AIMessage({
+        content: [{ type: 'tool_use', id: 'c2', name: 'search', input: {} }],
+      }),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Let me search.');
+  });
+
+  it('salvages from earlier AIMessage when last has empty string content', () => {
+    const messages: BaseMessage[] = [
+      new AIMessage('Partial answer.'),
+      new ToolMessage({ content: 'tool out', tool_call_id: 'x' }),
+      new AIMessage(''),
+    ];
+    expect(filterSubagentResult(messages)).toBe('Partial answer.');
+  });
+});
+
+describe('resolveSubagentConfigs', () => {
+  const parentInputs: AgentInputs = {
+    agentId: 'parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o', apiKey: 'test' },
+    instructions: 'You are a parent agent.',
+    maxContextTokens: 16000,
+  };
+
+  it('passes through configs with explicit agentInputs', () => {
+    const config = makeConfig();
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const resolved = resolveSubagentConfigs([config], parentContext);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].agentInputs.agentId).toBe('child-agent');
+  });
+
+  it('resolves self-spawn from parent _sourceInputs', () => {
+    const selfConfig = {
+      type: 'self',
+      name: 'Self Spawn',
+      description: 'Context isolation only',
+      self: true,
+    };
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const resolved = resolveSubagentConfigs([selfConfig], parentContext);
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].agentInputs.provider).toBe(Providers.OPENAI);
+    expect(resolved[0].agentInputs.instructions).toBe(
+      'You are a parent agent.'
+    );
+  });
+
+  it('filters out configs with self=true when _sourceInputs is missing', () => {
+    const selfConfig = {
+      type: 'self',
+      name: 'Self Spawn',
+      description: 'Context isolation only',
+      self: true,
+    };
+    const parentContext = new AgentContext({
+      agentId: 'bare',
+      provider: Providers.OPENAI,
+      instructionTokens: 0,
+    });
+    const resolved = resolveSubagentConfigs([selfConfig], parentContext);
+    expect(resolved).toHaveLength(0);
+  });
+
+  it('filters out configs without agentInputs and self=false', () => {
+    const badConfig = {
+      type: 'broken',
+      name: 'Broken',
+      description: 'Missing inputs',
+    };
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const resolved = resolveSubagentConfigs([badConfig], parentContext);
+    expect(resolved).toHaveLength(0);
+  });
+
+  it('throws on duplicate subagent types', () => {
+    const parentContext = AgentContext.fromConfig(parentInputs);
+    const dup1 = makeConfig('researcher');
+    const dup2 = makeConfig('researcher');
+    expect(() => resolveSubagentConfigs([dup1, dup2], parentContext)).toThrow(
+      /Duplicate subagent type "researcher"/
+    );
+  });
+});
+
+describe('buildChildInputs', () => {
+  const parentAgentInputs: AgentInputs = {
+    agentId: 'parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test' },
+    instructions: 'parent',
+    maxContextTokens: 8000,
+    subagentConfigs: [{ type: 'researcher', name: 'R', description: 'd' }],
+    maxSubagentDepth: 3,
+  };
+
+  it('strips subagentConfigs and maxSubagentDepth when allowNested is false', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    expect(result.subagentConfigs).toBeUndefined();
+    expect(result.maxSubagentDepth).toBeUndefined();
+  });
+
+  it('decrements maxSubagentDepth when allowNested is true', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+      allowNested: true,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    expect(result.maxSubagentDepth).toBe(2);
+    expect(result.subagentConfigs).toEqual(parentAgentInputs.subagentConfigs);
+  });
+
+  it('clamps decremented depth to 0 (never negative)', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+      allowNested: true,
+    };
+    const result = buildChildInputs(config, 'child', 0);
+    expect(result.maxSubagentDepth).toBe(0);
+  });
+
+  it('always strips toolDefinitions (forces traditional mode)', () => {
+    const inputsWithToolDefs: AgentInputs = {
+      ...parentAgentInputs,
+      toolDefinitions: [{ name: 't', description: 'x' }],
+    };
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: inputsWithToolDefs,
+    };
+    const result = buildChildInputs(config, 'child', 3);
+    expect(result.toolDefinitions).toBeUndefined();
+  });
+
+  it('overrides agentId with the passed childAgentId', () => {
+    const config: ResolvedSubagentConfig = {
+      type: 'researcher',
+      name: 'R',
+      description: 'd',
+      agentInputs: parentAgentInputs,
+    };
+    const result = buildChildInputs(config, 'my-child', 3);
+    expect(result.agentId).toBe('my-child');
+  });
+});
+
+describe('SubagentExecutor', () => {
+  const config = makeConfig();
+
+  /**
+   * Build a stub `createChildGraph` factory that returns a minimal
+   * `StandardGraph`-shaped object whose `createWorkflow().invoke()`
+   * resolves to `invokeResult`. Avoids `jest.spyOn(StandardGraph)` so
+   * that SubagentExecutor does not need a runtime dep on the graphs
+   * module (circular-dep-safe).
+   */
+  function makeStubGraphFactory(
+    invokeResult: { messages: BaseMessage[] },
+    clearSpy?: jest.Mock
+  ): { factory: () => StandardGraph; clearHeavyState: jest.Mock } {
+    const mockClear = clearSpy ?? jest.fn();
+    const factory = (): StandardGraph =>
+      ({
+        createWorkflow: (): { invoke: jest.Mock } => ({
+          invoke: jest.fn().mockResolvedValue(invokeResult),
+        }),
+        clearHeavyState: mockClear,
+      }) as unknown as StandardGraph;
+    return { factory, clearHeavyState: mockClear };
+  }
+
+  function makeThrowingGraphFactory(error: Error): () => StandardGraph {
+    return (): StandardGraph =>
+      ({
+        createWorkflow: (): { invoke: jest.Mock } => ({
+          invoke: jest.fn().mockRejectedValue(error),
+        }),
+        clearHeavyState: jest.fn(),
+      }) as unknown as StandardGraph;
+  }
+
+  /** No-op factory for tests that never reach child graph construction. */
+  function makeNoopGraphFactory(): () => StandardGraph {
+    return (): StandardGraph =>
+      ({
+        createWorkflow: (): { invoke: jest.Mock } => ({
+          invoke: jest.fn().mockResolvedValue({ messages: [] }),
+        }),
+        clearHeavyState: jest.fn(),
+      }) as unknown as StandardGraph;
+  }
+
+  function createExecutor(
+    overrides: Partial<ConstructorParameters<typeof SubagentExecutor>[0]> = {}
+  ): SubagentExecutor {
+    return new SubagentExecutor({
+      configs: new Map([[config.type, config]]),
+      parentRunId: 'test-run',
+      parentAgentId: 'parent-agent',
+      createChildGraph: makeNoopGraphFactory(),
+      ...overrides,
+    });
+  }
+
+  it('returns error for unknown subagent type', async () => {
+    const executor = createExecutor();
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'nonexistent',
+    });
+    expect(result.content).toContain('Unknown subagent type');
+    expect(result.content).toContain('nonexistent');
+    expect(result.content).toContain('researcher');
+    expect(result.messages).toEqual([]);
+  });
+
+  it('returns error when maxDepth is 0 (nesting budget exhausted)', async () => {
+    const executor = createExecutor({ maxDepth: 0 });
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+    expect(result.content).toContain('Maximum subagent nesting depth');
+    expect(result.messages).toEqual([]);
+  });
+
+  it('executes child graph and returns filtered content', async () => {
+    const { factory, clearHeavyState } = makeStubGraphFactory({
+      messages: [
+        new HumanMessage('research this topic'),
+        new AIMessage('Here is my research summary.'),
+      ],
+    });
+    const executor = createExecutor({ createChildGraph: factory });
+
+    const result = await executor.execute({
+      description: 'Research this topic',
+      subagentType: 'researcher',
+    });
+
+    expect(result.content).toBe('Here is my research summary.');
+    expect(result.messages).toHaveLength(2);
+    expect(clearHeavyState).toHaveBeenCalled();
+  });
+
+  it('returns error message when child graph throws', async () => {
+    const executor = createExecutor({
+      createChildGraph: makeThrowingGraphFactory(
+        new Error('Graph recursion limit reached')
+      ),
+    });
+
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+
+    expect(result.content).toContain('Subagent error');
+    expect(result.content).toContain('Graph recursion limit reached');
+    expect(result.messages).toEqual([]);
+  });
+
+  it('truncates long error messages to 200 chars', async () => {
+    const longMessage = 'x'.repeat(500);
+    const executor = createExecutor({
+      createChildGraph: makeThrowingGraphFactory(new Error(longMessage)),
+    });
+
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+
+    /**
+     * Expected composition: "Subagent error: " (16) + 200 truncated chars + "..." (3) = 219.
+     * Assert the exact envelope to catch regressions in the truncation constant.
+     */
+    const MAX_TRUNCATED_LENGTH = 'Subagent error: '.length + 200 + '...'.length;
+    expect(result.content.length).toBe(MAX_TRUNCATED_LENGTH);
+    expect(result.content.startsWith('Subagent error: ')).toBe(true);
+    expect(result.content.endsWith('...')).toBe(true);
+  });
+
+  it('does not truncate short error messages', async () => {
+    const shortMessage = 'brief error detail';
+    const executor = createExecutor({
+      createChildGraph: makeThrowingGraphFactory(new Error(shortMessage)),
+    });
+
+    const result = await executor.execute({
+      description: 'Do something',
+      subagentType: 'researcher',
+    });
+
+    expect(result.content).toBe(`Subagent error: ${shortMessage}`);
+    expect(result.content.endsWith('...')).toBe(false);
+  });
+
+  it('builds child with decremented maxSubagentDepth when allowNested=true', async () => {
+    const nestedConfig: ResolvedSubagentConfig = {
+      type: 'nested',
+      name: 'Nested',
+      description: 'allows nesting',
+      allowNested: true,
+      agentInputs: {
+        ...makeChildInputs('nested-child'),
+        subagentConfigs: [
+          {
+            type: 'nested',
+            name: 'Nested',
+            description: 'allows nesting',
+            allowNested: true,
+          },
+        ],
+        maxSubagentDepth: 3,
+      },
+    };
+
+    let observedChildInputs: AgentInputs | undefined;
+    const executor = new SubagentExecutor({
+      configs: new Map([[nestedConfig.type, nestedConfig]]),
+      parentRunId: 'test-run',
+      parentAgentId: 'parent',
+      maxDepth: 3,
+      createChildGraph: (input): StandardGraph => {
+        observedChildInputs = input.agents[0];
+        return {
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockResolvedValue({
+              messages: [new AIMessage('nested done')],
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      },
+    });
+
+    await executor.execute({
+      description: 'nested task',
+      subagentType: 'nested',
+    });
+
+    expect(observedChildInputs).toBeDefined();
+    expect(observedChildInputs!.maxSubagentDepth).toBe(2);
+    expect(observedChildInputs!.subagentConfigs).toBeDefined();
+  });
+
+  it('strips subagentConfigs from child when allowNested is not set', async () => {
+    let observedChildInputs: AgentInputs | undefined;
+    const executor = createExecutor({
+      maxDepth: 3,
+      createChildGraph: (input): StandardGraph => {
+        observedChildInputs = input.agents[0];
+        return {
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockResolvedValue({
+              messages: [new AIMessage('done')],
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      },
+    });
+
+    await executor.execute({
+      description: 'task',
+      subagentType: 'researcher',
+    });
+
+    expect(observedChildInputs).toBeDefined();
+    expect(observedChildInputs!.subagentConfigs).toBeUndefined();
+    expect(observedChildInputs!.maxSubagentDepth).toBeUndefined();
+  });
+
+  describe('hooks', () => {
+    let capturedStart: unknown;
+    let capturedStop: unknown;
+
+    beforeEach(() => {
+      capturedStart = undefined;
+      capturedStop = undefined;
+    });
+
+    it('fires SubagentStart before execution', async () => {
+      const registry = new HookRegistry();
+      registry.register('SubagentStart', {
+        hooks: [
+          async (input): Promise<Record<string, never>> => {
+            capturedStart = input;
+            return {};
+          },
+        ],
+      });
+
+      const { factory } = makeStubGraphFactory({
+        messages: [new AIMessage('done')],
+      });
+      const executor = createExecutor({
+        hookRegistry: registry,
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Test task',
+        subagentType: 'researcher',
+      });
+
+      expect(capturedStart).toBeDefined();
+      const input = capturedStart as Record<string, unknown>;
+      expect(input.hook_event_name).toBe('SubagentStart');
+      expect(input.parentAgentId).toBe('parent-agent');
+      expect(input.agentType).toBe('researcher');
+    });
+
+    it('fires SubagentStop after execution', async () => {
+      const registry = new HookRegistry();
+      registry.register('SubagentStop', {
+        hooks: [
+          async (input): Promise<Record<string, never>> => {
+            capturedStop = input;
+            return {};
+          },
+        ],
+      });
+
+      const { factory } = makeStubGraphFactory({
+        messages: [new AIMessage('done')],
+      });
+      const executor = createExecutor({
+        hookRegistry: registry,
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Test task',
+        subagentType: 'researcher',
+      });
+
+      expect(capturedStop).toBeDefined();
+      const input = capturedStop as Record<string, unknown>;
+      expect(input.hook_event_name).toBe('SubagentStop');
+      expect(input.agentType).toBe('researcher');
+    });
+
+    it('SubagentStart deny blocks execution', async () => {
+      const registry = new HookRegistry();
+      registry.register('SubagentStart', {
+        hooks: [
+          async (): Promise<{ decision: 'deny'; reason: string }> => ({
+            decision: 'deny',
+            reason: 'Not authorized',
+          }),
+        ],
+      });
+
+      const executor = createExecutor({ hookRegistry: registry });
+      const result = await executor.execute({
+        description: 'Blocked task',
+        subagentType: 'researcher',
+      });
+
+      expect(result.content).toBe('Blocked: Not authorized');
+      expect(result.messages).toEqual([]);
+    });
+  });
+});

--- a/src/tools/__tests__/SubagentTool.test.ts
+++ b/src/tools/__tests__/SubagentTool.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from '@jest/globals';
+import { Constants } from '@/common';
+import {
+  SubagentToolName,
+  SubagentToolDescription,
+  SubagentToolDefinition,
+  SubagentToolSchema,
+  createSubagentToolDefinition,
+  buildSubagentToolParams,
+} from '../SubagentTool';
+import type { SubagentConfig } from '@/types';
+
+describe('SubagentTool', () => {
+  describe('schema structure', () => {
+    it('has description as required string property', () => {
+      expect(SubagentToolSchema.properties.description.type).toBe('string');
+      expect(SubagentToolSchema.required).toContain('description');
+    });
+
+    it('has subagent_type as required string property', () => {
+      expect(SubagentToolSchema.properties.subagent_type.type).toBe('string');
+      expect(SubagentToolSchema.required).toContain('subagent_type');
+    });
+
+    it('is an object type schema', () => {
+      expect(SubagentToolSchema.type).toBe('object');
+    });
+  });
+
+  describe('SubagentToolDefinition', () => {
+    it('has correct name', () => {
+      expect(SubagentToolDefinition.name).toBe(Constants.SUBAGENT);
+    });
+
+    it('references the same schema object', () => {
+      expect(SubagentToolDefinition.parameters).toBe(SubagentToolSchema);
+    });
+
+    it('has a non-empty description', () => {
+      expect(SubagentToolDefinition.description).toBe(SubagentToolDescription);
+      expect(SubagentToolDefinition.description!.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SubagentToolName', () => {
+    it('equals Constants.SUBAGENT', () => {
+      expect(SubagentToolName).toBe('subagent');
+      expect(SubagentToolName).toBe(Constants.SUBAGENT);
+    });
+  });
+
+  describe('createSubagentToolDefinition', () => {
+    const configs: SubagentConfig[] = [
+      {
+        type: 'researcher',
+        name: 'Research Agent',
+        description: 'Searches and summarizes information',
+      },
+      {
+        type: 'coder',
+        name: 'Coding Agent',
+        description: 'Writes and reviews code',
+      },
+    ];
+
+    it('populates subagent_type enum from configs', () => {
+      const def = createSubagentToolDefinition(configs);
+      const schema = def.parameters as Record<string, unknown>;
+      const props = schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.subagent_type.enum).toEqual(['researcher', 'coder']);
+    });
+
+    it('includes type descriptions in tool description', () => {
+      const def = createSubagentToolDefinition(configs);
+      expect(def.description).toContain('"researcher" (Research Agent)');
+      expect(def.description).toContain('"coder" (Coding Agent)');
+      expect(def.description).toContain('Searches and summarizes information');
+      expect(def.description).toContain('Writes and reviews code');
+    });
+
+    it('has correct name', () => {
+      const def = createSubagentToolDefinition(configs);
+      expect(def.name).toBe(Constants.SUBAGENT);
+    });
+
+    it('has required description and subagent_type fields', () => {
+      const def = createSubagentToolDefinition(configs);
+      const schema = def.parameters as Record<string, unknown>;
+      expect(schema.required).toContain('description');
+      expect(schema.required).toContain('subagent_type');
+    });
+
+    it('works with single config', () => {
+      const def = createSubagentToolDefinition([configs[0]]);
+      const schema = def.parameters as Record<string, unknown>;
+      const props = schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.subagent_type.enum).toEqual(['researcher']);
+    });
+  });
+
+  describe('buildSubagentToolParams', () => {
+    const configs: SubagentConfig[] = [
+      {
+        type: 'researcher',
+        name: 'Research Agent',
+        description: 'Searches and summarizes information',
+      },
+      {
+        type: 'coder',
+        name: 'Coding Agent',
+        description: 'Writes and reviews code',
+      },
+    ];
+
+    it('returns name matching Constants.SUBAGENT', () => {
+      const params = buildSubagentToolParams(configs);
+      expect(params.name).toBe(Constants.SUBAGENT);
+    });
+
+    it('schema has enum populated from config types', () => {
+      const params = buildSubagentToolParams(configs);
+      const props = params.schema.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.subagent_type.enum).toEqual(['researcher', 'coder']);
+    });
+
+    it('description includes type listings', () => {
+      const params = buildSubagentToolParams(configs);
+      expect(params.description).toContain('"researcher" (Research Agent)');
+      expect(params.description).toContain('"coder" (Coding Agent)');
+    });
+
+    it('produces same schema as createSubagentToolDefinition', () => {
+      const params = buildSubagentToolParams(configs);
+      const def = createSubagentToolDefinition(configs);
+      expect(params.name).toBe(def.name);
+      expect(params.description).toBe(def.description);
+      expect(params.schema).toEqual(def.parameters);
+    });
+  });
+});

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -216,7 +216,7 @@ describe('ToolNode code execution session management', () => {
         toolNode as unknown as {
           storeCodeSessionFromResults: (
             results: t.ToolExecuteResult[],
-            requests: t.ToolCallRequest[]
+            requestMap: Map<string, t.ToolCallRequest>
           ) => void;
         }
       ).storeCodeSessionFromResults.bind(toolNode);
@@ -233,7 +233,7 @@ describe('ToolNode code execution session management', () => {
             status: 'success',
           },
         ],
-        [{ id: 'tc1', name: Constants.EXECUTE_CODE, args: {} }]
+        new Map([['tc1', { id: 'tc1', name: Constants.EXECUTE_CODE, args: {} }]])
       );
 
       const stored = sessions.get(
@@ -265,7 +265,7 @@ describe('ToolNode code execution session management', () => {
         toolNode as unknown as {
           storeCodeSessionFromResults: (
             results: t.ToolExecuteResult[],
-            requests: t.ToolCallRequest[]
+            requestMap: Map<string, t.ToolCallRequest>
           ) => void;
         }
       ).storeCodeSessionFromResults.bind(toolNode);
@@ -279,7 +279,7 @@ describe('ToolNode code execution session management', () => {
             status: 'success',
           },
         ],
-        [{ id: 'tc2', name: Constants.EXECUTE_CODE, args: {} }]
+        new Map([['tc2', { id: 'tc2', name: Constants.EXECUTE_CODE, args: {} }]])
       );
 
       const stored = sessions.get(
@@ -312,7 +312,7 @@ describe('ToolNode code execution session management', () => {
         toolNode as unknown as {
           storeCodeSessionFromResults: (
             results: t.ToolExecuteResult[],
-            requests: t.ToolCallRequest[]
+            requestMap: Map<string, t.ToolCallRequest>
           ) => void;
         }
       ).storeCodeSessionFromResults.bind(toolNode);
@@ -329,7 +329,7 @@ describe('ToolNode code execution session management', () => {
             status: 'success',
           },
         ],
-        [{ id: 'tc3', name: Constants.EXECUTE_CODE, args: {} }]
+        new Map([['tc3', { id: 'tc3', name: Constants.EXECUTE_CODE, args: {} }]])
       );
 
       const stored = sessions.get(
@@ -365,7 +365,7 @@ describe('ToolNode code execution session management', () => {
         toolNode as unknown as {
           storeCodeSessionFromResults: (
             results: t.ToolExecuteResult[],
-            requests: t.ToolCallRequest[]
+            requestMap: Map<string, t.ToolCallRequest>
           ) => void;
         }
       ).storeCodeSessionFromResults.bind(toolNode);
@@ -379,7 +379,7 @@ describe('ToolNode code execution session management', () => {
             status: 'success',
           },
         ],
-        [{ id: 'tc4', name: Constants.EXECUTE_CODE, args: {} }]
+        new Map([['tc4', { id: 'tc4', name: Constants.EXECUTE_CODE, args: {} }]])
       );
 
       const stored = sessions.get(
@@ -404,7 +404,7 @@ describe('ToolNode code execution session management', () => {
         toolNode as unknown as {
           storeCodeSessionFromResults: (
             results: t.ToolExecuteResult[],
-            requests: t.ToolCallRequest[]
+            requestMap: Map<string, t.ToolCallRequest>
           ) => void;
         }
       ).storeCodeSessionFromResults.bind(toolNode);
@@ -418,7 +418,7 @@ describe('ToolNode code execution session management', () => {
             status: 'success',
           },
         ],
-        [{ id: 'tc5', name: 'web_search', args: {} }]
+        new Map([['tc5', { id: 'tc5', name: 'web_search', args: {} }]])
       );
 
       expect(sessions.has(Constants.EXECUTE_CODE)).toBe(false);
@@ -438,7 +438,7 @@ describe('ToolNode code execution session management', () => {
         toolNode as unknown as {
           storeCodeSessionFromResults: (
             results: t.ToolExecuteResult[],
-            requests: t.ToolCallRequest[]
+            requestMap: Map<string, t.ToolCallRequest>
           ) => void;
         }
       ).storeCodeSessionFromResults.bind(toolNode);
@@ -456,7 +456,7 @@ describe('ToolNode code execution session management', () => {
             errorMessage: 'execution failed',
           },
         ],
-        [{ id: 'tc6', name: Constants.EXECUTE_CODE, args: {} }]
+        new Map([['tc6', { id: 'tc6', name: Constants.EXECUTE_CODE, args: {} }]])
       );
 
       expect(sessions.has(Constants.EXECUTE_CODE)).toBe(false);

--- a/src/tools/__tests__/skillCatalog.test.ts
+++ b/src/tools/__tests__/skillCatalog.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from '@jest/globals';
+import { formatSkillCatalog } from '../skillCatalog';
+import type { SkillCatalogEntry } from '@/types';
+
+describe('formatSkillCatalog', () => {
+  it('returns empty string for empty array', () => {
+    expect(formatSkillCatalog([])).toBe('');
+  });
+
+  it('formats a single skill with header', () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: 'pdf-processor',
+        description: 'Processes PDF files into structured data.',
+      },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe(
+      '## Available Skills\n\n- pdf-processor: Processes PDF files into structured data.'
+    );
+  });
+
+  it('formats multiple skills within budget', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'pdf-processor', description: 'Processes PDF files.' },
+      { name: 'review-pr', description: 'Reviews pull requests.' },
+      { name: 'meeting-notes', description: 'Formats meeting transcripts.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('## Available Skills');
+    expect(result).toContain('- pdf-processor: Processes PDF files.');
+    expect(result).toContain('- review-pr: Reviews pull requests.');
+    expect(result).toContain('- meeting-notes: Formats meeting transcripts.');
+  });
+
+  it('caps per-entry descriptions at maxEntryChars', () => {
+    const longDesc = 'A'.repeat(300);
+    const skills: SkillCatalogEntry[] = [
+      { name: 'long-skill', description: longDesc },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('- long-skill: ' + 'A'.repeat(249) + '\u2026');
+    expect(result).not.toContain('A'.repeat(300));
+  });
+
+  it('truncates descriptions proportionally when over budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      name: `sk-${i}`,
+      description: 'D'.repeat(200),
+    }));
+    // Budget = 10000 * 0.01 * 4 = 400 chars — enough for names + short descs, not full 200-char descs
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 10000,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    expect(result).toContain('## Available Skills');
+    for (let i = 0; i < 10; i++) {
+      expect(result).toContain(`sk-${i}`);
+    }
+    // Full 200-char descriptions should be truncated
+    expect(result).not.toContain('D'.repeat(200));
+  });
+
+  it('falls back to names-only when extremely over budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      name: `s${i}`,
+      description: 'Very detailed description that is quite long and verbose.',
+    }));
+    // Budget = 2000 * 0.01 * 4 = 80 chars — enough for names-only but not descriptions
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 2000,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    expect(result).toContain('## Available Skills');
+    expect(result).toContain('- s0');
+    // Verify entry lines have no descriptions (names-only format)
+    const entryLines = result.split('\n').filter((l) => l.startsWith('- '));
+    for (const line of entryLines) {
+      expect(line).toMatch(/^- s\d+$/);
+    }
+  });
+
+  it('respects custom options', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'test', description: 'A'.repeat(100) },
+    ];
+    const result = formatSkillCatalog(skills, { maxEntryChars: 50 });
+    expect(result).toContain('A'.repeat(49) + '\u2026');
+    expect(result).not.toContain('A'.repeat(100));
+  });
+
+  it('includes skills with descriptions shorter than minDescLength', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'short', description: 'Hi' },
+      { name: 'normal', description: 'A normal description here.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toContain('- short: Hi');
+    expect(result).toContain('- normal: A normal description here.');
+  });
+
+  it('handles all skills with zero-length descriptions as names-only', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'alpha', description: '' },
+      { name: 'beta', description: '' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe('## Available Skills\n\n- alpha\n- beta');
+  });
+
+  it('has no trailing or leading whitespace', () => {
+    const skills: SkillCatalogEntry[] = [
+      { name: 'test', description: 'A test skill.' },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).toBe(result.trim());
+    const lines = result.split('\n');
+    for (const line of lines) {
+      expect(line).toBe(line.trimEnd());
+    }
+  });
+
+  it('truncates names-only list when even names exceed budget', () => {
+    const skills: SkillCatalogEntry[] = Array.from({ length: 100 }, (_, i) => ({
+      name: `skill-with-a-long-name-${i}`,
+      description: 'Some description.',
+    }));
+    // Budget so small that even names-only for 100 skills exceeds it
+    const result = formatSkillCatalog(skills, {
+      contextWindowTokens: 100,
+      budgetPercent: 0.01,
+      charsPerToken: 4,
+    });
+    // Should still have the header and at least one entry, but not all 100
+    if (result === '') {
+      // Budget too small for even one entry — valid edge case
+      expect(result).toBe('');
+    } else {
+      expect(result).toContain('## Available Skills');
+      const entryLines = result.split('\n').filter((l) => l.startsWith('- '));
+      expect(entryLines.length).toBeLessThan(100);
+      expect(entryLines.length).toBeGreaterThan(0);
+      expect(result.length).toBeLessThanOrEqual(100 * 0.01 * 4);
+    }
+  });
+
+  it('ignores displayTitle in output', () => {
+    const skills: SkillCatalogEntry[] = [
+      {
+        name: 'my-skill',
+        description: 'Does stuff.',
+        displayTitle: 'My Fancy Skill',
+      },
+    ];
+    const result = formatSkillCatalog(skills);
+    expect(result).not.toContain('My Fancy Skill');
+    expect(result).toContain('- my-skill: Does stuff.');
+  });
+});

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1,0 +1,215 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type * as t from '@/types';
+import type {
+  HookCallback,
+  SubagentStartHookInput,
+  SubagentStartHookOutput,
+  SubagentStopHookInput,
+  SubagentStopHookOutput,
+} from '@/hooks/types';
+import { HookRegistry } from '@/hooks/HookRegistry';
+import { Run } from '@/run';
+import {
+  Constants,
+  GraphEvents,
+  Providers,
+  ToolEndHandler,
+  ModelEndHandler,
+} from '@/index';
+import * as providers from '@/llm/providers';
+
+const CHILD_RESPONSE = 'Hook test child response.';
+
+const callerConfig = {
+  configurable: { thread_id: 'hook-test-thread' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+const originalGetChatModelClass = providers.getChatModelClass;
+
+function makeSubagentToolCall(): ToolCall {
+  return {
+    name: Constants.SUBAGENT,
+    args: {
+      description: 'Test task for hook verification',
+      subagent_type: 'researcher',
+    },
+    id: `call_sub_${Date.now()}`,
+    type: 'tool_call',
+  };
+}
+
+function createParentAgent(): t.AgentInputs {
+  return {
+    agentId: 'hook-parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+    instructions: 'Delegate research tasks to subagents.',
+    maxContextTokens: 8000,
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Researcher',
+        description: 'Researches topics',
+        agentInputs: {
+          agentId: 'researcher-child',
+          provider: Providers.OPENAI,
+          clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+          instructions: 'Answer concisely.',
+          maxContextTokens: 8000,
+        },
+      },
+    ],
+  };
+}
+
+async function createSubagentRun(
+  hooks: HookRegistry,
+  runId = `subagent-hook-${Date.now()}`
+): Promise<Run<t.IState>> {
+  return Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      agents: [createParentAgent()],
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers: {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    },
+    hooks,
+  });
+}
+
+describe('Subagent hook integration (end-to-end via Run)', () => {
+  jest.setTimeout(15000);
+
+  let getChatModelClassSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getChatModelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return class extends FakeListChatModel {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            constructor(_options: any) {
+              super({ responses: [CHILD_RESPONSE] });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
+  });
+
+  afterEach(() => {
+    getChatModelClassSpy.mockRestore();
+  });
+
+  it('SubagentStart fires with correct payload through real Run pipeline', async () => {
+    const registry = new HookRegistry();
+    let captured: SubagentStartHookInput | undefined;
+
+    const hook: HookCallback<'SubagentStart'> = async (
+      input
+    ): Promise<SubagentStartHookOutput> => {
+      captured = input;
+      return {};
+    };
+    registry.register('SubagentStart', { hooks: [hook] });
+
+    const tc = makeSubagentToolCall();
+    const run = await createSubagentRun(registry);
+    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('research something')] },
+      callerConfig
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.hook_event_name).toBe('SubagentStart');
+    expect(captured!.agentType).toBe('researcher');
+    expect(captured!.parentAgentId).toBe('hook-parent');
+    expect(captured!.threadId).toBe('hook-test-thread');
+    expect(captured!.inputs).toHaveLength(1);
+    expect(captured!.inputs[0].content).toContain(
+      'Test task for hook verification'
+    );
+  });
+
+  it('SubagentStop fires with messages from child execution', async () => {
+    const registry = new HookRegistry();
+    let captured: SubagentStopHookInput | undefined;
+
+    const hook: HookCallback<'SubagentStop'> = async (
+      input
+    ): Promise<SubagentStopHookOutput> => {
+      captured = input;
+      return {};
+    };
+    registry.register('SubagentStop', { hooks: [hook] });
+
+    const tc = makeSubagentToolCall();
+    const run = await createSubagentRun(registry);
+    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('research something')] },
+      callerConfig
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.hook_event_name).toBe('SubagentStop');
+    expect(captured!.agentType).toBe('researcher');
+    expect(captured!.threadId).toBe('hook-test-thread');
+    expect(captured!.messages.length).toBeGreaterThan(0);
+  });
+
+  it('SubagentStart deny blocks subagent execution and returns blocked message', async () => {
+    const registry = new HookRegistry();
+    const denyHook: HookCallback<
+      'SubagentStart'
+    > = async (): Promise<SubagentStartHookOutput> => ({
+      decision: 'deny',
+      reason: 'policy violation',
+    });
+    registry.register('SubagentStart', {
+      pattern: '^researcher$',
+      hooks: [denyHook],
+    });
+
+    const tc = makeSubagentToolCall();
+    const run = await createSubagentRun(registry);
+    run.Graph!.overrideTestModel(
+      ['Delegating...', 'The subagent was blocked.'],
+      5,
+      [tc]
+    );
+
+    await run.processStream(
+      { messages: [new HumanMessage('research something')] },
+      callerConfig
+    );
+
+    const runMessages = run.getRunMessages();
+    expect(runMessages).toBeDefined();
+
+    const toolMessages = runMessages!.filter(
+      (msg) =>
+        msg._getType() === 'tool' &&
+        'name' in msg &&
+        msg.name === Constants.SUBAGENT
+    );
+    expect(toolMessages.length).toBe(1);
+    expect(String(toolMessages[0].content)).toContain(
+      'Blocked: policy violation'
+    );
+  });
+});

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -104,13 +104,23 @@ function fitNamesOnly(
   entries: { name: string }[],
   budgetChars: number
 ): string {
-  const namesOnly = entries.map((s) => ({ name: s.name, description: '' }));
-  const full = formatEntries(namesOnly);
-  if (full.length <= budgetChars) return full;
+  // Format: "HEADER\n\n- name1\n- name2\n..."
+  // Running sum avoids O(n²) repeated string construction.
+  const prefix = HEADER.length + 2; // "HEADER\n\n"
+  const entryOverhead = 2; // "- "
+  let total = prefix;
+  let fitCount = 0;
 
-  for (let count = namesOnly.length - 1; count > 0; count--) {
-    const trimmed = formatEntries(namesOnly.slice(0, count));
-    if (trimmed.length <= budgetChars) return trimmed;
+  for (let i = 0; i < entries.length; i++) {
+    const added = (i > 0 ? 1 : 0) + entryOverhead + entries[i].name.length;
+    if (total + added > budgetChars) break;
+    total += added;
+    fitCount = i + 1;
   }
-  return '';
+
+  if (fitCount === 0) return '';
+  const namesOnly = entries
+    .slice(0, fitCount)
+    .map((s) => ({ name: s.name, description: '' }));
+  return formatEntries(namesOnly);
 }

--- a/src/tools/skillCatalog.ts
+++ b/src/tools/skillCatalog.ts
@@ -1,0 +1,116 @@
+// src/tools/skillCatalog.ts
+import type { SkillCatalogEntry } from '@/types';
+
+const HEADER = '## Available Skills';
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+const DEFAULT_BUDGET_PERCENT = 0.01;
+const DEFAULT_MAX_ENTRY_CHARS = 250;
+const DEFAULT_MIN_DESC_LENGTH = 20;
+const DEFAULT_CHARS_PER_TOKEN = 4;
+
+export type SkillCatalogOptions = {
+  /** Total context window in tokens. Default: 200_000 */
+  contextWindowTokens?: number;
+  /** Fraction of context budget for catalog. Default: 0.01 (1%) */
+  budgetPercent?: number;
+  /** Max chars per entry description. Default: 250 */
+  maxEntryChars?: number;
+  /** Descriptions below this length trigger names-only fallback. Default: 20 */
+  minDescLength?: number;
+  /** Approximate chars per token for budget calculation. Default: 4 */
+  charsPerToken?: number;
+};
+
+/**
+ * Formats a skill catalog for injection into agent context.
+ * Uses a truncation ladder: full descriptions, proportional truncation, names-only.
+ * Returns empty string for empty input.
+ */
+export function formatSkillCatalog(
+  skills: SkillCatalogEntry[],
+  opts?: SkillCatalogOptions
+): string {
+  if (skills.length === 0) return '';
+
+  const contextWindowTokens =
+    opts?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS;
+  const budgetPercent = opts?.budgetPercent ?? DEFAULT_BUDGET_PERCENT;
+  const maxEntryChars = Math.max(
+    1,
+    opts?.maxEntryChars ?? DEFAULT_MAX_ENTRY_CHARS
+  );
+  const minDescLength = opts?.minDescLength ?? DEFAULT_MIN_DESC_LENGTH;
+  const charsPerToken = opts?.charsPerToken ?? DEFAULT_CHARS_PER_TOKEN;
+
+  const budgetChars = Math.floor(
+    contextWindowTokens * budgetPercent * charsPerToken
+  );
+
+  const capped = skills.map((s) => ({
+    name: s.name,
+    description:
+      s.description.length > maxEntryChars
+        ? s.description.slice(0, maxEntryChars - 1) + '\u2026'
+        : s.description,
+  }));
+
+  const fullOutput = formatEntries(capped);
+  if (fullOutput.length <= budgetChars) return fullOutput;
+
+  const headerLen = HEADER.length + 2;
+  const newlineChars = capped.length > 1 ? capped.length - 1 : 0;
+  const availableChars = budgetChars - headerLen - newlineChars;
+  const perEntryOverhead = 4;
+  const nameCharsTotal = capped.reduce(
+    (sum, s) => sum + s.name.length + perEntryOverhead,
+    0
+  );
+  const availableForDescs = availableChars - nameCharsTotal;
+
+  if (availableForDescs <= 0) {
+    return fitNamesOnly(capped, budgetChars);
+  }
+
+  const maxDescPerEntry = Math.floor(availableForDescs / capped.length);
+
+  if (maxDescPerEntry < minDescLength) {
+    return fitNamesOnly(capped, budgetChars);
+  }
+
+  const truncated = capped.map((s) => ({
+    name: s.name,
+    description:
+      s.description.length > maxDescPerEntry
+        ? s.description.slice(0, maxDescPerEntry - 1) + '\u2026'
+        : s.description,
+  }));
+
+  const result = formatEntries(truncated);
+  if (result.length <= budgetChars) return result;
+  return fitNamesOnly(capped, budgetChars);
+}
+
+function formatEntries(
+  entries: { name: string; description: string }[]
+): string {
+  const lines = entries.map((e) =>
+    e.description ? `- ${e.name}: ${e.description}` : `- ${e.name}`
+  );
+  return `${HEADER}\n\n${lines.join('\n')}`;
+}
+
+/** Names-only fallback that drops trailing entries if the list still exceeds budget. */
+function fitNamesOnly(
+  entries: { name: string }[],
+  budgetChars: number
+): string {
+  const namesOnly = entries.map((s) => ({ name: s.name, description: '' }));
+  const full = formatEntries(namesOnly);
+  if (full.length <= budgetChars) return full;
+
+  for (let count = namesOnly.length - 1; count > 0; count--) {
+    const trimmed = formatEntries(namesOnly.slice(0, count));
+    if (trimmed.length <= budgetChars) return trimmed;
+  }
+  return '';
+}

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1,0 +1,344 @@
+import { nanoid } from 'nanoid';
+import { HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  AgentInputs,
+  StandardGraphInput,
+  ResolvedSubagentConfig,
+  SubagentConfig,
+  TokenCounter,
+} from '@/types';
+import type { AggregatedHookResult, HookRegistry } from '@/hooks';
+import type { AgentContext } from '@/agents/AgentContext';
+import type { StandardGraph } from '@/graphs/Graph';
+import { executeHooks } from '@/hooks';
+
+const DEFAULT_MAX_TURNS = 25;
+const RECURSION_MULTIPLIER = 3;
+const ERROR_MESSAGE_MAX_CHARS = 200;
+
+const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
+  additionalContexts: [] as string[],
+  errors: [] as string[],
+});
+
+export type SubagentExecuteParams = {
+  description: string;
+  subagentType: string;
+  threadId?: string;
+};
+
+export type SubagentExecuteResult = {
+  content: string;
+  messages: BaseMessage[];
+};
+
+/**
+ * Factory that constructs a child graph for subagent execution. Injected
+ * rather than imported so that `SubagentExecutor` does not have a runtime
+ * dependency on `StandardGraph` — this avoids a circular dependency between
+ * `src/graphs/Graph.ts` and `src/tools/subagent/` that would otherwise break
+ * Rollup's chunking under `preserveModules`.
+ */
+export type ChildGraphFactory = (input: StandardGraphInput) => StandardGraph;
+
+export type SubagentExecutorOptions = {
+  configs: Map<string, ResolvedSubagentConfig>;
+  parentSignal?: AbortSignal;
+  hookRegistry?: HookRegistry;
+  parentRunId: string;
+  parentAgentId?: string;
+  tokenCounter?: TokenCounter;
+  /** Remaining nesting budget. 0 or negative blocks execution. */
+  maxDepth?: number;
+  /**
+   * Factory for constructing the isolated child graph. Callers pass
+   * `(input) => new StandardGraph(input)` — injected to break a circular
+   * module dependency.
+   */
+  createChildGraph: ChildGraphFactory;
+};
+
+export class SubagentExecutor {
+  private readonly configs: Map<string, ResolvedSubagentConfig>;
+  private readonly parentSignal?: AbortSignal;
+  private readonly hookRegistry?: HookRegistry;
+  private readonly parentRunId: string;
+  private readonly parentAgentId?: string;
+  private readonly tokenCounter?: TokenCounter;
+  private readonly maxDepth: number;
+  private readonly createChildGraph: ChildGraphFactory;
+
+  constructor(options: SubagentExecutorOptions) {
+    this.configs = options.configs;
+    this.parentSignal = options.parentSignal;
+    this.hookRegistry = options.hookRegistry;
+    this.parentRunId = options.parentRunId;
+    this.parentAgentId = options.parentAgentId;
+    this.tokenCounter = options.tokenCounter;
+    this.maxDepth = options.maxDepth ?? 1;
+    this.createChildGraph = options.createChildGraph;
+  }
+
+  async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
+    const { description, subagentType, threadId } = params;
+    const config = this.configs.get(subagentType);
+
+    if (!config) {
+      const available = [...this.configs.keys()].join(', ');
+      return {
+        content: `Error: Unknown subagent type "${subagentType}". Available types: ${available}`,
+        messages: [],
+      };
+    }
+
+    if (this.maxDepth <= 0) {
+      return {
+        content: 'Error: Maximum subagent nesting depth exceeded.',
+        messages: [],
+      };
+    }
+
+    const childAgentId =
+      config.agentInputs.agentId ||
+      `${this.parentAgentId ?? 'agent'}_sub_${nanoid(8)}`;
+
+    if (
+      this.hookRegistry?.hasHookFor('SubagentStart', this.parentRunId) === true
+    ) {
+      const hookResult = await executeHooks({
+        registry: this.hookRegistry,
+        input: {
+          hook_event_name: 'SubagentStart',
+          runId: this.parentRunId,
+          threadId,
+          parentAgentId: this.parentAgentId,
+          agentId: childAgentId,
+          agentType: subagentType,
+          inputs: [new HumanMessage(description)],
+        },
+        sessionId: this.parentRunId,
+        matchQuery: subagentType,
+      }).catch((): AggregatedHookResult => HOOK_FALLBACK);
+
+      /**
+       * `ask` is treated identically to `deny` in the subagent context:
+       * subagents are non-interactive, so there is no prompt path for `ask`.
+       * Both decisions block execution and return a "Blocked" tool result.
+       */
+      if (hookResult.decision === 'deny' || hookResult.decision === 'ask') {
+        return {
+          content: `Blocked: ${hookResult.reason ?? 'Blocked by hook'}`,
+          messages: [],
+        };
+      }
+    }
+
+    const childInputs = buildChildInputs(config, childAgentId, this.maxDepth);
+    const childRunId = `${this.parentRunId}_sub_${nanoid(8)}`;
+    const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
+
+    const childGraph = this.createChildGraph({
+      runId: childRunId,
+      signal: this.parentSignal,
+      agents: [childInputs],
+      tokenCounter: this.tokenCounter,
+    });
+
+    let result: { messages: BaseMessage[] };
+    try {
+      const workflow = childGraph.createWorkflow();
+      /**
+       * Detach the child invocation from the parent's callback chain.
+       * Without this, `streamEvents` in the parent's `Run.processStream`
+       * captures events from the child graph's LLM calls (e.g.
+       * `on_chat_model_stream` for the "researcher" agent) and delivers
+       * them to the parent's handlers. The parent then tries to resolve
+       * the child's agent ID in its own `agentContexts` map and throws
+       * "No agent context found for agent ID …". Setting `callbacks: []`
+       * overrides the inherited callbacks for this invoke; combined with
+       * the child's own empty `handlerRegistry`/`hookRegistry`, the child
+       * runs fully isolated.
+       *
+       * `runName` gives the child a distinct LangSmith trace root (avoids
+       * nested trace pollution).
+       */
+      result = await workflow.invoke(
+        { messages: [new HumanMessage(description)] },
+        {
+          recursionLimit: maxTurns * RECURSION_MULTIPLIER,
+          signal: this.parentSignal,
+          callbacks: [],
+          runName: `subagent:${subagentType}`,
+          configurable: {
+            thread_id: childRunId,
+          },
+        }
+      );
+    } catch (error) {
+      childGraph.clearHeavyState();
+      return {
+        content: `Subagent error: ${truncateErrorMessage(error)}`,
+        messages: [],
+      };
+    }
+
+    const filteredContent = filterSubagentResult(result.messages);
+
+    if (
+      this.hookRegistry?.hasHookFor('SubagentStop', this.parentRunId) === true
+    ) {
+      /**
+       * Awaited (not fire-and-forget) for deterministic test synchronization
+       * and consistency with PostCompact. The parent is already waiting on the
+       * tool result, so the small extra latency is acceptable. Errors are
+       * swallowed — SubagentStop is observational.
+       */
+      await executeHooks({
+        registry: this.hookRegistry,
+        input: {
+          hook_event_name: 'SubagentStop',
+          runId: this.parentRunId,
+          threadId,
+          agentId: childAgentId,
+          agentType: subagentType,
+          messages: result.messages,
+        },
+        sessionId: this.parentRunId,
+        matchQuery: subagentType,
+      }).catch(() => {
+        /* SubagentStop is observational — swallow errors */
+      });
+    }
+
+    childGraph.clearHeavyState();
+
+    return { content: filteredContent, messages: result.messages };
+  }
+}
+
+/**
+ * Walk messages from last to first, returning the text content of the most
+ * recent AIMessage that has any. Non-text blocks (tool_use, thinking,
+ * redacted_thinking, tool_result) are stripped. If the last AIMessage is
+ * pure tool_use (e.g. the subagent hit `maxTurns` mid-tool-call), the walk
+ * continues to earlier AIMessages so partial progress is salvaged — this
+ * matches Claude Code's behavior in `agentToolUtils.finalizeAgentTool`.
+ * Returns "Task completed" only when no AIMessage in the history contains
+ * any text.
+ */
+export function filterSubagentResult(messages: BaseMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]._getType() !== 'ai') {
+      continue;
+    }
+
+    const content = messages[i].content;
+
+    if (typeof content === 'string') {
+      if (content) return content;
+      continue;
+    }
+
+    if (!Array.isArray(content)) {
+      continue;
+    }
+
+    const textParts: string[] = [];
+    for (const block of content) {
+      if (typeof block === 'string') {
+        textParts.push(block);
+      } else if ('type' in block && block.type === 'text' && 'text' in block) {
+        textParts.push(block.text as string);
+      }
+    }
+
+    if (textParts.length > 0) {
+      return textParts.join('\n');
+    }
+  }
+
+  return 'Task completed';
+}
+
+/**
+ * Resolve self-spawn configs by filling in agentInputs from the parent context.
+ * Returns configs with agentInputs guaranteed present. Throws on duplicate
+ * `type` values to prevent silent config shadowing.
+ */
+export function resolveSubagentConfigs(
+  configs: SubagentConfig[],
+  parentContext: AgentContext
+): ResolvedSubagentConfig[] {
+  const resolved = configs
+    .map((config) => {
+      if (config.agentInputs != null) {
+        return config as ResolvedSubagentConfig;
+      }
+      if (config.self !== true || parentContext._sourceInputs == null) {
+        return null;
+      }
+      return {
+        ...config,
+        agentInputs: { ...parentContext._sourceInputs },
+      } as ResolvedSubagentConfig;
+    })
+    .filter((c): c is ResolvedSubagentConfig => c != null);
+
+  const seenTypes = new Set<string>();
+  for (const config of resolved) {
+    if (seenTypes.has(config.type)) {
+      throw new Error(
+        `Duplicate subagent type "${config.type}". Each SubagentConfig must have a unique "type" field.`
+      );
+    }
+    seenTypes.add(config.type);
+  }
+
+  return resolved;
+}
+
+/**
+ * Build child AgentInputs from a resolved config, stripping nesting and
+ * event-driven fields. When `allowNested: true`, the child's
+ * `maxSubagentDepth` is decremented so that depth is consumed as the call
+ * chain deepens across graph boundaries — the parent's executor-level check
+ * alone cannot see into the child graph's separate executor.
+ *
+ * @remarks Advanced utility: exported primarily for testing and by
+ * {@link SubagentExecutor}. Host applications configuring subagents should
+ * not need to call this directly — it is invoked internally when a subagent
+ * tool is dispatched. The depth-countdown contract (parent's `maxDepth` in,
+ * child's decremented `maxSubagentDepth` on the returned inputs) is the
+ * mechanism that bounds nesting across graph boundaries; callers must
+ * respect it.
+ */
+export function buildChildInputs(
+  config: ResolvedSubagentConfig,
+  childAgentId: string,
+  parentMaxDepth: number
+): AgentInputs {
+  const { agentInputs } = config;
+  const childInputs: AgentInputs = {
+    ...agentInputs,
+    agentId: childAgentId,
+    toolDefinitions: undefined,
+  };
+
+  if (config.allowNested === true) {
+    childInputs.maxSubagentDepth = Math.max(0, parentMaxDepth - 1);
+  } else {
+    childInputs.subagentConfigs = undefined;
+    childInputs.maxSubagentDepth = undefined;
+  }
+
+  return childInputs;
+}
+
+function truncateErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.length <= ERROR_MESSAGE_MAX_CHARS) {
+    return message;
+  }
+  return `${message.slice(0, ERROR_MESSAGE_MAX_CHARS)}...`;
+}

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1,16 +1,23 @@
 import { nanoid } from 'nanoid';
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { Callbacks } from '@langchain/core/callbacks/manager';
 import type {
   AgentInputs,
   StandardGraphInput,
   ResolvedSubagentConfig,
   SubagentConfig,
+  SubagentUpdateEvent,
+  SubagentUpdatePhase,
+  ToolExecuteBatchRequest,
   TokenCounter,
 } from '@/types';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
+import { GraphEvents, Callback } from '@/common';
+import type { HandlerRegistry } from '@/events';
 import { executeHooks } from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
@@ -26,6 +33,13 @@ export type SubagentExecuteParams = {
   description: string;
   subagentType: string;
   threadId?: string;
+  /**
+   * Parent-side `tool_call_id` of the `subagent` tool invocation that
+   * triggered this execution. Surfaced on {@link SubagentUpdateEvent} so
+   * hosts can correlate child updates back to the originating tool call
+   * without relying on event ordering heuristics.
+   */
+  parentToolCallId?: string;
 };
 
 export type SubagentExecuteResult = {
@@ -57,6 +71,19 @@ export type SubagentExecutorOptions = {
    * module dependency.
    */
   createChildGraph: ChildGraphFactory;
+  /**
+   * Parent's event handler registry. When provided, child-graph events are
+   * forwarded through this registry so hosts can:
+   *   (a) execute event-driven tools (`ON_TOOL_EXECUTE` routed to parent's handler),
+   *   (b) surface child activity to a UI via wrapped {@link GraphEvents.ON_SUBAGENT_UPDATE}.
+   * When omitted, the child runs fully isolated (legacy behavior).
+   *
+   * Can be a direct `HandlerRegistry` or a zero-arg getter — use the getter
+   * form when the registry is assigned to the graph AFTER the executor is
+   * constructed (the current `Run.create` flow sets `handlerRegistry`
+   * post-`createWorkflow`, so `createAgentNode` must capture lazily).
+   */
+  parentHandlerRegistry?: HandlerRegistry | (() => HandlerRegistry | undefined);
 };
 
 export class SubagentExecutor {
@@ -68,6 +95,9 @@ export class SubagentExecutor {
   private readonly tokenCounter?: TokenCounter;
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
+  private readonly resolveParentHandlerRegistry?: () =>
+    | HandlerRegistry
+    | undefined;
 
   constructor(options: SubagentExecutorOptions) {
     this.configs = options.configs;
@@ -78,10 +108,21 @@ export class SubagentExecutor {
     this.tokenCounter = options.tokenCounter;
     this.maxDepth = options.maxDepth ?? 1;
     this.createChildGraph = options.createChildGraph;
+    const rawRegistry = options.parentHandlerRegistry;
+    if (typeof rawRegistry === 'function') {
+      this.resolveParentHandlerRegistry = rawRegistry;
+    } else if (rawRegistry != null) {
+      this.resolveParentHandlerRegistry = (): HandlerRegistry => rawRegistry;
+    }
+  }
+
+  /** Snapshot of the parent's registry at the moment a subagent is dispatched. */
+  private getParentHandlerRegistry(): HandlerRegistry | undefined {
+    return this.resolveParentHandlerRegistry?.();
   }
 
   async execute(params: SubagentExecuteParams): Promise<SubagentExecuteResult> {
-    const { description, subagentType, threadId } = params;
+    const { description, subagentType, threadId, parentToolCallId } = params;
     const config = this.configs.get(subagentType);
 
     if (!config) {
@@ -134,7 +175,25 @@ export class SubagentExecutor {
       }
     }
 
-    const childInputs = buildChildInputs(config, childAgentId, this.maxDepth);
+    const parentRegistry = this.getParentHandlerRegistry();
+    const forwardingEnabled = parentRegistry != null;
+    /**
+     * Keep `toolDefinitions` only when the host has actually wired an
+     * `ON_TOOL_EXECUTE` handler. `Run` always constructs a `HandlerRegistry`,
+     * so treating any registry as "forwarding enabled" would leak
+     * `toolDefinitions` into children whose hosts cannot execute them — the
+     * child's `ToolNode` batch promise would hang forever with no handler to
+     * resolve/reject. Gating on the tool-execute handler preserves the
+     * recoverable "no tools" path for registry-but-no-handler configs.
+     */
+    const hasToolExecuteHandler =
+      parentRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) != null;
+    const childInputs = buildChildInputs(
+      config,
+      childAgentId,
+      this.maxDepth,
+      /* keepToolDefinitions */ hasToolExecuteHandler
+    );
     const childRunId = `${this.parentRunId}_sub_${nanoid(8)}`;
     const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
 
@@ -145,30 +204,54 @@ export class SubagentExecutor {
       tokenCounter: this.tokenCounter,
     });
 
+    const forwarder = forwardingEnabled
+      ? this.createForwarderCallback({
+        parentRegistry: parentRegistry!,
+        subagentType,
+        subagentAgentId: childAgentId,
+        childRunId,
+        parentToolCallId,
+      })
+      : undefined;
+
+    if (forwarder) {
+      await this.emitSubagentUpdate(parentRegistry!, {
+        childRunId,
+        subagentType,
+        subagentAgentId: childAgentId,
+        parentToolCallId,
+        phase: 'start',
+        label: `Subagent "${subagentType}" started`,
+      });
+    }
+
     let result: { messages: BaseMessage[] };
     try {
       const workflow = childGraph.createWorkflow();
       /**
-       * Detach the child invocation from the parent's callback chain.
-       * Without this, `streamEvents` in the parent's `Run.processStream`
-       * captures events from the child graph's LLM calls (e.g.
-       * `on_chat_model_stream` for the "researcher" agent) and delivers
-       * them to the parent's handlers. The parent then tries to resolve
-       * the child's agent ID in its own `agentContexts` map and throws
-       * "No agent context found for agent ID …". Setting `callbacks: []`
-       * overrides the inherited callbacks for this invoke; combined with
-       * the child's own empty `handlerRegistry`/`hookRegistry`, the child
-       * runs fully isolated.
+       * When `parentHandlerRegistry` is provided (forwarding mode), attach a
+       * lightweight callback that intercepts the child's `on_custom_event`
+       * dispatches and routes them to the parent's registry — either as
+       * operational events (ON_TOOL_EXECUTE) or wrapped ON_SUBAGENT_UPDATE
+       * envelopes. Native LangChain streaming events (on_chat_model_stream,
+       * etc.) still do NOT propagate to the parent's outer streamEvents
+       * iterator — the `callbacks` array REPLACES the inherited chain, so
+       * parent handlers won't receive child stream chunks and raise "No
+       * agent context found" lookups on the parent's agentContexts map.
+       *
+       * When no registry is provided (legacy isolation), `callbacks: []`
+       * fully detaches the child.
        *
        * `runName` gives the child a distinct LangSmith trace root (avoids
        * nested trace pollution).
        */
+      const callbacks: Callbacks = forwarder ? [forwarder] : [];
       result = await workflow.invoke(
         { messages: [new HumanMessage(description)] },
         {
           recursionLimit: maxTurns * RECURSION_MULTIPLIER,
           signal: this.parentSignal,
-          callbacks: [],
+          callbacks,
           runName: `subagent:${subagentType}`,
           configurable: {
             thread_id: childRunId,
@@ -176,9 +259,21 @@ export class SubagentExecutor {
         }
       );
     } catch (error) {
+      const errorMessage = truncateErrorMessage(error);
+      if (forwarder) {
+        await this.emitSubagentUpdate(parentRegistry!, {
+          childRunId,
+          subagentType,
+          subagentAgentId: childAgentId,
+          parentToolCallId,
+          phase: 'error',
+          label: `Subagent "${subagentType}" errored: ${errorMessage}`,
+          data: { message: errorMessage },
+        });
+      }
       childGraph.clearHeavyState();
       return {
-        content: `Subagent error: ${truncateErrorMessage(error)}`,
+        content: `Subagent error: ${errorMessage}`,
         messages: [],
       };
     }
@@ -211,10 +306,228 @@ export class SubagentExecutor {
       });
     }
 
+    if (forwarder) {
+      await this.emitSubagentUpdate(parentRegistry!, {
+        childRunId,
+        subagentType,
+        subagentAgentId: childAgentId,
+        parentToolCallId,
+        phase: 'stop',
+        label: `Subagent "${subagentType}" finished`,
+      });
+    }
+
     childGraph.clearHeavyState();
 
     return { content: filteredContent, messages: result.messages };
   }
+
+  /**
+   * Emits a single {@link GraphEvents.ON_SUBAGENT_UPDATE} envelope through the
+   * parent's handler registry. Silent no-op when no parent registry is set.
+   * Errors are swallowed — update events are observational.
+   */
+  private async emitSubagentUpdate(
+    parentRegistry: HandlerRegistry,
+    args: {
+      childRunId: string;
+      subagentType: string;
+      subagentAgentId: string;
+      parentToolCallId?: string;
+      phase: SubagentUpdatePhase;
+      data?: unknown;
+      label?: string;
+    }
+  ): Promise<void> {
+    const handler = parentRegistry.getHandler(GraphEvents.ON_SUBAGENT_UPDATE);
+    if (!handler) {
+      return;
+    }
+    const event: SubagentUpdateEvent = {
+      runId: this.parentRunId,
+      subagentRunId: args.childRunId,
+      subagentType: args.subagentType,
+      subagentAgentId: args.subagentAgentId,
+      parentAgentId: this.parentAgentId,
+      parentToolCallId: args.parentToolCallId,
+      phase: args.phase,
+      data: args.data,
+      label: args.label,
+      timestamp: new Date().toISOString(),
+    };
+    try {
+      await handler.handle(GraphEvents.ON_SUBAGENT_UPDATE, event);
+    } catch {
+      /* observational — swallow */
+    }
+  }
+
+  /**
+   * Builds a BaseCallbackHandler that intercepts the child graph's custom
+   * events. Routing rules:
+   *   - `ON_TOOL_EXECUTE` → forwarded as-is to the parent's ON_TOOL_EXECUTE
+   *     handler (so event-driven tools work identically for child and parent).
+   *   - `ON_RUN_STEP` / `ON_RUN_STEP_DELTA` / `ON_RUN_STEP_COMPLETED` /
+   *     `ON_MESSAGE_DELTA` / `ON_REASONING_DELTA` → wrapped in a
+   *     {@link GraphEvents.ON_SUBAGENT_UPDATE} envelope with a human-readable
+   *     label, delivered to the parent's subagent-update handler.
+   *   - Everything else → ignored (keeps parent's UI scoped to the events it
+   *     cares about; host apps can extend by registering more phases).
+   */
+  private createForwarderCallback(args: {
+    parentRegistry: HandlerRegistry;
+    subagentType: string;
+    subagentAgentId: string;
+    childRunId: string;
+    parentToolCallId?: string;
+  }): BaseCallbackHandler {
+    const {
+      parentRegistry,
+      subagentType,
+      subagentAgentId,
+      childRunId,
+      parentToolCallId,
+    } = args;
+    const parentRunId = this.parentRunId;
+    const parentAgentId = this.parentAgentId;
+
+    const wrap = async (
+      eventName: string,
+      phase: SubagentUpdatePhase,
+      data: unknown
+    ): Promise<void> => {
+      const handler = parentRegistry.getHandler(GraphEvents.ON_SUBAGENT_UPDATE);
+      if (!handler) {
+        return;
+      }
+      const event: SubagentUpdateEvent = {
+        runId: parentRunId,
+        subagentRunId: childRunId,
+        subagentType,
+        subagentAgentId,
+        parentAgentId,
+        parentToolCallId,
+        phase,
+        data,
+        label: summarizeEvent(eventName, data),
+        timestamp: new Date().toISOString(),
+      };
+      try {
+        await handler.handle(GraphEvents.ON_SUBAGENT_UPDATE, event);
+      } catch {
+        /* observational — swallow */
+      }
+    };
+
+    const handler = BaseCallbackHandler.fromMethods({
+      [Callback.CUSTOM_EVENT]: async (
+        eventName: string,
+        data: unknown
+      ): Promise<void> => {
+        if (eventName === GraphEvents.ON_TOOL_EXECUTE) {
+          const toolHandler = parentRegistry.getHandler(
+            GraphEvents.ON_TOOL_EXECUTE
+          );
+          if (toolHandler) {
+            await toolHandler.handle(
+              GraphEvents.ON_TOOL_EXECUTE,
+              data as ToolExecuteBatchRequest
+            );
+          }
+          /**
+           * We also surface a short notice in the subagent-update stream so
+           * the UI can show "calling <tool>" for each tool the child spawns.
+           */
+          await wrap(eventName, 'run_step', data);
+          return;
+        }
+
+        if (eventName === GraphEvents.ON_RUN_STEP) {
+          await wrap(eventName, 'run_step', data);
+          return;
+        }
+        if (eventName === GraphEvents.ON_RUN_STEP_DELTA) {
+          await wrap(eventName, 'run_step_delta', data);
+          return;
+        }
+        if (eventName === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          await wrap(eventName, 'run_step_completed', data);
+          return;
+        }
+        if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
+          await wrap(eventName, 'message_delta', data);
+          return;
+        }
+        if (eventName === GraphEvents.ON_REASONING_DELTA) {
+          await wrap(eventName, 'reasoning_delta', data);
+          return;
+        }
+      },
+    });
+    /**
+     * `awaitHandlers = true` is required so the child's `ToolNode` actually
+     * blocks on the parent's `ON_TOOL_EXECUTE` handler until it resolves
+     * the batch request. The same flag applies to observational events
+     * (message_delta, run_step, …), which means a slow
+     * `ON_SUBAGENT_UPDATE` handler on the host serializes the child
+     * stream. If host-side latency becomes a concern, a future
+     * refinement could split operational and observational events into
+     * separate callback handlers with distinct await semantics.
+     */
+    handler.awaitHandlers = true;
+    return handler;
+  }
+}
+
+/**
+ * Produces a short single-line label for an arbitrary forwarded child event.
+ * Used to populate {@link SubagentUpdateEvent.label} so the host UI can show
+ * a compact status ticker without parsing the raw payload.
+ */
+export function summarizeEvent(eventName: string, data: unknown): string {
+  if (eventName === GraphEvents.ON_TOOL_EXECUTE) {
+    const req = data as { toolCalls?: Array<{ name?: string }> };
+    const names = (req.toolCalls ?? [])
+      .map((c) => c.name)
+      .filter((n): n is string => typeof n === 'string');
+    return names.length > 0 ? `Calling ${names.join(', ')}` : 'Calling tool';
+  }
+  if (eventName === GraphEvents.ON_RUN_STEP) {
+    const step = data as {
+      type?: string;
+      stepDetails?: { type?: string; tool_calls?: Array<{ name?: string }> };
+    };
+    const detailType = step.stepDetails?.type ?? step.type ?? 'step';
+    if (detailType === 'tool_calls') {
+      const names = (step.stepDetails?.tool_calls ?? [])
+        .map((c) => c.name)
+        .filter((n): n is string => typeof n === 'string');
+      return names.length > 0
+        ? `Using tool: ${names.join(', ')}`
+        : 'Planning tool call';
+    }
+    if (detailType === 'message_creation') {
+      return 'Thinking…';
+    }
+    return `Step: ${detailType}`;
+  }
+  if (eventName === GraphEvents.ON_RUN_STEP_COMPLETED) {
+    const step = data as {
+      result?: {
+        type?: string;
+        tool_call?: { name?: string; output?: string };
+      };
+    };
+    const tool = step.result?.tool_call;
+    if (tool?.name != null && tool.name !== '') {
+      return `Tool ${tool.name} complete`;
+    }
+    return 'Step complete';
+  }
+  if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
+    return 'Streaming…';
+  }
+  return eventName;
 }
 
 /**
@@ -300,10 +613,15 @@ export function resolveSubagentConfigs(
 
 /**
  * Build child AgentInputs from a resolved config, stripping nesting and
- * event-driven fields. When `allowNested: true`, the child's
+ * (optionally) event-driven fields. When `allowNested: true`, the child's
  * `maxSubagentDepth` is decremented so that depth is consumed as the call
  * chain deepens across graph boundaries — the parent's executor-level check
  * alone cannot see into the child graph's separate executor.
+ *
+ * When `keepToolDefinitions` is `true`, the child retains the parent's
+ * `toolDefinitions` so event-driven tools remain usable. This is only safe
+ * when the caller has wired a forwarder for `ON_TOOL_EXECUTE` to a
+ * registered handler — otherwise the child will hang on tool dispatch.
  *
  * @remarks Advanced utility: exported primarily for testing and by
  * {@link SubagentExecutor}. Host applications configuring subagents should
@@ -316,13 +634,27 @@ export function resolveSubagentConfigs(
 export function buildChildInputs(
   config: ResolvedSubagentConfig,
   childAgentId: string,
-  parentMaxDepth: number
+  parentMaxDepth: number,
+  keepToolDefinitions: boolean = false
 ): AgentInputs {
   const { agentInputs } = config;
   const childInputs: AgentInputs = {
     ...agentInputs,
     agentId: childAgentId,
-    toolDefinitions: undefined,
+    toolDefinitions: keepToolDefinitions
+      ? agentInputs.toolDefinitions
+      : undefined,
+    /**
+     * Subagents run in an isolated context by contract. Parent-run-scoped
+     * fields that would otherwise survive the shallow-spread clone — the
+     * cross-run conversation summary and the prior-turn tool-discovery
+     * set — are cleared here so the child starts fresh. Host applications
+     * that want a subagent to see parent context must thread it in
+     * explicitly (e.g. via the `description` argument to the subagent
+     * tool), not via inherited state.
+     */
+    initialSummary: undefined,
+    discoveredTools: undefined,
   };
 
   if (config.allowNested === true) {

--- a/src/tools/subagent/index.ts
+++ b/src/tools/subagent/index.ts
@@ -1,0 +1,12 @@
+export {
+  SubagentExecutor,
+  filterSubagentResult,
+  resolveSubagentConfigs,
+  buildChildInputs,
+} from './SubagentExecutor';
+export type {
+  SubagentExecuteParams,
+  SubagentExecuteResult,
+  SubagentExecutorOptions,
+  ChildGraphFactory,
+} from './SubagentExecutor';

--- a/src/tools/subagent/index.ts
+++ b/src/tools/subagent/index.ts
@@ -3,6 +3,7 @@ export {
   filterSubagentResult,
   resolveSubagentConfigs,
   buildChildInputs,
+  summarizeEvent,
 } from './SubagentExecutor';
 export type {
   SubagentExecuteParams,

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -388,6 +388,29 @@ export type MultiAgentGraphInput = StandardGraphInput & {
   edges: GraphEdge[];
 };
 
+/** Configuration for a subagent type that can be spawned by a parent agent. */
+export type SubagentConfig = {
+  /** Identifier used in the tool's `subagent_type` enum (e.g. 'researcher', 'coder'). */
+  type: string;
+  /** Human-readable display name. */
+  name: string;
+  /** What this subagent specializes in — shown to the LLM. */
+  description: string;
+  /** Full agent config for the child graph. Omit when `self` is true. */
+  agentInputs?: AgentInputs;
+  /** When true, reuse the parent's AgentInputs (context isolation without separate config). */
+  self?: boolean;
+  /** Max AGENT→TOOLS cycles before forced stop (default: 25). */
+  maxTurns?: number;
+  /** Allow this subagent to spawn its own subagents (default: false). */
+  allowNested?: boolean;
+};
+
+/** SubagentConfig with agentInputs guaranteed present (self-spawn resolved). */
+export type ResolvedSubagentConfig = SubagentConfig & {
+  agentInputs: AgentInputs;
+};
+
 export interface AgentInputs {
   agentId: string;
   /** Human-readable name for the agent (used in handoff context). Defaults to agentId if not provided. */
@@ -431,6 +454,10 @@ export interface AgentInputs {
   maxToolResultChars?: number;
   /** Pre-computed tool schema token count (from cache). Skips recalculation when provided. */
   toolSchemaTokens?: number;
+  /** Subagent configurations for hierarchical delegation. Each defines a child agent type. */
+  subagentConfigs?: SubagentConfig[];
+  /** Maximum subagent nesting depth. Default 1 means top-level agents can spawn subagents but subagents cannot nest further. */
+  maxSubagentDepth?: number;
 }
 
 export interface ContextPruningConfig {

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -18,7 +18,13 @@ import type {
 import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type { GoogleAIToolType } from '@langchain/google-common';
-import type { ToolMap, ToolEndEvent, GenericTool, LCTool } from '@/types/tools';
+import type {
+  ToolMap,
+  ToolEndEvent,
+  GenericTool,
+  LCTool,
+  ToolExecuteBatchRequest,
+} from '@/types/tools';
 import type { Providers, Callback, GraphNodeKeys } from '@/common';
 import type { StandardGraph, MultiAgentGraph } from '@/graphs';
 import type { ClientOptions } from '@/types/llm';
@@ -105,7 +111,9 @@ export interface EventHandler {
       | SummarizeStartEvent
       | SummarizeDeltaEvent
       | SummarizeCompleteEvent
+      | SubagentUpdateEvent
       | AgentLogEvent
+      | ToolExecuteBatchRequest
       | { result: ToolEndEvent },
     metadata?: Record<string, unknown>,
     graph?: StandardGraph | MultiAgentGraph
@@ -410,6 +418,50 @@ export type SubagentConfig = {
 export type ResolvedSubagentConfig = SubagentConfig & {
   agentInputs: AgentInputs;
 };
+
+/** Lifecycle phase carried on {@link SubagentUpdateEvent}. */
+export type SubagentUpdatePhase =
+  | 'start'
+  | 'run_step'
+  | 'run_step_delta'
+  | 'run_step_completed'
+  | 'message_delta'
+  | 'reasoning_delta'
+  | 'stop'
+  | 'error';
+
+/**
+ * Wrapper event emitted when a subagent's child graph dispatches activity.
+ * Lets hosts show subagent progress in a UI surface separate from the parent
+ * conversation without having to untangle events by agent ID.
+ */
+export interface SubagentUpdateEvent {
+  /** Parent run ID. */
+  runId: string;
+  /** Child run ID (unique per subagent execution). */
+  subagentRunId: string;
+  /**
+   * Parent-side `tool_call_id` for the `subagent` tool invocation that
+   * triggered this run. Stable for the duration of the child; lets hosts
+   * correlate updates deterministically instead of inferring by ordering.
+   * Omitted when the executor was invoked outside of a tool-call context.
+   */
+  parentToolCallId?: string;
+  /** Subagent `type` identifier from the SubagentConfig. */
+  subagentType: string;
+  /** Child agent ID assigned to this subagent execution. */
+  subagentAgentId: string;
+  /** Parent agent ID that spawned this subagent. */
+  parentAgentId?: string;
+  /** Lifecycle phase carried by this update. */
+  phase: SubagentUpdatePhase;
+  /** Underlying event payload (shape depends on phase). */
+  data?: unknown;
+  /** Short human-readable description. Hosts can render this directly. */
+  label?: string;
+  /** ISO timestamp for ordering / display. */
+  timestamp: string;
+}
 
 export interface AgentInputs {
   agentId: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@
 export * from './graph';
 export * from './llm';
 export * from './run';
+export * from './skill';
 export * from './stream';
 export * from './tools';
 export * from './summarize';

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -11,6 +11,7 @@ import type * as s from '@/types/stream';
 import type * as e from '@/common/enum';
 import type * as g from '@/types/graph';
 import type * as l from '@/types/llm';
+import type { HookRegistry } from '@/hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ZodObjectAny = z.ZodObject<any, any, any, any>;
@@ -112,6 +113,17 @@ export type RunConfig = {
   runId: string;
   graphConfig: LegacyGraphConfig | StandardGraphConfig | MultiAgentGraphConfig;
   customHandlers?: Record<string, g.EventHandler>;
+  /**
+   * Pre-constructed hook registry for this run. Hooks fire at lifecycle
+   * points in `processStream` (RunStart, UserPromptSubmit, Stop,
+   * StopFailure) and — once the tool-hook PR lands — around tool calls.
+   *
+   * Pass `undefined` (the default) to skip all hook dispatch. When a
+   * registry is provided, the run attaches it to the `Graph` so internal
+   * nodes can fire hooks too, and clears the session in the `finally`
+   * block to prevent leaks.
+   */
+  hooks?: HookRegistry;
   returnContent?: boolean;
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -117,7 +117,8 @@ export type RunConfig = {
   /**
    * Pre-constructed hook registry for this run. Hooks fire at lifecycle
    * points in `processStream` (RunStart, UserPromptSubmit, Stop,
-   * StopFailure) and — once the tool-hook PR lands — around tool calls.
+   * StopFailure) and around tool calls (PreToolUse, PostToolUse,
+   * PostToolUseFailure, PermissionDenied).
    *
    * Pass `undefined` (the default) to skip all hook dispatch. When a
    * registry is provided, the run attaches it to the `Graph` so internal

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -11,6 +11,7 @@ import type * as s from '@/types/stream';
 import type * as e from '@/common/enum';
 import type * as g from '@/types/graph';
 import type * as l from '@/types/llm';
+import type { ToolSessionMap } from '@/types/tools';
 import type { HookRegistry } from '@/hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -138,6 +139,12 @@ export type RunConfig = {
   calibrationRatio?: number;
   /** Skip post-stream cleanup (clearHeavyState) — useful for tests that inspect graph state after processStream */
   skipCleanup?: boolean;
+  /**
+   * Initial session state to seed the Graph's ToolSessionMap.
+   * Used to carry over code environment sessions from skill file priming
+   * at run start, so ToolNode can inject session_id + files into tool calls.
+   */
+  initialSessions?: ToolSessionMap;
 };
 
 export type ProvidedCallbacks =

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -1,0 +1,11 @@
+// src/types/skill.ts
+
+/** Minimal skill metadata for catalog assembly. The host provides these from its own data layer. */
+export type SkillCatalogEntry = {
+  /** Kebab-case identifier (what the model passes to SkillTool) */
+  name: string;
+  /** One-line description for the catalog listing */
+  description: string;
+  /** Optional human-readable label (UI only, not shown to model) */
+  displayTitle?: string;
+};

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -3,7 +3,7 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { HookRegistry } from '@/hooks';
-import type { ToolErrorData } from './stream';
+import type { MessageContentComplex, ToolErrorData } from './stream';
 import { EnvVar } from '@/common';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
@@ -193,6 +193,26 @@ export type ToolExecuteBatchRequest = {
   reject: (error: Error) => void;
 };
 
+/**
+ * A message injected into graph state by any tool execution handler.
+ * Generic mechanism: any tool returning `injectedMessages` in its `ToolExecuteResult`
+ * will have these appended to state after the ToolMessage for this call.
+ */
+export type InjectedMessage = {
+  /** 'user' for skill body injection, 'system' for context hints.
+   *  Both are converted to HumanMessage at runtime; the original role
+   *  is preserved in additional_kwargs.role. */
+  role: 'user' | 'system';
+  /** Message content: string for simple text, array for complex multi-part content */
+  content: string | MessageContentComplex[];
+  /** When true, the message is framework-internal: not shown in UI, not counted as a user turn */
+  isMeta?: boolean;
+  /** Origin tag for downstream consumers (UI, pruner, compaction) */
+  source?: 'skill' | 'hook' | 'system';
+  /** Only set when source is 'skill', for compaction preservation */
+  skillName?: string;
+};
+
 /** Result for a single tool call in event-driven execution */
 export type ToolExecuteResult = {
   /** Matches ToolCallRequest.id */
@@ -205,6 +225,13 @@ export type ToolExecuteResult = {
   status: 'success' | 'error';
   /** Error message if status is 'error' */
   errorMessage?: string;
+  /**
+   * Messages to inject into graph state after the ToolMessage for this call.
+   * Placed after tool results to respect provider message ordering (tool_call -> tool_result adjacency).
+   * The host's message formatter may merge injected user messages with the preceding tool_result turn.
+   * Generic mechanism: any tool execution handler can use this.
+   */
+  injectedMessages?: InjectedMessage[];
 };
 
 /** Map of tool names to tool definitions */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -2,6 +2,7 @@
 import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
+import type { HookRegistry } from '@/hooks';
 import type { ToolErrorData } from './stream';
 import { EnvVar } from '@/common';
 
@@ -49,6 +50,12 @@ export type ToolNodeOptions = {
   agentId?: string;
   /** Tool names that must be executed directly (via runTool) even in event-driven mode (e.g., graph-managed handoff tools) */
   directToolNames?: Set<string>;
+  /**
+   * Hook registry for PreToolUse/PostToolUse lifecycle hooks.
+   * Only fires for event-driven tool calls (`dispatchToolEvents`). Tools
+   * routed through `directToolNames` bypass hook dispatch entirely.
+   */
+  hookRegistry?: HookRegistry;
   /** Max context tokens for the agent — used to compute tool result truncation limits. */
   maxContextTokens?: number;
   /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -352,6 +352,12 @@ export type ProgrammaticExecutionArtifact = {
   files?: FileRefs;
 };
 
+/** Parameters for creating a bash execution tool (same API as CodeExecutor, bash-only) */
+export type BashExecutionToolParams = CodeExecutionToolParams;
+
+/** Parameters for creating a bash programmatic tool calling tool (same API as PTC, bash-only) */
+export type BashProgrammaticToolCallingParams = ProgrammaticToolCallingParams;
+
 /**
  * Initialization parameters for the PTC tool
  */


### PR DESCRIPTION
## Summary

- Move `initializeModel` inside the try/catch in `executeSummarizationWithFallback` so that errors thrown during model construction (e.g. `Unsupported LLM provider: <name>`) are surfaced through the `log('error', ...)` path and fall through to the metadata-stub fallback, instead of bubbling up silently.
- This is the defense-in-depth half of the fix for [LibreChat Discussion #12614](https://github.com/danny-avila/LibreChat/discussions/12614): when a caller forwards an unrecognized summarization provider name (e.g. a custom-endpoint label), the error is now observable in operator logs and summarization continues with a metadata stub rather than crashing the node.
- Related to [LibreChat Discussion #12733](https://github.com/danny-avila/LibreChat/discussions/12733), which reports exactly this silent-failure mode.

The companion fix in LibreChat translates custom-endpoint provider names before they reach the SDK, so most users should never see this error path — this PR is a safety net for misconfigurations and future edge cases.

## Test plan
- [x] `npx jest src/summarization/` — all 24 tests pass, including the new `catches model initialization errors and falls back to metadata stub`.
- [x] New test verifies the fix by mocking `getChatModelClass` to throw and asserting the node resolves instead of rejecting, and that `setSummary` receives the metadata stub.
- [x] `tsc --noEmit` and `eslint` clean on the modified files.