### PR TITLE
🗝️ feat: Make CODE_API_KEY optional for sandbox tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
         env:
           NODE_OPTIONS: '--experimental-vm-modules'
           NODE_ENV: test
-          LIBRECHAT_CODE_API_KEY: ${{ secrets.LIBRECHAT_CODE_API_KEY }}
           LIBRECHAT_CODE_BASEURL: ${{ secrets.LIBRECHAT_CODE_BASEURL }}
 
       - name: Check for Tool Search changes
@@ -175,5 +174,4 @@ jobs:
         env:
           NODE_OPTIONS: '--experimental-vm-modules'
           NODE_ENV: test
-          LIBRECHAT_CODE_API_KEY: ${{ secrets.LIBRECHAT_CODE_API_KEY }}
           LIBRECHAT_CODE_BASEURL: ${{ secrets.LIBRECHAT_CODE_BASEURL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,7 +130,6 @@ jobs:
         run: npx jest src/tools/__tests__/ProgrammaticToolCalling.test.ts
         env:
           NODE_ENV: test
-          LIBRECHAT_CODE_API_KEY: ${{ secrets.LIBRECHAT_CODE_API_KEY }}
           LIBRECHAT_CODE_BASEURL: ${{ secrets.LIBRECHAT_CODE_BASEURL }}
 
       - name: Check for Tool Search changes
@@ -155,7 +154,6 @@ jobs:
         run: npx jest src/tools/__tests__/ToolSearch.test.ts
         env:
           NODE_ENV: test
-          LIBRECHAT_CODE_API_KEY: ${{ secrets.LIBRECHAT_CODE_API_KEY }}
           LIBRECHAT_CODE_BASEURL: ${{ secrets.LIBRECHAT_CODE_BASEURL }}
 
       - name: Prune development dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.68-dev.0",
+  "version": "3.1.68-dev.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.68-dev.0",
+      "version": "3.1.68-dev.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.68-dev.0",
+  "version": "3.1.68-dev.1",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -206,6 +206,5 @@ export enum TitleMethod {
 }
 
 export enum EnvVar {
-  CODE_API_KEY = 'LIBRECHAT_CODE_API_KEY',
   CODE_BASEURL = 'LIBRECHAT_CODE_BASEURL',
 }

--- a/src/scripts/programmatic_exec.ts
+++ b/src/scripts/programmatic_exec.ts
@@ -94,15 +94,6 @@ async function main(): Promise<void> {
   console.log('==============================================');
   console.log('Demonstrating runtime toolMap injection\n');
 
-  const apiKey = process.env.LIBRECHAT_CODE_API_KEY;
-  if (!apiKey) {
-    console.error(
-      'Error: LIBRECHAT_CODE_API_KEY environment variable is not set.'
-    );
-    console.log('Please set it in your .env file or environment.');
-    process.exit(1);
-  }
-
   console.log('Creating mock tools...');
   const mockTools: StructuredToolInterface[] = [
     createGetTeamMembersTool(),
@@ -119,7 +110,7 @@ async function main(): Promise<void> {
   );
 
   console.log('\nCreating PTC tool (without toolMap)...');
-  const ptcTool = createProgrammaticToolCallingTool({ apiKey });
+  const ptcTool = createProgrammaticToolCallingTool();
   console.log('PTC tool created successfully!');
   console.log(
     'Note: toolMap will be passed at runtime with each invocation.\n'

--- a/src/scripts/test_code_api.ts
+++ b/src/scripts/test_code_api.ts
@@ -11,15 +11,9 @@ config();
 import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
-const API_KEY = process.env.LIBRECHAT_CODE_API_KEY ?? '';
 const BASE_URL =
   process.env.LIBRECHAT_CODE_BASEURL ?? 'https://api.librechat.ai/v1';
 const PROXY = process.env.PROXY;
-
-if (!API_KEY) {
-  console.error('LIBRECHAT_CODE_API_KEY not set');
-  process.exit(1);
-}
 
 interface FileRef {
   id: string;
@@ -53,7 +47,6 @@ async function makeRequest(
     headers: {
       'Content-Type': 'application/json',
       'User-Agent': 'LibreChat/1.0',
-      'X-API-Key': API_KEY,
     },
   };
 

--- a/src/scripts/tool_search.ts
+++ b/src/scripts/tool_search.ts
@@ -66,15 +66,6 @@ async function main(): Promise<void> {
   console.log('================================');
   console.log('Demonstrating runtime tool registry injection\n');
 
-  const apiKey = process.env.LIBRECHAT_CODE_API_KEY;
-  if (!apiKey) {
-    console.error(
-      'Error: LIBRECHAT_CODE_API_KEY environment variable is not set.'
-    );
-    console.log('Please set it in your .env file or environment.');
-    process.exit(1);
-  }
-
   console.log('Creating sample tool registry...');
   const toolRegistry = createToolSearchToolRegistry();
   console.log(
@@ -82,7 +73,7 @@ async function main(): Promise<void> {
   );
 
   console.log('\nCreating Tool Search Regex tool WITH registry for testing...');
-  const searchTool = createToolSearch({ apiKey, toolRegistry });
+  const searchTool = createToolSearch({ toolRegistry });
   console.log('Tool created successfully!');
   console.log(
     'Note: In production, ToolNode injects toolRegistry via params when invoked through the graph.\n'

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -2,10 +2,9 @@ import { config } from 'dotenv';
 import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
-import { getEnvironmentVariable } from '@langchain/core/utils/env';
 import type * as t from '@/types';
 import { imageExtRegex, getCodeBaseURL } from './CodeExecutor';
-import { EnvVar, Constants } from '@/common';
+import { Constants } from '@/common';
 
 config();
 
@@ -63,15 +62,6 @@ export const BashExecutionToolDefinition = {
 function createBashExecutionTool(
   params: t.BashExecutionToolParams = {}
 ): DynamicStructuredTool {
-  const apiKey =
-    params[EnvVar.CODE_API_KEY] ??
-    params.apiKey ??
-    getEnvironmentVariable(EnvVar.CODE_API_KEY) ??
-    '';
-  if (!apiKey) {
-    throw new Error('No API key provided for bash execution tool.');
-  }
-
   return tool(
     async (rawInput, config) => {
       const { command, ...rest } = rawInput as {
@@ -99,7 +89,6 @@ function createBashExecutionTool(
             method: 'GET',
             headers: {
               'User-Agent': 'LibreChat/1.0',
-              'X-API-Key': apiKey,
             },
           };
 
@@ -141,7 +130,6 @@ function createBashExecutionTool(
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
-            'X-API-Key': apiKey,
           },
           body: JSON.stringify(postData),
         };

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -1,5 +1,4 @@
 import { config } from 'dotenv';
-import { getEnvironmentVariable } from '@langchain/core/utils/env';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
@@ -10,7 +9,7 @@ import {
   formatCompletedResponse,
 } from './ProgrammaticToolCalling';
 import { getCodeBaseURL } from './CodeExecutor';
-import { EnvVar, Constants } from '@/common';
+import { Constants } from '@/common';
 
 config();
 
@@ -242,19 +241,6 @@ export function filterBashToolsByUsage(
 export function createBashProgrammaticToolCallingTool(
   initParams: t.BashProgrammaticToolCallingParams = {}
 ): DynamicStructuredTool {
-  const apiKey =
-    (initParams[EnvVar.CODE_API_KEY] as string | undefined) ??
-    initParams.apiKey ??
-    getEnvironmentVariable(EnvVar.CODE_API_KEY) ??
-    '';
-
-  if (!apiKey) {
-    throw new Error(
-      'No API key provided for bash programmatic tool calling. ' +
-        'Set CODE_API_KEY environment variable or pass apiKey in initParams.'
-    );
-  }
-
   const baseUrl = initParams.baseUrl ?? getCodeBaseURL();
   const maxRoundTrips = initParams.maxRoundTrips ?? DEFAULT_MAX_ROUND_TRIPS;
   const proxy = initParams.proxy ?? process.env.PROXY;
@@ -308,12 +294,11 @@ export function createBashProgrammaticToolCallingTool(
         if (_injected_files && _injected_files.length > 0) {
           files = _injected_files;
         } else if (session_id != null && session_id.length > 0) {
-          files = await fetchSessionFiles(baseUrl, apiKey, session_id, proxy);
+          files = await fetchSessionFiles(baseUrl, session_id, proxy);
         }
 
         let response = await makeRequest(
           EXEC_ENDPOINT,
-          apiKey,
           {
             lang: 'bash',
             code,
@@ -354,7 +339,6 @@ export function createBashProgrammaticToolCallingTool(
 
           response = await makeRequest(
             EXEC_ENDPOINT,
-            apiKey,
             {
               continuation_token: response.continuation_token,
               tool_results: toolResults,

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -95,15 +95,6 @@ export const CodeExecutionToolDefinition = {
 function createCodeExecutionTool(
   params: t.CodeExecutionToolParams = {}
 ): DynamicStructuredTool {
-  const apiKey =
-    params[EnvVar.CODE_API_KEY] ??
-    params.apiKey ??
-    getEnvironmentVariable(EnvVar.CODE_API_KEY) ??
-    '';
-  if (!apiKey) {
-    throw new Error('No API key provided for code execution tool.');
-  }
-
   return tool(
     async (rawInput, config) => {
       const { lang, code, ...rest } = rawInput as {
@@ -143,7 +134,6 @@ function createCodeExecutionTool(
             method: 'GET',
             headers: {
               'User-Agent': 'LibreChat/1.0',
-              'X-API-Key': apiKey,
             },
           };
 
@@ -185,7 +175,6 @@ function createCodeExecutionTool(
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
-            'X-API-Key': apiKey,
           },
           body: JSON.stringify(postData),
         };

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -2,12 +2,11 @@
 import { config } from 'dotenv';
 import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import { getEnvironmentVariable } from '@langchain/core/utils/env';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import { imageExtRegex, getCodeBaseURL } from './CodeExecutor';
-import { EnvVar, Constants } from '@/common';
+import { Constants } from '@/common';
 
 config();
 
@@ -261,14 +260,12 @@ export function filterToolsByUsage(
  * Fetches files from a previous session to make them available for the current execution.
  * Files are returned as CodeEnvFile references to be included in the request.
  * @param baseUrl - The base URL for the Code API
- * @param apiKey - The API key for authentication
  * @param sessionId - The session ID to fetch files from
  * @param proxy - Optional HTTP proxy URL
  * @returns Array of CodeEnvFile references, or empty array if fetch fails
  */
 export async function fetchSessionFiles(
   baseUrl: string,
-  apiKey: string,
   sessionId: string,
   proxy?: string
 ): Promise<t.CodeEnvFile[]> {
@@ -278,7 +275,6 @@ export async function fetchSessionFiles(
       method: 'GET',
       headers: {
         'User-Agent': 'LibreChat/1.0',
-        'X-API-Key': apiKey,
       },
     };
 
@@ -321,14 +317,12 @@ export async function fetchSessionFiles(
 /**
  * Makes an HTTP request to the Code API.
  * @param endpoint - The API endpoint URL
- * @param apiKey - The API key for authentication
  * @param body - The request body
  * @param proxy - Optional HTTP proxy URL
  * @returns The parsed API response
  */
 export async function makeRequest(
   endpoint: string,
-  apiKey: string,
   body: Record<string, unknown>,
   proxy?: string
 ): Promise<t.ProgrammaticExecutionResponse> {
@@ -337,7 +331,6 @@ export async function makeRequest(
     headers: {
       'Content-Type': 'application/json',
       'User-Agent': 'LibreChat/1.0',
-      'X-API-Key': apiKey,
     },
     body: JSON.stringify(body),
   };
@@ -596,14 +589,11 @@ export function formatCompletedResponse(
  *
  * The tool map must be provided at runtime via config.configurable.toolMap.
  *
- * @param params - Configuration parameters (apiKey, baseUrl, maxRoundTrips, proxy)
+ * @param params - Configuration parameters (baseUrl, maxRoundTrips, proxy)
  * @returns A LangChain DynamicStructuredTool for programmatic tool calling
  *
  * @example
- * const ptcTool = createProgrammaticToolCallingTool({
- *   apiKey: process.env.CODE_API_KEY,
- *   maxRoundTrips: 20
- * });
+ * const ptcTool = createProgrammaticToolCallingTool({ maxRoundTrips: 20 });
  *
  * const [output, artifact] = await ptcTool.invoke(
  *   { code, tools },
@@ -613,19 +603,6 @@ export function formatCompletedResponse(
 export function createProgrammaticToolCallingTool(
   initParams: t.ProgrammaticToolCallingParams = {}
 ): DynamicStructuredTool {
-  const apiKey =
-    (initParams[EnvVar.CODE_API_KEY] as string | undefined) ??
-    initParams.apiKey ??
-    getEnvironmentVariable(EnvVar.CODE_API_KEY) ??
-    '';
-
-  if (!apiKey) {
-    throw new Error(
-      'No API key provided for programmatic tool calling. ' +
-        'Set CODE_API_KEY environment variable or pass apiKey in initParams.'
-    );
-  }
-
   const baseUrl = initParams.baseUrl ?? getCodeBaseURL();
   const maxRoundTrips = initParams.maxRoundTrips ?? DEFAULT_MAX_ROUND_TRIPS;
   const proxy = initParams.proxy ?? process.env.PROXY;
@@ -685,12 +662,11 @@ export function createProgrammaticToolCallingTool(
         if (_injected_files && _injected_files.length > 0) {
           files = _injected_files;
         } else if (session_id != null && session_id.length > 0) {
-          files = await fetchSessionFiles(baseUrl, apiKey, session_id, proxy);
+          files = await fetchSessionFiles(baseUrl, session_id, proxy);
         }
 
         let response = await makeRequest(
           EXEC_ENDPOINT,
-          apiKey,
           {
             code,
             tools: effectiveTools,
@@ -730,7 +706,6 @@ export function createProgrammaticToolCallingTool(
 
           response = await makeRequest(
             EXEC_ENDPOINT,
-            apiKey,
             {
               continuation_token: response.continuation_token,
               tool_results: toolResults,

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -22,11 +22,10 @@ function getBM25Function(): BM25Fn {
 const BM25 = getBM25Function();
 import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-import { getEnvironmentVariable } from '@langchain/core/utils/env';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { getCodeBaseURL } from './CodeExecutor';
-import { EnvVar, Constants } from '@/common';
+import { Constants } from '@/common';
 
 config();
 
@@ -837,11 +836,11 @@ function formatServerListing(
  *
  * @example
  * // Option 1: Code interpreter mode (regex via sandbox)
- * const tool = createToolSearch({ apiKey, toolRegistry });
+ * const tool = createToolSearch({ toolRegistry });
  * await tool.invoke({ query: 'expense.*report' });
  *
  * @example
- * // Option 2: Local mode (safe substring search, no API key needed)
+ * // Option 2: Local mode (safe substring search)
  * const tool = createToolSearch({ mode: 'local', toolRegistry });
  * await tool.invoke({ query: 'expense' });
  */
@@ -852,20 +851,6 @@ function createToolSearch(
   const defaultOnlyDeferred = initParams.onlyDeferred ?? true;
   const mcpNameFormat: t.McpNameFormat = initParams.mcpNameFormat ?? 'full';
   const schema = createToolSearchSchema(mode);
-
-  const apiKey: string =
-    mode === 'code_interpreter'
-      ? ((initParams[EnvVar.CODE_API_KEY] as string | undefined) ??
-        initParams.apiKey ??
-        getEnvironmentVariable(EnvVar.CODE_API_KEY) ??
-        '')
-      : '';
-
-  if (mode === 'code_interpreter' && !apiKey) {
-    throw new Error(
-      'No API key provided for tool search in code_interpreter mode. Use mode: "local" to search without an API key.'
-    );
-  }
 
   const baseEndpoint = initParams.baseUrl ?? getCodeBaseURL();
   const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
@@ -1052,7 +1037,6 @@ ${mcpNote}${toolsListSection}
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
-            'X-API-Key': apiKey,
           },
           body: JSON.stringify(postData),
         };

--- a/src/tools/__tests__/ProgrammaticToolCalling.integration.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.integration.test.ts
@@ -3,10 +3,10 @@
  * Integration tests for Programmatic Tool Calling.
  * These tests hit the LIVE Code API and verify end-to-end functionality.
  *
- * Run with: npm test -- ProgrammaticToolCalling.integration.test.ts
+ * Run with: RUN_CODE_INTEGRATION_TESTS=1 npm test -- ProgrammaticToolCalling.integration.test.ts
  *
- * Requires LIBRECHAT_CODE_API_KEY environment variable.
- * Tests are skipped when the API key is not available.
+ * Opt-in via the `RUN_CODE_INTEGRATION_TESTS` environment variable —
+ * these tests hit a real sandbox so they don't run in CI by default.
  */
 import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
@@ -22,12 +22,11 @@ import {
   createProgrammaticToolRegistry,
 } from '@/test/mockTools';
 
-const apiKey = process.env.LIBRECHAT_CODE_API_KEY;
-const shouldSkip = apiKey == null || apiKey === '';
+const shouldSkip = process.env.RUN_CODE_INTEGRATION_TESTS !== '1';
 
-const describeIfApiKey = shouldSkip ? describe.skip : describe;
+const describeIfLive = shouldSkip ? describe.skip : describe;
 
-describeIfApiKey('ProgrammaticToolCalling - Live API Integration', () => {
+describeIfLive('ProgrammaticToolCalling - Live API Integration', () => {
   let ptcTool: ReturnType<typeof createProgrammaticToolCallingTool>;
   let toolMap: t.ToolMap;
   let toolDefinitions: t.LCTool[];
@@ -43,7 +42,7 @@ describeIfApiKey('ProgrammaticToolCalling - Live API Integration', () => {
     toolMap = new Map(tools.map((t) => [t.name, t]));
     toolDefinitions = Array.from(createProgrammaticToolRegistry().values());
 
-    ptcTool = createProgrammaticToolCallingTool({ apiKey: apiKey! });
+    ptcTool = createProgrammaticToolCallingTool();
   });
 
   it('executes simple single tool call', async () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -685,7 +685,6 @@ for member in team:
       );
 
       ptcTool = createProgrammaticToolCallingTool({
-        apiKey: 'test-key',
         baseUrl: 'http://mock-api',
       });
     });

--- a/src/tools/__tests__/ToolSearch.integration.test.ts
+++ b/src/tools/__tests__/ToolSearch.integration.test.ts
@@ -3,10 +3,10 @@
  * Integration tests for Tool Search Regex.
  * These tests hit the LIVE Code API and verify end-to-end search functionality.
  *
- * Run with: npm test -- ToolSearch.integration.test.ts
+ * Run with: RUN_CODE_INTEGRATION_TESTS=1 npm test -- ToolSearch.integration.test.ts
  *
- * Requires LIBRECHAT_CODE_API_KEY environment variable.
- * Tests are skipped when the API key is not available.
+ * Opt-in via the `RUN_CODE_INTEGRATION_TESTS` environment variable —
+ * these tests hit a real sandbox so they don't run in CI by default.
  */
 import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
@@ -15,17 +15,16 @@ import { describe, it, expect, beforeAll } from '@jest/globals';
 import { createToolSearch } from '../ToolSearch';
 import { createToolSearchToolRegistry } from '@/test/mockTools';
 
-const apiKey = process.env.LIBRECHAT_CODE_API_KEY;
-const shouldSkip = apiKey == null || apiKey === '';
+const shouldSkip = process.env.RUN_CODE_INTEGRATION_TESTS !== '1';
 
-const describeIfApiKey = shouldSkip ? describe.skip : describe;
+const describeIfLive = shouldSkip ? describe.skip : describe;
 
-describeIfApiKey('ToolSearch - Live API Integration', () => {
+describeIfLive('ToolSearch - Live API Integration', () => {
   let searchTool: ReturnType<typeof createToolSearch>;
   const toolRegistry = createToolSearchToolRegistry();
 
   beforeAll(() => {
-    searchTool = createToolSearch({ apiKey: apiKey!, toolRegistry });
+    searchTool = createToolSearch({ toolRegistry });
   });
 
   it('searches for expense-related tools', async () => {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -4,7 +4,6 @@ import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { HookRegistry } from '@/hooks';
 import type { MessageContentComplex, ToolErrorData } from './stream';
-import { EnvVar } from '@/common';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
 export type CustomToolCall = {
@@ -88,9 +87,7 @@ export type CodeExecutionToolParams =
   | {
       session_id?: string;
       user_id?: string;
-      apiKey?: string;
       files?: CodeEnvFile[];
-      [EnvVar.CODE_API_KEY]?: string;
     };
 
 export type FileRef = {
@@ -247,7 +244,6 @@ export type McpNameFormat = 'full' | 'base';
 
 /** Parameters for creating a Tool Search tool */
 export type ToolSearchParams = {
-  apiKey?: string;
   toolRegistry?: LCToolRegistry;
   onlyDeferred?: boolean;
   baseUrl?: string;
@@ -257,7 +253,6 @@ export type ToolSearchParams = {
   mcpServer?: string | string[];
   /** Format for MCP tool names: 'full' (tool_mcp_server) or 'base' (tool only). Default: 'full' */
   mcpNameFormat?: McpNameFormat;
-  [key: string]: unknown;
 };
 
 /** Simplified tool metadata for search purposes */
@@ -362,8 +357,6 @@ export type BashProgrammaticToolCallingParams = ProgrammaticToolCallingParams;
  * Initialization parameters for the PTC tool
  */
 export type ProgrammaticToolCallingParams = {
-  /** Code API key (or use CODE_API_KEY env var) */
-  apiKey?: string;
   /** Code API base URL (or use CODE_BASEURL env var) */
   baseUrl?: string;
   /** Safety limit for round-trips (default: 20) */
@@ -372,8 +365,6 @@ export type ProgrammaticToolCallingParams = {
   proxy?: string;
   /** Enable debug logging (or set PTC_DEBUG=true env var) */
   debug?: boolean;
-  /** Environment variable key for API key */
-  [key: string]: unknown;
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Phase 8 (LibreChat [#12767](https://github.com/danny-avila/LibreChat/pull/12767)) deprecates \`LIBRECHAT_CODE_API_KEY\` across every LibreChat-side reference. The sandbox service now authenticates consumers via other channels (network boundary, service token, etc.), so the library layer can drop the concept entirely — not just make it optional.

## What's removed

**Enum / types:**
- \`EnvVar.CODE_API_KEY\` (the \`CODE_BASEURL\` entry stays).
- \`apiKey\` + \`[EnvVar.CODE_API_KEY]\` on \`CodeExecutionToolParams\`, \`ProgrammaticToolCallingParams\`, \`ToolSearchParams\`. \`BashExecutionToolParams\` / \`BashProgrammaticToolCallingParams\` inherit the cleaner shapes.

**Tool factories (5):** \`createBashExecutionTool\`, \`createCodeExecutionTool\`, \`createProgrammaticToolCallingTool\`, \`createBashProgrammaticToolCallingTool\`, \`createToolSearch\`
- No more \`params[EnvVar.CODE_API_KEY] ?? params.apiKey ?? getEnvironmentVariable(EnvVar.CODE_API_KEY) ?? ''\` resolution chain.
- No more \`throw new Error('No API key provided for …')\` (five sites).
- No more \`X-API-Key\` outbound headers on any fetch.

**Helpers:**
- \`fetchSessionFiles(baseUrl, sessionId, proxy)\` — \`apiKey\` param dropped.
- \`makeRequest(endpoint, body, proxy)\` — \`apiKey\` param dropped.
- All internal callers updated accordingly.

**Scripts:**
- \`programmatic_exec.ts\`, \`tool_search.ts\`: env reads + pre-flight \`process.exit(1)\` guards + \`{ apiKey }\` args removed.
- \`test_code_api.ts\`: \`API_KEY\` constant + \`X-API-Key\` header dropped.

**Integration tests:**
- Gate flipped from "\`LIBRECHAT_CODE_API_KEY\` present" to explicit \`RUN_CODE_INTEGRATION_TESTS=1\` opt-in. Live-sandbox tests don't run by default in CI either way.

## Backward compat

Consumers that previously passed \`apiKey\` in params now get a TS error — the correct remediation is to drop the arg. Since the header is gone too, no runtime behavior remains for stragglers.

## Verification

- \`grep -rn "CODE_API_KEY\|LIBRECHAT_CODE_API_KEY" src/\` → 0 hits.
- \`grep -rn "X-API-Key" src/tools/\` → only the SEARX search tool header (unrelated feature, its own apiKey field).
- \`npx tsc --noEmit\`: clean.
- \`npx jest src/tools\`: 379 passing, 23 skipped (integration, gated on the new opt-in var). No regressions.
- \`npx eslint\` clean on every touched file.

Paired with [danny-avila/LibreChat#12767](https://github.com/danny-avila/LibreChat/pull/12767).