### PR TITLE
🪢 feat: Reference Previous Tool Outputs in Subsequent Calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.70",
+  "version": "3.1.71-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.70",
+      "version": "3.1.71-dev.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.70",
+  "version": "3.1.71-dev.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -168,6 +168,15 @@ export abstract class Graph<
     this.handlerRegistry = undefined;
     this.hookRegistry = undefined;
     this.toolOutputReferences = undefined;
+    /**
+     * ToolNodes compiled from this graph captured the registry
+     * instance at construction time, so simply dropping the Graph's
+     * own reference would leave their captured reference — and every
+     * stored `tool<i>turn<n>` entry, plus up to `maxTotalSize` of raw
+     * output — alive across subsequent `processStream()` calls. Wipe
+     * the registry's contents first so subsequent runs start fresh.
+     */
+    this._toolOutputRegistry?.clear();
     this._toolOutputRegistry = undefined;
     this.sessions.clear();
   }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -43,6 +43,7 @@ import {
 import { SubagentExecutor, resolveSubagentConfigs } from '@/tools/subagent';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
+import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { shouldTriggerSummarization } from '@/summarization';
@@ -135,6 +136,13 @@ export abstract class Graph<
    */
   toolOutputReferences: t.ToolOutputReferencesConfig | undefined;
   /**
+   * Shared registry instance used by every ToolNode compiled from this
+   * graph. Lazily constructed on first access so multi-agent graphs
+   * produce one registry per run (not one per agent), letting cross-
+   * agent `{{tool<i>turn<n>}}` substitutions resolve.
+   */
+  private _toolOutputRegistry?: ToolOutputReferenceRegistry;
+  /**
    * Tool session contexts for automatic state persistence across tool invocations.
    * Keyed by tool name (e.g., Constants.EXECUTE_CODE).
    * Currently supports code execution session tracking (session_id, files).
@@ -160,7 +168,29 @@ export abstract class Graph<
     this.handlerRegistry = undefined;
     this.hookRegistry = undefined;
     this.toolOutputReferences = undefined;
+    this._toolOutputRegistry = undefined;
     this.sessions.clear();
+  }
+
+  /**
+   * Returns the shared `ToolOutputReferenceRegistry` for this run,
+   * constructing it on first access. Returns `undefined` when the
+   * feature is disabled. All ToolNodes compiled from this graph share
+   * this single instance so cross-agent `{{…}}` references resolve.
+   */
+  protected getOrCreateToolOutputRegistry():
+    | ToolOutputReferenceRegistry
+    | undefined {
+    if (this.toolOutputReferences?.enabled !== true) {
+      return undefined;
+    }
+    if (this._toolOutputRegistry == null) {
+      this._toolOutputRegistry = new ToolOutputReferenceRegistry({
+        maxOutputSize: this.toolOutputReferences.maxOutputSize,
+        maxTotalSize: this.toolOutputReferences.maxTotalSize,
+      });
+    }
+    return this._toolOutputRegistry;
   }
 }
 
@@ -523,7 +553,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,
         maxToolResultChars: agentContext?.maxToolResultChars,
-        toolOutputReferences: this.toolOutputReferences,
+        toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
         errorHandler: (data, metadata) =>
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       });
@@ -555,7 +585,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sessions: this.sessions,
       maxContextTokens: agentContext?.maxContextTokens,
       maxToolResultChars: agentContext?.maxToolResultChars,
-      toolOutputReferences: this.toolOutputReferences,
+      toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
     });
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -129,6 +129,12 @@ export abstract class Graph<
   handlerRegistry: HandlerRegistry | undefined;
   hookRegistry: HookRegistry | undefined;
   /**
+   * Run-scoped config for the tool output reference registry. Threaded
+   * from `RunConfig.toolOutputReferences` down into every ToolNode this
+   * graph compiles.
+   */
+  toolOutputReferences: t.ToolOutputReferencesConfig | undefined;
+  /**
    * Tool session contexts for automatic state persistence across tool invocations.
    * Keyed by tool name (e.g., Constants.EXECUTE_CODE).
    * Currently supports code execution session tracking (session_id, files).
@@ -153,6 +159,7 @@ export abstract class Graph<
     this.invokedToolIds = undefined;
     this.handlerRegistry = undefined;
     this.hookRegistry = undefined;
+    this.toolOutputReferences = undefined;
     this.sessions.clear();
   }
 }
@@ -516,6 +523,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,
         maxToolResultChars: agentContext?.maxToolResultChars,
+        toolOutputReferences: this.toolOutputReferences,
         errorHandler: (data, metadata) =>
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       });
@@ -547,6 +555,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sessions: this.sessions,
       maxContextTokens: agentContext?.maxContextTokens,
       maxToolResultChars: agentContext?.maxToolResultChars,
+      toolOutputReferences: this.toolOutputReferences,
     });
   }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -45,6 +45,7 @@ export class Run<_T extends t.BaseGraphState> {
   private tokenCounter?: t.TokenCounter;
   private handlerRegistry?: HandlerRegistry;
   private hookRegistry?: HookRegistry;
+  private toolOutputReferences?: t.ToolOutputReferencesConfig;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   graphRunnable?: t.CompiledStateWorkflow;
@@ -78,6 +79,7 @@ export class Run<_T extends t.BaseGraphState> {
 
     this.handlerRegistry = handlerRegistry;
     this.hookRegistry = config.hooks;
+    this.toolOutputReferences = config.toolOutputReferences;
 
     if (!config.graphConfig) {
       throw new Error('Graph config not provided');
@@ -154,6 +156,7 @@ export class Run<_T extends t.BaseGraphState> {
     /** Propagate compile options from graph config */
     standardGraph.compileOptions = config.compileOptions;
     standardGraph.hookRegistry = this.hookRegistry;
+    standardGraph.toolOutputReferences = this.toolOutputReferences;
     this.Graph = standardGraph;
     return standardGraph.createWorkflow();
   }
@@ -177,6 +180,7 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     multiAgentGraph.hookRegistry = this.hookRegistry;
+    multiAgentGraph.toolOutputReferences = this.toolOutputReferences;
     this.Graph = multiAgentGraph;
     return multiAgentGraph.createWorkflow();
   }

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -49,7 +49,19 @@ Usage:
 - No network access available.
 - Generated files are automatically delivered; **DO NOT** provide download links.
 - NEVER use this tool to execute malicious commands.
+`.trim();
 
+/**
+ * Supplemental prompt documenting the tool-output reference feature.
+ *
+ * Hosts should append this (separated by a blank line) to the base
+ * {@link BashExecutionToolDescription} only when
+ * `RunConfig.toolOutputReferences.enabled` is `true`. When the feature
+ * is disabled, including this text would tell the LLM to emit
+ * `{{tool0turn0}}` placeholders that pass through unsubstituted and
+ * leak into the shell.
+ */
+export const BashToolOutputReferencesGuide = `
 Referencing previous tool outputs:
 - Every successful tool result is tagged with a reference key of the form \`tool<idx>turn<turn>\` (e.g., \`tool0turn0\`). The key appears either as a \`[ref: tool0turn0]\` prefix line or, when the output is a JSON object, as a \`_ref\` field on the object.
 - To pipe a previous tool output into this tool, embed the placeholder \`{{tool<idx>turn<turn>}}\` literally anywhere in the \`command\` string (or any string arg). It will be substituted with the stored output verbatim before the command runs.
@@ -57,6 +69,22 @@ Referencing previous tool outputs:
 - Example: \`echo '{{tool0turn0}}' | jq '.foo'\` takes the full output of the first tool from the first turn and pipes it into jq.
 - Unknown reference keys are left in place and surfaced as \`[unresolved refs: …]\` after the output.
 `.trim();
+
+/**
+ * Composes the bash tool description, optionally appending the
+ * tool-output references guide. Hosts that enable
+ * `RunConfig.toolOutputReferences` should pass `enableToolOutputReferences: true`
+ * when registering the tool so the LLM learns the `{{…}}` syntax it
+ * will actually be able to use.
+ */
+export function buildBashExecutionToolDescription(options?: {
+  enableToolOutputReferences?: boolean;
+}): string {
+  if (options?.enableToolOutputReferences === true) {
+    return `${BashExecutionToolDescription}\n\n${BashToolOutputReferencesGuide}`;
+  }
+  return BashExecutionToolDescription;
+}
 
 export const BashExecutionToolName = Constants.BASH_TOOL;
 

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -88,6 +88,16 @@ export function buildBashExecutionToolDescription(options?: {
 
 export const BashExecutionToolName = Constants.BASH_TOOL;
 
+/**
+ * Default bash tool definition using the base description.
+ *
+ * When `RunConfig.toolOutputReferences.enabled` is `true`, build a
+ * reference-aware description with
+ * {@link buildBashExecutionToolDescription}
+ * (`{ enableToolOutputReferences: true }`) and construct a custom
+ * definition using it — using this constant as-is leaves the LLM
+ * unaware of the `{{tool<i>turn<n>}}` syntax.
+ */
 export const BashExecutionToolDefinition = {
   name: BashExecutionToolName,
   description: BashExecutionToolDescription,

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -49,6 +49,13 @@ Usage:
 - No network access available.
 - Generated files are automatically delivered; **DO NOT** provide download links.
 - NEVER use this tool to execute malicious commands.
+
+Referencing previous tool outputs:
+- Every successful tool result is tagged with a reference key of the form \`tool<idx>turn<turn>\` (e.g., \`tool0turn0\`). The key appears either as a \`[ref: tool0turn0]\` prefix line or, when the output is a JSON object, as a \`_ref\` field on the object.
+- To pipe a previous tool output into this tool, embed the placeholder \`{{tool<idx>turn<turn>}}\` literally anywhere in the \`command\` string (or any string arg). It will be substituted with the stored output verbatim before the command runs.
+- The substituted value is the original output string (no \`[ref: …]\` prefix, no \`_ref\` key), so it is safe to pipe directly into \`jq\`, \`grep\`, \`awk\`, etc.
+- Example: \`echo '{{tool0turn0}}' | jq '.foo'\` takes the full output of the first tool from the first turn and pipes it into jq.
+- Unknown reference keys are left in place and surfaced as \`[unresolved refs: …]\` after the output.
 `.trim();
 
 export const BashExecutionToolName = Constants.BASH_TOOL;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -126,6 +126,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   private resolvedArgsByCallId: Map<string, Record<string, unknown>> =
     new Map();
+  /**
+   * Monotonic counter used to mint a unique scope id for anonymous
+   * batches (ones invoked without a `run_id` in
+   * `config.configurable`). Each such batch gets its own registry
+   * partition so concurrent anonymous invocations can't delete each
+   * other's in-flight state.
+   */
+  private anonBatchCounter: number = 0;
 
   constructor({
     tools,
@@ -243,7 +251,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     call: ToolCall,
     config: RunnableConfig,
     batchIndex?: number,
-    turn?: number
+    turn?: number,
+    batchScopeId?: string
   ): Promise<BaseMessage | Command> {
     const tool = this.toolMap.get(call.name);
     const registry = this.toolOutputRegistry;
@@ -263,7 +272,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      * the self-correction signal this feature is meant to provide.
      */
     let unresolvedRefs: string[] = [];
-    const runId = config.configurable?.run_id as string | undefined;
+    /**
+     * Use the caller-provided `batchScopeId` when threaded from
+     * `run()` (so anonymous batches get their own unique scope).
+     * Fall back to the config's `run_id` when runTool is invoked
+     * from a context that doesn't thread it — that still preserves
+     * the runId-based partitioning for named runs.
+     */
+    const runId =
+      batchScopeId ?? (config.configurable?.run_id as string | undefined);
     try {
       if (tool === undefined) {
         throw new Error(`Tool "${call.name}" not found.`);
@@ -731,16 +748,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     preResolvedArgs?: Map<
       string,
       { resolved: Record<string, unknown>; unresolved: string[] }
-    >
+    >,
+    batchScopeId?: string
   ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     /**
-     * Registry-facing runId preserves `undefined` so the registry
-     * treats anonymous callers as fresh-per-batch instead of lumping
-     * them all under an empty-string bucket. Hooks and event payloads
-     * keep using the empty-string coerced `runId` for backward compat.
+     * Registry-facing scope id — prefers the caller-threaded
+     * `batchScopeId` so anonymous batches target their own unique
+     * bucket and don't step on concurrent anonymous invocations.
+     * Hooks and event payloads keep using the empty-string coerced
+     * `runId` for backward compat.
      */
-    const registryRunId = config.configurable?.run_id as string | undefined;
+    const registryRunId =
+      batchScopeId ?? (config.configurable?.run_id as string | undefined);
     const threadId = config.configurable?.thread_id as string | undefined;
     const registry = this.toolOutputRegistry;
     const unresolvedByCallId = new Map<string, string[]>();
@@ -1178,13 +1198,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any,
     batchIndices?: number[],
-    turn?: number
+    turn?: number,
+    batchScopeId?: string
   ): Promise<T> {
     const { toolMessages, injected } = await this.dispatchToolEvents(
       toolCalls,
       config,
       batchIndices,
-      turn
+      turn,
+      undefined,
+      batchScopeId
     );
     const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
@@ -1196,16 +1219,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.resolvedArgsByCallId.clear();
     /**
      * Claim this batch's turn synchronously from the registry (or
-     * fall back to 0 when the feature is disabled). The registry
-     * handles run-crossing resets: when `run_id` changes — or is
-     * absent — it clears stored entries, warn memo, and its own
-     * counter before returning turn 0. Capturing `turn` in a local
-     * is essential: reading it back from shared state after the
-     * tool `await` would race when the same ToolNode is `invoke()`d
-     * concurrently.
+     * fall back to 0 when the feature is disabled). The registry is
+     * partitioned by scope id so overlapping batches cannot
+     * overwrite each other's state even under a shared registry.
+     *
+     * For anonymous callers (no `run_id` in config), mint a unique
+     * per-batch scope id so two concurrent anonymous invocations
+     * don't target the same bucket. The scope is threaded down to
+     * every subsequent registry call on this batch.
      */
     const incomingRunId = config.configurable?.run_id as string | undefined;
-    const turn = this.toolOutputRegistry?.nextTurn(incomingRunId) ?? 0;
+    const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
+    const turn = this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
     let outputs: (BaseMessage | Command)[];
 
     if (this.isSendInput(input)) {
@@ -1216,10 +1241,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           config,
           input,
           [0],
-          turn
+          turn,
+          batchScopeId
         );
       }
-      outputs = [await this.runTool(input.lg_tool_call, config, 0, turn)];
+      outputs = [
+        await this.runTool(input.lg_tool_call, config, 0, turn, batchScopeId),
+      ];
       this.handleRunToolCompletions([input.lg_tool_call], outputs, config);
     } else {
       let messages: BaseMessage[];
@@ -1287,7 +1315,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             config,
             input,
             filteredIndices,
-            turn
+            turn,
+            batchScopeId
           );
         }
 
@@ -1327,7 +1356,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           for (const entry of eventEntries) {
             if (entry.call.id != null) {
               const { resolved, unresolved } = this.toolOutputRegistry.resolve(
-                incomingRunId,
+                batchScopeId,
                 entry.call.args as Record<string, unknown>
               );
               preResolvedEventArgs.set(entry.call.id, {
@@ -1342,7 +1371,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           directCalls.length > 0
             ? await Promise.all(
               directCalls.map((call, i) =>
-                this.runTool(call, config, directIndices[i], turn)
+                this.runTool(
+                  call,
+                  config,
+                  directIndices[i],
+                  turn,
+                  batchScopeId
+                )
               )
             )
             : [];
@@ -1358,7 +1393,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               config,
               eventIndices,
               turn,
-              preResolvedEventArgs
+              preResolvedEventArgs,
+              batchScopeId
             )
             : {
               toolMessages: [] as ToolMessage[],
@@ -1372,7 +1408,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         ];
       } else {
         outputs = await Promise.all(
-          filteredCalls.map((call, i) => this.runTool(call, config, i, turn))
+          filteredCalls.map((call, i) =>
+            this.runTool(call, config, i, turn, batchScopeId)
+          )
         );
         this.handleRunToolCompletions(filteredCalls, outputs, config);
       }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -105,34 +105,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   /** Hook registry for PreToolUse/PostToolUse lifecycle hooks */
   private hookRegistry?: HookRegistry;
   /**
-   * Registry of tool outputs keyed by `tool<idx>turn<turn>` — populated
-   * only when `toolOutputReferences.enabled` is true. Shared across all
-   * batches within the life of this ToolNode.
+   * Registry of tool outputs keyed by `tool<idx>turn<turn>`.
+   *
+   * Populated only when `toolOutputReferences.enabled` is true. The
+   * registry owns the run-scoped state (turn counter, last-seen runId,
+   * warn-once memo, stored outputs), so sharing a single instance
+   * across multiple ToolNodes in a run lets cross-agent `{{…}}`
+   * references resolve — which is why multi-agent graphs pass the
+   * *same* instance to every ToolNode they compile rather than each
+   * ToolNode building its own.
    */
   private toolOutputRegistry?: ToolOutputReferenceRegistry;
-  /**
-   * Monotonic batch counter. Incremented once per `run()` invocation
-   * so every tool call in a batch shares the same `turn` index for its
-   * reference key. Zero-based, matches the `turn<N>` segment.
-   */
-  private turnCounter: number = 0;
-  /** Turn index for the batch currently being processed. */
-  private currentTurn: number = 0;
-  /**
-   * Last observed runId from `config.configurable.run_id`. When a new
-   * run starts (e.g. a host reuses the same Run / compiled workflow
-   * across multiple `processStream` calls), we detect the runId change
-   * and clear the registry + turn counter so a stale `tool<i>turn<n>`
-   * from the previous run cannot be served to a new run's tool calls.
-   */
-  private lastRunId: string | undefined;
-  /**
-   * Per-run memo of tool names we've already warned about for returning
-   * non-string `ToolMessage.content` (and thus being ineligible for the
-   * reference registry). Cleared on runId change so each run gets its
-   * own single log line per offending tool.
-   */
-  private warnedNonStringRefTools: Set<string> = new Set();
 
   constructor({
     tools,
@@ -152,6 +135,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     maxToolResultChars,
     hookRegistry,
     toolOutputReferences,
+    toolOutputRegistry,
   }: t.ToolNodeConstructorParams) {
     super({ name, tags, func: (input, config) => this.run(input, config) });
     this.toolMap = toolMap ?? new Map(tools.map((tool) => [tool.name, tool]));
@@ -168,15 +152,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
     this.hookRegistry = hookRegistry;
-    if (toolOutputReferences?.enabled === true) {
-      /**
-       * Registry caps are intentionally *decoupled* from
-       * `maxToolResultChars`: the registry stores the raw untruncated
-       * output so a later `{{…}}` substitution pipes the full payload
-       * into the next tool, even when the LLM saw a truncated preview.
-       * Pass the caller's config through unchanged — the registry fills
-       * in its own 5 MB defaults.
-       */
+    /**
+     * Precedence: an explicitly passed `toolOutputRegistry` instance
+     * wins over a config object so a host (`Graph`) can share one
+     * registry across many ToolNodes. When only the config is
+     * provided (direct ToolNode usage), build a local registry so
+     * the feature still works without graph-level plumbing. Registry
+     * caps are intentionally decoupled from `maxToolResultChars`:
+     * the registry stores the raw untruncated output so a later
+     * `{{…}}` substitution pipes the full payload into the next
+     * tool, even when the LLM saw a truncated preview.
+     */
+    if (toolOutputRegistry != null) {
+      this.toolOutputRegistry = toolOutputRegistry;
+    } else if (toolOutputReferences?.enabled === true) {
       this.toolOutputRegistry = new ToolOutputReferenceRegistry({
         maxOutputSize: toolOutputReferences.maxOutputSize,
         maxTotalSize: toolOutputReferences.maxTotalSize,
@@ -385,10 +374,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
              * and therefore cannot be cited via `{{tool<i>turn<n>}}`.
              * Registering would require deciding which block is
              * canonical, which differs per tool. Warn once per tool
-             * per run so repeated invocations don't flood the logs.
+             * per run (memo lives on the registry so multi-agent
+             * graphs don't double-warn from each ToolNode).
              */
-            if (!this.warnedNonStringRefTools.has(call.name)) {
-              this.warnedNonStringRefTools.add(call.name);
+            if (this.toolOutputRegistry!.claimWarnOnce(call.name)) {
               // eslint-disable-next-line no-console
               console.warn(
                 `[ToolNode] Skipping tool output reference for "${call.name}": ` +
@@ -1115,33 +1104,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
+    /**
+     * Claim this batch's turn synchronously from the registry (or
+     * fall back to 0 when the feature is disabled). The registry
+     * handles run-crossing resets: when `run_id` changes — or is
+     * absent — it clears stored entries, warn memo, and its own
+     * counter before returning turn 0. Capturing `turn` in a local
+     * is essential: reading it back from shared state after the
+     * tool `await` would race when the same ToolNode is `invoke()`d
+     * concurrently.
+     */
     const incomingRunId = config.configurable?.run_id as string | undefined;
-    /**
-     * Reset the registry and per-run counters when we cross into a new
-     * run. If `run_id` is missing we cannot distinguish "still the same
-     * run" from "a different caller reusing the same ToolNode", so we
-     * err on the side of isolation and clear on every batch — treating
-     * anonymous runs as if each batch were fresh. Production callers
-     * (anyone going through `Run`) always have a `run_id` set, so this
-     * only affects ToolNode being invoked directly without one.
-     */
-    const isNewRun = incomingRunId == null || incomingRunId !== this.lastRunId;
-    if (isNewRun) {
-      this.turnCounter = 0;
-      this.toolOutputRegistry?.clear();
-      this.warnedNonStringRefTools.clear();
-      this.lastRunId = incomingRunId;
-    }
-    /**
-     * Capture this batch's turn value in a local and thread it down.
-     * Reading it from a mutable field after `await tool.invoke(...)`
-     * would race when the same ToolNode gets `invoke()`d concurrently
-     * — another invocation could overwrite the field before our
-     * registration runs. `this.currentTurn` is retained for external
-     * observability only; registration paths rely on the local `turn`.
-     */
-    const turn = this.turnCounter++;
-    this.currentTurn = turn;
+    const turn = this.toolOutputRegistry?.nextTurn(incomingRunId) ?? 0;
     let outputs: (BaseMessage | Command)[];
 
     if (this.isSendInput(input)) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -263,6 +263,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      * the self-correction signal this feature is meant to provide.
      */
     let unresolvedRefs: string[] = [];
+    const runId = config.configurable?.run_id as string | undefined;
     try {
       if (tool === undefined) {
         throw new Error(`Tool "${call.name}" not found.`);
@@ -274,7 +275,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       let args = call.args;
       if (registry != null) {
-        const { resolved, unresolved } = registry.resolve(args);
+        const { resolved, unresolved } = registry.resolve(runId, args);
         args = resolved;
         unresolvedRefs = unresolved;
         /**
@@ -372,6 +373,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             typeof toolMsg.content === 'string'
           ) {
             toolMsg.content = this.applyOutputReference(
+              runId,
               toolMsg.content,
               toolMsg.content,
               undefined,
@@ -388,6 +390,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               this.maxToolResultChars
             );
             toolMsg.content = this.applyOutputReference(
+              runId,
               llmContent,
               rawContent,
               refKey,
@@ -418,7 +421,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             }
             if (
               refKey != null &&
-              this.toolOutputRegistry!.claimWarnOnce(call.name)
+              this.toolOutputRegistry!.claimWarnOnce(runId, call.name)
             ) {
               // eslint-disable-next-line no-console
               console.warn(
@@ -437,6 +440,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         this.maxToolResultChars
       );
       const content = this.applyOutputReference(
+        runId,
         truncated,
         rawContent,
         refKey,
@@ -495,6 +499,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       let errorContent = `Error: ${e.message}\n Please fix your mistakes.`;
       if (unresolvedRefs.length > 0) {
         errorContent = this.applyOutputReference(
+          runId,
           errorContent,
           errorContent,
           undefined,
@@ -532,13 +537,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * the shared turn field.
    */
   private applyOutputReference(
+    runId: string | undefined,
     llmContent: string,
     registryContent: string,
     refKey: string | undefined,
     unresolved: string[]
   ): string {
     if (this.toolOutputRegistry != null && refKey != null) {
-      this.toolOutputRegistry.set(refKey, registryContent);
+      this.toolOutputRegistry.set(runId, refKey, registryContent);
     }
     /**
      * `annotateToolOutputWithReference` handles both the ref-key and
@@ -721,9 +727,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolCalls: ToolCall[],
     config: RunnableConfig,
     batchIndices?: number[],
-    turn?: number
+    turn?: number,
+    preResolvedArgs?: Map<
+      string,
+      { resolved: Record<string, unknown>; unresolved: string[] }
+    >
   ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
+    /**
+     * Registry-facing runId preserves `undefined` so the registry
+     * treats anonymous callers as fresh-per-batch instead of lumping
+     * them all under an empty-string bucket. Hooks and event payloads
+     * keep using the empty-string coerced `runId` for backward compat.
+     */
+    const registryRunId = config.configurable?.run_id as string | undefined;
     const threadId = config.configurable?.thread_id as string | undefined;
     const registry = this.toolOutputRegistry;
     const unresolvedByCallId = new Map<string, string[]>();
@@ -731,8 +748,25 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const preToolCalls = toolCalls.map((call, i) => {
       const originalArgs = call.args as Record<string, unknown>;
       let resolvedArgs = originalArgs;
-      if (registry != null) {
-        const { resolved, unresolved } = registry.resolve(originalArgs);
+      /**
+       * When the caller provided a pre-resolved map (the mixed
+       * direct+event path snapshots event args synchronously before
+       * awaiting directs so they can't accidentally resolve
+       * same-turn direct outputs), use those entries verbatim instead
+       * of re-resolving against a registry that may have changed
+       * since the batch started.
+       */
+      const pre = call.id != null ? preResolvedArgs?.get(call.id) : undefined;
+      if (pre != null) {
+        resolvedArgs = pre.resolved;
+        if (pre.unresolved.length > 0 && call.id != null) {
+          unresolvedByCallId.set(call.id, pre.unresolved);
+        }
+      } else if (registry != null) {
+        const { resolved, unresolved } = registry.resolve(
+          registryRunId,
+          originalArgs
+        );
         resolvedArgs = resolved as Record<string, unknown>;
         if (unresolved.length > 0 && call.id != null) {
           unresolvedByCallId.set(call.id, unresolved);
@@ -831,6 +865,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
            */
           if (registry != null) {
             const { resolved, unresolved } = registry.resolve(
+              registryRunId,
               hookResult.updatedInput
             );
             entry.args = resolved as Record<string, unknown>;
@@ -943,6 +978,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           const unresolved = unresolvedByCallId.get(result.toolCallId) ?? [];
           if (unresolved.length > 0) {
             contentString = this.applyOutputReference(
+              registryRunId,
               contentString,
               contentString,
               undefined,
@@ -1027,6 +1063,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               ? buildReferenceKey(batchIndex, turn)
               : undefined;
           contentString = this.applyOutputReference(
+            registryRunId,
             contentString,
             registryRaw,
             refKey,
@@ -1272,45 +1309,61 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const eventIndices = eventEntries.map((e) => e.batchIndex);
 
         /**
-         * Run direct and event branches in parallel so both sync
-         * prefixes — which include `registry.resolve(args)` for every
-         * call — complete against the *pre-batch* registry state
-         * before either branch's registrations run. Serializing them
-         * (directs first, then events) would let event-call args
-         * resolve same-turn direct outputs that just registered,
-         * making `{{tool<i>turn<n>}}` semantics mode-dependent. JS
-         * single-threaded execution guarantees no microtask
-         * (= no registration) runs between the two synchronous
-         * sync-prefix passes here.
+         * Snapshot the event calls' args against the *pre-batch*
+         * registry state synchronously, before any await runs. The
+         * directs are then awaited first (preserving fail-fast
+         * semantics — a thrown error in a direct tool, e.g. with
+         * `handleToolErrors=false` or a `GraphInterrupt`, aborts
+         * before we dispatch any event-driven tools to the host).
+         * Because the event args were captured pre-await, they stay
+         * isolated from same-turn direct outputs that register
+         * during the await.
          */
-        const directPromise: Promise<(BaseMessage | Command)[]> =
+        const preResolvedEventArgs = new Map<
+          string,
+          { resolved: Record<string, unknown>; unresolved: string[] }
+        >();
+        if (this.toolOutputRegistry != null) {
+          for (const entry of eventEntries) {
+            if (entry.call.id != null) {
+              const { resolved, unresolved } = this.toolOutputRegistry.resolve(
+                incomingRunId,
+                entry.call.args as Record<string, unknown>
+              );
+              preResolvedEventArgs.set(entry.call.id, {
+                resolved: resolved as Record<string, unknown>,
+                unresolved,
+              });
+            }
+          }
+        }
+
+        const directOutputs: (BaseMessage | Command)[] =
           directCalls.length > 0
-            ? Promise.all(
+            ? await Promise.all(
               directCalls.map((call, i) =>
                 this.runTool(call, config, directIndices[i], turn)
               )
             )
-            : Promise.resolve([]);
-
-        const eventPromise: Promise<{
-          toolMessages: ToolMessage[];
-          injected: BaseMessage[];
-        }> =
-          eventCalls.length > 0
-            ? this.dispatchToolEvents(eventCalls, config, eventIndices, turn)
-            : Promise.resolve({
-              toolMessages: [] as ToolMessage[],
-              injected: [] as BaseMessage[],
-            });
-
-        const [directOutputs, eventResult] = await Promise.all([
-          directPromise,
-          eventPromise,
-        ]);
+            : [];
 
         if (directCalls.length > 0 && directOutputs.length > 0) {
           this.handleRunToolCompletions(directCalls, directOutputs, config);
         }
+
+        const eventResult =
+          eventCalls.length > 0
+            ? await this.dispatchToolEvents(
+              eventCalls,
+              config,
+              eventIndices,
+              turn,
+              preResolvedEventArgs
+            )
+            : {
+              toolMessages: [] as ToolMessage[],
+              injected: [] as BaseMessage[],
+            };
 
         outputs = [
           ...directOutputs,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1068,7 +1068,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
     const incomingRunId = config.configurable?.run_id as string | undefined;
-    if (incomingRunId !== this.lastRunId) {
+    /**
+     * Reset the registry and per-run counters when we cross into a new
+     * run. If `run_id` is missing we cannot distinguish "still the same
+     * run" from "a different caller reusing the same ToolNode", so we
+     * err on the side of isolation and clear on every batch — treating
+     * anonymous runs as if each batch were fresh. Production callers
+     * (anyone going through `Run`) always have a `run_id` set, so this
+     * only affects ToolNode being invoked directly without one.
+     */
+    const isNewRun = incomingRunId == null || incomingRunId !== this.lastRunId;
+    if (isNewRun) {
       this.turnCounter = 0;
       this.toolOutputRegistry?.clear();
       this.warnedNonStringRefTools.clear();

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -696,17 +696,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * By handling completions here in graph context (rather than in the
    * stream consumer via ToolEndHandler), the race between the stream
    * consumer and graph execution is eliminated.
+   *
+   * @param resolvedArgsByCallId  Per-batch resolved-args sink populated
+   *   by `runTool`. Threaded as a local map (instead of instance state)
+   *   so concurrent batches cannot read each other's entries.
    */
   private handleRunToolCompletions(
     calls: ToolCall[],
     outputs: (BaseMessage | Command)[],
     config: RunnableConfig,
-    /**
-     * Per-batch resolved-args sink populated by `runTool`. Threaded
-     * as a local instead of an instance field so concurrent batches
-     * cannot read each other's state.
-     */
-    resolvedArgsByCallId?: Map<string, Record<string, unknown>>
+    resolvedArgsByCallId?: ResolvedArgsByCallId
   ): void {
     for (let i = 0; i < calls.length; i++) {
       const call = calls[i];

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1271,31 +1271,46 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const eventCalls = eventEntries.map((e) => e.call);
         const eventIndices = eventEntries.map((e) => e.batchIndex);
 
-        const directOutputs: (BaseMessage | Command)[] =
+        /**
+         * Run direct and event branches in parallel so both sync
+         * prefixes — which include `registry.resolve(args)` for every
+         * call — complete against the *pre-batch* registry state
+         * before either branch's registrations run. Serializing them
+         * (directs first, then events) would let event-call args
+         * resolve same-turn direct outputs that just registered,
+         * making `{{tool<i>turn<n>}}` semantics mode-dependent. JS
+         * single-threaded execution guarantees no microtask
+         * (= no registration) runs between the two synchronous
+         * sync-prefix passes here.
+         */
+        const directPromise: Promise<(BaseMessage | Command)[]> =
           directCalls.length > 0
-            ? await Promise.all(
+            ? Promise.all(
               directCalls.map((call, i) =>
                 this.runTool(call, config, directIndices[i], turn)
               )
             )
-            : [];
+            : Promise.resolve([]);
+
+        const eventPromise: Promise<{
+          toolMessages: ToolMessage[];
+          injected: BaseMessage[];
+        }> =
+          eventCalls.length > 0
+            ? this.dispatchToolEvents(eventCalls, config, eventIndices, turn)
+            : Promise.resolve({
+              toolMessages: [] as ToolMessage[],
+              injected: [] as BaseMessage[],
+            });
+
+        const [directOutputs, eventResult] = await Promise.all([
+          directPromise,
+          eventPromise,
+        ]);
 
         if (directCalls.length > 0 && directOutputs.length > 0) {
           this.handleRunToolCompletions(directCalls, directOutputs, config);
         }
-
-        const eventResult =
-          eventCalls.length > 0
-            ? await this.dispatchToolEvents(
-              eventCalls,
-              config,
-              eventIndices,
-              turn
-            )
-            : {
-              toolMessages: [] as ToolMessage[],
-              injected: [] as BaseMessage[],
-            };
 
         outputs = [
           ...directOutputs,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -118,6 +118,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private turnCounter: number = 0;
   /** Turn index for the batch currently being processed. */
   private currentTurn: number = 0;
+  /**
+   * Last observed runId from `config.configurable.run_id`. When a new
+   * run starts (e.g. a host reuses the same Run / compiled workflow
+   * across multiple `processStream` calls), we detect the runId change
+   * and clear the registry + turn counter so a stale `tool<i>turn<n>`
+   * from the previous run cannot be served to a new run's tool calls.
+   */
+  private lastRunId: string | undefined;
 
   constructor({
     tools,
@@ -162,8 +170,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
   }
 
-  /** Returns the run-scoped tool output registry, or `undefined` when disabled. */
-  public getToolOutputRegistry(): ToolOutputReferenceRegistry | undefined {
+  /**
+   * Returns the run-scoped tool output registry, or `undefined` when
+   * the feature is disabled.
+   *
+   * @internal Exposed for test observation only. Host code should rely
+   * on `{{tool<i>turn<n>}}` substitution at tool-invocation time and
+   * not mutate the registry directly.
+   */
+  public _unsafeGetToolOutputRegistry():
+    | ToolOutputReferenceRegistry
+    | undefined {
     return this.toolOutputRegistry;
   }
 
@@ -300,14 +317,31 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const toolMsg = output as ToolMessage;
         if (
           toolMsg.status !== 'error' &&
-          (this.toolOutputRegistry != null || unresolvedRefs.length > 0) &&
-          typeof toolMsg.content === 'string'
+          (this.toolOutputRegistry != null || unresolvedRefs.length > 0)
         ) {
-          toolMsg.content = this.applyOutputReference(
-            toolMsg.content,
-            shouldRegister ? batchIndex : undefined,
-            unresolvedRefs
-          );
+          if (typeof toolMsg.content === 'string') {
+            toolMsg.content = this.applyOutputReference(
+              toolMsg.content,
+              shouldRegister ? batchIndex : undefined,
+              unresolvedRefs
+            );
+          } else if (shouldRegister) {
+            /**
+             * Known limitation: tools that return a `ToolMessage` with
+             * array-type content (multi-part content blocks such as
+             * text + image) are not registered under a reference key
+             * and therefore cannot be cited via `{{tool<i>turn<n>}}`.
+             * Registering would require deciding which block is
+             * canonical, which differs per tool. Keep the output
+             * un-annotated and log once so the absence of a ref is
+             * visible during debugging.
+             */
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[ToolNode] Skipping tool output reference for "${call.name}" ` +
+                `(callId=${call.id ?? 'n/a'}): ToolMessage content is not a string.`
+            );
+          }
         }
         return toolMsg;
       }
@@ -671,7 +705,29 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           continue;
         }
         if (hookResult.updatedInput != null) {
-          entry.args = hookResult.updatedInput;
+          /**
+           * Re-resolve after PreToolUse replaces the input: a hook may
+           * introduce new `{{tool<i>turn<n>}}` placeholders (e.g., by
+           * copying user-supplied text) that the pre-hook pass never
+           * saw. Re-running the resolver on the hook-rewritten args
+           * keeps substitution and the unresolved-refs record in sync
+           * with what the tool will actually receive.
+           */
+          if (registry != null) {
+            const { resolved, unresolved } = registry.resolve(
+              hookResult.updatedInput
+            );
+            entry.args = resolved as Record<string, unknown>;
+            if (entry.call.id != null) {
+              if (unresolved.length > 0) {
+                unresolvedByCallId.set(entry.call.id, unresolved);
+              } else {
+                unresolvedByCallId.delete(entry.call.id);
+              }
+            }
+          } else {
+            entry.args = hookResult.updatedInput;
+          }
         }
         approvedEntries.push(entry);
       }
@@ -959,6 +1015,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
+    const incomingRunId = config.configurable?.run_id as string | undefined;
+    if (incomingRunId !== this.lastRunId) {
+      this.turnCounter = 0;
+      this.toolOutputRegistry?.clear();
+      this.lastRunId = incomingRunId;
+    }
     this.currentTurn = this.turnCounter++;
     let outputs: (BaseMessage | Command)[];
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -169,9 +169,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
     this.hookRegistry = hookRegistry;
     if (toolOutputReferences?.enabled === true) {
+      /**
+       * Registry caps are intentionally *decoupled* from
+       * `maxToolResultChars`: the registry stores the raw untruncated
+       * output so a later `{{…}}` substitution pipes the full payload
+       * into the next tool, even when the LLM saw a truncated preview.
+       * Pass the caller's config through unchanged — the registry fills
+       * in its own 5 MB defaults.
+       */
       this.toolOutputRegistry = new ToolOutputReferenceRegistry({
-        maxOutputSize:
-          toolOutputReferences.maxOutputSize ?? this.maxToolResultChars,
+        maxOutputSize: toolOutputReferences.maxOutputSize,
         maxTotalSize: toolOutputReferences.maxTotalSize,
       });
     }
@@ -236,11 +243,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   protected async runTool(
     call: ToolCall,
     config: RunnableConfig,
-    batchIndex?: number
+    batchIndex?: number,
+    turn?: number
   ): Promise<BaseMessage | Command> {
     const tool = this.toolMap.get(call.name);
     const registry = this.toolOutputRegistry;
-    const shouldRegister = registry != null && batchIndex != null;
+    /**
+     * Precompute the reference key once per call — captured locally
+     * so concurrent `invoke()` calls on the same ToolNode cannot race
+     * on a shared turn field.
+     */
+    const refKey =
+      registry != null && batchIndex != null && turn != null
+        ? buildReferenceKey(batchIndex, turn)
+        : undefined;
     /**
      * Hoisted outside the try so the catch branch can append
      * `[unresolved refs: …]` to error messages — otherwise the LLM
@@ -341,6 +357,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           ) {
             toolMsg.content = this.applyOutputReference(
               toolMsg.content,
+              toolMsg.content,
               undefined,
               unresolvedRefs
             );
@@ -349,12 +366,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
         if (this.toolOutputRegistry != null || unresolvedRefs.length > 0) {
           if (typeof toolMsg.content === 'string') {
+            const rawContent = toolMsg.content;
+            const llmContent = truncateToolResultContent(
+              rawContent,
+              this.maxToolResultChars
+            );
             toolMsg.content = this.applyOutputReference(
-              toolMsg.content,
-              shouldRegister ? batchIndex : undefined,
+              llmContent,
+              rawContent,
+              refKey,
               unresolvedRefs
             );
-          } else if (shouldRegister) {
+          } else if (refKey != null) {
             /**
              * Known limitation: tools that return a `ToolMessage` with
              * array-type content (multi-part content blocks such as
@@ -384,7 +407,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       );
       const content = this.applyOutputReference(
         truncated,
-        shouldRegister ? batchIndex : undefined,
+        rawContent,
+        refKey,
         unresolvedRefs
       );
       return new ToolMessage({
@@ -441,6 +465,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (unresolvedRefs.length > 0) {
         errorContent = this.applyOutputReference(
           errorContent,
+          errorContent,
           undefined,
           unresolvedRefs
         );
@@ -455,26 +480,36 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
-   * Registers a successful tool output under its batch-scoped reference
-   * key (when the registry is enabled) and returns the annotated content
-   * the LLM will see. When `batchIndex` is undefined, the output is
-   * neither registered nor annotated — only any unresolved reference
-   * warnings are appended.
+   * Finalizes the LLM-visible content for a tool call and (when a
+   * `refKey` is provided) registers the full, raw output under that
+   * key.
    *
-   * The *stored* value is the truncated-but-unannotated content so that
-   * piping it into a later tool call via `{{tool<idx>turn<turn>}}`
-   * delivers pristine output (no `_ref` key, no `[ref: …]` prefix).
+   * @param llmContent  The content string the LLM will see. This is
+   *   the already-truncated, post-hook view; the annotation is
+   *   applied on top of it.
+   * @param registryContent  The full, untruncated output to store in
+   *   the registry so `{{tool<i>turn<n>}}` substitutions deliver the
+   *   complete payload. Ignored when `refKey` is undefined.
+   * @param refKey  Precomputed `tool<i>turn<n>` key, or undefined when
+   *   the output is not to be registered (errors, disabled feature,
+   *   unavailable batch/turn).
+   * @param unresolved  Placeholder keys that did not resolve; appended
+   *   as `[unresolved refs: …]` so the LLM can self-correct.
+   *
+   * `refKey` is passed in (rather than built from `this.currentTurn`)
+   * so parallel `invoke()` calls on the same ToolNode cannot race on
+   * the shared turn field.
    */
   private applyOutputReference(
-    truncated: string,
-    batchIndex: number | undefined,
+    llmContent: string,
+    registryContent: string,
+    refKey: string | undefined,
     unresolved: string[]
   ): string {
-    let content = truncated;
-    if (this.toolOutputRegistry != null && batchIndex != null) {
-      const key = buildReferenceKey(batchIndex, this.currentTurn);
-      this.toolOutputRegistry.set(key, truncated);
-      content = annotateToolOutputWithReference(truncated, key);
+    let content = llmContent;
+    if (this.toolOutputRegistry != null && refKey != null) {
+      this.toolOutputRegistry.set(refKey, registryContent);
+      content = annotateToolOutputWithReference(llmContent, refKey);
     }
     if (unresolved.length > 0) {
       content += `\n[unresolved refs: ${unresolved.join(', ')}]`;
@@ -644,7 +679,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig,
-    batchIndices?: number[]
+    batchIndices?: number[],
+    turn?: number
   ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const threadId = config.configurable?.thread_id as string | undefined;
@@ -867,6 +903,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           if (unresolved.length > 0) {
             contentString = this.applyOutputReference(
               contentString,
+              contentString,
               undefined,
               unresolved
             );
@@ -900,12 +937,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             });
           }
         } else {
-          const rawContent =
+          let registryRaw =
             typeof result.content === 'string'
               ? result.content
               : JSON.stringify(result.content);
           contentString = truncateToolResultContent(
-            rawContent,
+            registryRaw,
             this.maxToolResultChars
           );
 
@@ -932,6 +969,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 typeof hookResult.updatedOutput === 'string'
                   ? hookResult.updatedOutput
                   : JSON.stringify(hookResult.updatedOutput);
+              registryRaw = replaced;
               contentString = truncateToolResultContent(
                 replaced,
                 this.maxToolResultChars
@@ -941,9 +979,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
           const batchIndex = batchIndexByCallId.get(result.toolCallId);
           const unresolved = unresolvedByCallId.get(result.toolCallId) ?? [];
+          const refKey =
+            this.toolOutputRegistry != null &&
+            batchIndex != null &&
+            turn != null
+              ? buildReferenceKey(batchIndex, turn)
+              : undefined;
           contentString = this.applyOutputReference(
             contentString,
-            batchIndex,
+            registryRaw,
+            refKey,
             unresolved
           );
 
@@ -1045,20 +1090,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * by their ToolMessage results).
    *
    * `batchIndices` mirrors `toolCalls` and carries each call's position
-   * within the parent batch, which the registry uses to form reference
-   * keys. It's omitted when the registry is disabled.
+   * within the parent batch. `turn` is the per-`run()` batch index
+   * captured locally by the caller. Both are threaded so concurrent
+   * invocations cannot race on shared mutable state.
    */
   private async executeViaEvent(
     toolCalls: ToolCall[],
     config: RunnableConfig,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any,
-    batchIndices?: number[]
+    batchIndices?: number[],
+    turn?: number
   ): Promise<T> {
     const { toolMessages, injected } = await this.dispatchToolEvents(
       toolCalls,
       config,
-      batchIndices
+      batchIndices,
+      turn
     );
     const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
@@ -1084,15 +1132,30 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       this.warnedNonStringRefTools.clear();
       this.lastRunId = incomingRunId;
     }
-    this.currentTurn = this.turnCounter++;
+    /**
+     * Capture this batch's turn value in a local and thread it down.
+     * Reading it from a mutable field after `await tool.invoke(...)`
+     * would race when the same ToolNode gets `invoke()`d concurrently
+     * — another invocation could overwrite the field before our
+     * registration runs. `this.currentTurn` is retained for external
+     * observability only; registration paths rely on the local `turn`.
+     */
+    const turn = this.turnCounter++;
+    this.currentTurn = turn;
     let outputs: (BaseMessage | Command)[];
 
     if (this.isSendInput(input)) {
       const isDirectTool = this.directToolNames?.has(input.lg_tool_call.name);
       if (this.eventDrivenMode && isDirectTool !== true) {
-        return this.executeViaEvent([input.lg_tool_call], config, input, [0]);
+        return this.executeViaEvent(
+          [input.lg_tool_call],
+          config,
+          input,
+          [0],
+          turn
+        );
       }
-      outputs = [await this.runTool(input.lg_tool_call, config, 0)];
+      outputs = [await this.runTool(input.lg_tool_call, config, 0, turn)];
       this.handleRunToolCompletions([input.lg_tool_call], outputs, config);
     } else {
       let messages: BaseMessage[];
@@ -1159,7 +1222,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             filteredCalls,
             config,
             input,
-            filteredIndices
+            filteredIndices,
+            turn
           );
         }
 
@@ -1184,7 +1248,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           directCalls.length > 0
             ? await Promise.all(
               directCalls.map((call, i) =>
-                this.runTool(call, config, directIndices[i])
+                this.runTool(call, config, directIndices[i], turn)
               )
             )
             : [];
@@ -1195,7 +1259,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         const eventResult =
           eventCalls.length > 0
-            ? await this.dispatchToolEvents(eventCalls, config, eventIndices)
+            ? await this.dispatchToolEvents(
+              eventCalls,
+              config,
+              eventIndices,
+              turn
+            )
             : {
               toolMessages: [] as ToolMessage[],
               injected: [] as BaseMessage[],
@@ -1208,7 +1277,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         ];
       } else {
         outputs = await Promise.all(
-          filteredCalls.map((call, i) => this.runTool(call, config, i))
+          filteredCalls.map((call, i) => this.runTool(call, config, i, turn))
         );
         this.handleRunToolCompletions(filteredCalls, outputs, config);
       }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -126,6 +126,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * from the previous run cannot be served to a new run's tool calls.
    */
   private lastRunId: string | undefined;
+  /**
+   * Per-run memo of tool names we've already warned about for returning
+   * non-string `ToolMessage.content` (and thus being ineligible for the
+   * reference registry). Cleared on runId change so each run gets its
+   * own single log line per offending tool.
+   */
+  private warnedNonStringRefTools: Set<string> = new Set();
 
   constructor({
     tools,
@@ -232,6 +239,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     batchIndex?: number
   ): Promise<BaseMessage | Command> {
     const tool = this.toolMap.get(call.name);
+    const registry = this.toolOutputRegistry;
+    const shouldRegister = registry != null && batchIndex != null;
+    /**
+     * Hoisted outside the try so the catch branch can append
+     * `[unresolved refs: …]` to error messages — otherwise the LLM
+     * only sees a generic error when it references a bad key, losing
+     * the self-correction signal this feature is meant to provide.
+     */
+    let unresolvedRefs: string[] = [];
     try {
       if (tool === undefined) {
         throw new Error(`Tool "${call.name}" not found.`);
@@ -241,10 +257,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (call.id != null && call.id !== '') {
         this.toolCallTurns.set(call.id, turn);
       }
-      const registry = this.toolOutputRegistry;
-      const shouldRegister = registry != null && batchIndex != null;
       let args = call.args;
-      let unresolvedRefs: string[] = [];
       if (registry != null) {
         const { resolved, unresolved } = registry.resolve(args);
         args = resolved;
@@ -315,10 +328,26 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       if (isBaseMessage(output) && output._getType() === 'tool') {
         const toolMsg = output as ToolMessage;
-        if (
-          toolMsg.status !== 'error' &&
-          (this.toolOutputRegistry != null || unresolvedRefs.length > 0)
-        ) {
+        const isError = toolMsg.status === 'error';
+        if (isError) {
+          /**
+           * Error ToolMessages bypass registration/annotation but must
+           * still carry the unresolved-refs hint so the LLM can
+           * self-correct when its reference key caused the failure.
+           */
+          if (
+            unresolvedRefs.length > 0 &&
+            typeof toolMsg.content === 'string'
+          ) {
+            toolMsg.content = this.applyOutputReference(
+              toolMsg.content,
+              undefined,
+              unresolvedRefs
+            );
+          }
+          return toolMsg;
+        }
+        if (this.toolOutputRegistry != null || unresolvedRefs.length > 0) {
           if (typeof toolMsg.content === 'string') {
             toolMsg.content = this.applyOutputReference(
               toolMsg.content,
@@ -332,15 +361,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
              * text + image) are not registered under a reference key
              * and therefore cannot be cited via `{{tool<i>turn<n>}}`.
              * Registering would require deciding which block is
-             * canonical, which differs per tool. Keep the output
-             * un-annotated and log once so the absence of a ref is
-             * visible during debugging.
+             * canonical, which differs per tool. Warn once per tool
+             * per run so repeated invocations don't flood the logs.
              */
-            // eslint-disable-next-line no-console
-            console.warn(
-              `[ToolNode] Skipping tool output reference for "${call.name}" ` +
-                `(callId=${call.id ?? 'n/a'}): ToolMessage content is not a string.`
-            );
+            if (!this.warnedNonStringRefTools.has(call.name)) {
+              this.warnedNonStringRefTools.add(call.name);
+              // eslint-disable-next-line no-console
+              console.warn(
+                `[ToolNode] Skipping tool output reference for "${call.name}": ` +
+                  'ToolMessage content is not a string (further occurrences for this tool in the same run are suppressed).'
+              );
+            }
           }
         }
         return toolMsg;
@@ -406,9 +437,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           });
         }
       }
+      let errorContent = `Error: ${e.message}\n Please fix your mistakes.`;
+      if (unresolvedRefs.length > 0) {
+        errorContent = this.applyOutputReference(
+          errorContent,
+          undefined,
+          unresolvedRefs
+        );
+      }
       return new ToolMessage({
         status: 'error',
-        content: `Error: ${e.message}\n Please fix your mistakes.`,
+        content: errorContent,
         name: call.name,
         tool_call_id: call.id ?? '',
       });
@@ -819,6 +858,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         if (result.status === 'error') {
           contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
+          /**
+           * Error results bypass registration/annotation but must still
+           * carry the unresolved-refs hint so the LLM can self-correct
+           * when its reference key caused the failure.
+           */
+          const unresolved = unresolvedByCallId.get(result.toolCallId) ?? [];
+          if (unresolved.length > 0) {
+            contentString = this.applyOutputReference(
+              contentString,
+              undefined,
+              unresolved
+            );
+          }
           toolMessage = new ToolMessage({
             status: 'error',
             content: contentString,
@@ -1019,6 +1071,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     if (incomingRunId !== this.lastRunId) {
       this.turnCounter = 0;
       this.toolOutputRegistry?.clear();
+      this.warnedNonStringRefTools.clear();
       this.lastRunId = incomingRunId;
     }
     this.currentTurn = this.turnCounter++;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -29,6 +29,11 @@ import {
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { executeHooks } from '@/hooks';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
+import {
+  buildReferenceKey,
+  annotateToolOutputWithReference,
+  ToolOutputReferenceRegistry,
+} from './toolOutputReferences';
 
 /**
  * Helper to check if a value is a Send object
@@ -99,6 +104,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private maxToolResultChars: number;
   /** Hook registry for PreToolUse/PostToolUse lifecycle hooks */
   private hookRegistry?: HookRegistry;
+  /**
+   * Registry of tool outputs keyed by `tool<idx>turn<turn>` — populated
+   * only when `toolOutputReferences.enabled` is true. Shared across all
+   * batches within the life of this ToolNode.
+   */
+  private toolOutputRegistry?: ToolOutputReferenceRegistry;
+  /**
+   * Monotonic batch counter. Incremented once per `run()` invocation
+   * so every tool call in a batch shares the same `turn` index for its
+   * reference key. Zero-based, matches the `turn<N>` segment.
+   */
+  private turnCounter: number = 0;
+  /** Turn index for the batch currently being processed. */
+  private currentTurn: number = 0;
 
   constructor({
     tools,
@@ -117,6 +136,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     maxContextTokens,
     maxToolResultChars,
     hookRegistry,
+    toolOutputReferences,
   }: t.ToolNodeConstructorParams) {
     super({ name, tags, func: (input, config) => this.run(input, config) });
     this.toolMap = toolMap ?? new Map(tools.map((tool) => [tool.name, tool]));
@@ -133,6 +153,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
     this.hookRegistry = hookRegistry;
+    if (toolOutputReferences?.enabled === true) {
+      this.toolOutputRegistry = new ToolOutputReferenceRegistry({
+        maxOutputSize:
+          toolOutputReferences.maxOutputSize ?? this.maxToolResultChars,
+        maxTotalSize: toolOutputReferences.maxTotalSize,
+      });
+    }
+  }
+
+  /** Returns the run-scoped tool output registry, or `undefined` when disabled. */
+  public getToolOutputRegistry(): ToolOutputReferenceRegistry | undefined {
+    return this.toolOutputRegistry;
   }
 
   /**
@@ -170,11 +202,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
-   * Runs a single tool call with error handling
+   * Runs a single tool call with error handling.
+   *
+   * `batchIndex` is the tool's position within the current ToolNode
+   * batch and, together with `this.currentTurn`, forms the key used to
+   * register the output for future `{{tool<idx>turn<turn>}}`
+   * substitutions. Omit when no registration should occur.
    */
   protected async runTool(
     call: ToolCall,
-    config: RunnableConfig
+    config: RunnableConfig,
+    batchIndex?: number
   ): Promise<BaseMessage | Command> {
     const tool = this.toolMap.get(call.name);
     try {
@@ -186,7 +224,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (call.id != null && call.id !== '') {
         this.toolCallTurns.set(call.id, turn);
       }
-      const args = call.args;
+      const registry = this.toolOutputRegistry;
+      const shouldRegister = registry != null && batchIndex != null;
+      let args = call.args;
+      let unresolvedRefs: string[] = [];
+      if (registry != null) {
+        const { resolved, unresolved } = registry.resolve(args);
+        args = resolved;
+        unresolvedRefs = unresolved;
+      }
       const stepId = this.toolCallStepIds?.get(call.id!);
 
       // Build invoke params - LangChain extracts non-schema fields to config.toolCall
@@ -247,24 +293,41 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const output = await tool.invoke(invokeParams, config);
-      if (
-        (isBaseMessage(output) && output._getType() === 'tool') ||
-        isCommand(output)
-      ) {
+      if (isCommand(output)) {
         return output;
-      } else {
-        const rawContent =
-          typeof output === 'string' ? output : JSON.stringify(output);
-        return new ToolMessage({
-          status: 'success',
-          name: tool.name,
-          content: truncateToolResultContent(
-            rawContent,
-            this.maxToolResultChars
-          ),
-          tool_call_id: call.id!,
-        });
       }
+      if (isBaseMessage(output) && output._getType() === 'tool') {
+        const toolMsg = output as ToolMessage;
+        if (
+          toolMsg.status !== 'error' &&
+          (this.toolOutputRegistry != null || unresolvedRefs.length > 0) &&
+          typeof toolMsg.content === 'string'
+        ) {
+          toolMsg.content = this.applyOutputReference(
+            toolMsg.content,
+            shouldRegister ? batchIndex : undefined,
+            unresolvedRefs
+          );
+        }
+        return toolMsg;
+      }
+      const rawContent =
+        typeof output === 'string' ? output : JSON.stringify(output);
+      const truncated = truncateToolResultContent(
+        rawContent,
+        this.maxToolResultChars
+      );
+      const content = this.applyOutputReference(
+        truncated,
+        shouldRegister ? batchIndex : undefined,
+        unresolvedRefs
+      );
+      return new ToolMessage({
+        status: 'success',
+        name: tool.name,
+        content,
+        tool_call_id: call.id!,
+      });
     } catch (_e: unknown) {
       const e = _e as Error;
       if (!this.handleToolErrors) {
@@ -316,6 +379,34 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         tool_call_id: call.id ?? '',
       });
     }
+  }
+
+  /**
+   * Registers a successful tool output under its batch-scoped reference
+   * key (when the registry is enabled) and returns the annotated content
+   * the LLM will see. When `batchIndex` is undefined, the output is
+   * neither registered nor annotated — only any unresolved reference
+   * warnings are appended.
+   *
+   * The *stored* value is the truncated-but-unannotated content so that
+   * piping it into a later tool call via `{{tool<idx>turn<turn>}}`
+   * delivers pristine output (no `_ref` key, no `[ref: …]` prefix).
+   */
+  private applyOutputReference(
+    truncated: string,
+    batchIndex: number | undefined,
+    unresolved: string[]
+  ): string {
+    let content = truncated;
+    if (this.toolOutputRegistry != null && batchIndex != null) {
+      const key = buildReferenceKey(batchIndex, this.currentTurn);
+      this.toolOutputRegistry.set(key, truncated);
+      content = annotateToolOutputWithReference(truncated, key);
+    }
+    if (unresolved.length > 0) {
+      content += `\n[unresolved refs: ${unresolved.join(', ')}]`;
+    }
+    return content;
   }
 
   /**
@@ -479,16 +570,31 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
-    config: RunnableConfig
+    config: RunnableConfig,
+    batchIndices?: number[]
   ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const threadId = config.configurable?.thread_id as string | undefined;
+    const registry = this.toolOutputRegistry;
+    const unresolvedByCallId = new Map<string, string[]>();
 
-    const preToolCalls = toolCalls.map((call) => ({
-      call,
-      stepId: this.toolCallStepIds?.get(call.id!) ?? '',
-      args: call.args as Record<string, unknown>,
-    }));
+    const preToolCalls = toolCalls.map((call, i) => {
+      const originalArgs = call.args as Record<string, unknown>;
+      let resolvedArgs = originalArgs;
+      if (registry != null) {
+        const { resolved, unresolved } = registry.resolve(originalArgs);
+        resolvedArgs = resolved as Record<string, unknown>;
+        if (unresolved.length > 0 && call.id != null) {
+          unresolvedByCallId.set(call.id, unresolved);
+        }
+      }
+      return {
+        call,
+        stepId: this.toolCallStepIds?.get(call.id!) ?? '',
+        args: resolvedArgs,
+        batchIndex: batchIndices?.[i],
+      };
+    });
 
     const messageByCallId = new Map<string, ToolMessage>();
     const approvedEntries: typeof preToolCalls = [];
@@ -575,10 +681,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     const injected: BaseMessage[] = [];
 
+    const batchIndexByCallId = new Map<string, number>();
+
     if (approvedEntries.length > 0) {
       const requests: t.ToolCallRequest[] = approvedEntries.map((entry) => {
         const turn = this.toolUsageCount.get(entry.call.name) ?? 0;
         this.toolUsageCount.set(entry.call.name, turn + 1);
+
+        if (entry.batchIndex != null && entry.call.id != null) {
+          batchIndexByCallId.set(entry.call.id, entry.batchIndex);
+        }
 
         const request: t.ToolCallRequest = {
           id: entry.call.id!,
@@ -719,6 +831,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             }
           }
 
+          const batchIndex = batchIndexByCallId.get(result.toolCallId);
+          const unresolved = unresolvedByCallId.get(result.toolCallId) ?? [];
+          contentString = this.applyOutputReference(
+            contentString,
+            batchIndex,
+            unresolved
+          );
+
           toolMessage = new ToolMessage({
             status: 'success',
             name: toolName,
@@ -815,16 +935,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * Injected messages are placed AFTER ToolMessages to respect provider
    * message ordering (AIMessage tool_calls must be immediately followed
    * by their ToolMessage results).
+   *
+   * `batchIndices` mirrors `toolCalls` and carries each call's position
+   * within the parent batch, which the registry uses to form reference
+   * keys. It's omitted when the registry is disabled.
    */
   private async executeViaEvent(
     toolCalls: ToolCall[],
     config: RunnableConfig,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    input: any
+    input: any,
+    batchIndices?: number[]
   ): Promise<T> {
     const { toolMessages, injected } = await this.dispatchToolEvents(
       toolCalls,
-      config
+      config,
+      batchIndices
     );
     const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
@@ -833,14 +959,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
+    this.currentTurn = this.turnCounter++;
     let outputs: (BaseMessage | Command)[];
 
     if (this.isSendInput(input)) {
       const isDirectTool = this.directToolNames?.has(input.lg_tool_call.name);
       if (this.eventDrivenMode && isDirectTool !== true) {
-        return this.executeViaEvent([input.lg_tool_call], config, input);
+        return this.executeViaEvent([input.lg_tool_call], config, input, [0]);
       }
-      outputs = [await this.runTool(input.lg_tool_call, config)];
+      outputs = [await this.runTool(input.lg_tool_call, config, 0)];
       this.handleRunToolCompletions([input.lg_tool_call], outputs, config);
     } else {
       let messages: BaseMessage[];
@@ -900,21 +1027,40 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }) ?? [];
 
       if (this.eventDrivenMode && filteredCalls.length > 0) {
+        const filteredIndices = filteredCalls.map((_, idx) => idx);
+
         if (!this.directToolNames || this.directToolNames.size === 0) {
-          return this.executeViaEvent(filteredCalls, config, input);
+          return this.executeViaEvent(
+            filteredCalls,
+            config,
+            input,
+            filteredIndices
+          );
         }
 
-        const directCalls = filteredCalls.filter((c) =>
-          this.directToolNames!.has(c.name)
-        );
-        const eventCalls = filteredCalls.filter(
-          (c) => !this.directToolNames!.has(c.name)
-        );
+        const directEntries: Array<{ call: ToolCall; batchIndex: number }> = [];
+        const eventEntries: Array<{ call: ToolCall; batchIndex: number }> = [];
+        for (let i = 0; i < filteredCalls.length; i++) {
+          const call = filteredCalls[i];
+          const entry = { call, batchIndex: i };
+          if (this.directToolNames!.has(call.name)) {
+            directEntries.push(entry);
+          } else {
+            eventEntries.push(entry);
+          }
+        }
+
+        const directCalls = directEntries.map((e) => e.call);
+        const directIndices = directEntries.map((e) => e.batchIndex);
+        const eventCalls = eventEntries.map((e) => e.call);
+        const eventIndices = eventEntries.map((e) => e.batchIndex);
 
         const directOutputs: (BaseMessage | Command)[] =
           directCalls.length > 0
             ? await Promise.all(
-              directCalls.map((call) => this.runTool(call, config))
+              directCalls.map((call, i) =>
+                this.runTool(call, config, directIndices[i])
+              )
             )
             : [];
 
@@ -924,7 +1070,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         const eventResult =
           eventCalls.length > 0
-            ? await this.dispatchToolEvents(eventCalls, config)
+            ? await this.dispatchToolEvents(eventCalls, config, eventIndices)
             : {
               toolMessages: [] as ToolMessage[],
               injected: [] as BaseMessage[],
@@ -937,7 +1083,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         ];
       } else {
         outputs = await Promise.all(
-          filteredCalls.map((call) => this.runTool(call, config))
+          filteredCalls.map((call, i) => this.runTool(call, config, i))
         );
         this.handleRunToolCompletions(filteredCalls, outputs, config);
       }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -33,7 +33,8 @@ import {
   buildReferenceKey,
   annotateToolOutputWithReference,
   ToolOutputReferenceRegistry,
-} from './toolOutputReferences';
+} from '@/tools/toolOutputReferences';
+import type { ToolOutputResolveView } from '@/tools/toolOutputReferences';
 
 /**
  * Helper to check if a value is a Send object
@@ -116,16 +117,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * ToolNode building its own.
    */
   private toolOutputRegistry?: ToolOutputReferenceRegistry;
-  /**
-   * Resolved (post-substitution) args keyed by `toolCallId` for the
-   * current `run()` batch. Populated in `runTool`/`dispatchToolEvents`
-   * right after `registry.resolve(args)` so downstream completion
-   * events (`ON_RUN_STEP_COMPLETED`) expose the args the tool
-   * *actually* ran with instead of the unresolved template. Cleared
-   * at the start of each batch.
-   */
-  private resolvedArgsByCallId: Map<string, Record<string, unknown>> =
-    new Map();
   /**
    * Monotonic counter used to mint a unique scope id for anonymous
    * batches (ones invoked without a `run_id` in
@@ -252,7 +243,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     config: RunnableConfig,
     batchIndex?: number,
     turn?: number,
-    batchScopeId?: string
+    batchScopeId?: string,
+    /**
+     * Per-batch sink for resolved (post-substitution) args, keyed by
+     * `toolCallId`. Threaded as a local map (instead of instance
+     * state) so concurrent `run()` calls on the same ToolNode cannot
+     * race on a shared field — each batch has its own map.
+     */
+    resolvedArgsByCallId?: Map<string, Record<string, unknown>>
   ): Promise<BaseMessage | Command> {
     const tool = this.toolMap.get(call.name);
     const registry = this.toolOutputRegistry;
@@ -285,10 +283,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (tool === undefined) {
         throw new Error(`Tool "${call.name}" not found.`);
       }
-      const turn = this.toolUsageCount.get(call.name) ?? 0;
-      this.toolUsageCount.set(call.name, turn + 1);
+      /**
+       * `usageCount` is the per-tool-name invocation index that
+       * web-search and other tools observe via `invokeParams.turn`.
+       * It is intentionally distinct from the outer `turn` parameter
+       * (the batch turn used for ref keys); the latter is captured
+       * before the try block when constructing `refKey`.
+       */
+      const usageCount = this.toolUsageCount.get(call.name) ?? 0;
+      this.toolUsageCount.set(call.name, usageCount + 1);
       if (call.id != null && call.id !== '') {
-        this.toolCallTurns.set(call.id, turn);
+        this.toolCallTurns.set(call.id, usageCount);
       }
       let args = call.args;
       if (registry != null) {
@@ -302,12 +307,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
          * template. Only string/object args are worth recording.
          */
         if (
+          resolvedArgsByCallId != null &&
           call.id != null &&
           call.id !== '' &&
           resolved !== call.args &&
           typeof resolved === 'object'
         ) {
-          this.resolvedArgsByCallId.set(
+          resolvedArgsByCallId.set(
             call.id,
             resolved as Record<string, unknown>
           );
@@ -316,12 +322,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const stepId = this.toolCallStepIds?.get(call.id!);
 
       // Build invoke params - LangChain extracts non-schema fields to config.toolCall
+      // `turn` here is the per-tool usage count (matches what tools have
+      // observed historically via config.toolCall.turn — e.g. web search).
       let invokeParams: Record<string, unknown> = {
         ...call,
         args,
         type: 'tool_call',
         stepId,
-        turn,
+        turn: usageCount,
       };
 
       // Inject runtime data for special tools (becomes available at config.toolCall)
@@ -652,7 +660,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private handleRunToolCompletions(
     calls: ToolCall[],
     outputs: (BaseMessage | Command)[],
-    config: RunnableConfig
+    config: RunnableConfig,
+    /**
+     * Per-batch resolved-args sink populated by `runTool`. Threaded
+     * as a local instead of an instance field so concurrent batches
+     * cannot read each other's state.
+     */
+    resolvedArgsByCallId?: Map<string, Record<string, unknown>>
   ): void {
     for (let i = 0; i < calls.length; i++) {
       const call = calls[i];
@@ -698,8 +712,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * `ON_RUN_STEP_COMPLETED.tool_call.args` consistent with what
        * the tool actually received rather than leaking the template.
        */
-      const effectiveArgs =
-        this.resolvedArgsByCallId.get(toolCallId) ?? call.args;
+      const effectiveArgs = resolvedArgsByCallId?.get(toolCallId) ?? call.args;
       const tool_call: t.ProcessedToolCall = {
         args:
           typeof effectiveArgs === 'string'
@@ -749,7 +762,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       string,
       { resolved: Record<string, unknown>; unresolved: string[] }
     >,
-    batchScopeId?: string
+    batchScopeId?: string,
+    /**
+     * Frozen snapshot of the registry taken before any direct-branch
+     * registrations could land. Set by the mixed direct+event path so
+     * any `PreToolUse` hook that rewrites event args via
+     * `updatedInput` resolves new placeholders against the same
+     * pre-batch state — preserving same-turn isolation. When unset,
+     * re-resolution falls back to the live registry (correct for the
+     * pure-event path where no in-batch registrations have happened
+     * yet).
+     */
+    preBatchSnapshot?: ToolOutputResolveView
   ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     /**
@@ -884,8 +908,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
            * with what the tool will actually receive.
            */
           if (registry != null) {
-            const { resolved, unresolved } = registry.resolve(
-              registryRunId,
+            /**
+             * Mixed direct+event batches must use the pre-batch
+             * snapshot so a hook-introduced placeholder cannot
+             * accidentally resolve to a same-turn direct output that
+             * has just registered. Pure event batches don't have a
+             * snapshot and resolve against the live registry — safe
+             * because no event-side registrations have happened yet.
+             */
+            const view: ToolOutputResolveView = preBatchSnapshot ?? {
+              resolve: <T>(args: T) => registry.resolve(registryRunId, args),
+            };
+            const { resolved, unresolved } = view.resolve(
               hookResult.updatedInput
             );
             entry.args = resolved as Record<string, unknown>;
@@ -1207,7 +1241,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       batchIndices,
       turn,
       undefined,
-      batchScopeId
+      batchScopeId,
+      undefined
     );
     const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
@@ -1216,7 +1251,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
-    this.resolvedArgsByCallId.clear();
+    /**
+     * Per-batch local map for resolved (post-substitution) args.
+     * Lives on the stack so concurrent `run()` calls on the same
+     * ToolNode cannot read or wipe each other's entries.
+     */
+    const resolvedArgsByCallId = new Map<string, Record<string, unknown>>();
     /**
      * Claim this batch's turn synchronously from the registry (or
      * fall back to 0 when the feature is disabled). The registry is
@@ -1246,9 +1286,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
       }
       outputs = [
-        await this.runTool(input.lg_tool_call, config, 0, turn, batchScopeId),
+        await this.runTool(
+          input.lg_tool_call,
+          config,
+          0,
+          turn,
+          batchScopeId,
+          resolvedArgsByCallId
+        ),
       ];
-      this.handleRunToolCompletions([input.lg_tool_call], outputs, config);
+      this.handleRunToolCompletions(
+        [input.lg_tool_call],
+        outputs,
+        config,
+        resolvedArgsByCallId
+      );
     } else {
       let messages: BaseMessage[];
       if (Array.isArray(input)) {
@@ -1352,11 +1404,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           string,
           { resolved: Record<string, unknown>; unresolved: string[] }
         >();
-        if (this.toolOutputRegistry != null) {
+        /**
+         * Take a frozen snapshot of the registry state before any
+         * direct registrations land. The snapshot resolves
+         * placeholders against this point-in-time view, so a
+         * `PreToolUse` hook later rewriting event args via
+         * `updatedInput` can introduce placeholders that resolve
+         * cross-batch (against prior runs) without ever picking up
+         * same-turn direct outputs.
+         */
+        const preBatchSnapshot =
+          this.toolOutputRegistry?.snapshot(batchScopeId);
+        if (preBatchSnapshot != null) {
           for (const entry of eventEntries) {
             if (entry.call.id != null) {
-              const { resolved, unresolved } = this.toolOutputRegistry.resolve(
-                batchScopeId,
+              const { resolved, unresolved } = preBatchSnapshot.resolve(
                 entry.call.args as Record<string, unknown>
               );
               preResolvedEventArgs.set(entry.call.id, {
@@ -1376,14 +1438,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                   config,
                   directIndices[i],
                   turn,
-                  batchScopeId
+                  batchScopeId,
+                  resolvedArgsByCallId
                 )
               )
             )
             : [];
 
         if (directCalls.length > 0 && directOutputs.length > 0) {
-          this.handleRunToolCompletions(directCalls, directOutputs, config);
+          this.handleRunToolCompletions(
+            directCalls,
+            directOutputs,
+            config,
+            resolvedArgsByCallId
+          );
         }
 
         const eventResult =
@@ -1394,7 +1462,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               eventIndices,
               turn,
               preResolvedEventArgs,
-              batchScopeId
+              batchScopeId,
+              preBatchSnapshot
             )
             : {
               toolMessages: [] as ToolMessage[],
@@ -1409,10 +1478,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       } else {
         outputs = await Promise.all(
           filteredCalls.map((call, i) =>
-            this.runTool(call, config, i, turn, batchScopeId)
+            this.runTool(
+              call,
+              config,
+              i,
+              turn,
+              batchScopeId,
+              resolvedArgsByCallId
+            )
           )
         );
-        this.handleRunToolCompletions(filteredCalls, outputs, config);
+        this.handleRunToolCompletions(
+          filteredCalls,
+          outputs,
+          config,
+          resolvedArgsByCallId
+        );
       }
     }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -495,15 +495,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     refKey: string | undefined,
     unresolved: string[]
   ): string {
-    let content = llmContent;
     if (this.toolOutputRegistry != null && refKey != null) {
       this.toolOutputRegistry.set(refKey, registryContent);
-      content = annotateToolOutputWithReference(llmContent, refKey);
     }
-    if (unresolved.length > 0) {
-      content += `\n[unresolved refs: ${unresolved.join(', ')}]`;
-    }
-    return content;
+    /**
+     * `annotateToolOutputWithReference` handles both the ref-key and
+     * unresolved-refs cases together so JSON-object outputs stay
+     * parseable: unresolved refs land in an `_unresolved_refs` field
+     * instead of as a trailing text line that would break
+     * `JSON.parse` for downstream consumers.
+     */
+    return annotateToolOutputWithReference(llmContent, refKey, unresolved);
   }
 
   /**

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -116,6 +116,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * ToolNode building its own.
    */
   private toolOutputRegistry?: ToolOutputReferenceRegistry;
+  /**
+   * Resolved (post-substitution) args keyed by `toolCallId` for the
+   * current `run()` batch. Populated in `runTool`/`dispatchToolEvents`
+   * right after `registry.resolve(args)` so downstream completion
+   * events (`ON_RUN_STEP_COMPLETED`) expose the args the tool
+   * *actually* ran with instead of the unresolved template. Cleared
+   * at the start of each batch.
+   */
+  private resolvedArgsByCallId: Map<string, Record<string, unknown>> =
+    new Map();
 
   constructor({
     tools,
@@ -267,6 +277,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const { resolved, unresolved } = registry.resolve(args);
         args = resolved;
         unresolvedRefs = unresolved;
+        /**
+         * Expose the post-substitution args to downstream completion
+         * events so audit logs / host-side `ON_RUN_STEP_COMPLETED`
+         * handlers observe what actually ran, not the `{{…}}`
+         * template. Only string/object args are worth recording.
+         */
+        if (
+          call.id != null &&
+          call.id !== '' &&
+          resolved !== call.args &&
+          typeof resolved === 'object'
+        ) {
+          this.resolvedArgsByCallId.set(
+            call.id,
+            resolved as Record<string, unknown>
+          );
+        }
       }
       const stepId = this.toolCallStepIds?.get(call.id!);
 
@@ -366,18 +393,33 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               refKey,
               unresolvedRefs
             );
-          } else if (refKey != null) {
+          } else {
             /**
-             * Known limitation: tools that return a `ToolMessage` with
-             * array-type content (multi-part content blocks such as
-             * text + image) are not registered under a reference key
-             * and therefore cannot be cited via `{{tool<i>turn<n>}}`.
-             * Registering would require deciding which block is
-             * canonical, which differs per tool. Warn once per tool
-             * per run (memo lives on the registry so multi-agent
-             * graphs don't double-warn from each ToolNode).
+             * Non-string content (multi-part content blocks — text +
+             * image). Known limitation: we cannot register under a
+             * reference key because there's no canonical serialized
+             * form. Warn once per tool per run when the caller
+             * intended to register.
+             *
+             * Still surface unresolved-ref warnings so the LLM gets
+             * the self-correction signal that the string and error
+             * paths already emit. Prepended as a leading text block
+             * to keep the original content ordering intact.
              */
-            if (this.toolOutputRegistry!.claimWarnOnce(call.name)) {
+            if (unresolvedRefs.length > 0 && Array.isArray(toolMsg.content)) {
+              const warningBlock = {
+                type: 'text',
+                text: `[unresolved refs: ${unresolvedRefs.join(', ')}]`,
+              };
+              toolMsg.content = [
+                warningBlock,
+                ...toolMsg.content,
+              ] as typeof toolMsg.content;
+            }
+            if (
+              refKey != null &&
+              this.toolOutputRegistry!.claimWarnOnce(call.name)
+            ) {
               // eslint-disable-next-line no-console
               console.warn(
                 `[ToolNode] Skipping tool output reference for "${call.name}": ` +
@@ -627,11 +669,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           ? toolMessage.content
           : JSON.stringify(toolMessage.content);
 
+      /**
+       * Prefer the post-substitution args when a `{{…}}` placeholder
+       * was resolved in `runTool`. This keeps
+       * `ON_RUN_STEP_COMPLETED.tool_call.args` consistent with what
+       * the tool actually received rather than leaking the template.
+       */
+      const effectiveArgs =
+        this.resolvedArgsByCallId.get(toolCallId) ?? call.args;
       const tool_call: t.ProcessedToolCall = {
         args:
-          typeof call.args === 'string'
-            ? (call.args as string)
-            : JSON.stringify((call.args as unknown) ?? {}),
+          typeof effectiveArgs === 'string'
+            ? (effectiveArgs as string)
+            : JSON.stringify((effectiveArgs as unknown) ?? {}),
         name: call.name,
         id: toolCallId,
         output: contentString,
@@ -1106,6 +1156,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected async run(input: any, config: RunnableConfig): Promise<T> {
     this.toolCallTurns.clear();
+    this.resolvedArgsByCallId.clear();
     /**
      * Claim this batch's turn synchronously from the registry (or
      * fall back to 0 when the feature is disabled). The registry

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -19,8 +19,13 @@ import type {
 } from '@langchain/core/runnables';
 import type { BaseMessage, AIMessage } from '@langchain/core/messages';
 import type { StructuredToolInterface } from '@langchain/core/tools';
-import type * as t from '@/types';
+import type {
+  ToolOutputResolveView,
+  PreResolvedArgsMap,
+  ResolvedArgsByCallId,
+} from '@/tools/toolOutputReferences';
 import type { HookRegistry, AggregatedHookResult } from '@/hooks';
+import type * as t from '@/types';
 import { RunnableCallable } from '@/utils';
 import {
   calculateMaxToolResultChars,
@@ -34,7 +39,49 @@ import {
   annotateToolOutputWithReference,
   ToolOutputReferenceRegistry,
 } from '@/tools/toolOutputReferences';
-import type { ToolOutputResolveView } from '@/tools/toolOutputReferences';
+
+/**
+ * Per-call batch context for `runTool`. Bundles every optional
+ * batch-scoped value the method needs so the signature stays at
+ * three positional parameters even as new context fields are added.
+ */
+type RunToolBatchContext = {
+  /** Position of this call within the parent ToolNode batch. */
+  batchIndex?: number;
+  /** Batch turn shared across every call in the batch. */
+  turn?: number;
+  /** Registry partition scope (run id or anonymous batch id). */
+  batchScopeId?: string;
+  /** Batch-local sink for post-substitution args. */
+  resolvedArgsByCallId?: ResolvedArgsByCallId;
+};
+
+/**
+ * Per-batch context for `dispatchToolEvents` / `executeViaEvent`.
+ * Mirrors {@link RunToolBatchContext} for the event-driven path,
+ * with bulk indices and the snapshot/pre-resolved-args carriers
+ * used in the mixed direct+event flow.
+ */
+type DispatchBatchContext = {
+  /** Per-call batch indices, parallel to the `toolCalls` array. */
+  batchIndices?: number[];
+  /** Batch turn shared across every call in the batch. */
+  turn?: number;
+  /** Registry partition scope (run id or anonymous batch id). */
+  batchScopeId?: string;
+  /**
+   * Pre-resolved args keyed by `toolCallId`. Populated by the mixed
+   * path so event calls don't re-resolve against a registry that
+   * already contains same-turn direct outputs.
+   */
+  preResolvedArgs?: PreResolvedArgsMap;
+  /**
+   * Frozen pre-batch registry view used to re-resolve placeholders
+   * a `PreToolUse` hook injects via `updatedInput` — preserves the
+   * same-turn isolation guarantee for hook-rewritten args.
+   */
+  preBatchSnapshot?: ToolOutputResolveView;
+};
 
 /**
  * Helper to check if a value is a Send object
@@ -241,17 +288,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   protected async runTool(
     call: ToolCall,
     config: RunnableConfig,
-    batchIndex?: number,
-    turn?: number,
-    batchScopeId?: string,
-    /**
-     * Per-batch sink for resolved (post-substitution) args, keyed by
-     * `toolCallId`. Threaded as a local map (instead of instance
-     * state) so concurrent `run()` calls on the same ToolNode cannot
-     * race on a shared field — each batch has its own map.
-     */
-    resolvedArgsByCallId?: Map<string, Record<string, unknown>>
+    batchContext: RunToolBatchContext = {}
   ): Promise<BaseMessage | Command> {
+    const { batchIndex, turn, batchScopeId, resolvedArgsByCallId } =
+      batchContext;
     const tool = this.toolMap.get(call.name);
     const registry = this.toolOutputRegistry;
     /**
@@ -756,25 +796,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private async dispatchToolEvents(
     toolCalls: ToolCall[],
     config: RunnableConfig,
-    batchIndices?: number[],
-    turn?: number,
-    preResolvedArgs?: Map<
-      string,
-      { resolved: Record<string, unknown>; unresolved: string[] }
-    >,
-    batchScopeId?: string,
-    /**
-     * Frozen snapshot of the registry taken before any direct-branch
-     * registrations could land. Set by the mixed direct+event path so
-     * any `PreToolUse` hook that rewrites event args via
-     * `updatedInput` resolves new placeholders against the same
-     * pre-batch state — preserving same-turn isolation. When unset,
-     * re-resolution falls back to the live registry (correct for the
-     * pure-event path where no in-batch registrations have happened
-     * yet).
-     */
-    preBatchSnapshot?: ToolOutputResolveView
+    batchContext: DispatchBatchContext = {}
   ): Promise<{ toolMessages: ToolMessage[]; injected: BaseMessage[] }> {
+    const {
+      batchIndices,
+      turn,
+      batchScopeId,
+      preResolvedArgs,
+      preBatchSnapshot,
+    } = batchContext;
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     /**
      * Registry-facing scope id — prefers the caller-threaded
@@ -1231,18 +1261,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     config: RunnableConfig,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     input: any,
-    batchIndices?: number[],
-    turn?: number,
-    batchScopeId?: string
+    batchContext: DispatchBatchContext = {}
   ): Promise<T> {
     const { toolMessages, injected } = await this.dispatchToolEvents(
       toolCalls,
       config,
-      batchIndices,
-      turn,
-      undefined,
-      batchScopeId,
-      undefined
+      batchContext
     );
     const outputs: BaseMessage[] = [...toolMessages, ...injected];
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
@@ -1276,24 +1300,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     if (this.isSendInput(input)) {
       const isDirectTool = this.directToolNames?.has(input.lg_tool_call.name);
       if (this.eventDrivenMode && isDirectTool !== true) {
-        return this.executeViaEvent(
-          [input.lg_tool_call],
-          config,
-          input,
-          [0],
-          turn,
-          batchScopeId
-        );
-      }
-      outputs = [
-        await this.runTool(
-          input.lg_tool_call,
-          config,
-          0,
+        return this.executeViaEvent([input.lg_tool_call], config, input, {
+          batchIndices: [0],
           turn,
           batchScopeId,
-          resolvedArgsByCallId
-        ),
+        });
+      }
+      outputs = [
+        await this.runTool(input.lg_tool_call, config, {
+          batchIndex: 0,
+          turn,
+          batchScopeId,
+          resolvedArgsByCallId,
+        }),
       ];
       this.handleRunToolCompletions(
         [input.lg_tool_call],
@@ -1362,14 +1381,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const filteredIndices = filteredCalls.map((_, idx) => idx);
 
         if (!this.directToolNames || this.directToolNames.size === 0) {
-          return this.executeViaEvent(
-            filteredCalls,
-            config,
-            input,
-            filteredIndices,
+          return this.executeViaEvent(filteredCalls, config, input, {
+            batchIndices: filteredIndices,
             turn,
-            batchScopeId
-          );
+            batchScopeId,
+          });
         }
 
         const directEntries: Array<{ call: ToolCall; batchIndex: number }> = [];
@@ -1433,14 +1449,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           directCalls.length > 0
             ? await Promise.all(
               directCalls.map((call, i) =>
-                this.runTool(
-                  call,
-                  config,
-                  directIndices[i],
+                this.runTool(call, config, {
+                  batchIndex: directIndices[i],
                   turn,
                   batchScopeId,
-                  resolvedArgsByCallId
-                )
+                  resolvedArgsByCallId,
+                })
               )
             )
             : [];
@@ -1456,15 +1470,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         const eventResult =
           eventCalls.length > 0
-            ? await this.dispatchToolEvents(
-              eventCalls,
-              config,
-              eventIndices,
+            ? await this.dispatchToolEvents(eventCalls, config, {
+              batchIndices: eventIndices,
               turn,
-              preResolvedEventArgs,
               batchScopeId,
-              preBatchSnapshot
-            )
+              preResolvedArgs: preResolvedEventArgs,
+              preBatchSnapshot,
+            })
             : {
               toolMessages: [] as ToolMessage[],
               injected: [] as BaseMessage[],
@@ -1478,14 +1490,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       } else {
         outputs = await Promise.all(
           filteredCalls.map((call, i) =>
-            this.runTool(
-              call,
-              config,
-              i,
+            this.runTool(call, config, {
+              batchIndex: i,
               turn,
               batchScopeId,
-              resolvedArgsByCallId
-            )
+              resolvedArgsByCallId,
+            })
           )
         );
         this.handleRunToolCompletions(

--- a/src/tools/__tests__/BashExecutor.test.ts
+++ b/src/tools/__tests__/BashExecutor.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  BashExecutionToolDescription,
+  BashToolOutputReferencesGuide,
+  buildBashExecutionToolDescription,
+} from '../BashExecutor';
+
+describe('buildBashExecutionToolDescription', () => {
+  it('returns the base description by default', () => {
+    expect(buildBashExecutionToolDescription()).toBe(
+      BashExecutionToolDescription
+    );
+    expect(buildBashExecutionToolDescription({})).toBe(
+      BashExecutionToolDescription
+    );
+    expect(
+      buildBashExecutionToolDescription({ enableToolOutputReferences: false })
+    ).toBe(BashExecutionToolDescription);
+  });
+
+  it('appends the tool-output references guide when enabled', () => {
+    const composed = buildBashExecutionToolDescription({
+      enableToolOutputReferences: true,
+    });
+    expect(composed.startsWith(BashExecutionToolDescription)).toBe(true);
+    expect(composed).toContain(BashToolOutputReferencesGuide);
+    expect(composed).toContain('{{tool<idx>turn<turn>}}');
+  });
+
+  it('separates base and guide with a blank line', () => {
+    const composed = buildBashExecutionToolDescription({
+      enableToolOutputReferences: true,
+    });
+    expect(composed.includes(`${BashExecutionToolDescription}\n\n`)).toBe(true);
+  });
+});

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -916,6 +916,123 @@ describe('ToolNode tool output references', () => {
       );
     });
 
+    it('keeps same-turn refs isolated in the mixed direct+event path', async () => {
+      // Build a ToolNode with both a direct tool (via directToolNames)
+      // and an event-driven schema stub. Share one registry across
+      // both batches so refs only cross batch boundaries.
+      const sharedRegistry = new ToolOutputReferenceRegistry();
+
+      const directCapturedArgs: string[] = [];
+      const directTool = createEchoTool({
+        capturedArgs: directCapturedArgs,
+        outputs: ['direct-A-output', 'direct-B-output'],
+        name: 'directTool',
+      });
+      const eventStub = tool(async () => 'unused', {
+        name: 'eventTool',
+        description: 'schema-only stub',
+        schema: z.object({ command: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      const hostCapturedArgs: Record<string, unknown>[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const batch = data as t.ToolExecuteBatchRequest;
+          for (const req of batch.toolCalls) {
+            hostCapturedArgs.push(req.args);
+          }
+          batch.resolve(
+            batch.toolCalls.map((req) => ({
+              toolCallId: req.id,
+              content: `event-${(req.args as { command: string }).command}`,
+              status: 'success' as const,
+            }))
+          );
+        });
+
+      const node = new ToolNode({
+        tools: [directTool, eventStub],
+        eventDrivenMode: true,
+        agentId: 'agent-mixed',
+        directToolNames: new Set(['directTool']),
+        toolCallStepIds: new Map([
+          ['d1', 'step_d1'],
+          ['e1', 'step_e1'],
+          ['d2', 'step_d2'],
+          ['e2', 'step_e2'],
+        ]),
+        toolOutputRegistry: sharedRegistry,
+      });
+
+      // Batch 1: mixed direct (index 0) + event (index 1). The event
+      // call attempts `{{tool0turn0}}` — which points at the direct
+      // call running *in the same batch*. Correct behavior: the
+      // placeholder stays unresolved (cross-batch only), and the
+      // event args received by the host must carry the literal
+      // template string plus the LLM-visible `[unresolved refs:…]`
+      // trailer.
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                {
+                  id: 'd1',
+                  name: 'directTool',
+                  args: { command: 'first' },
+                },
+                {
+                  id: 'e1',
+                  name: 'eventTool',
+                  args: { command: 'echo {{tool0turn0}}' },
+                },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'mixed-run' } }
+      );
+
+      expect(hostCapturedArgs).toHaveLength(1);
+      expect(hostCapturedArgs[0]).toEqual({
+        command: 'echo {{tool0turn0}}',
+      });
+
+      // Batch 2: ref across the boundary now resolves — direct's
+      // registered output from batch 1 (tool0turn0) is available.
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                {
+                  id: 'd2',
+                  name: 'directTool',
+                  args: { command: 'second' },
+                },
+                {
+                  id: 'e2',
+                  name: 'eventTool',
+                  args: { command: 'echo {{tool0turn0}}' },
+                },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'mixed-run' } }
+      );
+
+      expect(hostCapturedArgs[1]).toEqual({
+        command: 'echo direct-A-output',
+      });
+    });
+
     it('re-resolves placeholders when PreToolUse rewrites args', async () => {
       const hooks = new HookRegistry();
       hooks.register('PreToolUse', {

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -242,6 +242,107 @@ describe('ToolNode tool output references', () => {
       expect(msg.content).toContain('[unresolved refs: tool9turn9]');
     });
 
+    it('stores the raw untruncated output in the registry, independent of the LLM-visible truncation', async () => {
+      const raw = 'X'.repeat(8_000);
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: [raw, 'second'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        maxToolResultChars: 200,
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [first] = await invokeBatch(
+        node,
+        [{ id: 'c1', name: 'echo', command: 'first' }],
+        'raw-preservation'
+      );
+
+      expect((first.content as string).length).toBeLessThan(raw.length);
+      expect(first.content).toContain('truncated');
+
+      await invokeBatch(
+        node,
+        [{ id: 'c2', name: 'echo', command: 'echo {{tool0turn0}}' }],
+        'raw-preservation'
+      );
+
+      expect(capturedArgs[1]).toBe(`echo ${raw}`);
+      expect(node._unsafeGetToolOutputRegistry()!.get('tool0turn0')).toBe(raw);
+    });
+
+    it('uses each batch\'s own turn when ToolNode is invoked concurrently within a run', async () => {
+      const gates: Record<string, () => void> = {};
+      const slowTool = tool(
+        async (input) => {
+          const args = input as { command: string };
+          await new Promise<void>((resolve) => {
+            gates[args.command] = resolve;
+          });
+          return `output-${args.command}`;
+        },
+        {
+          name: 'slow',
+          description: 'awaits a per-command gate',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      const node = new ToolNode({
+        tools: [slowTool],
+        toolOutputReferences: { enabled: true },
+      });
+
+      // Two batches of the SAME run, started concurrently — batch A
+      // captures turn 0 in its sync prefix, batch B captures turn 1.
+      // If the turn were read from shared state after the awaits, the
+      // reads would race and both batches would see the latest value.
+      const first = node.invoke(
+        {
+          messages: [aiMsgWithCalls([{ id: 'a', name: 'slow', command: 'A' }])],
+        },
+        { configurable: { run_id: 'concurrent-run' } }
+      );
+      const second = node.invoke(
+        {
+          messages: [aiMsgWithCalls([{ id: 'b', name: 'slow', command: 'B' }])],
+        },
+        { configurable: { run_id: 'concurrent-run' } }
+      );
+
+      await new Promise<void>((resolve) => {
+        const check = (): void => {
+          if (gates.A != null && gates.B != null) {
+            resolve();
+          } else {
+            setTimeout(check, 5);
+          }
+        };
+        check();
+      });
+      // Release B first (the later-scheduled batch), then A. Under the
+      // old code this would bake turn=1 into BOTH results because
+      // `currentTurn` was overwritten during B's sync prefix.
+      gates.B();
+      gates.A();
+
+      const [resA, resB] = (await Promise.all([first, second])) as Array<{
+        messages: ToolMessage[];
+      }>;
+
+      expect(resA.messages[0].content).toContain('[ref: tool0turn0]');
+      expect(resA.messages[0].content).toContain('output-A');
+      expect(resB.messages[0].content).toContain('[ref: tool0turn1]');
+      expect(resB.messages[0].content).toContain('output-B');
+
+      const registry = node._unsafeGetToolOutputRegistry()!;
+      expect(registry.get('tool0turn0')).toBe('output-A');
+      expect(registry.get('tool0turn1')).toBe('output-B');
+    });
+
     it('clips registered outputs to maxOutputSize', async () => {
       const t1 = createEchoTool({
         capturedArgs: [],

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -552,6 +552,96 @@ describe('ToolNode tool output references', () => {
       expect(sharedRegistry.get('tool0turn1')).toBe('agent-B-output');
     });
 
+    it('emits resolved args in ON_RUN_STEP_COMPLETED, not the template', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: ['STORED', 'second'],
+      });
+      const stepCompletedArgs: string[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event === 'on_run_step_completed') {
+            const step = data as {
+              result: { tool_call: { args: string } };
+            };
+            stepCompletedArgs.push(step.result.tool_call.args);
+          }
+        });
+
+      const node = new ToolNode({
+        tools: [t1],
+        toolCallStepIds: new Map([
+          ['a1', 'step_a1'],
+          ['a2', 'step_a2'],
+        ]),
+        toolOutputReferences: { enabled: true },
+      });
+
+      await invokeBatch(
+        node,
+        [{ id: 'a1', name: 'echo', command: 'first' }],
+        'resolved-args'
+      );
+      await invokeBatch(
+        node,
+        [
+          {
+            id: 'a2',
+            name: 'echo',
+            command: 'echo {{tool0turn0}}',
+          },
+        ],
+        'resolved-args'
+      );
+
+      // Second step-completed event should reflect the post-
+      // substitution command, not the `{{…}}` template.
+      expect(stepCompletedArgs).toHaveLength(2);
+      expect(JSON.parse(stepCompletedArgs[1]).command).toBe('echo STORED');
+    });
+
+    it('prepends unresolved-refs warning to non-string ToolMessage content', async () => {
+      const complexTool = tool(
+        async () =>
+          new ToolMessage({
+            status: 'success',
+            content: [
+              { type: 'text', text: 'data' },
+              { type: 'image_url', image_url: { url: 'data:...' } },
+            ],
+            name: 'complex',
+            tool_call_id: 'c1',
+          }),
+        {
+          name: 'complex',
+          description: 'returns multi-part content',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      const node = new ToolNode({
+        tools: [complexTool],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(
+        node,
+        [{ id: 'c1', name: 'complex', command: 'see {{tool9turn9}}' }],
+        'non-string'
+      );
+
+      expect(Array.isArray(msg.content)).toBe(true);
+      const blocks = msg.content as Array<{ type: string; text?: string }>;
+      expect(blocks[0].type).toBe('text');
+      expect(blocks[0].text).toContain('[unresolved refs: tool9turn9]');
+      // Original blocks follow the warning.
+      expect(blocks[1].type).toBe('text');
+      expect(blocks[1].text).toBe('data');
+      expect(blocks[2].type).toBe('image_url');
+    });
+
     it('resets the registry and turn counter when the runId changes', async () => {
       const capturedArgs: string[] = [];
       const t1 = createEchoTool({

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -1103,6 +1103,99 @@ describe('ToolNode tool output references', () => {
       expect(hostCalled).toBe(false);
     });
 
+    it('isolates PreToolUse-injected refs from same-turn direct outputs in the mixed path', async () => {
+      // PreToolUse hook rewrites the event call's args to include
+      // `{{tool0turn0}}`. In the mixed direct+event path that
+      // placeholder must NOT resolve to the same-turn direct
+      // output that just registered — it should be reported as
+      // unresolved (matching cross-batch resolution semantics).
+      const directCapturedArgs: string[] = [];
+      const directTool = createEchoTool({
+        capturedArgs: directCapturedArgs,
+        outputs: ['direct-same-turn'],
+        name: 'directTool',
+      });
+      const eventStub = tool(async () => 'unused', {
+        name: 'eventTool',
+        description: 'schema-only stub',
+        schema: z.object({ command: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      const hooks = new HookRegistry();
+      hooks.register('PreToolUse', {
+        pattern: 'eventTool',
+        hooks: [
+          async (): Promise<{ updatedInput: { command: string } }> => ({
+            updatedInput: { command: 'see {{tool0turn0}}' },
+          }),
+        ],
+      });
+
+      const hostCapturedArgs: Record<string, unknown>[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const batch = data as t.ToolExecuteBatchRequest;
+          for (const req of batch.toolCalls) {
+            hostCapturedArgs.push(req.args);
+          }
+          batch.resolve(
+            batch.toolCalls.map((req) => ({
+              toolCallId: req.id,
+              content: 'event-out',
+              status: 'success' as const,
+            }))
+          );
+        });
+
+      const node = new ToolNode({
+        tools: [directTool, eventStub],
+        eventDrivenMode: true,
+        agentId: 'agent-snap',
+        directToolNames: new Set(['directTool']),
+        toolCallStepIds: new Map([
+          ['d1', 'step_d1'],
+          ['e1', 'step_e1'],
+        ]),
+        hookRegistry: hooks,
+        toolOutputReferences: { enabled: true },
+      });
+
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                {
+                  id: 'd1',
+                  name: 'directTool',
+                  args: { command: 'first' },
+                },
+                {
+                  id: 'e1',
+                  name: 'eventTool',
+                  args: { command: 'orig' },
+                },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'snap-run' } }
+      );
+
+      // Hook injected `{{tool0turn0}}`. The direct tool registered
+      // `tool0turn0` in the same batch, but the snapshot was taken
+      // pre-direct so the placeholder must remain unresolved.
+      expect(hostCapturedArgs).toHaveLength(1);
+      expect(hostCapturedArgs[0]).toEqual({
+        command: 'see {{tool0turn0}}',
+      });
+    });
+
     it('keeps same-turn refs isolated in the mixed direct+event path', async () => {
       // Build a ToolNode with both a direct tool (via directToolNames)
       // and an event-driven schema stub. Share one registry across

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import * as events from '@/utils/events';
+import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
 import { TOOL_OUTPUT_REF_KEY } from '../toolOutputReferences';
 
@@ -73,7 +76,7 @@ describe('ToolNode tool output references', () => {
       ]);
 
       expect(msg.content).toBe('plain-output');
-      expect(node.getToolOutputRegistry()).toBeUndefined();
+      expect(node._unsafeGetToolOutputRegistry()).toBeUndefined();
     });
 
     it('does not substitute placeholders when disabled', async () => {
@@ -249,7 +252,7 @@ describe('ToolNode tool output references', () => {
 
       await invokeBatch(node, [{ id: 'c1', name: 'echo', command: 'x' }]);
 
-      const registry = node.getToolOutputRegistry();
+      const registry = node._unsafeGetToolOutputRegistry();
       expect(registry).toBeDefined();
       expect(registry!.get('tool0turn0')!.length).toBeLessThanOrEqual(40);
     });
@@ -272,7 +275,7 @@ describe('ToolNode tool output references', () => {
       await invokeBatch(node, [{ id: 'c2', name: 'echo', command: 'x' }]);
       await invokeBatch(node, [{ id: 'c3', name: 'echo', command: 'x' }]);
 
-      const registry = node.getToolOutputRegistry()!;
+      const registry = node._unsafeGetToolOutputRegistry()!;
       expect(registry.get('tool0turn0')).toBeUndefined();
       expect(registry.get('tool0turn1')).toBe('bbbbb');
       expect(registry.get('tool0turn2')).toBe('ccccc');
@@ -300,7 +303,318 @@ describe('ToolNode tool output references', () => {
       ]);
 
       expect((msg.content as string).startsWith('[ref:')).toBe(false);
-      expect(node.getToolOutputRegistry()!.get('tool0turn0')).toBeUndefined();
+      expect(
+        node._unsafeGetToolOutputRegistry()!.get('tool0turn0')
+      ).toBeUndefined();
+    });
+
+    it('resets the registry and turn counter when the runId changes', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: ['from-run-A', 'from-run-B'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const aiMsgA = aiMsgWithCalls([
+        { id: 'a1', name: 'echo', command: 'first' },
+      ]);
+      await node.invoke(
+        { messages: [aiMsgA] },
+        { configurable: { run_id: 'run-A' } }
+      );
+
+      const aiMsgB = aiMsgWithCalls([
+        {
+          id: 'b1',
+          name: 'echo',
+          command: 'echo {{tool0turn0}}',
+        },
+      ]);
+      const resultB = (await node.invoke(
+        { messages: [aiMsgB] },
+        { configurable: { run_id: 'run-B' } }
+      )) as { messages: ToolMessage[] };
+
+      expect(capturedArgs[1]).toBe('echo {{tool0turn0}}');
+      expect(resultB.messages[0].content).toContain('[ref: tool0turn0]');
+      expect(resultB.messages[0].content).toContain(
+        '[unresolved refs: tool0turn0]'
+      );
+    });
+  });
+
+  describe('event-driven dispatch path', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    function mockEventDispatch(mockResults: t.ToolExecuteResult[]): void {
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const request = data as Record<string, unknown>;
+          if (typeof request.resolve === 'function') {
+            (request.resolve as (r: t.ToolExecuteResult[]) => void)(
+              mockResults
+            );
+          }
+        });
+    }
+
+    function createSchemaStub(name: string): StructuredToolInterface {
+      return tool(async () => 'unused', {
+        name,
+        description: 'schema-only stub; host executes via ON_TOOL_EXECUTE',
+        schema: z.object({ command: z.string() }),
+      }) as unknown as StructuredToolInterface;
+    }
+
+    it('annotates the output the host returns', async () => {
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        toolCallStepIds: new Map([['ec1', 'step_ec1']]),
+        toolOutputReferences: { enabled: true },
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'ec1', content: 'host-output', status: 'success' },
+      ]);
+
+      const aiMsg = new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'ec1', name: 'echo', args: { command: 'run' } }],
+      });
+      const result = (await node.invoke({ messages: [aiMsg] })) as {
+        messages: ToolMessage[];
+      };
+
+      expect(result.messages[0].content).toBe('[ref: tool0turn0]\nhost-output');
+      expect(node._unsafeGetToolOutputRegistry()!.get('tool0turn0')).toBe(
+        'host-output'
+      );
+    });
+
+    it('substitutes `{{…}}` in the request sent to the host', async () => {
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        toolCallStepIds: new Map([
+          ['ec1', 'step_ec1'],
+          ['ec2', 'step_ec2'],
+        ]),
+        toolOutputReferences: { enabled: true },
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'ec1', content: 'FIRST', status: 'success' },
+      ]);
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'ec1', name: 'echo', args: { command: 'a' } }],
+          }),
+        ],
+      });
+
+      jest.restoreAllMocks();
+      const capturedRequests: t.ToolCallRequest[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const batch = data as t.ToolExecuteBatchRequest;
+          for (const req of batch.toolCalls) {
+            capturedRequests.push(req);
+          }
+          batch.resolve([
+            { toolCallId: 'ec2', content: 'SECOND', status: 'success' },
+          ]);
+        });
+
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'ec2',
+                name: 'echo',
+                args: { command: 'see {{tool0turn0}}' },
+              },
+            ],
+          }),
+        ],
+      });
+
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0].args).toEqual({ command: 'see FIRST' });
+    });
+
+    it('reports unresolved refs even when the host succeeds', async () => {
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        toolCallStepIds: new Map([['ec1', 'step_ec1']]),
+        toolOutputReferences: { enabled: true },
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'ec1', content: 'done', status: 'success' },
+      ]);
+      const result = (await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'ec1',
+                name: 'echo',
+                args: { command: 'see {{tool9turn9}}' },
+              },
+            ],
+          }),
+        ],
+      })) as { messages: ToolMessage[] };
+
+      expect(result.messages[0].content).toContain(
+        '[unresolved refs: tool9turn9]'
+      );
+    });
+
+    it('registers the post-hook output when PostToolUse replaces it', async () => {
+      const hooks = new HookRegistry();
+      hooks.register('PostToolUse', {
+        hooks: [
+          async (): Promise<{ updatedOutput: string }> => ({
+            updatedOutput: 'hooked-output',
+          }),
+        ],
+      });
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        toolCallStepIds: new Map([['ec1', 'step_ec1']]),
+        toolOutputReferences: { enabled: true },
+        hookRegistry: hooks,
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'ec1', content: 'raw-output', status: 'success' },
+      ]);
+      const result = (await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                { id: 'ec1', name: 'echo', args: { command: 'run' } },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-posthook' } }
+      )) as { messages: ToolMessage[] };
+
+      expect(result.messages[0].content).toBe(
+        '[ref: tool0turn0]\nhooked-output'
+      );
+      expect(node._unsafeGetToolOutputRegistry()!.get('tool0turn0')).toBe(
+        'hooked-output'
+      );
+    });
+
+    it('re-resolves placeholders when PreToolUse rewrites args', async () => {
+      const hooks = new HookRegistry();
+      hooks.register('PreToolUse', {
+        hooks: [
+          async (): Promise<{ updatedInput: { command: string } }> => ({
+            updatedInput: { command: 'rewritten {{tool0turn0}}' },
+          }),
+        ],
+      });
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        toolCallStepIds: new Map([
+          ['ec1', 'step_ec1'],
+          ['ec2', 'step_ec2'],
+        ]),
+        toolOutputReferences: { enabled: true },
+        hookRegistry: hooks,
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'ec1', content: 'STORED', status: 'success' },
+      ]);
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                { id: 'ec1', name: 'echo', args: { command: 'first' } },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-hookresolve' } }
+      );
+
+      jest.restoreAllMocks();
+      const capturedRequests: t.ToolCallRequest[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const batch = data as t.ToolExecuteBatchRequest;
+          for (const req of batch.toolCalls) {
+            capturedRequests.push(req);
+          }
+          batch.resolve([
+            { toolCallId: 'ec2', content: 'done', status: 'success' },
+          ]);
+        });
+
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                {
+                  id: 'ec2',
+                  name: 'echo',
+                  args: { command: 'input-without-placeholder' },
+                },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-hookresolve' } }
+      );
+
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0].args).toEqual({
+        command: 'rewritten STORED',
+      });
     });
   });
 });

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -308,6 +308,60 @@ describe('ToolNode tool output references', () => {
       ).toBeUndefined();
     });
 
+    it('surfaces unresolved refs on thrown-error ToolMessages', async () => {
+      const boom = tool(
+        async () => {
+          throw new Error('nope');
+        },
+        {
+          name: 'boom',
+          description: 'always errors',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      const node = new ToolNode({
+        tools: [boom],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(node, [
+        { id: 'c1', name: 'boom', command: 'see {{tool9turn9}}' },
+      ]);
+
+      expect(msg.content).toContain('Error: nope');
+      expect(msg.content).toContain('[unresolved refs: tool9turn9]');
+    });
+
+    it('surfaces unresolved refs on tool-returned error ToolMessages', async () => {
+      const errReturn = tool(
+        async () =>
+          new ToolMessage({
+            status: 'error',
+            content: 'handled failure',
+            name: 'errReturn',
+            tool_call_id: 'c1',
+          }),
+        {
+          name: 'errReturn',
+          description: 'returns error ToolMessage',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      const node = new ToolNode({
+        tools: [errReturn],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(node, [
+        { id: 'c1', name: 'errReturn', command: 'see {{tool9turn9}}' },
+      ]);
+
+      expect(msg.content).toContain('handled failure');
+      expect(msg.content).toContain('[unresolved refs: tool9turn9]');
+    });
+
     it('resets the registry and turn counter when the runId changes', async () => {
       const capturedArgs: string[] = [];
       const t1 = createEchoTool({
@@ -461,6 +515,44 @@ describe('ToolNode tool output references', () => {
 
       expect(capturedRequests).toHaveLength(1);
       expect(capturedRequests[0].args).toEqual({ command: 'see FIRST' });
+    });
+
+    it('surfaces unresolved refs on host-returned error results', async () => {
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        toolCallStepIds: new Map([['ec1', 'step_ec1']]),
+        toolOutputReferences: { enabled: true },
+      });
+
+      mockEventDispatch([
+        {
+          toolCallId: 'ec1',
+          content: '',
+          status: 'error',
+          errorMessage: 'host failure',
+        },
+      ]);
+      const result = (await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              {
+                id: 'ec1',
+                name: 'echo',
+                args: { command: 'see {{tool9turn9}}' },
+              },
+            ],
+          }),
+        ],
+      })) as { messages: ToolMessage[] };
+
+      expect(result.messages[0].content).toContain('Error: host failure');
+      expect(result.messages[0].content).toContain(
+        '[unresolved refs: tool9turn9]'
+      );
     });
 
     it('reports unresolved refs even when the host succeeds', async () => {

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -1,0 +1,306 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { describe, it, expect } from '@jest/globals';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import { ToolNode } from '../ToolNode';
+import { TOOL_OUTPUT_REF_KEY } from '../toolOutputReferences';
+
+/**
+ * Captures the `command` arg each time the tool is invoked and returns
+ * a configurable string output. The tool shape matches a typical bash
+ * executor: single required string arg, string response.
+ */
+function createEchoTool(options: {
+  capturedArgs: string[];
+  outputs: string[];
+  name?: string;
+}): StructuredToolInterface {
+  const { capturedArgs, outputs, name = 'echo' } = options;
+  let callCount = 0;
+  return tool(
+    async (input) => {
+      const args = input as { command: string };
+      capturedArgs.push(args.command);
+      const output = outputs[callCount] ?? outputs[outputs.length - 1];
+      callCount++;
+      return output;
+    },
+    {
+      name,
+      description: 'Echo test tool',
+      schema: z.object({ command: z.string() }),
+    }
+  ) as unknown as StructuredToolInterface;
+}
+
+function aiMsgWithCalls(
+  calls: Array<{ id: string; name: string; command: string }>
+): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: calls.map((c) => ({
+      id: c.id,
+      name: c.name,
+      args: { command: c.command },
+    })),
+  });
+}
+
+async function invokeBatch(
+  toolNode: ToolNode,
+  calls: Array<{ id: string; name: string; command: string }>
+): Promise<ToolMessage[]> {
+  const aiMsg = aiMsgWithCalls(calls);
+  const result = (await toolNode.invoke({ messages: [aiMsg] })) as
+    | ToolMessage[]
+    | { messages: ToolMessage[] };
+  return Array.isArray(result) ? result : result.messages;
+}
+
+describe('ToolNode tool output references', () => {
+  describe('disabled (default)', () => {
+    it('does not annotate outputs or register anything when disabled', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: ['plain-output'],
+      });
+      const node = new ToolNode({ tools: [t1] });
+
+      const [msg] = await invokeBatch(node, [
+        { id: 'c1', name: 'echo', command: 'hello' },
+      ]);
+
+      expect(msg.content).toBe('plain-output');
+      expect(node.getToolOutputRegistry()).toBeUndefined();
+    });
+
+    it('does not substitute placeholders when disabled', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({ capturedArgs, outputs: ['X'] });
+      const node = new ToolNode({ tools: [t1] });
+
+      await invokeBatch(node, [
+        { id: 'c1', name: 'echo', command: 'raw {{tool0turn0}}' },
+      ]);
+
+      expect(capturedArgs).toEqual(['raw {{tool0turn0}}']);
+    });
+  });
+
+  describe('enabled', () => {
+    it('annotates string outputs with a [ref: …] prefix line', async () => {
+      const t1 = createEchoTool({
+        capturedArgs: [],
+        outputs: ['hello world'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(node, [
+        { id: 'c1', name: 'echo', command: 'run' },
+      ]);
+
+      expect(msg.content).toBe('[ref: tool0turn0]\nhello world');
+    });
+
+    it('injects _ref into JSON-object string outputs', async () => {
+      const t1 = createEchoTool({
+        capturedArgs: [],
+        outputs: ['{"a":1,"b":"x"}'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(node, [
+        { id: 'c1', name: 'echo', command: 'run' },
+      ]);
+
+      const parsed = JSON.parse(msg.content as string);
+      expect(parsed[TOOL_OUTPUT_REF_KEY]).toBe('tool0turn0');
+      expect(parsed.a).toBe(1);
+    });
+
+    it('uses the [ref: …] prefix for JSON array outputs', async () => {
+      const t1 = createEchoTool({ capturedArgs: [], outputs: ['[1,2,3]'] });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(node, [
+        { id: 'c1', name: 'echo', command: 'run' },
+      ]);
+
+      expect(msg.content).toBe('[ref: tool0turn0]\n[1,2,3]');
+    });
+
+    it('registers the un-annotated output for piping into later calls', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: ['raw-payload', 'second-call'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      await invokeBatch(node, [{ id: 'c1', name: 'echo', command: 'first' }]);
+      await invokeBatch(node, [
+        {
+          id: 'c2',
+          name: 'echo',
+          command: 'echo {{tool0turn0}}',
+        },
+      ]);
+
+      expect(capturedArgs).toEqual(['first', 'echo raw-payload']);
+    });
+
+    it('increments the turn counter per ToolNode batch', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: ['one', 'two', 'three'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [m0] = await invokeBatch(node, [
+        { id: 'b1c1', name: 'echo', command: 'a' },
+      ]);
+      const [m1] = await invokeBatch(node, [
+        { id: 'b2c1', name: 'echo', command: 'b' },
+      ]);
+      const [m2] = await invokeBatch(node, [
+        { id: 'b3c1', name: 'echo', command: '{{tool0turn1}}' },
+      ]);
+
+      expect(m0.content).toContain('[ref: tool0turn0]');
+      expect(m1.content).toContain('[ref: tool0turn1]');
+      expect(m2.content).toContain('[ref: tool0turn2]');
+      expect(capturedArgs[2]).toBe('two');
+    });
+
+    it('uses array index within a batch for the tool<idx> segment', async () => {
+      const capturedA: string[] = [];
+      const capturedB: string[] = [];
+      const tA = createEchoTool({
+        capturedArgs: capturedA,
+        outputs: ['A-out'],
+        name: 'alpha',
+      });
+      const tB = createEchoTool({
+        capturedArgs: capturedB,
+        outputs: ['B-out'],
+        name: 'beta',
+      });
+      const node = new ToolNode({
+        tools: [tA, tB],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const messages = await invokeBatch(node, [
+        { id: 'c1', name: 'alpha', command: 'a' },
+        { id: 'c2', name: 'beta', command: 'b' },
+      ]);
+
+      expect(messages[0].content).toContain('[ref: tool0turn0]');
+      expect(messages[1].content).toContain('[ref: tool1turn0]');
+    });
+
+    it('reports unresolved placeholders after the output', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({ capturedArgs, outputs: ['done'] });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(node, [
+        {
+          id: 'c1',
+          name: 'echo',
+          command: 'see {{tool9turn9}}',
+        },
+      ]);
+
+      expect(capturedArgs[0]).toBe('see {{tool9turn9}}');
+      expect(msg.content).toContain('[unresolved refs: tool9turn9]');
+    });
+
+    it('clips registered outputs to maxOutputSize', async () => {
+      const t1 = createEchoTool({
+        capturedArgs: [],
+        outputs: ['{"payload":"' + 'y'.repeat(200) + '"}'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true, maxOutputSize: 40 },
+      });
+
+      await invokeBatch(node, [{ id: 'c1', name: 'echo', command: 'x' }]);
+
+      const registry = node.getToolOutputRegistry();
+      expect(registry).toBeDefined();
+      expect(registry!.get('tool0turn0')!.length).toBeLessThanOrEqual(40);
+    });
+
+    it('honors maxTotalSize via FIFO eviction across batches', async () => {
+      const t1 = createEchoTool({
+        capturedArgs: [],
+        outputs: ['aaaaa', 'bbbbb', 'ccccc'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: {
+          enabled: true,
+          maxOutputSize: 10,
+          maxTotalSize: 10,
+        },
+      });
+
+      await invokeBatch(node, [{ id: 'c1', name: 'echo', command: 'x' }]);
+      await invokeBatch(node, [{ id: 'c2', name: 'echo', command: 'x' }]);
+      await invokeBatch(node, [{ id: 'c3', name: 'echo', command: 'x' }]);
+
+      const registry = node.getToolOutputRegistry()!;
+      expect(registry.get('tool0turn0')).toBeUndefined();
+      expect(registry.get('tool0turn1')).toBe('bbbbb');
+      expect(registry.get('tool0turn2')).toBe('ccccc');
+    });
+
+    it('does not register error outputs', async () => {
+      const boom = tool(
+        async () => {
+          throw new Error('nope');
+        },
+        {
+          name: 'boom',
+          description: 'always errors',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      const node = new ToolNode({
+        tools: [boom],
+        toolOutputReferences: { enabled: true },
+      });
+
+      const [msg] = await invokeBatch(node, [
+        { id: 'c1', name: 'boom', command: 'x' },
+      ]);
+
+      expect((msg.content as string).startsWith('[ref:')).toBe(false);
+      expect(node.getToolOutputRegistry()!.get('tool0turn0')).toBeUndefined();
+    });
+  });
+});

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -531,6 +531,68 @@ describe('ToolNode tool output references', () => {
       expect(capturedArgs[2]).toBe('see out-B');
     });
 
+    it('gives concurrent anonymous invocations independent scopes', async () => {
+      const gates: Record<string, () => void> = {};
+      const slowTool = tool(
+        async (input) => {
+          const args = input as { command: string };
+          await new Promise<void>((resolve) => {
+            gates[args.command] = resolve;
+          });
+          return `out-${args.command}`;
+        },
+        {
+          name: 'slow',
+          description: 'awaits a per-command gate',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+
+      const node = new ToolNode({
+        tools: [slowTool],
+        toolOutputReferences: { enabled: true },
+      });
+
+      // Two invocations without `run_id`, started concurrently. Before
+      // the unique-anon-scope fix, the second invocation's sync prefix
+      // would have deleted the shared anonymous bucket that the first
+      // invocation's tool was about to register into.
+      const first = node.invoke({
+        messages: [aiMsgWithCalls([{ id: 'a1', name: 'slow', command: 'A' }])],
+      });
+      const second = node.invoke({
+        messages: [aiMsgWithCalls([{ id: 'b1', name: 'slow', command: 'B' }])],
+      });
+
+      await new Promise<void>((resolve) => {
+        const check = (): void => {
+          if (
+            Object.prototype.hasOwnProperty.call(gates, 'A') &&
+            Object.prototype.hasOwnProperty.call(gates, 'B')
+          ) {
+            resolve();
+          } else {
+            setTimeout(check, 5);
+          }
+        };
+        check();
+      });
+      gates.B();
+      gates.A();
+
+      const [resA, resB] = (await Promise.all([first, second])) as Array<{
+        messages: ToolMessage[];
+      }>;
+
+      // Each invocation produces its own annotated output — neither's
+      // registered tool0turn0 was clobbered by the other's sync-prefix
+      // reset.
+      expect(resA.messages[0].content).toContain('[ref: tool0turn0]');
+      expect(resA.messages[0].content).toContain('out-A');
+      expect(resB.messages[0].content).toContain('[ref: tool0turn0]');
+      expect(resB.messages[0].content).toContain('out-B');
+    });
+
     it('clears state on every batch when run_id is absent (anonymous caller)', async () => {
       const capturedArgs: string[] = [];
       const t1 = createEchoTool({
@@ -791,13 +853,14 @@ describe('ToolNode tool output references', () => {
         content: '',
         tool_calls: [{ id: 'ec1', name: 'echo', args: { command: 'run' } }],
       });
-      const result = (await node.invoke({ messages: [aiMsg] })) as {
-        messages: ToolMessage[];
-      };
+      const result = (await node.invoke(
+        { messages: [aiMsg] },
+        { configurable: { run_id: 'run-host' } }
+      )) as { messages: ToolMessage[] };
 
       expect(result.messages[0].content).toBe('[ref: tool0turn0]\nhost-output');
       expect(
-        node._unsafeGetToolOutputRegistry()!.get(undefined, 'tool0turn0')
+        node._unsafeGetToolOutputRegistry()!.get('run-host', 'tool0turn0')
       ).toBe('host-output');
     });
 

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -7,7 +7,10 @@ import type * as t from '@/types';
 import * as events from '@/utils/events';
 import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
-import { TOOL_OUTPUT_REF_KEY } from '../toolOutputReferences';
+import {
+  ToolOutputReferenceRegistry,
+  TOOL_OUTPUT_REF_KEY,
+} from '../toolOutputReferences';
 
 /**
  * Captures the `command` arg each time the tool is invoked and returns
@@ -315,7 +318,10 @@ describe('ToolNode tool output references', () => {
 
       await new Promise<void>((resolve) => {
         const check = (): void => {
-          if (gates.A != null && gates.B != null) {
+          if (
+            Object.prototype.hasOwnProperty.call(gates, 'A') &&
+            Object.prototype.hasOwnProperty.call(gates, 'B')
+          ) {
             resolve();
           } else {
             setTimeout(check, 5);
@@ -491,6 +497,59 @@ describe('ToolNode tool output references', () => {
       expect(result.messages[0].content).toContain(
         '[unresolved refs: tool0turn0]'
       );
+    });
+
+    it('lets two ToolNodes sharing a registry resolve each other\'s refs', async () => {
+      const sharedRegistry = new ToolOutputReferenceRegistry();
+      const capturedA: string[] = [];
+      const capturedB: string[] = [];
+      const toolA = createEchoTool({
+        capturedArgs: capturedA,
+        outputs: ['agent-A-output'],
+        name: 'alpha',
+      });
+      const toolB = createEchoTool({
+        capturedArgs: capturedB,
+        outputs: ['agent-B-output'],
+        name: 'beta',
+      });
+
+      // Two independent ToolNodes (simulating one per agent in a
+      // multi-agent graph) sharing one registry instance.
+      const nodeA = new ToolNode({
+        tools: [toolA],
+        toolOutputRegistry: sharedRegistry,
+      });
+      const nodeB = new ToolNode({
+        tools: [toolB],
+        toolOutputRegistry: sharedRegistry,
+      });
+
+      await nodeA.invoke(
+        {
+          messages: [
+            aiMsgWithCalls([{ id: 'a1', name: 'alpha', command: 'first' }]),
+          ],
+        },
+        { configurable: { run_id: 'shared-run' } }
+      );
+
+      await nodeB.invoke(
+        {
+          messages: [
+            aiMsgWithCalls([
+              { id: 'b1', name: 'beta', command: 'see {{tool0turn0}}' },
+            ]),
+          ],
+        },
+        { configurable: { run_id: 'shared-run' } }
+      );
+
+      // nodeB resolved nodeA's tool0turn0 placeholder (cross-node),
+      // and its own output landed under the *next* turn (1), not 0.
+      expect(capturedB[0]).toBe('see agent-A-output');
+      expect(sharedRegistry.get('tool0turn0')).toBe('agent-A-output');
+      expect(sharedRegistry.get('tool0turn1')).toBe('agent-B-output');
     });
 
     it('resets the registry and turn counter when the runId changes', async () => {

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -274,7 +274,11 @@ describe('ToolNode tool output references', () => {
       );
 
       expect(capturedArgs[1]).toBe(`echo ${raw}`);
-      expect(node._unsafeGetToolOutputRegistry()!.get('tool0turn0')).toBe(raw);
+      expect(
+        node
+          ._unsafeGetToolOutputRegistry()!
+          .get('raw-preservation', 'tool0turn0')
+      ).toBe(raw);
     });
 
     it('uses each batch\'s own turn when ToolNode is invoked concurrently within a run', async () => {
@@ -345,8 +349,8 @@ describe('ToolNode tool output references', () => {
       expect(resB.messages[0].content).toContain('output-B');
 
       const registry = node._unsafeGetToolOutputRegistry()!;
-      expect(registry.get('tool0turn0')).toBe('output-A');
-      expect(registry.get('tool0turn1')).toBe('output-B');
+      expect(registry.get('concurrent-run', 'tool0turn0')).toBe('output-A');
+      expect(registry.get('concurrent-run', 'tool0turn1')).toBe('output-B');
     });
 
     it('clips registered outputs to maxOutputSize', async () => {
@@ -363,7 +367,9 @@ describe('ToolNode tool output references', () => {
 
       const registry = node._unsafeGetToolOutputRegistry();
       expect(registry).toBeDefined();
-      expect(registry!.get('tool0turn0')!.length).toBeLessThanOrEqual(40);
+      expect(
+        registry!.get('test-run', 'tool0turn0')!.length
+      ).toBeLessThanOrEqual(40);
     });
 
     it('honors maxTotalSize via FIFO eviction across batches', async () => {
@@ -385,9 +391,9 @@ describe('ToolNode tool output references', () => {
       await invokeBatch(node, [{ id: 'c3', name: 'echo', command: 'x' }]);
 
       const registry = node._unsafeGetToolOutputRegistry()!;
-      expect(registry.get('tool0turn0')).toBeUndefined();
-      expect(registry.get('tool0turn1')).toBe('bbbbb');
-      expect(registry.get('tool0turn2')).toBe('ccccc');
+      expect(registry.get('test-run', 'tool0turn0')).toBeUndefined();
+      expect(registry.get('test-run', 'tool0turn1')).toBe('bbbbb');
+      expect(registry.get('test-run', 'tool0turn2')).toBe('ccccc');
     });
 
     it('does not register error outputs', async () => {
@@ -413,7 +419,7 @@ describe('ToolNode tool output references', () => {
 
       expect((msg.content as string).startsWith('[ref:')).toBe(false);
       expect(
-        node._unsafeGetToolOutputRegistry()!.get('tool0turn0')
+        node._unsafeGetToolOutputRegistry()!.get('test-run', 'tool0turn0')
       ).toBeUndefined();
     });
 
@@ -469,6 +475,60 @@ describe('ToolNode tool output references', () => {
 
       expect(msg.content).toContain('handled failure');
       expect(msg.content).toContain('[unresolved refs: tool9turn9]');
+    });
+
+    it('isolates state between overlapping runs on the same ToolNode', async () => {
+      const sharedRegistry = new ToolOutputReferenceRegistry();
+      const capturedArgs: string[] = [];
+      const tl = createEchoTool({
+        capturedArgs,
+        outputs: ['out-A', 'out-B', 'resolved-in-B'],
+      });
+
+      const node = new ToolNode({
+        tools: [tl],
+        toolOutputRegistry: sharedRegistry,
+      });
+
+      // Run A records `tool0turn0` → 'out-A' in its bucket.
+      await node.invoke(
+        {
+          messages: [
+            aiMsgWithCalls([{ id: 'a1', name: 'echo', command: 'a' }]),
+          ],
+        },
+        { configurable: { run_id: 'run-A' } }
+      );
+      expect(sharedRegistry.get('run-A', 'tool0turn0')).toBe('out-A');
+
+      // Run B records `tool0turn0` → 'out-B' in its own bucket.
+      // Under the old global-reset design, starting run B would have
+      // wiped run A's registered output; with partitioning, A's
+      // bucket survives untouched.
+      await node.invoke(
+        {
+          messages: [
+            aiMsgWithCalls([{ id: 'b1', name: 'echo', command: 'b' }]),
+          ],
+        },
+        { configurable: { run_id: 'run-B' } }
+      );
+      expect(sharedRegistry.get('run-A', 'tool0turn0')).toBe('out-A');
+      expect(sharedRegistry.get('run-B', 'tool0turn0')).toBe('out-B');
+
+      // Run B's next batch resolves `{{tool0turn0}}` against its own
+      // partition (out-B), not run A's partition (out-A).
+      await node.invoke(
+        {
+          messages: [
+            aiMsgWithCalls([
+              { id: 'b2', name: 'echo', command: 'see {{tool0turn0}}' },
+            ]),
+          ],
+        },
+        { configurable: { run_id: 'run-B' } }
+      );
+      expect(capturedArgs[2]).toBe('see out-B');
     });
 
     it('clears state on every batch when run_id is absent (anonymous caller)', async () => {
@@ -548,8 +608,12 @@ describe('ToolNode tool output references', () => {
       // nodeB resolved nodeA's tool0turn0 placeholder (cross-node),
       // and its own output landed under the *next* turn (1), not 0.
       expect(capturedB[0]).toBe('see agent-A-output');
-      expect(sharedRegistry.get('tool0turn0')).toBe('agent-A-output');
-      expect(sharedRegistry.get('tool0turn1')).toBe('agent-B-output');
+      expect(sharedRegistry.get('shared-run', 'tool0turn0')).toBe(
+        'agent-A-output'
+      );
+      expect(sharedRegistry.get('shared-run', 'tool0turn1')).toBe(
+        'agent-B-output'
+      );
     });
 
     it('emits resolved args in ON_RUN_STEP_COMPLETED, not the template', async () => {
@@ -732,9 +796,9 @@ describe('ToolNode tool output references', () => {
       };
 
       expect(result.messages[0].content).toBe('[ref: tool0turn0]\nhost-output');
-      expect(node._unsafeGetToolOutputRegistry()!.get('tool0turn0')).toBe(
-        'host-output'
-      );
+      expect(
+        node._unsafeGetToolOutputRegistry()!.get(undefined, 'tool0turn0')
+      ).toBe('host-output');
     });
 
     it('substitutes `{{…}}` in the request sent to the host', async () => {
@@ -911,9 +975,69 @@ describe('ToolNode tool output references', () => {
       expect(result.messages[0].content).toBe(
         '[ref: tool0turn0]\nhooked-output'
       );
-      expect(node._unsafeGetToolOutputRegistry()!.get('tool0turn0')).toBe(
-        'hooked-output'
-      );
+      expect(
+        node._unsafeGetToolOutputRegistry()!.get('run-posthook', 'tool0turn0')
+      ).toBe('hooked-output');
+    });
+
+    it('aborts event dispatch when a direct tool throws with handleToolErrors=false', async () => {
+      const directBoom = tool(
+        async () => {
+          throw new Error('direct branch failed');
+        },
+        {
+          name: 'directBoom',
+          description: 'direct tool that throws',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+      const eventStub = tool(async () => 'unused', {
+        name: 'eventTool',
+        description: 'schema-only stub',
+        schema: z.object({ command: z.string() }),
+      }) as unknown as StructuredToolInterface;
+
+      let hostCalled = false;
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event === 'on_tool_execute') {
+            hostCalled = true;
+            (data as t.ToolExecuteBatchRequest).resolve([]);
+          }
+        });
+
+      const node = new ToolNode({
+        tools: [directBoom, eventStub],
+        eventDrivenMode: true,
+        handleToolErrors: false,
+        agentId: 'agent-failfast',
+        directToolNames: new Set(['directBoom']),
+        toolCallStepIds: new Map([
+          ['d1', 'step_d1'],
+          ['e1', 'step_e1'],
+        ]),
+        toolOutputReferences: { enabled: true },
+      });
+
+      await expect(
+        node.invoke(
+          {
+            messages: [
+              new AIMessage({
+                content: '',
+                tool_calls: [
+                  { id: 'd1', name: 'directBoom', args: { command: 'x' } },
+                  { id: 'e1', name: 'eventTool', args: { command: 'y' } },
+                ],
+              }),
+            ],
+          },
+          { configurable: { run_id: 'failfast-run' } }
+        )
+      ).rejects.toThrow('direct branch failed');
+
+      expect(hostCalled).toBe(false);
     });
 
     it('keeps same-turn refs isolated in the mixed direct+event path', async () => {

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -52,12 +52,14 @@ function aiMsgWithCalls(
 
 async function invokeBatch(
   toolNode: ToolNode,
-  calls: Array<{ id: string; name: string; command: string }>
+  calls: Array<{ id: string; name: string; command: string }>,
+  runId: string = 'test-run'
 ): Promise<ToolMessage[]> {
   const aiMsg = aiMsgWithCalls(calls);
-  const result = (await toolNode.invoke({ messages: [aiMsg] })) as
-    | ToolMessage[]
-    | { messages: ToolMessage[] };
+  const result = (await toolNode.invoke(
+    { messages: [aiMsg] },
+    { configurable: { run_id: runId } }
+  )) as ToolMessage[] | { messages: ToolMessage[] };
   return Array.isArray(result) ? result : result.messages;
 }
 
@@ -362,6 +364,34 @@ describe('ToolNode tool output references', () => {
       expect(msg.content).toContain('[unresolved refs: tool9turn9]');
     });
 
+    it('clears state on every batch when run_id is absent (anonymous caller)', async () => {
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: ['first-anonymous', 'second-anonymous'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        toolOutputReferences: { enabled: true },
+      });
+
+      await node.invoke({
+        messages: [aiMsgWithCalls([{ id: 'a1', name: 'echo', command: 'a' }])],
+      });
+      const result = (await node.invoke({
+        messages: [
+          aiMsgWithCalls([
+            { id: 'a2', name: 'echo', command: 'echo {{tool0turn0}}' },
+          ]),
+        ],
+      })) as { messages: ToolMessage[] };
+
+      expect(capturedArgs[1]).toBe('echo {{tool0turn0}}');
+      expect(result.messages[0].content).toContain(
+        '[unresolved refs: tool0turn0]'
+      );
+    });
+
     it('resets the registry and turn counter when the runId changes', async () => {
       const capturedArgs: string[] = [];
       const t1 = createEchoTool({
@@ -472,14 +502,17 @@ describe('ToolNode tool output references', () => {
       mockEventDispatch([
         { toolCallId: 'ec1', content: 'FIRST', status: 'success' },
       ]);
-      await node.invoke({
-        messages: [
-          new AIMessage({
-            content: '',
-            tool_calls: [{ id: 'ec1', name: 'echo', args: { command: 'a' } }],
-          }),
-        ],
-      });
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id: 'ec1', name: 'echo', args: { command: 'a' } }],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-subst' } }
+      );
 
       jest.restoreAllMocks();
       const capturedRequests: t.ToolCallRequest[] = [];
@@ -498,20 +531,23 @@ describe('ToolNode tool output references', () => {
           ]);
         });
 
-      await node.invoke({
-        messages: [
-          new AIMessage({
-            content: '',
-            tool_calls: [
-              {
-                id: 'ec2',
-                name: 'echo',
-                args: { command: 'see {{tool0turn0}}' },
-              },
-            ],
-          }),
-        ],
-      });
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                {
+                  id: 'ec2',
+                  name: 'echo',
+                  args: { command: 'see {{tool0turn0}}' },
+                },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-subst' } }
+      );
 
       expect(capturedRequests).toHaveLength(1);
       expect(capturedRequests[0].args).toEqual({ command: 'see FIRST' });

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -194,14 +194,17 @@ describe('ToolOutputReferenceRegistry', () => {
   });
 
   describe('TOOL_OUTPUT_REF_PATTERN', () => {
-    it('matches only braced tool<N>turn<M> tokens', () => {
-      TOOL_OUTPUT_REF_PATTERN.lastIndex = 0;
-      const matches = Array.from(
-        'prefix {{tool0turn0}} and {{tool12turn34}} but not tool0turn0'.matchAll(
-          TOOL_OUTPUT_REF_PATTERN
-        )
-      );
-      expect(matches.map((m) => m[1])).toEqual(['tool0turn0', 'tool12turn34']);
+    it('matches braced tool<N>turn<M> tokens and captures the key', () => {
+      const match = '{{tool0turn0}}'.match(TOOL_OUTPUT_REF_PATTERN);
+      expect(match?.[1]).toBe('tool0turn0');
+    });
+
+    it('rejects bare tool<N>turn<M> tokens without braces', () => {
+      expect(TOOL_OUTPUT_REF_PATTERN.test('tool0turn0')).toBe(false);
+    });
+
+    it('is non-global so callers cannot trip on stale lastIndex', () => {
+      expect(TOOL_OUTPUT_REF_PATTERN.flags).not.toContain('g');
     });
   });
 });

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -19,15 +19,15 @@ describe('ToolOutputReferenceRegistry', () => {
   describe('set / get', () => {
     it('stores and retrieves outputs by key', () => {
       const reg = new ToolOutputReferenceRegistry();
-      reg.set('tool0turn0', 'hello world');
-      expect(reg.get('tool0turn0')).toBe('hello world');
+      reg.set('r', 'tool0turn0', 'hello world');
+      expect(reg.get('r', 'tool0turn0')).toBe('hello world');
       expect(reg.size).toBe(1);
     });
 
     it('clips stored values to the per-output limit', () => {
       const reg = new ToolOutputReferenceRegistry({ maxOutputSize: 5 });
-      reg.set('tool0turn0', 'abcdefghij');
-      expect(reg.get('tool0turn0')).toBe('abcde');
+      reg.set('r', 'tool0turn0', 'abcdefghij');
+      expect(reg.get('r', 'tool0turn0')).toBe('abcde');
     });
 
     it('replaces existing entries under the same key without double-counting size', () => {
@@ -35,9 +35,9 @@ describe('ToolOutputReferenceRegistry', () => {
         maxOutputSize: 100,
         maxTotalSize: 20,
       });
-      reg.set('tool0turn0', 'hello');
-      reg.set('tool0turn0', 'world-longer');
-      expect(reg.get('tool0turn0')).toBe('world-longer');
+      reg.set('r', 'tool0turn0', 'hello');
+      reg.set('r', 'tool0turn0', 'world-longer');
+      expect(reg.get('r', 'tool0turn0')).toBe('world-longer');
       expect(reg.size).toBe(1);
     });
   });
@@ -48,14 +48,14 @@ describe('ToolOutputReferenceRegistry', () => {
         maxOutputSize: 10,
         maxTotalSize: 12,
       });
-      reg.set('tool0turn0', '1234567'); // 7 chars
-      reg.set('tool1turn0', '89'); // 9 total
-      reg.set('tool2turn0', 'abc'); // 12 total — at limit
-      reg.set('tool3turn0', 'XY'); // 14 → must evict oldest
-      expect(reg.get('tool0turn0')).toBeUndefined();
-      expect(reg.get('tool1turn0')).toBe('89');
-      expect(reg.get('tool2turn0')).toBe('abc');
-      expect(reg.get('tool3turn0')).toBe('XY');
+      reg.set('r', 'tool0turn0', '1234567'); // 7 chars
+      reg.set('r', 'tool1turn0', '89'); // 9 total
+      reg.set('r', 'tool2turn0', 'abc'); // 12 total — at limit
+      reg.set('r', 'tool3turn0', 'XY'); // 14 → must evict oldest
+      expect(reg.get('r', 'tool0turn0')).toBeUndefined();
+      expect(reg.get('r', 'tool1turn0')).toBe('89');
+      expect(reg.get('r', 'tool2turn0')).toBe('abc');
+      expect(reg.get('r', 'tool3turn0')).toBe('XY');
     });
 
     it('keeps evicting oldest entries until the aggregate fits', () => {
@@ -63,12 +63,12 @@ describe('ToolOutputReferenceRegistry', () => {
         maxOutputSize: 10,
         maxTotalSize: 8,
       });
-      reg.set('tool0turn0', 'aaa');
-      reg.set('tool1turn0', 'bbb');
-      reg.set('tool2turn0', 'ccccccc'); // total 3+3+7=13 > 8, evict aaa then bbb
-      expect(reg.get('tool0turn0')).toBeUndefined();
-      expect(reg.get('tool1turn0')).toBeUndefined();
-      expect(reg.get('tool2turn0')).toBe('ccccccc');
+      reg.set('r', 'tool0turn0', 'aaa');
+      reg.set('r', 'tool1turn0', 'bbb');
+      reg.set('r', 'tool2turn0', 'ccccccc'); // total 3+3+7=13 > 8, evict aaa then bbb
+      expect(reg.get('r', 'tool0turn0')).toBeUndefined();
+      expect(reg.get('r', 'tool1turn0')).toBeUndefined();
+      expect(reg.get('r', 'tool2turn0')).toBe('ccccccc');
     });
 
     it('clamps the per-output cap to maxTotalSize so no entry exceeds the aggregate', () => {
@@ -76,8 +76,8 @@ describe('ToolOutputReferenceRegistry', () => {
         maxOutputSize: 1000,
         maxTotalSize: 10,
       });
-      reg.set('tool0turn0', 'x'.repeat(500));
-      const stored = reg.get('tool0turn0');
+      reg.set('r', 'tool0turn0', 'x'.repeat(500));
+      const stored = reg.get('r', 'tool0turn0');
       expect(stored).toBeDefined();
       expect(stored!.length).toBeLessThanOrEqual(10);
     });
@@ -86,20 +86,20 @@ describe('ToolOutputReferenceRegistry', () => {
   describe('resolve', () => {
     it('replaces placeholders in string args', () => {
       const reg = new ToolOutputReferenceRegistry();
-      reg.set('tool0turn0', 'HELLO');
-      const { resolved, unresolved } = reg.resolve('echo {{tool0turn0}}');
+      reg.set('r', 'tool0turn0', 'HELLO');
+      const { resolved, unresolved } = reg.resolve('r', 'echo {{tool0turn0}}');
       expect(resolved).toBe('echo HELLO');
       expect(unresolved).toEqual([]);
     });
 
     it('replaces placeholders in nested object args', () => {
       const reg = new ToolOutputReferenceRegistry();
-      reg.set('tool0turn0', 'DATA');
+      reg.set('r', 'tool0turn0', 'DATA');
       const input = {
         command: 'cat {{tool0turn0}}',
         meta: { note: 'uses {{tool0turn0}} twice' },
       };
-      const { resolved } = reg.resolve(input);
+      const { resolved } = reg.resolve('r', input);
       expect(resolved).toEqual({
         command: 'cat DATA',
         meta: { note: 'uses DATA twice' },
@@ -108,8 +108,8 @@ describe('ToolOutputReferenceRegistry', () => {
 
     it('replaces placeholders inside array values', () => {
       const reg = new ToolOutputReferenceRegistry();
-      reg.set('tool1turn2', '42');
-      const { resolved } = reg.resolve({
+      reg.set('r', 'tool1turn2', '42');
+      const { resolved } = reg.resolve('r', {
         args: ['--id', '{{tool1turn2}}', 'plain'],
       });
       expect(resolved).toEqual({ args: ['--id', '42', 'plain'] });
@@ -117,8 +117,9 @@ describe('ToolOutputReferenceRegistry', () => {
 
     it('reports unresolved references and leaves the placeholder in place', () => {
       const reg = new ToolOutputReferenceRegistry();
-      reg.set('tool0turn0', 'known');
+      reg.set('r', 'tool0turn0', 'known');
       const { resolved, unresolved } = reg.resolve(
+        'r',
         'use {{tool0turn0}} and {{tool5turn9}}'
       );
       expect(resolved).toBe('use known and {{tool5turn9}}');
@@ -128,6 +129,7 @@ describe('ToolOutputReferenceRegistry', () => {
     it('deduplicates repeated unresolved keys', () => {
       const reg = new ToolOutputReferenceRegistry();
       const { unresolved } = reg.resolve(
+        'r',
         '{{tool7turn0}} and {{tool7turn0}} again'
       );
       expect(unresolved).toEqual(['tool7turn0']);
@@ -135,14 +137,18 @@ describe('ToolOutputReferenceRegistry', () => {
 
     it('does not touch non-placeholder strings', () => {
       const reg = new ToolOutputReferenceRegistry();
-      reg.set('tool0turn0', 'X');
-      const { resolved } = reg.resolve('nothing to see here');
+      reg.set('r', 'tool0turn0', 'X');
+      const { resolved } = reg.resolve('r', 'nothing to see here');
       expect(resolved).toBe('nothing to see here');
     });
 
     it('passes through primitive values untouched', () => {
       const reg = new ToolOutputReferenceRegistry();
-      const { resolved } = reg.resolve({ count: 3, enabled: true, note: null });
+      const { resolved } = reg.resolve('r', {
+        count: 3,
+        enabled: true,
+        note: null,
+      });
       expect(resolved).toEqual({ count: 3, enabled: true, note: null });
     });
   });

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -42,6 +42,28 @@ describe('ToolOutputReferenceRegistry', () => {
     });
   });
 
+  describe('clear / releaseRun', () => {
+    it('clear() drops every run bucket', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('run-A', 'tool0turn0', 'A');
+      reg.set('run-B', 'tool0turn0', 'B');
+      expect(reg.size).toBe(2);
+      reg.clear();
+      expect(reg.size).toBe(0);
+      expect(reg.get('run-A', 'tool0turn0')).toBeUndefined();
+      expect(reg.get('run-B', 'tool0turn0')).toBeUndefined();
+    });
+
+    it('releaseRun() drops only the named run', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('run-A', 'tool0turn0', 'A');
+      reg.set('run-B', 'tool0turn0', 'B');
+      reg.releaseRun('run-A');
+      expect(reg.get('run-A', 'tool0turn0')).toBeUndefined();
+      expect(reg.get('run-B', 'tool0turn0')).toBe('B');
+    });
+  });
+
   describe('FIFO eviction', () => {
     it('evicts oldest entries when the aggregate cap is exceeded', () => {
       const reg = new ToolOutputReferenceRegistry({

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -214,6 +214,14 @@ describe('ToolOutputReferenceRegistry', () => {
       expect(unresolved).toEqual(['tool1turn0']);
     });
 
+    it('returns an empty view for a runId with no bucket', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      const view = reg.snapshot('never-touched');
+      const { resolved, unresolved } = view.resolve('see {{tool0turn0}}');
+      expect(resolved).toBe('see {{tool0turn0}}');
+      expect(unresolved).toEqual(['tool0turn0']);
+    });
+
     it('returns an isolated view per snapshot call', () => {
       const reg = new ToolOutputReferenceRegistry();
       reg.set('r', 'tool0turn0', 'A');

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  ToolOutputReferenceRegistry,
+  annotateToolOutputWithReference,
+  buildReferenceKey,
+  buildReferencePrefix,
+  TOOL_OUTPUT_REF_KEY,
+  TOOL_OUTPUT_REF_PATTERN,
+} from '../toolOutputReferences';
+
+describe('ToolOutputReferenceRegistry', () => {
+  describe('buildReferenceKey', () => {
+    it('formats keys as tool<idx>turn<turn>', () => {
+      expect(buildReferenceKey(0, 0)).toBe('tool0turn0');
+      expect(buildReferenceKey(3, 7)).toBe('tool3turn7');
+    });
+  });
+
+  describe('set / get', () => {
+    it('stores and retrieves outputs by key', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('tool0turn0', 'hello world');
+      expect(reg.get('tool0turn0')).toBe('hello world');
+      expect(reg.size).toBe(1);
+    });
+
+    it('clips stored values to the per-output limit', () => {
+      const reg = new ToolOutputReferenceRegistry({ maxOutputSize: 5 });
+      reg.set('tool0turn0', 'abcdefghij');
+      expect(reg.get('tool0turn0')).toBe('abcde');
+    });
+
+    it('replaces existing entries under the same key without double-counting size', () => {
+      const reg = new ToolOutputReferenceRegistry({
+        maxOutputSize: 100,
+        maxTotalSize: 20,
+      });
+      reg.set('tool0turn0', 'hello');
+      reg.set('tool0turn0', 'world-longer');
+      expect(reg.get('tool0turn0')).toBe('world-longer');
+      expect(reg.size).toBe(1);
+    });
+  });
+
+  describe('FIFO eviction', () => {
+    it('evicts oldest entries when the aggregate cap is exceeded', () => {
+      const reg = new ToolOutputReferenceRegistry({
+        maxOutputSize: 10,
+        maxTotalSize: 12,
+      });
+      reg.set('tool0turn0', '1234567'); // 7 chars
+      reg.set('tool1turn0', '89'); // 9 total
+      reg.set('tool2turn0', 'abc'); // 12 total — at limit
+      reg.set('tool3turn0', 'XY'); // 14 → must evict oldest
+      expect(reg.get('tool0turn0')).toBeUndefined();
+      expect(reg.get('tool1turn0')).toBe('89');
+      expect(reg.get('tool2turn0')).toBe('abc');
+      expect(reg.get('tool3turn0')).toBe('XY');
+    });
+
+    it('keeps evicting oldest entries until the aggregate fits', () => {
+      const reg = new ToolOutputReferenceRegistry({
+        maxOutputSize: 10,
+        maxTotalSize: 8,
+      });
+      reg.set('tool0turn0', 'aaa');
+      reg.set('tool1turn0', 'bbb');
+      reg.set('tool2turn0', 'ccccccc'); // total 3+3+7=13 > 8, evict aaa then bbb
+      expect(reg.get('tool0turn0')).toBeUndefined();
+      expect(reg.get('tool1turn0')).toBeUndefined();
+      expect(reg.get('tool2turn0')).toBe('ccccccc');
+    });
+  });
+
+  describe('resolve', () => {
+    it('replaces placeholders in string args', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('tool0turn0', 'HELLO');
+      const { resolved, unresolved } = reg.resolve('echo {{tool0turn0}}');
+      expect(resolved).toBe('echo HELLO');
+      expect(unresolved).toEqual([]);
+    });
+
+    it('replaces placeholders in nested object args', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('tool0turn0', 'DATA');
+      const input = {
+        command: 'cat {{tool0turn0}}',
+        meta: { note: 'uses {{tool0turn0}} twice' },
+      };
+      const { resolved } = reg.resolve(input);
+      expect(resolved).toEqual({
+        command: 'cat DATA',
+        meta: { note: 'uses DATA twice' },
+      });
+    });
+
+    it('replaces placeholders inside array values', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('tool1turn2', '42');
+      const { resolved } = reg.resolve({
+        args: ['--id', '{{tool1turn2}}', 'plain'],
+      });
+      expect(resolved).toEqual({ args: ['--id', '42', 'plain'] });
+    });
+
+    it('reports unresolved references and leaves the placeholder in place', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('tool0turn0', 'known');
+      const { resolved, unresolved } = reg.resolve(
+        'use {{tool0turn0}} and {{tool5turn9}}'
+      );
+      expect(resolved).toBe('use known and {{tool5turn9}}');
+      expect(unresolved).toEqual(['tool5turn9']);
+    });
+
+    it('deduplicates repeated unresolved keys', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      const { unresolved } = reg.resolve(
+        '{{tool7turn0}} and {{tool7turn0}} again'
+      );
+      expect(unresolved).toEqual(['tool7turn0']);
+    });
+
+    it('does not touch non-placeholder strings', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('tool0turn0', 'X');
+      const { resolved } = reg.resolve('nothing to see here');
+      expect(resolved).toBe('nothing to see here');
+    });
+
+    it('passes through primitive values untouched', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      const { resolved } = reg.resolve({ count: 3, enabled: true, note: null });
+      expect(resolved).toEqual({ count: 3, enabled: true, note: null });
+    });
+  });
+
+  describe('annotateToolOutputWithReference', () => {
+    it('injects _ref into plain JSON objects', () => {
+      const content = '{"a":1,"b":"x"}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      const parsed = JSON.parse(annotated);
+      expect(parsed[TOOL_OUTPUT_REF_KEY]).toBe('tool0turn0');
+      expect(parsed.a).toBe(1);
+      expect(parsed.b).toBe('x');
+    });
+
+    it('preserves pretty-printed formatting when the original was pretty', () => {
+      const content = '{\n  "a": 1\n}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      expect(annotated).toContain('\n  "');
+      const parsed = JSON.parse(annotated);
+      expect(parsed[TOOL_OUTPUT_REF_KEY]).toBe('tool0turn0');
+    });
+
+    it('uses the [ref: …] prefix for JSON arrays', () => {
+      const content = '[1,2,3]';
+      const annotated = annotateToolOutputWithReference(content, 'tool1turn0');
+      expect(annotated).toBe(`${buildReferencePrefix('tool1turn0')}\n[1,2,3]`);
+    });
+
+    it('uses the [ref: …] prefix for JSON primitives', () => {
+      expect(annotateToolOutputWithReference('42', 'tool0turn0')).toBe(
+        '[ref: tool0turn0]\n42'
+      );
+    });
+
+    it('uses the [ref: …] prefix for plain strings', () => {
+      expect(annotateToolOutputWithReference('hello', 'tool0turn0')).toBe(
+        '[ref: tool0turn0]\nhello'
+      );
+    });
+
+    it('falls back to the prefix on JSON _ref collision', () => {
+      const content = '{"_ref":"other-value","data":1}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      expect(annotated.startsWith('[ref: tool0turn0]\n')).toBe(true);
+    });
+
+    it('injects when the existing _ref matches the target key', () => {
+      const content = '{"_ref":"tool0turn0","data":1}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      const parsed = JSON.parse(annotated);
+      expect(parsed._ref).toBe('tool0turn0');
+      expect(parsed.data).toBe(1);
+    });
+
+    it('falls back to the prefix when parsing fails', () => {
+      const content = '{ not actually json';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      expect(annotated).toBe(`[ref: tool0turn0]\n${content}`);
+    });
+  });
+
+  describe('TOOL_OUTPUT_REF_PATTERN', () => {
+    it('matches only braced tool<N>turn<M> tokens', () => {
+      TOOL_OUTPUT_REF_PATTERN.lastIndex = 0;
+      const matches = Array.from(
+        'prefix {{tool0turn0}} and {{tool12turn34}} but not tool0turn0'.matchAll(
+          TOOL_OUTPUT_REF_PATTERN
+        )
+      );
+      expect(matches.map((m) => m[1])).toEqual(['tool0turn0', 'tool12turn34']);
+    });
+  });
+});

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -205,6 +205,17 @@ describe('ToolOutputReferenceRegistry', () => {
       expect(parsed.data).toBe(1);
     });
 
+    it('places the injected _ref as the first key in the serialized JSON', () => {
+      const content = '{"a":1,"b":"x"}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      expect(annotated.indexOf('"_ref"')).toBe(1);
+      const annotatedFromNull = annotateToolOutputWithReference(
+        '{"_ref":null,"a":1}',
+        'tool0turn0'
+      );
+      expect(annotatedFromNull.indexOf('"_ref"')).toBe(1);
+    });
+
     it('falls back to the prefix when parsing fails', () => {
       const content = '{ not actually json';
       const annotated = annotateToolOutputWithReference(content, 'tool0turn0');

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -271,6 +271,45 @@ describe('ToolOutputReferenceRegistry', () => {
         'plain'
       );
     });
+
+    it('preserves an existing _unresolved_refs payload when only injecting a ref key', () => {
+      const content = '{"data":1,"_unresolved_refs":["user-supplied"]}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      const parsed = JSON.parse(annotated);
+      expect(parsed._ref).toBe('tool0turn0');
+      expect(parsed._unresolved_refs).toEqual(['user-supplied']);
+      expect(parsed.data).toBe(1);
+    });
+
+    it('preserves an existing _ref payload on the unresolved-only path', () => {
+      const content = '{"data":1,"_ref":"preserved-value"}';
+      const annotated = annotateToolOutputWithReference(content, undefined, [
+        'tool9turn9',
+      ]);
+      const parsed = JSON.parse(annotated);
+      expect(parsed._ref).toBe('preserved-value');
+      expect(parsed._unresolved_refs).toEqual(['tool9turn9']);
+      expect(parsed.data).toBe(1);
+    });
+
+    it('falls back to the prefix when _unresolved_refs conflicts with a non-matching array', () => {
+      const content = '{"data":1,"_unresolved_refs":["legacy"]}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0', [
+        'tool9turn9',
+      ]);
+      expect(annotated.startsWith('[ref: tool0turn0]\n')).toBe(true);
+      expect(annotated).toContain('[unresolved refs: tool9turn9]');
+    });
+
+    it('accepts a deep-equal existing _unresolved_refs array', () => {
+      const content = '{"data":1,"_unresolved_refs":["tool9turn9"]}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0', [
+        'tool9turn9',
+      ]);
+      const parsed = JSON.parse(annotated);
+      expect(parsed._unresolved_refs).toEqual(['tool9turn9']);
+      expect(parsed._ref).toBe('tool0turn0');
+    });
   });
 
   describe('TOOL_OUTPUT_REF_PATTERN', () => {

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -114,6 +114,18 @@ describe('ToolOutputReferenceRegistry', () => {
       // Per-output is also bound by the same effective total.
       expect(reg.perOutputLimit).toBeLessThanOrEqual(5_000_000);
     });
+
+    it('evicts the oldest run bucket when maxActiveRuns is exceeded', () => {
+      const reg = new ToolOutputReferenceRegistry({ maxActiveRuns: 2 });
+      reg.set('run-A', 'tool0turn0', 'A');
+      reg.set('run-B', 'tool0turn0', 'B');
+      reg.set('run-C', 'tool0turn0', 'C');
+      // run-A was the oldest insertion; LRU evicted it when run-C
+      // pushed the bucket count above the cap.
+      expect(reg.get('run-A', 'tool0turn0')).toBeUndefined();
+      expect(reg.get('run-B', 'tool0turn0')).toBe('B');
+      expect(reg.get('run-C', 'tool0turn0')).toBe('C');
+    });
   });
 
   describe('resolve', () => {
@@ -183,6 +195,33 @@ describe('ToolOutputReferenceRegistry', () => {
         note: null,
       });
       expect(resolved).toEqual({ count: 3, enabled: true, note: null });
+    });
+  });
+
+  describe('snapshot', () => {
+    it('resolves against the captured state and ignores later mutations', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'OLD');
+      const view = reg.snapshot('r');
+      // Mutate after taking the snapshot.
+      reg.set('r', 'tool0turn0', 'NEW');
+      reg.set('r', 'tool1turn0', 'LATER');
+      // Snapshot still resolves to the captured value and treats
+      // post-snapshot additions as unresolved.
+      expect(view.resolve('echo {{tool0turn0}}').resolved).toBe('echo OLD');
+      const { resolved, unresolved } = view.resolve('see {{tool1turn0}}');
+      expect(resolved).toBe('see {{tool1turn0}}');
+      expect(unresolved).toEqual(['tool1turn0']);
+    });
+
+    it('returns an isolated view per snapshot call', () => {
+      const reg = new ToolOutputReferenceRegistry();
+      reg.set('r', 'tool0turn0', 'A');
+      const view1 = reg.snapshot('r');
+      reg.set('r', 'tool0turn0', 'B');
+      const view2 = reg.snapshot('r');
+      expect(view1.resolve('{{tool0turn0}}').resolved).toBe('A');
+      expect(view2.resolve('{{tool0turn0}}').resolved).toBe('B');
     });
   });
 

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -70,6 +70,17 @@ describe('ToolOutputReferenceRegistry', () => {
       expect(reg.get('tool1turn0')).toBeUndefined();
       expect(reg.get('tool2turn0')).toBe('ccccccc');
     });
+
+    it('clamps the per-output cap to maxTotalSize so no entry exceeds the aggregate', () => {
+      const reg = new ToolOutputReferenceRegistry({
+        maxOutputSize: 1000,
+        maxTotalSize: 10,
+      });
+      reg.set('tool0turn0', 'x'.repeat(500));
+      const stored = reg.get('tool0turn0');
+      expect(stored).toBeDefined();
+      expect(stored!.length).toBeLessThanOrEqual(10);
+    });
   });
 
   describe('resolve', () => {
@@ -180,6 +191,14 @@ describe('ToolOutputReferenceRegistry', () => {
 
     it('injects when the existing _ref matches the target key', () => {
       const content = '{"_ref":"tool0turn0","data":1}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
+      const parsed = JSON.parse(annotated);
+      expect(parsed._ref).toBe('tool0turn0');
+      expect(parsed.data).toBe(1);
+    });
+
+    it('overwrites an existing _ref:null with the injected key', () => {
+      const content = '{"_ref":null,"data":1}';
       const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
       const parsed = JSON.parse(annotated);
       expect(parsed._ref).toBe('tool0turn0');

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -221,6 +221,56 @@ describe('ToolOutputReferenceRegistry', () => {
       const annotated = annotateToolOutputWithReference(content, 'tool0turn0');
       expect(annotated).toBe(`[ref: tool0turn0]\n${content}`);
     });
+
+    it('carries unresolved refs as a JSON field on parseable objects', () => {
+      const content = '{"a":1}';
+      const annotated = annotateToolOutputWithReference(content, 'tool0turn0', [
+        'tool9turn9',
+        'tool7turn0',
+      ]);
+      const parsed = JSON.parse(annotated);
+      expect(parsed._ref).toBe('tool0turn0');
+      expect(parsed._unresolved_refs).toEqual(['tool9turn9', 'tool7turn0']);
+      expect(parsed.a).toBe(1);
+    });
+
+    it('appends unresolved refs as a trailer line on non-object content', () => {
+      const annotated = annotateToolOutputWithReference(
+        'plain text',
+        'tool0turn0',
+        ['tool9turn9']
+      );
+      expect(annotated).toBe(
+        '[ref: tool0turn0]\nplain text\n[unresolved refs: tool9turn9]'
+      );
+    });
+
+    it('supports unresolved-only annotation (no ref key)', () => {
+      const annotated = annotateToolOutputWithReference(
+        'error text',
+        undefined,
+        ['tool9turn9']
+      );
+      expect(annotated).toBe('error text\n[unresolved refs: tool9turn9]');
+    });
+
+    it('keeps JSON parseable for unresolved-only annotation on object content', () => {
+      const annotated = annotateToolOutputWithReference(
+        '{"error":"bad"}',
+        undefined,
+        ['tool9turn9']
+      );
+      const parsed = JSON.parse(annotated);
+      expect(parsed._unresolved_refs).toEqual(['tool9turn9']);
+      expect(parsed.error).toBe('bad');
+      expect(parsed._ref).toBeUndefined();
+    });
+
+    it('returns content unchanged when there is nothing to annotate', () => {
+      expect(annotateToolOutputWithReference('plain', undefined, [])).toBe(
+        'plain'
+      );
+    });
   });
 
   describe('TOOL_OUTPUT_REF_PATTERN', () => {

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -103,6 +103,17 @@ describe('ToolOutputReferenceRegistry', () => {
       expect(stored).toBeDefined();
       expect(stored!.length).toBeLessThanOrEqual(10);
     });
+
+    it('clamps a caller-supplied maxTotalSize to the documented hard cap', () => {
+      // 50 MB requested; should be clamped to the 5 MB hard cap.
+      const reg = new ToolOutputReferenceRegistry({
+        maxTotalSize: 50_000_000,
+      });
+      // `totalLimit` getter exposes the effective post-clamp value.
+      expect(reg.totalLimit).toBeLessThanOrEqual(5_000_000);
+      // Per-output is also bound by the same effective total.
+      expect(reg.perOutputLimit).toBeLessThanOrEqual(5_000_000);
+    });
   });
 
   describe('resolve', () => {

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -24,7 +24,7 @@
 
 import {
   calculateMaxTotalToolOutputSize,
-  HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
+  HARD_MAX_TOOL_RESULT_CHARS,
 } from '@/utils/truncation';
 
 /**
@@ -37,6 +37,14 @@ export const TOOL_OUTPUT_REF_PATTERN = /\{\{(tool\d+turn\d+)\}\}/;
 
 /** Object key used when a parsed-object output has `_ref` injected. */
 export const TOOL_OUTPUT_REF_KEY = '_ref';
+
+/**
+ * Object key used to carry unresolved reference warnings on a parsed-
+ * object output. Using a dedicated field instead of a trailing text
+ * line keeps the annotated `ToolMessage.content` parseable as JSON for
+ * downstream consumers that rely on the object shape.
+ */
+export const TOOL_OUTPUT_UNRESOLVED_KEY = '_unresolved_refs';
 
 /** Single-line prefix prepended to non-object tool outputs so the LLM sees the reference key. */
 export function buildReferencePrefix(key: string): string {
@@ -105,10 +113,19 @@ export class ToolOutputReferenceRegistry {
   private static readonly PLACEHOLDER_MATCHER = /\{\{(tool\d+turn\d+)\}\}/g;
 
   constructor(options: ToolOutputReferenceRegistryOptions = {}) {
+    /**
+     * Per-output default is the same ~400 KB budget as the standard
+     * tool-result truncation (`HARD_MAX_TOOL_RESULT_CHARS`). This
+     * keeps a single `{{…}}` substitution at a size that is safe to
+     * pass through typical shell `ARG_MAX` limits and matches what
+     * the LLM would otherwise have seen. Hosts that want larger per-
+     * output payloads (API consumers, long JSON streams) can raise
+     * the cap explicitly up to the 5 MB total budget.
+     */
     const perOutput =
       options.maxOutputSize != null && options.maxOutputSize > 0
         ? options.maxOutputSize
-        : HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE;
+        : HARD_MAX_TOOL_RESULT_CHARS;
     const totalRaw =
       options.maxTotalSize != null && options.maxTotalSize > 0
         ? options.maxTotalSize
@@ -306,39 +323,59 @@ function hasAnyPlaceholder(value: unknown): boolean {
 }
 
 /**
- * Attempts to annotate `content` with its reference key so the LLM sees
- * the key alongside the output.
+ * Annotates `content` with a reference key and/or unresolved-ref
+ * warnings so the LLM sees both alongside the tool output.
  *
  * Behavior:
  *  - If `content` parses as a plain (non-array, non-null) JSON object
- *    and does not already have a conflicting `_ref` key, the key is
- *    injected and the object re-serialized (compact or pretty,
- *    matching the original layout).
- *  - Otherwise (string output, JSON array/primitive, parse failure, or
- *    `_ref` collision), a `[ref: <key>]\n` prefix line is prepended.
+ *    and the object does not already have a conflicting `_ref` key,
+ *    the reference key and (when present) `_unresolved_refs` array
+ *    are injected as object fields, preserving JSON validity for
+ *    downstream consumers that parse the output.
+ *  - Otherwise (string output, JSON array/primitive, parse failure,
+ *    or `_ref` collision), a `[ref: <key>]\n` prefix line is
+ *    prepended and unresolved refs are appended as a trailing
+ *    `[unresolved refs: …]` line.
  *
  * The annotated string is what the LLM sees as `ToolMessage.content`.
  * The *original* (un-annotated) value is what gets stored in the
  * registry, so downstream piping remains pristine.
+ *
+ * @param content     Raw (post-truncation) tool output.
+ * @param key         Reference key for this output, or undefined when
+ *                    there is nothing to register (errors etc.).
+ * @param unresolved  Reference keys that failed to resolve during
+ *                    argument substitution. Surfaced so the LLM can
+ *                    self-correct its next tool call.
  */
 export function annotateToolOutputWithReference(
   content: string,
-  key: string
+  key: string | undefined,
+  unresolved: string[] = []
 ): string {
-  const prefix = buildReferencePrefix(key);
+  const hasRefKey = key != null;
+  const hasUnresolved = unresolved.length > 0;
+  if (!hasRefKey && !hasUnresolved) {
+    return content;
+  }
   const trimmed = content.trimStart();
   if (trimmed.startsWith('{')) {
-    const annotated = tryInjectRefIntoJsonObject(content, key);
+    const annotated = tryInjectRefIntoJsonObject(content, key, unresolved);
     if (annotated != null) {
       return annotated;
     }
   }
-  return `${prefix}\n${content}`;
+  const prefix = hasRefKey ? `${buildReferencePrefix(key!)}\n` : '';
+  const trailer = hasUnresolved
+    ? `\n[unresolved refs: ${unresolved.join(', ')}]`
+    : '';
+  return `${prefix}${content}${trailer}`;
 }
 
 function tryInjectRefIntoJsonObject(
   content: string,
-  key: string
+  key: string | undefined,
+  unresolved: string[]
 ): string | null {
   let parsed: unknown;
   try {
@@ -353,6 +390,7 @@ function tryInjectRefIntoJsonObject(
 
   const obj = parsed as Record<string, unknown>;
   if (
+    key != null &&
     TOOL_OUTPUT_REF_KEY in obj &&
     obj[TOOL_OUTPUT_REF_KEY] !== key &&
     obj[TOOL_OUTPUT_REF_KEY] != null
@@ -361,19 +399,28 @@ function tryInjectRefIntoJsonObject(
   }
 
   /**
-   * Drop any pre-existing `_ref` (the guard above already rejected
-   * real conflicts; what reaches here is either a null or a matching
-   * value) so we can place our injected key *first* in the serialized
-   * JSON. Leading-key placement means the LLM sees the reference
-   * identifier before it reads the payload, which matters for large
-   * objects where the tail might be truncated by downstream consumers.
+   * Drop any pre-existing `_ref` / `_unresolved_refs` (the guard
+   * above already rejected real `_ref` conflicts; any value that
+   * reaches here is either null or matching) so we can place our
+   * injected keys *first* in the serialized JSON. Leading-key
+   * placement means the LLM sees the reference identifier before
+   * it reads the payload.
    */
-  const { [TOOL_OUTPUT_REF_KEY]: _existing, ...rest } = obj;
-  void _existing;
-  const injected: Record<string, unknown> = {
-    [TOOL_OUTPUT_REF_KEY]: key,
-    ...rest,
-  };
+  const {
+    [TOOL_OUTPUT_REF_KEY]: _existingRef,
+    [TOOL_OUTPUT_UNRESOLVED_KEY]: _existingUnresolved,
+    ...rest
+  } = obj;
+  void _existingRef;
+  void _existingUnresolved;
+  const injected: Record<string, unknown> = {};
+  if (key != null) {
+    injected[TOOL_OUTPUT_REF_KEY] = key;
+  }
+  if (unresolved.length > 0) {
+    injected[TOOL_OUTPUT_UNRESOLVED_KEY] = unresolved;
+  }
+  Object.assign(injected, rest);
 
   const pretty = /^\{\s*\n/.test(content);
   return pretty ? JSON.stringify(injected, null, 2) : JSON.stringify(injected);

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -86,11 +86,20 @@ export class ToolOutputReferenceRegistry {
       options.maxOutputSize != null && options.maxOutputSize > 0
         ? options.maxOutputSize
         : HARD_MAX_TOOL_RESULT_CHARS;
-    this.maxOutputSize = perOutput;
-    this.maxTotalSize =
+    const totalRaw =
       options.maxTotalSize != null && options.maxTotalSize > 0
         ? options.maxTotalSize
         : calculateMaxTotalToolOutputSize(perOutput);
+    this.maxTotalSize = totalRaw;
+    /**
+     * The per-output cap can never exceed the aggregate cap: if a
+     * single entry were allowed to be larger than `maxTotalSize`, the
+     * eviction loop would either blow the cap (to keep the entry) or
+     * self-evict a just-stored value. Clamping here turns
+     * `maxTotalSize` into a hard upper bound on *any* state the
+     * registry retains.
+     */
+    this.maxOutputSize = Math.min(perOutput, totalRaw);
   }
 
   /** Registers (or replaces) the output stored under `key`. */
@@ -197,9 +206,6 @@ export class ToolOutputReferenceRegistry {
       if (this.totalSize <= this.maxTotalSize) {
         return;
       }
-      if (this.entries.size <= 1) {
-        return;
-      }
       const entry = this.entries.get(key);
       if (entry == null) {
         continue;
@@ -293,9 +299,16 @@ function tryInjectRefIntoJsonObject(
     return null;
   }
 
+  /**
+   * Spread the tool output *first* so any existing `_ref: null`
+   * (treated as non-conflicting by the guard above) is overwritten by
+   * our injected key rather than the other way around. Without this
+   * ordering, the LLM would see `_ref: null` in the annotated content
+   * even though the output is registered.
+   */
   const injected: Record<string, unknown> = {
-    [TOOL_OUTPUT_REF_KEY]: key,
     ...obj,
+    [TOOL_OUTPUT_REF_KEY]: key,
   };
 
   const pretty = /^\{\s*\n/.test(content);

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -89,6 +89,24 @@ export interface ToolOutputResolveView {
   resolve<T>(args: T): ResolveResult<T>;
 }
 
+/**
+ * Pre-resolved arg map keyed by `toolCallId`. Used by the mixed
+ * direct+event dispatch path to feed event calls' resolved args
+ * (captured pre-batch) into the dispatcher without re-resolving
+ * against the now-stale live registry.
+ */
+export type PreResolvedArgsMap = Map<
+  string,
+  { resolved: Record<string, unknown>; unresolved: string[] }
+>;
+
+/**
+ * Per-call sink for resolved args, keyed by `toolCallId`. Threaded
+ * as a per-batch local map so concurrent `ToolNode.run()` calls do
+ * not race on shared sink state.
+ */
+export type ResolvedArgsByCallId = Map<string, Record<string, unknown>>;
+
 const EMPTY_ENTRIES: ReadonlyMap<string, string> = new Map<string, string>();
 
 /**

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -300,15 +300,18 @@ function tryInjectRefIntoJsonObject(
   }
 
   /**
-   * Spread the tool output *first* so any existing `_ref: null`
-   * (treated as non-conflicting by the guard above) is overwritten by
-   * our injected key rather than the other way around. Without this
-   * ordering, the LLM would see `_ref: null` in the annotated content
-   * even though the output is registered.
+   * Drop any pre-existing `_ref` (the guard above already rejected
+   * real conflicts; what reaches here is either a null or a matching
+   * value) so we can place our injected key *first* in the serialized
+   * JSON. Leading-key placement means the LLM sees the reference
+   * identifier before it reads the payload, which matters for large
+   * objects where the tail might be truncated by downstream consumers.
    */
+  const { [TOOL_OUTPUT_REF_KEY]: _existing, ...rest } = obj;
+  void _existing;
   const injected: Record<string, unknown> = {
-    ...obj,
     [TOOL_OUTPUT_REF_KEY]: key,
+    ...rest,
   };
 
   const pretty = /^\{\s*\n/.test(content);

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -23,13 +23,18 @@ import {
   HARD_MAX_TOOL_RESULT_CHARS,
 } from '@/utils/truncation';
 
-/** Key shape produced by {@link buildReferenceKey}. */
-export const TOOL_OUTPUT_REF_PATTERN = /\{\{(tool\d+turn\d+)\}\}/g;
+/**
+ * Non-global matcher for a single `{{tool<i>turn<n>}}` placeholder.
+ * Exported for consumers that want to detect references (e.g., syntax
+ * highlighting, docs). The stateful `g` variant lives inside the
+ * registry so nobody trips on `lastIndex`.
+ */
+export const TOOL_OUTPUT_REF_PATTERN = /\{\{(tool\d+turn\d+)\}\}/;
 
 /** Object key used when a parsed-object output has `_ref` injected. */
 export const TOOL_OUTPUT_REF_KEY = '_ref';
 
-/** Single-line prefix appended to non-object tool outputs so the LLM sees the reference key. */
+/** Single-line prefix prepended to non-object tool outputs so the LLM sees the reference key. */
 export function buildReferencePrefix(key: string): string {
   return `[ref: ${key}]`;
 }
@@ -44,11 +49,6 @@ export type ToolOutputReferenceRegistryOptions = {
   maxOutputSize?: number;
   /** Maximum total characters retained across all registered outputs. */
   maxTotalSize?: number;
-};
-
-type RegistryEntry = {
-  key: string;
-  value: string;
 };
 
 /**
@@ -70,10 +70,16 @@ export type ResolveResult<T> = {
  * heavy state is cleared.
  */
 export class ToolOutputReferenceRegistry {
-  private entries: Map<string, RegistryEntry> = new Map();
+  private entries: Map<string, string> = new Map();
   private totalSize: number = 0;
   private readonly maxOutputSize: number;
   private readonly maxTotalSize: number;
+  /**
+   * Local stateful matcher used only by `replaceInString`. Kept
+   * off-module so callers of the exported `TOOL_OUTPUT_REF_PATTERN`
+   * never see a stale `lastIndex`.
+   */
+  private static readonly PLACEHOLDER_MATCHER = /\{\{(tool\d+turn\d+)\}\}/g;
 
   constructor(options: ToolOutputReferenceRegistryOptions = {}) {
     const perOutput =
@@ -95,19 +101,19 @@ export class ToolOutputReferenceRegistry {
         : value;
 
     const existing = this.entries.get(key);
-    if (existing) {
-      this.totalSize -= existing.value.length;
+    if (existing != null) {
+      this.totalSize -= existing.length;
       this.entries.delete(key);
     }
 
-    this.entries.set(key, { key, value: clipped });
+    this.entries.set(key, clipped);
     this.totalSize += clipped.length;
     this.evictUntilWithinLimit();
   }
 
   /** Returns the stored value for `key`, or `undefined` if unknown. */
   get(key: string): string | undefined {
-    return this.entries.get(key)?.value;
+    return this.entries.get(key);
   }
 
   /** Current number of registered outputs. */
@@ -135,9 +141,14 @@ export class ToolOutputReferenceRegistry {
    * Walks `args` and replaces every `{{tool<i>turn<n>}}` placeholder in
    * string values with the stored output. Non-string values and object
    * keys are left untouched. Unresolved references are left in-place and
-   * reported so the caller can surface them to the LLM.
+   * reported so the caller can surface them to the LLM. When no
+   * placeholder appears anywhere in the serialized args, the original
+   * input is returned without walking the tree.
    */
   resolve<T>(args: T): ResolveResult<T> {
+    if (!hasAnyPlaceholder(args)) {
+      return { resolved: args, unresolved: [] };
+    }
     const unresolved = new Set<string>();
     const resolved = this.transform(args, unresolved) as T;
     return { resolved, unresolved: Array.from(unresolved) };
@@ -165,14 +176,17 @@ export class ToolOutputReferenceRegistry {
     if (input.indexOf('{{tool') === -1) {
       return input;
     }
-    return input.replace(TOOL_OUTPUT_REF_PATTERN, (match, key: string) => {
-      const stored = this.get(key);
-      if (stored == null) {
-        unresolved.add(key);
-        return match;
+    return input.replace(
+      ToolOutputReferenceRegistry.PLACEHOLDER_MATCHER,
+      (match, key: string) => {
+        const stored = this.get(key);
+        if (stored == null) {
+          unresolved.add(key);
+          return match;
+        }
+        return stored;
       }
-      return stored;
-    });
+    );
   }
 
   private evictUntilWithinLimit(): void {
@@ -187,13 +201,41 @@ export class ToolOutputReferenceRegistry {
         return;
       }
       const entry = this.entries.get(key);
-      if (!entry) {
+      if (entry == null) {
         continue;
       }
-      this.totalSize -= entry.value.length;
+      this.totalSize -= entry.length;
       this.entries.delete(key);
     }
   }
+}
+
+/**
+ * Cheap pre-check: returns true if any string value in `args` contains
+ * the `{{tool` substring. Lets `resolve()` skip the deep tree walk (and
+ * its object allocations) for the common case of plain args.
+ */
+function hasAnyPlaceholder(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.indexOf('{{tool') !== -1;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (hasAnyPlaceholder(item)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      if (hasAnyPlaceholder(item)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return false;
 }
 
 /**

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -389,39 +389,73 @@ function tryInjectRefIntoJsonObject(
   }
 
   const obj = parsed as Record<string, unknown>;
+  const injectingRef = key != null;
+  const injectingUnresolved = unresolved.length > 0;
+
+  /**
+   * Reject the JSON-injection path (fall back to prefix form) when
+   * either of our keys collides with real payload data:
+   *  - `_ref` collision: existing value is non-null and differs from
+   *    the key we're about to inject.
+   *  - `_unresolved_refs` collision: existing value is non-null and
+   *    is not a deep-equal match for the array we'd inject.
+   * This keeps us from silently overwriting legitimate tool output.
+   */
   if (
-    key != null &&
+    injectingRef &&
     TOOL_OUTPUT_REF_KEY in obj &&
     obj[TOOL_OUTPUT_REF_KEY] !== key &&
     obj[TOOL_OUTPUT_REF_KEY] != null
   ) {
     return null;
   }
+  if (
+    injectingUnresolved &&
+    TOOL_OUTPUT_UNRESOLVED_KEY in obj &&
+    obj[TOOL_OUTPUT_UNRESOLVED_KEY] != null &&
+    !arraysShallowEqual(obj[TOOL_OUTPUT_UNRESOLVED_KEY], unresolved)
+  ) {
+    return null;
+  }
 
   /**
-   * Drop any pre-existing `_ref` / `_unresolved_refs` (the guard
-   * above already rejected real `_ref` conflicts; any value that
-   * reaches here is either null or matching) so we can place our
-   * injected keys *first* in the serialized JSON. Leading-key
-   * placement means the LLM sees the reference identifier before
-   * it reads the payload.
+   * Only strip the framework-owned key we're actually injecting —
+   * leave everything else (including a pre-existing `_ref` on the
+   * unresolved-only path, or a pre-existing `_unresolved_refs` on a
+   * plain-annotation path) untouched so we annotate rather than
+   * mutate downstream payload data. Our injected keys land first in
+   * the serialized JSON so the LLM sees them before the body.
    */
-  const {
-    [TOOL_OUTPUT_REF_KEY]: _existingRef,
-    [TOOL_OUTPUT_UNRESOLVED_KEY]: _existingUnresolved,
-    ...rest
-  } = obj;
-  void _existingRef;
-  void _existingUnresolved;
+  const omitKeys = new Set<string>();
+  if (injectingRef) omitKeys.add(TOOL_OUTPUT_REF_KEY);
+  if (injectingUnresolved) omitKeys.add(TOOL_OUTPUT_UNRESOLVED_KEY);
+  const rest: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (!omitKeys.has(k)) {
+      rest[k] = v;
+    }
+  }
   const injected: Record<string, unknown> = {};
-  if (key != null) {
+  if (injectingRef) {
     injected[TOOL_OUTPUT_REF_KEY] = key;
   }
-  if (unresolved.length > 0) {
+  if (injectingUnresolved) {
     injected[TOOL_OUTPUT_UNRESOLVED_KEY] = unresolved;
   }
   Object.assign(injected, rest);
 
   const pretty = /^\{\s*\n/.test(content);
   return pretty ? JSON.stringify(injected, null, 2) : JSON.stringify(injected);
+}
+
+function arraysShallowEqual(a: unknown, b: readonly string[]): boolean {
+  if (!Array.isArray(a) || a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -80,6 +80,18 @@ export type ResolveResult<T> = {
 };
 
 /**
+ * Read-only view over a frozen registry snapshot. Returned by
+ * {@link ToolOutputReferenceRegistry.snapshot} for callers that need
+ * to resolve placeholders against the registry state at a specific
+ * point in time, ignoring any subsequent registrations.
+ */
+export interface ToolOutputResolveView {
+  resolve<T>(args: T): ResolveResult<T>;
+}
+
+const EMPTY_ENTRIES: ReadonlyMap<string, string> = new Map<string, string>();
+
+/**
  * Per-run state bucket held inside the registry. Each distinct
  * `run_id` gets its own bucket so overlapping concurrent runs on a
  * shared registry cannot leak outputs, turn counters, or warn-memos
@@ -295,27 +307,59 @@ export class ToolOutputReferenceRegistry {
       return { resolved: args, unresolved: [] };
     }
     const bucket = this.runStates.get(this.keyFor(runId));
+    return this.resolveAgainst(bucket?.entries ?? EMPTY_ENTRIES, args);
+  }
+
+  /**
+   * Captures a frozen snapshot of `runId`'s current entries and
+   * returns a view that resolves placeholders against *only* that
+   * snapshot. The snapshot is decoupled from the live registry, so
+   * subsequent `set()` calls (for example, same-turn direct outputs
+   * registering while an event branch is still in flight) are
+   * invisible to the snapshot's `resolve`. Used by the mixed
+   * direct+event dispatch path to preserve same-turn isolation when
+   * a `PreToolUse` hook rewrites event args after directs have
+   * completed.
+   */
+  snapshot(runId: string | undefined): ToolOutputResolveView {
+    const bucket = this.runStates.get(this.keyFor(runId));
+    const entries: ReadonlyMap<string, string> = bucket
+      ? new Map(bucket.entries)
+      : EMPTY_ENTRIES;
+    return {
+      resolve: <T>(args: T): ResolveResult<T> =>
+        this.resolveAgainst(entries, args),
+    };
+  }
+
+  private resolveAgainst<T>(
+    entries: ReadonlyMap<string, string>,
+    args: T
+  ): ResolveResult<T> {
+    if (!hasAnyPlaceholder(args)) {
+      return { resolved: args, unresolved: [] };
+    }
     const unresolved = new Set<string>();
-    const resolved = this.transform(bucket, args, unresolved) as T;
+    const resolved = this.transform(entries, args, unresolved) as T;
     return { resolved, unresolved: Array.from(unresolved) };
   }
 
   private transform(
-    bucket: RunStateBucket | undefined,
+    entries: ReadonlyMap<string, string>,
     value: unknown,
     unresolved: Set<string>
   ): unknown {
     if (typeof value === 'string') {
-      return this.replaceInString(bucket, value, unresolved);
+      return this.replaceInString(entries, value, unresolved);
     }
     if (Array.isArray(value)) {
-      return value.map((item) => this.transform(bucket, item, unresolved));
+      return value.map((item) => this.transform(entries, item, unresolved));
     }
     if (value !== null && typeof value === 'object') {
       const source = value as Record<string, unknown>;
       const next: Record<string, unknown> = {};
       for (const [key, item] of Object.entries(source)) {
-        next[key] = this.transform(bucket, item, unresolved);
+        next[key] = this.transform(entries, item, unresolved);
       }
       return next;
     }
@@ -323,7 +367,7 @@ export class ToolOutputReferenceRegistry {
   }
 
   private replaceInString(
-    bucket: RunStateBucket | undefined,
+    entries: ReadonlyMap<string, string>,
     input: string,
     unresolved: Set<string>
   ): string {
@@ -333,7 +377,7 @@ export class ToolOutputReferenceRegistry {
     return input.replace(
       ToolOutputReferenceRegistry.PLACEHOLDER_MATCHER,
       (match, key: string) => {
-        const stored = bucket?.entries.get(key);
+        const stored = entries.get(key);
         if (stored == null) {
           unresolved.add(key);
           return match;

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -25,6 +25,7 @@
 import {
   calculateMaxTotalToolOutputSize,
   HARD_MAX_TOOL_RESULT_CHARS,
+  HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
 } from '@/utils/truncation';
 
 /**
@@ -142,9 +143,17 @@ export class ToolOutputReferenceRegistry {
       options.maxOutputSize != null && options.maxOutputSize > 0
         ? options.maxOutputSize
         : HARD_MAX_TOOL_RESULT_CHARS;
+    /**
+     * Clamp a caller-supplied `maxTotalSize` to
+     * `HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE` (5 MB) so the documented
+     * absolute cap is enforced regardless of host config —
+     * `calculateMaxTotalToolOutputSize` already applies the same
+     * upper bound on its computed default, but the user-provided
+     * branch was bypassing it.
+     */
     const totalRaw =
       options.maxTotalSize != null && options.maxTotalSize > 0
-        ? options.maxTotalSize
+        ? Math.min(options.maxTotalSize, HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE)
         : calculateMaxTotalToolOutputSize(perOutput);
     this.maxTotalSize = totalRaw;
     /**

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -61,6 +61,11 @@ export type ToolOutputReferenceRegistryOptions = {
   maxOutputSize?: number;
   /** Maximum total characters retained across all registered outputs. */
   maxTotalSize?: number;
+  /**
+   * Upper bound on the number of concurrently-tracked runs. When
+   * exceeded, the oldest run bucket is evicted (FIFO). Defaults to 32.
+   */
+  maxActiveRuns?: number;
 };
 
 /**
@@ -74,37 +79,48 @@ export type ResolveResult<T> = {
 };
 
 /**
- * Ordered map of reference-key → stored output with FIFO eviction when
- * the aggregate size exceeds `maxTotalSize`.
+ * Per-run state bucket held inside the registry. Each distinct
+ * `run_id` gets its own bucket so overlapping concurrent runs on a
+ * shared registry cannot leak outputs, turn counters, or warn-memos
+ * into one another.
+ */
+class RunStateBucket {
+  entries: Map<string, string> = new Map();
+  totalSize: number = 0;
+  turnCounter: number = 0;
+  warnedNonStringTools: Set<string> = new Set();
+}
+
+/**
+ * Anonymous (`run_id` absent) bucket key. Anonymous batches are
+ * treated as fresh runs on every invocation — see `nextTurn`.
+ */
+const ANON_RUN_KEY = '\0anon';
+
+/**
+ * Default upper bound on the number of concurrently-tracked runs per
+ * registry. When exceeded, the oldest run's bucket (by insertion
+ * order) is evicted. Keeps memory bounded when a ToolNode is reused
+ * across many runs without explicit `releaseRun` calls.
+ */
+const DEFAULT_MAX_ACTIVE_RUNS = 32;
+
+/**
+ * Ordered map of reference-key → stored output, partitioned by run so
+ * concurrent / interleaved runs sharing one registry cannot leak
+ * outputs between each other.
  *
- * A single shared registry lives on the ToolNode for the duration of a
- * run; it is not persisted across runs and is cleared when the graph's
- * heavy state is cleared.
+ * Each public method takes a `runId` which selects the run's bucket.
+ * Hosts typically get one registry per run via `Graph`, in which
+ * case only a single bucket is ever populated; the partitioning
+ * exists so the registry also behaves correctly when a single
+ * instance is reused directly.
  */
 export class ToolOutputReferenceRegistry {
-  private entries: Map<string, string> = new Map();
-  private totalSize: number = 0;
+  private runStates: Map<string, RunStateBucket> = new Map();
   private readonly maxOutputSize: number;
   private readonly maxTotalSize: number;
-  /**
-   * Monotonic batch counter shared across every ToolNode that holds
-   * this registry. Multi-agent graphs use one registry per run so
-   * turns are globally unique across agents — `tool0turn3` from agent
-   * B does not collide with `tool0turn3` from agent A.
-   */
-  private turnCounter: number = 0;
-  /**
-   * Last observed `run_id`. Drives the reset when we cross into a
-   * new run. Undefined when the feature is invoked without a
-   * `run_id`; in that case every call is treated as a fresh run.
-   */
-  private lastRunId: string | undefined;
-  /**
-   * Per-run memo of tool names we've already logged a non-string-
-   * content warning for. Cleared on every run change so each run
-   * emits at most one line per offending tool.
-   */
-  private warnedNonStringTools: Set<string> = new Set();
+  private readonly maxActiveRuns: number;
   /**
    * Local stateful matcher used only by `replaceInString`. Kept
    * off-module so callers of the exported `TOOL_OUTPUT_REF_PATTERN`
@@ -132,42 +148,69 @@ export class ToolOutputReferenceRegistry {
         : calculateMaxTotalToolOutputSize(perOutput);
     this.maxTotalSize = totalRaw;
     /**
-     * The per-output cap can never exceed the aggregate cap: if a
-     * single entry were allowed to be larger than `maxTotalSize`, the
-     * eviction loop would either blow the cap (to keep the entry) or
-     * self-evict a just-stored value. Clamping here turns
+     * The per-output cap can never exceed the per-run aggregate cap:
+     * if a single entry were allowed to be larger than `maxTotalSize`,
+     * the eviction loop would either blow the cap (to keep the entry)
+     * or self-evict a just-stored value. Clamping here turns
      * `maxTotalSize` into a hard upper bound on *any* state the
-     * registry retains.
+     * registry retains per run.
      */
     this.maxOutputSize = Math.min(perOutput, totalRaw);
+    this.maxActiveRuns =
+      options.maxActiveRuns != null && options.maxActiveRuns > 0
+        ? options.maxActiveRuns
+        : DEFAULT_MAX_ACTIVE_RUNS;
   }
 
-  /** Registers (or replaces) the output stored under `key`. */
-  set(key: string, value: string): void {
+  private keyFor(runId: string | undefined): string {
+    return runId ?? ANON_RUN_KEY;
+  }
+
+  private getOrCreate(runId: string | undefined): RunStateBucket {
+    const key = this.keyFor(runId);
+    let state = this.runStates.get(key);
+    if (state == null) {
+      state = new RunStateBucket();
+      this.runStates.set(key, state);
+      if (this.runStates.size > this.maxActiveRuns) {
+        const oldest = this.runStates.keys().next().value;
+        if (oldest != null && oldest !== key) {
+          this.runStates.delete(oldest);
+        }
+      }
+    }
+    return state;
+  }
+
+  /** Registers (or replaces) the output stored under `key` for `runId`. */
+  set(runId: string | undefined, key: string, value: string): void {
+    const bucket = this.getOrCreate(runId);
     const clipped =
       value.length > this.maxOutputSize
         ? value.slice(0, this.maxOutputSize)
         : value;
-
-    const existing = this.entries.get(key);
+    const existing = bucket.entries.get(key);
     if (existing != null) {
-      this.totalSize -= existing.length;
-      this.entries.delete(key);
+      bucket.totalSize -= existing.length;
+      bucket.entries.delete(key);
     }
-
-    this.entries.set(key, clipped);
-    this.totalSize += clipped.length;
-    this.evictUntilWithinLimit();
+    bucket.entries.set(key, clipped);
+    bucket.totalSize += clipped.length;
+    this.evictWithinBucket(bucket);
   }
 
-  /** Returns the stored value for `key`, or `undefined` if unknown. */
-  get(key: string): string | undefined {
-    return this.entries.get(key);
+  /** Returns the stored value for `key` in `runId`'s bucket, or `undefined`. */
+  get(runId: string | undefined, key: string): string | undefined {
+    return this.runStates.get(this.keyFor(runId))?.entries.get(key);
   }
 
-  /** Current number of registered outputs. */
+  /** Total number of registered outputs across every run bucket. */
   get size(): number {
-    return this.entries.size;
+    let n = 0;
+    for (const bucket of this.runStates.values()) {
+      n += bucket.entries.size;
+    }
+    return n;
   }
 
   /** Maximum characters retained per output (post-clip). */
@@ -175,98 +218,113 @@ export class ToolOutputReferenceRegistry {
     return this.maxOutputSize;
   }
 
-  /** Maximum total characters retained across the registry. */
+  /** Maximum total characters retained *per run*. */
   get totalLimit(): number {
     return this.maxTotalSize;
   }
 
-  /** Drops all registered outputs. */
+  /** Drops every run's state. */
   clear(): void {
-    this.entries.clear();
-    this.totalSize = 0;
+    this.runStates.clear();
   }
 
   /**
-   * Claims the next batch turn synchronously.
+   * Explicitly release `runId`'s state. Safe to call when a run has
+   * finished. Hosts sharing one registry across runs should call this
+   * to reclaim memory deterministically; otherwise LRU eviction kicks
+   * in when `maxActiveRuns` runs accumulate.
+   */
+  releaseRun(runId: string | undefined): void {
+    this.runStates.delete(this.keyFor(runId));
+  }
+
+  /**
+   * Claims the next batch turn synchronously from `runId`'s bucket.
    *
    * Must be called once at the start of each ToolNode batch before
    * any `await`, so concurrent invocations within the same run see
    * distinct turn values (reads are effectively atomic by JS's
    * single-threaded execution of the sync prefix).
    *
-   * If `runId` differs from the last-seen value — or is missing —
-   * the registry, warn-set, and counter are cleared before claiming
-   * turn 0. Missing `runId` is treated as "always a new run" so
-   * anonymous callers never leak state across invocations.
+   * If `runId` is missing the anonymous bucket is dropped and a
+   * fresh one created so each anonymous call behaves as its own run.
    */
   nextTurn(runId: string | undefined): number {
-    if (runId == null || runId !== this.lastRunId) {
-      this.entries.clear();
-      this.totalSize = 0;
-      this.turnCounter = 0;
-      this.warnedNonStringTools.clear();
-      this.lastRunId = runId;
+    if (runId == null) {
+      this.runStates.delete(ANON_RUN_KEY);
     }
-    return this.turnCounter++;
+    const bucket = this.getOrCreate(runId);
+    return bucket.turnCounter++;
   }
 
   /**
-   * Records that `toolName` has been warned about (returns `true`
-   * on the first call per run, `false` after). Used by ToolNode to
-   * emit one log line per offending tool per run when a
+   * Records that `toolName` has been warned about in `runId` (returns
+   * `true` on the first call per run, `false` after). Used by
+   * ToolNode to emit one log line per offending tool per run when a
    * `ToolMessage.content` isn't a string.
    */
-  claimWarnOnce(toolName: string): boolean {
-    if (this.warnedNonStringTools.has(toolName)) {
+  claimWarnOnce(runId: string | undefined, toolName: string): boolean {
+    const bucket = this.getOrCreate(runId);
+    if (bucket.warnedNonStringTools.has(toolName)) {
       return false;
     }
-    this.warnedNonStringTools.add(toolName);
+    bucket.warnedNonStringTools.add(toolName);
     return true;
   }
 
   /**
    * Walks `args` and replaces every `{{tool<i>turn<n>}}` placeholder in
-   * string values with the stored output. Non-string values and object
-   * keys are left untouched. Unresolved references are left in-place and
-   * reported so the caller can surface them to the LLM. When no
-   * placeholder appears anywhere in the serialized args, the original
-   * input is returned without walking the tree.
+   * string values with the stored output *from `runId`'s bucket*. Non-
+   * string values and object keys are left untouched. Unresolved
+   * references are left in-place and reported so the caller can
+   * surface them to the LLM. When no placeholder appears anywhere in
+   * the serialized args, the original input is returned without
+   * walking the tree.
    */
-  resolve<T>(args: T): ResolveResult<T> {
+  resolve<T>(runId: string | undefined, args: T): ResolveResult<T> {
     if (!hasAnyPlaceholder(args)) {
       return { resolved: args, unresolved: [] };
     }
+    const bucket = this.runStates.get(this.keyFor(runId));
     const unresolved = new Set<string>();
-    const resolved = this.transform(args, unresolved) as T;
+    const resolved = this.transform(bucket, args, unresolved) as T;
     return { resolved, unresolved: Array.from(unresolved) };
   }
 
-  private transform(value: unknown, unresolved: Set<string>): unknown {
+  private transform(
+    bucket: RunStateBucket | undefined,
+    value: unknown,
+    unresolved: Set<string>
+  ): unknown {
     if (typeof value === 'string') {
-      return this.replaceInString(value, unresolved);
+      return this.replaceInString(bucket, value, unresolved);
     }
     if (Array.isArray(value)) {
-      return value.map((item) => this.transform(item, unresolved));
+      return value.map((item) => this.transform(bucket, item, unresolved));
     }
     if (value !== null && typeof value === 'object') {
       const source = value as Record<string, unknown>;
       const next: Record<string, unknown> = {};
       for (const [key, item] of Object.entries(source)) {
-        next[key] = this.transform(item, unresolved);
+        next[key] = this.transform(bucket, item, unresolved);
       }
       return next;
     }
     return value;
   }
 
-  private replaceInString(input: string, unresolved: Set<string>): string {
+  private replaceInString(
+    bucket: RunStateBucket | undefined,
+    input: string,
+    unresolved: Set<string>
+  ): string {
     if (input.indexOf('{{tool') === -1) {
       return input;
     }
     return input.replace(
       ToolOutputReferenceRegistry.PLACEHOLDER_MATCHER,
       (match, key: string) => {
-        const stored = this.get(key);
+        const stored = bucket?.entries.get(key);
         if (stored == null) {
           unresolved.add(key);
           return match;
@@ -276,20 +334,20 @@ export class ToolOutputReferenceRegistry {
     );
   }
 
-  private evictUntilWithinLimit(): void {
-    if (this.totalSize <= this.maxTotalSize) {
+  private evictWithinBucket(bucket: RunStateBucket): void {
+    if (bucket.totalSize <= this.maxTotalSize) {
       return;
     }
-    for (const key of this.entries.keys()) {
-      if (this.totalSize <= this.maxTotalSize) {
+    for (const key of bucket.entries.keys()) {
+      if (bucket.totalSize <= this.maxTotalSize) {
         return;
       }
-      const entry = this.entries.get(key);
+      const entry = bucket.entries.get(key);
       if (entry == null) {
         continue;
       }
-      this.totalSize -= entry.length;
-      this.entries.delete(key);
+      bucket.totalSize -= entry.length;
+      bucket.entries.delete(key);
     }
   }
 }

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -79,6 +79,25 @@ export class ToolOutputReferenceRegistry {
   private readonly maxOutputSize: number;
   private readonly maxTotalSize: number;
   /**
+   * Monotonic batch counter shared across every ToolNode that holds
+   * this registry. Multi-agent graphs use one registry per run so
+   * turns are globally unique across agents — `tool0turn3` from agent
+   * B does not collide with `tool0turn3` from agent A.
+   */
+  private turnCounter: number = 0;
+  /**
+   * Last observed `run_id`. Drives the reset when we cross into a
+   * new run. Undefined when the feature is invoked without a
+   * `run_id`; in that case every call is treated as a fresh run.
+   */
+  private lastRunId: string | undefined;
+  /**
+   * Per-run memo of tool names we've already logged a non-string-
+   * content warning for. Cleared on every run change so each run
+   * emits at most one line per offending tool.
+   */
+  private warnedNonStringTools: Set<string> = new Set();
+  /**
    * Local stateful matcher used only by `replaceInString`. Kept
    * off-module so callers of the exported `TOOL_OUTPUT_REF_PATTERN`
    * never see a stale `lastIndex`.
@@ -148,6 +167,44 @@ export class ToolOutputReferenceRegistry {
   clear(): void {
     this.entries.clear();
     this.totalSize = 0;
+  }
+
+  /**
+   * Claims the next batch turn synchronously.
+   *
+   * Must be called once at the start of each ToolNode batch before
+   * any `await`, so concurrent invocations within the same run see
+   * distinct turn values (reads are effectively atomic by JS's
+   * single-threaded execution of the sync prefix).
+   *
+   * If `runId` differs from the last-seen value — or is missing —
+   * the registry, warn-set, and counter are cleared before claiming
+   * turn 0. Missing `runId` is treated as "always a new run" so
+   * anonymous callers never leak state across invocations.
+   */
+  nextTurn(runId: string | undefined): number {
+    if (runId == null || runId !== this.lastRunId) {
+      this.entries.clear();
+      this.totalSize = 0;
+      this.turnCounter = 0;
+      this.warnedNonStringTools.clear();
+      this.lastRunId = runId;
+    }
+    return this.turnCounter++;
+  }
+
+  /**
+   * Records that `toolName` has been warned about (returns `true`
+   * on the first call per run, `false` after). Used by ToolNode to
+   * emit one log line per offending tool per run when a
+   * `ToolMessage.content` isn't a string.
+   */
+  claimWarnOnce(toolName: string): boolean {
+    if (this.warnedNonStringTools.has(toolName)) {
+      return false;
+    }
+    this.warnedNonStringTools.add(toolName);
+    return true;
   }
 
   /**

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -12,15 +12,19 @@
  * {@link ToolOutputReferenceRegistry.resolve} walks the args and
  * substitutes the placeholders immediately before invocation.
  *
- * Outputs are stored without any annotation (the `_ref` key or the
- * `[ref: ...]` prefix seen by the LLM is strictly a UX signal attached
- * to `ToolMessage.content`). Keeping the registry pristine means
- * downstream bash/jq piping does not see injected fields.
+ * The registry stores the *raw, untruncated* tool output so a later
+ * `{{…}}` substitution pipes the full payload into the next tool —
+ * even when the LLM only saw a head+tail-truncated preview in
+ * `ToolMessage.content`. Outputs are stored without any annotation
+ * (the `_ref` key or the `[ref: ...]` prefix seen by the LLM is
+ * strictly a UX signal attached to `ToolMessage.content`). Keeping the
+ * registry pristine means downstream bash/jq piping receives the
+ * complete, verbatim output with no injected fields.
  */
 
 import {
   calculateMaxTotalToolOutputSize,
-  HARD_MAX_TOOL_RESULT_CHARS,
+  HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
 } from '@/utils/truncation';
 
 /**
@@ -85,7 +89,7 @@ export class ToolOutputReferenceRegistry {
     const perOutput =
       options.maxOutputSize != null && options.maxOutputSize > 0
         ? options.maxOutputSize
-        : HARD_MAX_TOOL_RESULT_CHARS;
+        : HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE;
     const totalRaw =
       options.maxTotalSize != null && options.maxTotalSize > 0
         ? options.maxTotalSize

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -1,0 +1,261 @@
+/**
+ * Tool output reference registry.
+ *
+ * When enabled via `RunConfig.toolOutputReferences.enabled`, ToolNode
+ * stores each successful tool output under a stable key
+ * (`tool<idx>turn<turn>`) where `idx` is the tool's position within a
+ * ToolNode batch and `turn` is the batch index within the run
+ * (incremented once per ToolNode invocation).
+ *
+ * Subsequent tool calls can pipe a previous output into their args by
+ * embedding `{{tool<idx>turn<turn>}}` inside any string argument;
+ * {@link ToolOutputReferenceRegistry.resolve} walks the args and
+ * substitutes the placeholders immediately before invocation.
+ *
+ * Outputs are stored without any annotation (the `_ref` key or the
+ * `[ref: ...]` prefix seen by the LLM is strictly a UX signal attached
+ * to `ToolMessage.content`). Keeping the registry pristine means
+ * downstream bash/jq piping does not see injected fields.
+ */
+
+import {
+  calculateMaxTotalToolOutputSize,
+  HARD_MAX_TOOL_RESULT_CHARS,
+} from '@/utils/truncation';
+
+/** Key shape produced by {@link buildReferenceKey}. */
+export const TOOL_OUTPUT_REF_PATTERN = /\{\{(tool\d+turn\d+)\}\}/g;
+
+/** Object key used when a parsed-object output has `_ref` injected. */
+export const TOOL_OUTPUT_REF_KEY = '_ref';
+
+/** Single-line prefix appended to non-object tool outputs so the LLM sees the reference key. */
+export function buildReferencePrefix(key: string): string {
+  return `[ref: ${key}]`;
+}
+
+/** Stable registry key for a tool output. */
+export function buildReferenceKey(toolIndex: number, turn: number): string {
+  return `tool${toolIndex}turn${turn}`;
+}
+
+export type ToolOutputReferenceRegistryOptions = {
+  /** Maximum characters stored per registered output. */
+  maxOutputSize?: number;
+  /** Maximum total characters retained across all registered outputs. */
+  maxTotalSize?: number;
+};
+
+type RegistryEntry = {
+  key: string;
+  value: string;
+};
+
+/**
+ * Result of resolving placeholders in tool args.
+ */
+export type ResolveResult<T> = {
+  /** Arguments with placeholders replaced. Same shape as the input. */
+  resolved: T;
+  /** Reference keys that were referenced but had no stored value. */
+  unresolved: string[];
+};
+
+/**
+ * Ordered map of reference-key → stored output with FIFO eviction when
+ * the aggregate size exceeds `maxTotalSize`.
+ *
+ * A single shared registry lives on the ToolNode for the duration of a
+ * run; it is not persisted across runs and is cleared when the graph's
+ * heavy state is cleared.
+ */
+export class ToolOutputReferenceRegistry {
+  private entries: Map<string, RegistryEntry> = new Map();
+  private totalSize: number = 0;
+  private readonly maxOutputSize: number;
+  private readonly maxTotalSize: number;
+
+  constructor(options: ToolOutputReferenceRegistryOptions = {}) {
+    const perOutput =
+      options.maxOutputSize != null && options.maxOutputSize > 0
+        ? options.maxOutputSize
+        : HARD_MAX_TOOL_RESULT_CHARS;
+    this.maxOutputSize = perOutput;
+    this.maxTotalSize =
+      options.maxTotalSize != null && options.maxTotalSize > 0
+        ? options.maxTotalSize
+        : calculateMaxTotalToolOutputSize(perOutput);
+  }
+
+  /** Registers (or replaces) the output stored under `key`. */
+  set(key: string, value: string): void {
+    const clipped =
+      value.length > this.maxOutputSize
+        ? value.slice(0, this.maxOutputSize)
+        : value;
+
+    const existing = this.entries.get(key);
+    if (existing) {
+      this.totalSize -= existing.value.length;
+      this.entries.delete(key);
+    }
+
+    this.entries.set(key, { key, value: clipped });
+    this.totalSize += clipped.length;
+    this.evictUntilWithinLimit();
+  }
+
+  /** Returns the stored value for `key`, or `undefined` if unknown. */
+  get(key: string): string | undefined {
+    return this.entries.get(key)?.value;
+  }
+
+  /** Current number of registered outputs. */
+  get size(): number {
+    return this.entries.size;
+  }
+
+  /** Maximum characters retained per output (post-clip). */
+  get perOutputLimit(): number {
+    return this.maxOutputSize;
+  }
+
+  /** Maximum total characters retained across the registry. */
+  get totalLimit(): number {
+    return this.maxTotalSize;
+  }
+
+  /** Drops all registered outputs. */
+  clear(): void {
+    this.entries.clear();
+    this.totalSize = 0;
+  }
+
+  /**
+   * Walks `args` and replaces every `{{tool<i>turn<n>}}` placeholder in
+   * string values with the stored output. Non-string values and object
+   * keys are left untouched. Unresolved references are left in-place and
+   * reported so the caller can surface them to the LLM.
+   */
+  resolve<T>(args: T): ResolveResult<T> {
+    const unresolved = new Set<string>();
+    const resolved = this.transform(args, unresolved) as T;
+    return { resolved, unresolved: Array.from(unresolved) };
+  }
+
+  private transform(value: unknown, unresolved: Set<string>): unknown {
+    if (typeof value === 'string') {
+      return this.replaceInString(value, unresolved);
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.transform(item, unresolved));
+    }
+    if (value !== null && typeof value === 'object') {
+      const source = value as Record<string, unknown>;
+      const next: Record<string, unknown> = {};
+      for (const [key, item] of Object.entries(source)) {
+        next[key] = this.transform(item, unresolved);
+      }
+      return next;
+    }
+    return value;
+  }
+
+  private replaceInString(input: string, unresolved: Set<string>): string {
+    if (input.indexOf('{{tool') === -1) {
+      return input;
+    }
+    return input.replace(TOOL_OUTPUT_REF_PATTERN, (match, key: string) => {
+      const stored = this.get(key);
+      if (stored == null) {
+        unresolved.add(key);
+        return match;
+      }
+      return stored;
+    });
+  }
+
+  private evictUntilWithinLimit(): void {
+    if (this.totalSize <= this.maxTotalSize) {
+      return;
+    }
+    for (const key of this.entries.keys()) {
+      if (this.totalSize <= this.maxTotalSize) {
+        return;
+      }
+      if (this.entries.size <= 1) {
+        return;
+      }
+      const entry = this.entries.get(key);
+      if (!entry) {
+        continue;
+      }
+      this.totalSize -= entry.value.length;
+      this.entries.delete(key);
+    }
+  }
+}
+
+/**
+ * Attempts to annotate `content` with its reference key so the LLM sees
+ * the key alongside the output.
+ *
+ * Behavior:
+ *  - If `content` parses as a plain (non-array, non-null) JSON object
+ *    and does not already have a conflicting `_ref` key, the key is
+ *    injected and the object re-serialized (compact or pretty,
+ *    matching the original layout).
+ *  - Otherwise (string output, JSON array/primitive, parse failure, or
+ *    `_ref` collision), a `[ref: <key>]\n` prefix line is prepended.
+ *
+ * The annotated string is what the LLM sees as `ToolMessage.content`.
+ * The *original* (un-annotated) value is what gets stored in the
+ * registry, so downstream piping remains pristine.
+ */
+export function annotateToolOutputWithReference(
+  content: string,
+  key: string
+): string {
+  const prefix = buildReferencePrefix(key);
+  const trimmed = content.trimStart();
+  if (trimmed.startsWith('{')) {
+    const annotated = tryInjectRefIntoJsonObject(content, key);
+    if (annotated != null) {
+      return annotated;
+    }
+  }
+  return `${prefix}\n${content}`;
+}
+
+function tryInjectRefIntoJsonObject(
+  content: string,
+  key: string
+): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  if (
+    TOOL_OUTPUT_REF_KEY in obj &&
+    obj[TOOL_OUTPUT_REF_KEY] !== key &&
+    obj[TOOL_OUTPUT_REF_KEY] != null
+  ) {
+    return null;
+  }
+
+  const injected: Record<string, unknown> = {
+    [TOOL_OUTPUT_REF_KEY]: key,
+    ...obj,
+  };
+
+  const pretty = /^\{\s*\n/.test(content);
+  return pretty ? JSON.stringify(injected, null, 2) : JSON.stringify(injected);
+}

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -11,7 +11,7 @@ import type * as s from '@/types/stream';
 import type * as e from '@/common/enum';
 import type * as g from '@/types/graph';
 import type * as l from '@/types/llm';
-import type { ToolSessionMap } from '@/types/tools';
+import type { ToolSessionMap, ToolOutputReferencesConfig } from '@/types/tools';
 import type { HookRegistry } from '@/hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -146,6 +146,14 @@ export type RunConfig = {
    * at run start, so ToolNode can inject session_id + files into tool calls.
    */
   initialSessions?: ToolSessionMap;
+  /**
+   * Run-scoped tool output reference configuration. When `enabled` is
+   * `true`, tool outputs are registered under stable keys
+   * (`tool<idx>turn<turn>`) and subsequent tool calls can pipe previous
+   * outputs into their arguments via `{{tool<idx>turn<turn>}}`
+   * placeholders. Disabled by default so existing runs are unaffected.
+   */
+  toolOutputReferences?: ToolOutputReferencesConfig;
 };
 
 export type ProvidedCallbacks =

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -3,6 +3,7 @@ import type { StructuredToolInterface } from '@langchain/core/tools';
 import type { RunnableToolLike } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { HookRegistry } from '@/hooks';
+import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type { MessageContentComplex, ToolErrorData } from './stream';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
@@ -66,8 +67,18 @@ export type ToolNodeOptions = {
    * Run-scoped tool output reference configuration. When `enabled` is
    * `true`, ToolNode registers successful outputs and substitutes
    * `{{tool<idx>turn<turn>}}` placeholders found in string args.
+   *
+   * Ignored when `toolOutputRegistry` is also provided (host-supplied
+   * registry wins).
    */
   toolOutputReferences?: ToolOutputReferencesConfig;
+  /**
+   * Pre-constructed registry instance shared across ToolNodes for the
+   * run. Graphs pass the same registry to every ToolNode they compile
+   * so cross-agent `{{tool<i>turn<n>}}` substitutions resolve. Takes
+   * precedence over `toolOutputReferences` when both are set.
+   */
+  toolOutputRegistry?: ToolOutputReferenceRegistry;
 };
 
 export type ToolNodeConstructorParams = ToolRefs & ToolNodeOptions;

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -62,6 +62,12 @@ export type ToolNodeOptions = {
    * When provided, takes precedence over the value computed from maxContextTokens.
    */
   maxToolResultChars?: number;
+  /**
+   * Run-scoped tool output reference configuration. When `enabled` is
+   * `true`, ToolNode registers successful outputs and substitutes
+   * `{{tool<idx>turn<turn>}}` placeholders found in string args.
+   */
+  toolOutputReferences?: ToolOutputReferencesConfig;
 };
 
 export type ToolNodeConstructorParams = ToolRefs & ToolNodeOptions;
@@ -233,6 +239,35 @@ export type ToolExecuteResult = {
 
 /** Map of tool names to tool definitions */
 export type LCToolRegistry = Map<string, LCTool>;
+
+/**
+ * Run-scoped configuration for tool output references.
+ *
+ * When enabled, each successful tool result is registered under a stable
+ * key (`tool<idx>turn<turn>`). Later tool calls can pipe a previous
+ * output into their arguments by including the literal placeholder
+ * `{{tool<idx>turn<turn>}}` anywhere in a string argument; ToolNode
+ * substitutes it with the stored output immediately before invoking
+ * the tool.
+ *
+ * Size limits mirror the shape of `calculateMaxToolResultChars` so
+ * substituted content cannot exceed what the model has already seen.
+ */
+export type ToolOutputReferencesConfig = {
+  /** Enable the registry and placeholder substitution. Defaults to `false`. */
+  enabled?: boolean;
+  /**
+   * Maximum characters stored (and substituted) per registered output.
+   * Defaults to the ToolNode's `maxToolResultChars`.
+   */
+  maxOutputSize?: number;
+  /**
+   * Maximum total characters retained across all registered outputs for
+   * the run. When exceeded, the oldest registered outputs are evicted
+   * FIFO. Defaults to `calculateMaxTotalToolOutputSize(maxOutputSize)`.
+   */
+  maxTotalSize?: number;
+};
 
 export type ProgrammaticCache = { toolMap: ToolMap; toolDefs: LCTool[] };
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -250,8 +250,11 @@ export type LCToolRegistry = Map<string, LCTool>;
  * substitutes it with the stored output immediately before invoking
  * the tool.
  *
- * Size limits mirror the shape of `calculateMaxToolResultChars` so
- * substituted content cannot exceed what the model has already seen.
+ * The registry stores the *raw, untruncated* tool output (subject to
+ * its own size caps) so a later substitution can pipe the full payload
+ * into the next tool even when the LLM only saw a head+tail-truncated
+ * preview in `ToolMessage.content`. Size limits are decoupled from the
+ * LLM-visible truncation budget and default to 5 MB total.
  *
  * Known limitations:
  *  - Tools that return a `ToolMessage` with array-type content
@@ -269,7 +272,9 @@ export type ToolOutputReferencesConfig = {
   enabled?: boolean;
   /**
    * Maximum characters stored (and substituted) per registered output.
-   * Defaults to the ToolNode's `maxToolResultChars`.
+   * Applied to the *raw* output before storage. Defaults to
+   * `HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE` (5 MB), independent of the
+   * LLM-visible `maxToolResultChars` budget.
    */
   maxOutputSize?: number;
   /**
@@ -278,7 +283,7 @@ export type ToolOutputReferencesConfig = {
    * until the total fits. The effective per-output cap is
    * `min(maxOutputSize, maxTotalSize)` so a single stored output can
    * never exceed the aggregate bound. Defaults to
-   * `calculateMaxTotalToolOutputSize(maxOutputSize)`.
+   * `calculateMaxTotalToolOutputSize(maxOutputSize)` (5 MB).
    */
   maxTotalSize?: number;
 };

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -252,6 +252,17 @@ export type LCToolRegistry = Map<string, LCTool>;
  *
  * Size limits mirror the shape of `calculateMaxToolResultChars` so
  * substituted content cannot exceed what the model has already seen.
+ *
+ * Known limitations:
+ *  - Tools that return a `ToolMessage` with array-type content
+ *    (multi-part content blocks such as text + image) are not
+ *    registered and cannot be cited via `{{tool<i>turn<n>}}`. A
+ *    warning is logged so the missing reference is visible.
+ *  - When a `PostToolUse` hook replaces `ToolMessage.content`, the
+ *    *post-hook* content is what gets stored in the registry (and
+ *    what the model sees), so `{{…}}` substitutions deliver the
+ *    hooked output rather than the raw tool return. This matches the
+ *    hook's "authoritative" role for output shaping.
  */
 export type ToolOutputReferencesConfig = {
   /** Enable the registry and placeholder substitution. Defaults to `false`. */
@@ -262,9 +273,12 @@ export type ToolOutputReferencesConfig = {
    */
   maxOutputSize?: number;
   /**
-   * Maximum total characters retained across all registered outputs for
-   * the run. When exceeded, the oldest registered outputs are evicted
-   * FIFO. Defaults to `calculateMaxTotalToolOutputSize(maxOutputSize)`.
+   * Soft cap on total characters retained across all registered outputs
+   * for the run. When exceeded, the oldest entries are evicted FIFO
+   * until the total is ≤ this cap OR only the most-recent entry
+   * remains (the just-stored output is never self-evicted, even if it
+   * alone exceeds the cap). Defaults to
+   * `calculateMaxTotalToolOutputSize(maxOutputSize)`.
    */
   maxTotalSize?: number;
 };

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -284,8 +284,14 @@ export type ToolOutputReferencesConfig = {
   /**
    * Maximum characters stored (and substituted) per registered output.
    * Applied to the *raw* output before storage. Defaults to
-   * `HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE` (5 MB), independent of the
-   * LLM-visible `maxToolResultChars` budget.
+   * `HARD_MAX_TOOL_RESULT_CHARS` (~400 KB) — matching the
+   * LLM-visible tool-result truncation budget, which is also a safe
+   * payload size for shell `ARG_MAX` limits when a `{{…}}` expansion
+   * gets piped into a bash `command`. Hosts that want to preserve
+   * fuller fidelity (for example for non-bash API consumers) can
+   * raise this up to `maxTotalSize` (defaults to 5 MB) — be aware
+   * that large single-output substitutions may exceed shell
+   * argument-size limits on typical Linux/macOS.
    */
   maxOutputSize?: number;
   /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -273,11 +273,11 @@ export type ToolOutputReferencesConfig = {
    */
   maxOutputSize?: number;
   /**
-   * Soft cap on total characters retained across all registered outputs
+   * Hard cap on total characters retained across all registered outputs
    * for the run. When exceeded, the oldest entries are evicted FIFO
-   * until the total is ≤ this cap OR only the most-recent entry
-   * remains (the just-stored output is never self-evicted, even if it
-   * alone exceeds the cap). Defaults to
+   * until the total fits. The effective per-output cap is
+   * `min(maxOutputSize, maxTotalSize)` so a single stored output can
+   * never exceed the aggregate bound. Defaults to
    * `calculateMaxTotalToolOutputSize(maxOutputSize)`.
    */
   maxTotalSize?: number;

--- a/src/utils/__tests__/truncation.test.ts
+++ b/src/utils/__tests__/truncation.test.ts
@@ -4,7 +4,7 @@ import {
   HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
   calculateMaxToolResultChars,
   calculateMaxTotalToolOutputSize,
-} from './truncation';
+} from '@/utils/truncation';
 
 describe('truncation helpers', () => {
   describe('calculateMaxToolResultChars', () => {

--- a/src/utils/truncation.test.ts
+++ b/src/utils/truncation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  HARD_MAX_TOOL_RESULT_CHARS,
+  HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE,
+  calculateMaxToolResultChars,
+  calculateMaxTotalToolOutputSize,
+} from './truncation';
+
+describe('truncation helpers', () => {
+  describe('calculateMaxToolResultChars', () => {
+    it('returns the hard cap when context tokens are missing', () => {
+      expect(calculateMaxToolResultChars()).toBe(HARD_MAX_TOOL_RESULT_CHARS);
+      expect(calculateMaxToolResultChars(undefined)).toBe(
+        HARD_MAX_TOOL_RESULT_CHARS
+      );
+      expect(calculateMaxToolResultChars(0)).toBe(HARD_MAX_TOOL_RESULT_CHARS);
+      expect(calculateMaxToolResultChars(-100)).toBe(
+        HARD_MAX_TOOL_RESULT_CHARS
+      );
+    });
+
+    it('computes 30% of context-window characters for normal inputs', () => {
+      // 100k tokens * 0.3 = 30k tokens * 4 chars/token = 120k chars
+      expect(calculateMaxToolResultChars(100_000)).toBe(120_000);
+    });
+
+    it('clamps to the hard cap for large context windows', () => {
+      // 1M tokens * 0.3 * 4 = 1.2M chars, exceeds 400k cap
+      expect(calculateMaxToolResultChars(1_000_000)).toBe(
+        HARD_MAX_TOOL_RESULT_CHARS
+      );
+    });
+  });
+
+  describe('calculateMaxTotalToolOutputSize', () => {
+    it('returns the absolute hard cap when no per-output is provided', () => {
+      expect(calculateMaxTotalToolOutputSize()).toBe(
+        HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE
+      );
+      expect(calculateMaxTotalToolOutputSize(0)).toBe(
+        HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE
+      );
+      expect(calculateMaxTotalToolOutputSize(-1)).toBe(
+        HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE
+      );
+    });
+
+    it('doubles the per-output cap by default', () => {
+      expect(calculateMaxTotalToolOutputSize(100_000)).toBe(200_000);
+      expect(calculateMaxTotalToolOutputSize(1)).toBe(2);
+    });
+
+    it('clamps the doubled value to HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE', () => {
+      // 4M * 2 = 8M, exceeds 5M
+      expect(calculateMaxTotalToolOutputSize(4_000_000)).toBe(
+        HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE
+      );
+      // Right at the boundary: 2.5M * 2 = 5M (no clamp).
+      expect(calculateMaxTotalToolOutputSize(2_500_000)).toBe(5_000_000);
+      // Just past it: 2_500_001 * 2 = 5_000_002 -> clamped.
+      expect(calculateMaxTotalToolOutputSize(2_500_001)).toBe(
+        HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE
+      );
+    });
+  });
+});

--- a/src/utils/truncation.ts
+++ b/src/utils/truncation.ts
@@ -14,11 +14,13 @@ export const HARD_MAX_TOOL_RESULT_CHARS = 400_000;
 
 /**
  * Absolute hard cap on the aggregate size (characters) of all registered
- * tool outputs kept for `{{tool<i>turn<n>}}` substitution. Sized at 2×
- * the single-output cap so a run can keep a small working set without
- * letting the registry balloon unbounded.
+ * tool outputs kept for `{{tool<i>turn<n>}}` substitution. Set at 5 MB
+ * because the registry stores *raw, untruncated* tool output — full
+ * fidelity for piping into downstream bash/jq — so the budget needs
+ * enough headroom to keep a handful of large responses without
+ * ballooning unbounded.
  */
-export const HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE = 800_000;
+export const HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE = 5_000_000;
 
 /**
  * Computes the dynamic max tool result size based on the model's context window.

--- a/src/utils/truncation.ts
+++ b/src/utils/truncation.ts
@@ -13,6 +13,14 @@
 export const HARD_MAX_TOOL_RESULT_CHARS = 400_000;
 
 /**
+ * Absolute hard cap on the aggregate size (characters) of all registered
+ * tool outputs kept for `{{tool<i>turn<n>}}` substitution. Sized at 2×
+ * the single-output cap so a run can keep a small working set without
+ * letting the registry balloon unbounded.
+ */
+export const HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE = 800_000;
+
+/**
  * Computes the dynamic max tool result size based on the model's context window.
  * Uses 30% of the context window (in estimated characters, ~4 chars/token)
  * capped at HARD_MAX_TOOL_RESULT_CHARS.
@@ -30,6 +38,26 @@ export function calculateMaxToolResultChars(
     Math.floor(contextWindowTokens * 0.3) * 4,
     HARD_MAX_TOOL_RESULT_CHARS
   );
+}
+
+/**
+ * Computes the default aggregate size (characters) for the tool output
+ * reference registry based on the per-output budget. Mirrors
+ * `calculateMaxToolResultChars`'s shape: a multiple of the per-output
+ * cap, clamped to `HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE`.
+ *
+ * @param maxOutputSize - Per-output maximum characters (e.g., the
+ *   ToolNode's `maxToolResultChars`). When omitted or non-positive,
+ *   falls back to the absolute total cap.
+ * @returns Maximum total characters retained across the registry.
+ */
+export function calculateMaxTotalToolOutputSize(
+  maxOutputSize?: number
+): number {
+  if (maxOutputSize == null || maxOutputSize <= 0) {
+    return HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE;
+  }
+  return Math.min(maxOutputSize * 2, HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE);
 }
 
 /**


### PR DESCRIPTION
## Summary

I added an opt-in mechanism that lets any tool pipe a previously-executed tool's output into its own arguments via a `{{tool<idx>turn<turn>}}` placeholder, modeled after the turn-based anchors web search already uses. The feature is gated by a new `RunConfig.toolOutputReferences` field and is disabled by default; size limits default to match the existing tool-result truncation budget so nothing substituted can exceed what the model already saw.

- Added a run-scoped `ToolOutputReferenceRegistry` that stores successful tool outputs under stable `tool<idx>turn<turn>` keys, with per-output clipping and FIFO eviction when the aggregate exceeds `maxTotalSize`.
- Wired the registry into `ToolNode.runTool` and `ToolNode.dispatchToolEvents`: increments a per-run turn counter once per batch, resolves placeholders in string args before invoke, and annotates the returned `ToolMessage.content` for the LLM.
- Annotated content is a `_ref` key injected into parsed-JSON-object outputs (with pretty-print preservation and collision fallback) or a `[ref: …]\n` prefix for strings / arrays / primitives — the stored registry value stays un-annotated so piping into `jq`/`grep`/`awk` produces pristine input.
- Surfaced unresolved placeholders via a trailing `[unresolved refs: …]` line on the same tool message so the model can self-correct.
- Threaded `toolOutputReferences` from `RunConfig` through `Run` into both `StandardGraph` and `MultiAgentGraph`, which pass it into every compiled `ToolNode`; subagent-as-tool calls benefit automatically since they flow through the same paths.
- Introduced `HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE = 800_000` and a `calculateMaxTotalToolOutputSize(perOutput)` helper (`2× per-output, clamped`) alongside the existing `HARD_MAX_TOOL_RESULT_CHARS`.
- Updated the bash tool description with a dedicated section explaining the reference format, prefix vs `_ref` placement, how to embed placeholders, and what happens when a key is unknown.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

### Test Configuration

- Node + Jest via `npx jest`, typecheck via `npx tsc --noEmit`, lint via `npx eslint`.

I added 34 new tests (22 unit + 12 integration) across two new files and ran the full `src/tools/` and `src/graphs/` suites plus typecheck and lint.

- `src/tools/__tests__/toolOutputReferences.test.ts` covers registry set/get, per-output clipping, FIFO eviction across limit breaches, deep-walked resolution in strings/nested objects/arrays, deduplicated unresolved reporting, `_ref` injection for JSON objects (including pretty-print preservation and collision fallback), `[ref: …]` fallback for arrays/primitives/parse failures, and the regex pattern.
- `src/tools/__tests__/ToolNode.outputReferences.test.ts` covers disabled-by-default behavior, prefix vs `_ref` annotation in `ToolMessage.content`, un-annotated registry storage (so `{{tool0turn0}}` substitutes clean output downstream), per-batch turn counter increments, per-batch tool index assignment, unresolved-ref reporting, per-output clipping in the registry, aggregate FIFO eviction across batches, and the fact that errored tool calls are not registered.

To exercise manually: enable in `RunConfig` with `toolOutputReferences: { enabled: true }`, run a sequence of bash tool calls where the second command contains `{{tool0turn0}}`, and confirm the substituted stdout flows in and a `[ref: tool1turn0]` prefix (or `_ref` field) appears on the follow-up result.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes