### PR TITLE
fix: tolerate trailing tool_use without a thinking block

### DIFF
--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -683,10 +683,17 @@ export function getMessagesWithinTokenLimit({
         ) as ThinkingContentText | undefined;
         thinkingStartIndex = thinkingBlock != null ? currentIndex : -1;
       }
-      /** False start, the latest message was not part of a multi-assistant/tool sequence of messages */
+      /**
+       * Exited the trailing assistant/tool sequence without finding a
+       * thinking block. Anthropic does not require Claude to emit a
+       * thinking block before every tool call, so the absence of one is
+       * a valid sequence — clear thinkingEndIndex so the pruner does not
+       * treat it as malformed.
+       */
       if (
         thinkingEndIndex > -1 &&
-        currentIndex === thinkingEndIndex - 1 &&
+        thinkingStartIndex < 0 &&
+        !thinkingBlock &&
         messageType !== 'ai' &&
         messageType !== 'tool'
       ) {

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -21,6 +21,7 @@ import {
   createPruneMessages,
 } from '@/messages/prune';
 import { getLLMConfig } from '@/utils/llmConfig';
+import { ensureThinkingBlockInMessages } from '@/messages/format';
 import { Providers, ContentTypes } from '@/common';
 import { Run } from '@/run';
 
@@ -2170,6 +2171,89 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
     ];
 
     expect(() => pruneMessages({ messages: secondTurn })).not.toThrow();
+  });
+
+  it('integrates with ensureThinkingBlockInMessages so the API-bound payload stays valid', () => {
+    // Models the full Graph.ts pipeline: pruner runs first, then
+    // ensureThinkingBlockInMessages on the pruned context. The pruner used to
+    // throw on the issue #115 tail; with the fix it passes the messages
+    // through to ensureThinkingBlockInMessages, which converts the orphan
+    // AI(tool_use)+Tool into a `[Previous agent context]` HumanMessage. The
+    // outgoing payload is then a sequence Anthropic accepts.
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new HumanMessage('please read this doc and tell me X'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'f'.repeat(8000),
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    const pruneResult = realGetMessagesWithinTokenLimit({
+      messages,
+      maxContextTokens: 200,
+      indexTokenCountMap,
+      thinkingEnabled: true,
+      tokenCounter,
+      reasoningType: ContentTypes.THINKING,
+    });
+
+    const finalMessages = ensureThinkingBlockInMessages(
+      pruneResult.context,
+      Providers.ANTHROPIC
+    );
+
+    // ensureThinkingBlockInMessages folds the orphan AI(tool_use)+Tool tail
+    // into a synthetic HumanMessage; nothing in the outgoing payload is an
+    // AI tool_use without a thinking block, which is the API-level concern.
+    for (const m of finalMessages) {
+      if (m.getType() !== 'ai') {
+        continue;
+      }
+      const content = (m as AIMessage).content;
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      const hasToolUse = content.some(
+        (c) => typeof c === 'object' && c.type === 'tool_use'
+      );
+      if (!hasToolUse) {
+        continue;
+      }
+      const hasThinking = content.some(
+        (c) =>
+          typeof c === 'object' &&
+          (c.type === ContentTypes.THINKING ||
+            c.type === ContentTypes.REASONING_CONTENT ||
+            c.type === ContentTypes.REASONING ||
+            c.type === 'redacted_thinking')
+      );
+      expect(hasThinking).toBe(true);
+    }
   });
 
   it('still preserves the thinking block when the trailing AI message has one', () => {

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -2193,11 +2193,13 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
 
   it('integrates with ensureThinkingBlockInMessages so the API-bound payload stays valid', () => {
     // Models the full Graph.ts pipeline: pruner runs first, then
-    // ensureThinkingBlockInMessages on the pruned context. The pruner used to
-    // throw on the issue #115 tail; with the fix it passes the messages
-    // through to ensureThinkingBlockInMessages, which converts the orphan
-    // AI(tool_use)+Tool into a `[Previous agent context]` HumanMessage. The
-    // outgoing payload is then a sequence Anthropic accepts.
+    // ensureThinkingBlockInMessages on the pruned context. The pruner used
+    // to throw on the issue #115 tail; with the fix it returns the
+    // messages, and ensureThinkingBlockInMessages folds the orphan
+    // AI(tool_use)+Tool tail into a `[Previous agent context]`
+    // HumanMessage. The Tool size is tuned so the trailing sequence
+    // actually survives pruning — otherwise the assertions would be
+    // vacuous.
     const tokenCounter = createTestTokenCounter();
     const messages: BaseMessage[] = [
       new HumanMessage('please read this doc and tell me X'),
@@ -2220,7 +2222,7 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
         ],
       }),
       new ToolMessage({
-        content: 'f'.repeat(8000),
+        content: 'f'.repeat(100),
         tool_call_id: 'tc_get_doc',
         name: 'get_doc_content',
       }),
@@ -2233,45 +2235,50 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
 
     const pruneResult = realGetMessagesWithinTokenLimit({
       messages,
-      maxContextTokens: 200,
+      maxContextTokens: 300,
       indexTokenCountMap,
       thinkingEnabled: true,
       tokenCounter,
       reasoningType: ContentTypes.THINKING,
     });
 
+    expect(pruneResult.context.length).toBe(3);
+
     const finalMessages = ensureThinkingBlockInMessages(
       pruneResult.context,
       Providers.ANTHROPIC
     );
 
-    // ensureThinkingBlockInMessages folds the orphan AI(tool_use)+Tool tail
-    // into a synthetic HumanMessage; nothing in the outgoing payload is an
-    // AI tool_use without a thinking block, which is the API-level concern.
-    for (const m of finalMessages) {
+    // ensureThinkingBlockInMessages should fold the orphan AI(tool_use)+Tool
+    // into a synthetic HumanMessage carrying the `[Previous agent context]`
+    // marker, leaving no AI(tool_use) in the outgoing payload.
+    expect(finalMessages.length).toBe(2);
+    expect(finalMessages[0]).toBeInstanceOf(HumanMessage);
+    expect(finalMessages[1]).toBeInstanceOf(HumanMessage);
+
+    const folded = finalMessages[1] as HumanMessage;
+    const foldedContent = folded.content;
+    const foldedText = Array.isArray(foldedContent)
+      ? (foldedContent as t.ExtendedMessageContent[])
+        .filter((c) => typeof c === 'object' && c.type === 'text')
+        .map((c) => String(c.text ?? ''))
+        .join('\n')
+      : String(foldedContent);
+    expect(foldedText).toContain('[Previous agent context]');
+
+    const hasOrphanToolUse = finalMessages.some((m) => {
       if (m.getType() !== 'ai') {
-        continue;
+        return false;
       }
       const content = (m as AIMessage).content;
       if (!Array.isArray(content)) {
-        continue;
+        return false;
       }
-      const hasToolUse = content.some(
+      return content.some(
         (c) => typeof c === 'object' && c.type === 'tool_use'
       );
-      if (!hasToolUse) {
-        continue;
-      }
-      const hasThinking = content.some(
-        (c) =>
-          typeof c === 'object' &&
-          (c.type === ContentTypes.THINKING ||
-            c.type === ContentTypes.REASONING_CONTENT ||
-            c.type === ContentTypes.REASONING ||
-            c.type === 'redacted_thinking')
-      );
-      expect(hasThinking).toBe(true);
-    }
+    });
+    expect(hasOrphanToolUse).toBe(false);
   });
 
   it('still preserves the thinking block when the trailing AI message has one', () => {

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -2087,17 +2087,6 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
       indexTokenCountMap[i] = tokenCounter(messages[i]);
     }
 
-    expect(() =>
-      realGetMessagesWithinTokenLimit({
-        messages,
-        maxContextTokens: 200,
-        indexTokenCountMap,
-        thinkingEnabled: true,
-        tokenCounter,
-        reasoningType: ContentTypes.THINKING,
-      })
-    ).not.toThrow();
-
     const result = realGetMessagesWithinTokenLimit({
       messages,
       maxContextTokens: 200,
@@ -2109,10 +2098,16 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
     expect(result.thinkingStartIndex).toBeUndefined();
   });
 
-  it('does not throw via createPruneMessages when prior thinking carry-over precedes a no-thinking tail', () => {
+  it('honors prior runThinkingStartIndex carry-over when the next call has a no-thinking tail', () => {
+    // First call's tight budget forces pruning, which makes the closure
+    // record the AI(thinking) message's index in runThinkingStartIndex.
+    // Second call's tail is AI(tool_use) without a thinking block; the
+    // pre-loaded thinkingBlock from the carry-over keeps the new guard
+    // dormant and the existing reattachment path runs. Verifies the fix
+    // doesn't disturb the carry-over interaction.
     const tokenCounter = createTestTokenCounter();
     const firstTurn: BaseMessage[] = [
-      new HumanMessage('hi'),
+      new HumanMessage('h'.repeat(120)),
       new AIMessage({
         content: [
           {
@@ -2120,7 +2115,7 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
             thinking: 'planning the response',
             signature: 'sig-prior',
           },
-          { type: 'text', text: 'hello back' },
+          { type: 'text', text: 'hi' },
         ],
       }),
     ];
@@ -2131,7 +2126,7 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
     }
 
     const pruneMessages = createPruneMessages({
-      maxTokens: 1000,
+      maxTokens: 68,
       startIndex: 0,
       tokenCounter,
       indexTokenCountMap,
@@ -2140,7 +2135,8 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
     });
 
     const firstResult = pruneMessages({ messages: firstTurn });
-    expect(firstResult.context.length).toBe(2);
+    expect(firstResult.messagesToRefine?.length).toBeGreaterThan(0);
+    expect(firstResult.context.some((m) => m.getType() === 'ai')).toBe(true);
 
     const secondTurn: BaseMessage[] = [
       ...firstTurn,
@@ -2164,13 +2160,35 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
         ],
       }),
       new ToolMessage({
-        content: 'e'.repeat(8000),
+        content: 'e'.repeat(40),
         tool_call_id: 'tc_get_doc',
         name: 'get_doc_content',
       }),
     ];
 
-    expect(() => pruneMessages({ messages: secondTurn })).not.toThrow();
+    let secondResult: ReturnType<typeof pruneMessages> | undefined;
+    expect(() => {
+      secondResult = pruneMessages({ messages: secondTurn });
+    }).not.toThrow();
+
+    // Carry-over reattachment: even though the trailing AI(tool_use) has
+    // no thinking block of its own, the closure's runThinkingStartIndex
+    // points at the prior AI(thinking) and that block gets prepended to
+    // the surviving AI message in context.
+    const trailingAi = secondResult!.context.find(
+      (m) =>
+        m.getType() === 'ai' &&
+        Array.isArray(m.content) &&
+        (m.content as t.ExtendedMessageContent[]).some(
+          (c) => typeof c === 'object' && c.type === 'tool_use'
+        )
+    );
+    expect(trailingAi).toBeDefined();
+    expect(
+      (trailingAi!.content as t.ExtendedMessageContent[]).some(
+        (c) => typeof c === 'object' && c.type === ContentTypes.THINKING
+      )
+    ).toBe(true);
   });
 
   it('integrates with ensureThinkingBlockInMessages so the API-bound payload stays valid', () => {

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -2039,6 +2039,139 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
     expect(result.thinkingStartIndex).toBeUndefined();
   });
 
+  it('handles consecutive tool calls without any thinking block in the tail', () => {
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new HumanMessage('do two things'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_1',
+            name: 'tool_a',
+            input: { x: 1 },
+          },
+        ],
+        tool_calls: [
+          { id: 'tc_1', name: 'tool_a', args: { x: 1 }, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'result_a',
+        tool_call_id: 'tc_1',
+        name: 'tool_a',
+      }),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_2',
+            name: 'tool_b',
+            input: { y: 2 },
+          },
+        ],
+        tool_calls: [
+          { id: 'tc_2', name: 'tool_b', args: { y: 2 }, type: 'tool_call' },
+        ],
+      }),
+      new ToolMessage({
+        content: 'd'.repeat(6000),
+        tool_call_id: 'tc_2',
+        name: 'tool_b',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    expect(() =>
+      realGetMessagesWithinTokenLimit({
+        messages,
+        maxContextTokens: 200,
+        indexTokenCountMap,
+        thinkingEnabled: true,
+        tokenCounter,
+        reasoningType: ContentTypes.THINKING,
+      })
+    ).not.toThrow();
+
+    const result = realGetMessagesWithinTokenLimit({
+      messages,
+      maxContextTokens: 200,
+      indexTokenCountMap,
+      thinkingEnabled: true,
+      tokenCounter,
+      reasoningType: ContentTypes.THINKING,
+    });
+    expect(result.thinkingStartIndex).toBeUndefined();
+  });
+
+  it('does not throw via createPruneMessages when prior thinking carry-over precedes a no-thinking tail', () => {
+    const tokenCounter = createTestTokenCounter();
+    const firstTurn: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: ContentTypes.THINKING,
+            thinking: 'planning the response',
+            signature: 'sig-prior',
+          },
+          { type: 'text', text: 'hello back' },
+        ],
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < firstTurn.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(firstTurn[i]);
+    }
+
+    const pruneMessages = createPruneMessages({
+      maxTokens: 1000,
+      startIndex: 0,
+      tokenCounter,
+      indexTokenCountMap,
+      thinkingEnabled: true,
+      reserveRatio: 0,
+    });
+
+    const firstResult = pruneMessages({ messages: firstTurn });
+    expect(firstResult.context.length).toBe(2);
+
+    const secondTurn: BaseMessage[] = [
+      ...firstTurn,
+      new HumanMessage('please read the doc'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'e'.repeat(8000),
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    expect(() => pruneMessages({ messages: secondTurn })).not.toThrow();
+  });
+
   it('still preserves the thinking block when the trailing AI message has one', () => {
     const tokenCounter = createTestTokenCounter();
     const messages: BaseMessage[] = [

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -1930,3 +1930,174 @@ describe('prunedMemory ordering with thinking enabled', () => {
     }
   });
 });
+
+describe('thinking enabled — tail tool_use without a thinking block (issue #115)', () => {
+  it('does not throw when the trailing AI message issued a tool call without a thinking block', () => {
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new HumanMessage('first turn'),
+      new AIMessage({
+        content: [
+          {
+            type: ContentTypes.THINKING,
+            thinking: 'thinking about the first response',
+            signature: 'sig0',
+          },
+          { type: 'text', text: 'first reply' },
+        ],
+      }),
+      new HumanMessage('please read this doc and tell me X'),
+      // Anthropic may emit a tool_use without an accompanying thinking block —
+      // valid API behavior that the pruner must tolerate.
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'a'.repeat(8000), // huge tool result that pushes us past budget
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    expect(() =>
+      realGetMessagesWithinTokenLimit({
+        messages,
+        maxContextTokens: 200, // tight budget so pruning actually runs
+        indexTokenCountMap,
+        thinkingEnabled: true,
+        tokenCounter,
+        reasoningType: ContentTypes.THINKING,
+      })
+    ).not.toThrow();
+  });
+
+  it('returns a prunable context for the [AI tool_use, Tool] tail without a thinking block', () => {
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new HumanMessage('please read this doc'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'b'.repeat(6000),
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    const result = realGetMessagesWithinTokenLimit({
+      messages,
+      maxContextTokens: 200,
+      indexTokenCountMap,
+      thinkingEnabled: true,
+      tokenCounter,
+      reasoningType: ContentTypes.THINKING,
+    });
+
+    expect(result.context).toBeDefined();
+    expect(result.messagesToRefine.length).toBeGreaterThan(0);
+    expect(result.thinkingStartIndex).toBeUndefined();
+  });
+
+  it('still preserves the thinking block when the trailing AI message has one', () => {
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: [
+          {
+            type: ContentTypes.THINKING,
+            thinking: 'older thinking',
+            signature: 'sig-old',
+          },
+          { type: 'text', text: 'older reply' },
+        ],
+      }),
+      new HumanMessage('please read this doc'),
+      new AIMessage({
+        content: [
+          {
+            type: ContentTypes.THINKING,
+            thinking: 'I will fetch the doc',
+            signature: 'sig-new',
+          },
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'c'.repeat(6000),
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    const result = realGetMessagesWithinTokenLimit({
+      messages,
+      maxContextTokens: 200,
+      indexTokenCountMap,
+      thinkingEnabled: true,
+      tokenCounter,
+      reasoningType: ContentTypes.THINKING,
+    });
+
+    expect(result.thinkingStartIndex).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [#115](https://github.com/danny-avila/agents/issues/115).

When Anthropic thinking is enabled and Claude issues a tool call without emitting a thinking block first, the pruner saw `[AI tool_use, Tool]` at the tail and walked back searching for a thinking block. With none to find, it threw `The payload is malformed. There is a thinking sequence but no "AI" messages with thinking blocks` — permanently breaking any conversation that crossed the context limit on that turn.

Claude skipping a thinking block before a tool call is valid Anthropic API behavior, so the pruner's assumption that a tail AI/tool sequence always contains a thinking block is wrong.

## Fix

The false-start guard in `getMessagesWithinTokenLimit` previously only fired when the message *immediately* before `thinkingEndIndex` was non-AI/tool, so it never reset for the tail shape `[Human, AI(tool_use, no thinking), Tool]`. Broaden the guard to clear `thinkingEndIndex` whenever the loop exits the trailing AI/tool sequence (any non-AI/tool message) without having found a thinking block. The throw at line 780 is now unreachable for this valid case.

The fix is one localized condition change; the prior single-AI-tail behavior remains covered (`thinkingStartIndex < 0 && !thinkingBlock` is true in that case too).

## Test plan

- [x] New unit tests in `src/specs/prune.test.ts` covering issue #115:
  - [x] Bug reproducer: `[Human, AI(thinking+text), Human, AI(tool_use no thinking), Tool]` no longer throws
  - [x] Pure tail: `[Human, AI(tool_use no thinking), Tool]` returns a usable pruning result with `thinkingStartIndex` undefined
  - [x] Regression guard: when the trailing AI *does* have a thinking block, it's still preserved (`thinkingStartIndex >= 0`)
- [x] Full `src/messages/` test suite passes (280 tests)
- [x] Full `src/specs/prune.test.ts` suite passes (51 tests)
- [x] `tsc --noEmit` clean
- [x] `eslint src/` clean