### PR TITLE
refactor: lazy-annotate tool output refs at LLM request time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.71-dev.0",
+  "version": "3.1.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.71-dev.0",
+      "version": "3.1.71",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.71-dev.1",
+  "version": "3.1.71",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.71-dev.0",
+  "version": "3.1.71-dev.1",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -187,10 +187,12 @@ export abstract class Graph<
    * feature is disabled. All ToolNodes compiled from this graph share
    * this single instance so cross-agent `{{…}}` references resolve.
    *
-   * Public so `attemptInvoke` can read it through the typed
+   * @internal Public so `attemptInvoke` can read it through the typed
    * `InvokeContext` and project ToolMessages into LLM-facing annotated
    * copies right before each provider call (see
-   * `annotateMessagesForLLM`).
+   * `annotateMessagesForLLM`). Host code should not call this directly
+   * — registry mutations outside the ToolNode lifecycle break the
+   * partitioning, eviction, and turn-counter invariants.
    */
   public getOrCreateToolOutputRegistry():
     | ToolOutputReferenceRegistry

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -186,8 +186,13 @@ export abstract class Graph<
    * constructing it on first access. Returns `undefined` when the
    * feature is disabled. All ToolNodes compiled from this graph share
    * this single instance so cross-agent `{{…}}` references resolve.
+   *
+   * Public so `attemptInvoke` can read it through the typed
+   * `InvokeContext` and project ToolMessages into LLM-facing annotated
+   * copies right before each provider call (see
+   * `annotateMessagesForLLM`).
    */
-  protected getOrCreateToolOutputRegistry():
+  public getOrCreateToolOutputRegistry():
     | ToolOutputReferenceRegistry
     | undefined {
     if (this.toolOutputReferences?.enabled !== true) {

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -235,6 +235,48 @@ describe('attemptInvoke applies lazy ref annotation', () => {
       'Error: bad ref\n[unresolved refs: tool9turn9]'
     );
   });
+
+  it('annotates refs registered under an anonymous-batch scope (no run_id)', async () => {
+    /**
+     * Regression: anonymous ToolNode invocations register refs under
+     * a synthetic per-batch scope (`\0anon-<n>`) that
+     * `config.configurable.run_id` cannot recover. The transform must
+     * read the message-stamped `_refScope` rather than relying on the
+     * config-derived runId, otherwise the registry lookup misses and
+     * the LLM never sees the `[ref: …]` marker.
+     */
+    const registry = new ToolOutputReferenceRegistry();
+    const anonScope = '\0anon-0';
+    registry.set(anonScope, 'tool0turn0', 'stored');
+
+    const context = {
+      getOrCreateToolOutputRegistry: () => registry,
+    } as unknown as Parameters<typeof attemptInvoke>[0]['context'];
+
+    const messages: BaseMessage[] = [
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'tc1',
+        status: 'success',
+        content: 'output',
+        additional_kwargs: {
+          _refKey: 'tool0turn0',
+          _refScope: anonScope,
+        },
+      }),
+    ];
+
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke({
+      model: model as t.ChatModel,
+      messages,
+      provider: Providers.ANTHROPIC,
+      context,
+    });
+
+    expect(invokeMessages[0][0].content).toBe('[ref: tool0turn0]\noutput');
+  });
 });
 
 describe('tryFallbackProviders applies the same lazy annotation transform', () => {

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -1,0 +1,292 @@
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+import { describe, it, expect, jest } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
+import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import { Providers } from '@/common';
+
+/**
+ * Minimal stub model that records what `messages` get passed into
+ * `invoke`/`stream`. Extends `BaseChatModel` would pull in too much
+ * surface for a focused invoke-path test, so we shape just the fields
+ * `attemptInvoke` reads.
+ */
+function buildCapturingModel(): {
+  invokeMessages: BaseMessage[][];
+  streamMessages: BaseMessage[][];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: any;
+  } {
+  const invokeMessages: BaseMessage[][] = [];
+  const streamMessages: BaseMessage[][] = [];
+
+  const responseMsg = new AIMessage({ content: 'ok' });
+
+  const model = {
+    invoke: jest.fn(async (messages: BaseMessage[]): Promise<AIMessage> => {
+      invokeMessages.push(messages);
+      return responseMsg;
+    }),
+  } as Record<string, unknown>;
+
+  return { invokeMessages, streamMessages, model };
+}
+
+function buildStreamingCapturingModel(): {
+  streamMessages: BaseMessage[][];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  model: any;
+  } {
+  const streamMessages: BaseMessage[][] = [];
+  const model = {
+    stream: jest.fn(async function* (
+      messages: BaseMessage[]
+    ): AsyncGenerator<AIMessageChunk> {
+      streamMessages.push(messages);
+      yield new AIMessageChunk({ content: 'ok' });
+    }),
+  } as Record<string, unknown>;
+  return { streamMessages, model };
+}
+
+describe('attemptInvoke applies lazy ref annotation', () => {
+  it('annotates ToolMessages with live _refKey before sending to provider (non-streaming)', async () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('run-1', 'tool0turn0', 'stored');
+    const context = {
+      getOrCreateToolOutputRegistry: () => registry,
+    } as unknown as Parameters<typeof attemptInvoke>[0]['context'];
+
+    const messages: BaseMessage[] = [
+      new HumanMessage('hi'),
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'tc1',
+        status: 'success',
+        content: 'output',
+        additional_kwargs: { _refKey: 'tool0turn0' },
+      }),
+    ];
+
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke(
+      {
+        model: model as t.ChatModel,
+        messages,
+        provider: Providers.ANTHROPIC,
+        context,
+      },
+      { configurable: { run_id: 'run-1' } }
+    );
+
+    expect(invokeMessages).toHaveLength(1);
+    const sent = invokeMessages[0];
+    expect(sent[1].content).toBe('[ref: tool0turn0]\noutput');
+
+    const original = messages[1] as ToolMessage;
+    expect(original.content).toBe('output');
+    expect(original.additional_kwargs._refKey).toBe('tool0turn0');
+    expect(messages[1]).not.toBe(sent[1]);
+  });
+
+  it('annotates messages passed to model.stream (streaming path)', async () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('run-2', 'tool0turn0', 'stored');
+    const context = {
+      getOrCreateToolOutputRegistry: () => registry,
+    } as unknown as Parameters<typeof attemptInvoke>[0]['context'];
+
+    const messages: BaseMessage[] = [
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'tc1',
+        status: 'success',
+        content: 'output',
+        additional_kwargs: { _refKey: 'tool0turn0' },
+      }),
+    ];
+
+    const { streamMessages, model } = buildStreamingCapturingModel();
+
+    await attemptInvoke(
+      {
+        model: model as t.ChatModel,
+        messages,
+        provider: Providers.ANTHROPIC,
+        context,
+        onChunk: () => {
+          /* swallow */
+        },
+      },
+      { configurable: { run_id: 'run-2' } }
+    );
+
+    expect(streamMessages).toHaveLength(1);
+    expect(streamMessages[0][0].content).toBe('[ref: tool0turn0]\noutput');
+    expect(messages[0].content).toBe('output');
+  });
+
+  it('passes messages unchanged when no registry is exposed on context (e.g. summarization)', async () => {
+    const messages: BaseMessage[] = [
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'tc1',
+        status: 'success',
+        content: 'output',
+        additional_kwargs: { _refKey: 'tool0turn0' },
+      }),
+    ];
+
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke({
+      model: model as t.ChatModel,
+      messages,
+      provider: Providers.ANTHROPIC,
+    });
+
+    expect(invokeMessages).toHaveLength(1);
+    expect(invokeMessages[0][0].content).toBe('output');
+  });
+
+  it('skips annotation for stale _refKey not present in current run registry (cross-run scenario)', async () => {
+    const registry = new ToolOutputReferenceRegistry();
+    // run-3 registry holds tool0turn0 - the current run's live ref
+    registry.set('run-3', 'tool0turn0', 'live-stored');
+
+    const context = {
+      getOrCreateToolOutputRegistry: () => registry,
+    } as unknown as Parameters<typeof attemptInvoke>[0]['context'];
+
+    const messages: BaseMessage[] = [
+      // Stale ToolMessage from a hydrated prior run - its _refKey points
+      // at a key that exists in registry, but conceptually different
+      // semantics. For this test, use a key that doesn't exist in the
+      // current registry to demonstrate the no-op behavior.
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'old',
+        status: 'success',
+        content: 'old-output',
+        additional_kwargs: { _refKey: 'tool5turn5' },
+      }),
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'new',
+        status: 'success',
+        content: 'new-output',
+        additional_kwargs: { _refKey: 'tool0turn0' },
+      }),
+    ];
+
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke(
+      {
+        model: model as t.ChatModel,
+        messages,
+        provider: Providers.ANTHROPIC,
+        context,
+      },
+      { configurable: { run_id: 'run-3' } }
+    );
+
+    const sent = invokeMessages[0];
+    expect(sent[0].content).toBe('old-output');
+    expect(sent[1].content).toBe('[ref: tool0turn0]\nnew-output');
+  });
+
+  it('applies unresolved-refs annotation regardless of registry presence', async () => {
+    const registry = new ToolOutputReferenceRegistry();
+    const context = {
+      getOrCreateToolOutputRegistry: () => registry,
+    } as unknown as Parameters<typeof attemptInvoke>[0]['context'];
+
+    const messages: BaseMessage[] = [
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'tc1',
+        status: 'error',
+        content: 'Error: bad ref',
+        additional_kwargs: { _unresolvedRefs: ['tool9turn9'] },
+      }),
+    ];
+
+    const { invokeMessages, model } = buildCapturingModel();
+
+    await attemptInvoke(
+      {
+        model: model as t.ChatModel,
+        messages,
+        provider: Providers.ANTHROPIC,
+        context,
+      },
+      { configurable: { run_id: 'run-err' } }
+    );
+
+    expect(invokeMessages[0][0].content).toBe(
+      'Error: bad ref\n[unresolved refs: tool9turn9]'
+    );
+  });
+});
+
+describe('tryFallbackProviders applies the same lazy annotation transform', () => {
+  it('threads context through to attemptInvoke so fallback messages are annotated', async () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('run-fb', 'tool0turn0', 'stored');
+    const context = {
+      getOrCreateToolOutputRegistry: () => registry,
+    } as unknown as Parameters<typeof attemptInvoke>[0]['context'];
+
+    const messages: BaseMessage[] = [
+      new ToolMessage({
+        name: 'echo',
+        tool_call_id: 'tc1',
+        status: 'success',
+        content: 'output',
+        additional_kwargs: { _refKey: 'tool0turn0' },
+      }),
+    ];
+
+    const { invokeMessages, model } = buildCapturingModel();
+    /**
+     * Mock `initializeModel` indirectly by stubbing the LLM init via
+     * Jest's manual `mock` so the fallback path returns our capturing
+     * model. Skipping this here would require pulling in the real
+     * provider init chain (Anthropic, etc.) which the rest of this
+     * test layer does not bring in.
+     */
+    jest.doMock('@/llm/init', () => ({
+      initializeModel: (): unknown => model,
+    }));
+
+    // Reset the module so the doMock takes effect.
+    jest.resetModules();
+    const { tryFallbackProviders: freshTry } = (await import(
+      '@/llm/invoke'
+    )) as { tryFallbackProviders: typeof tryFallbackProviders };
+
+    await freshTry({
+      fallbacks: [{ provider: Providers.ANTHROPIC }],
+      messages,
+      primaryError: new Error('primary failed'),
+      context,
+      config: { configurable: { run_id: 'run-fb' } },
+    });
+
+    expect(invokeMessages.length).toBeGreaterThanOrEqual(1);
+    expect(invokeMessages[invokeMessages.length - 1][0].content).toBe(
+      '[ref: tool0turn0]\noutput'
+    );
+
+    jest.dontMock('@/llm/init');
+    jest.resetModules();
+  });
+});

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -28,10 +28,17 @@ type StubModel = {
   ) => AsyncGenerator<AIMessageChunk>;
 };
 
-function buildCapturingModel(): {
+type CapturingModel = {
   invokeMessages: BaseMessage[][];
   model: StubModel;
-  } {
+};
+
+type StreamingCapturingModel = {
+  streamMessages: BaseMessage[][];
+  model: StubModel;
+};
+
+function buildCapturingModel(): CapturingModel {
   const invokeMessages: BaseMessage[][] = [];
   const responseMsg = new AIMessage({ content: 'ok' });
   const model: StubModel = {
@@ -43,10 +50,7 @@ function buildCapturingModel(): {
   return { invokeMessages, model };
 }
 
-function buildStreamingCapturingModel(): {
-  streamMessages: BaseMessage[][];
-  model: StubModel;
-  } {
+function buildStreamingCapturingModel(): StreamingCapturingModel {
   const streamMessages: BaseMessage[][] = [];
   const model: StubModel = {
     stream: jest.fn(async function* (

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
 import {
   AIMessage,
   AIMessageChunk,
@@ -6,52 +8,54 @@ import {
 } from '@langchain/core/messages';
 import { describe, it, expect, jest } from '@jest/globals';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { StructuredToolInterface } from '@langchain/core/tools';
 import type * as t from '@/types';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import { ToolNode } from '@/tools/ToolNode';
 import { Providers } from '@/common';
 
 /**
- * Minimal stub model that records what `messages` get passed into
- * `invoke`/`stream`. Extends `BaseChatModel` would pull in too much
- * surface for a focused invoke-path test, so we shape just the fields
- * `attemptInvoke` reads.
+ * Minimal stub model shape `attemptInvoke` reads. Either `invoke` or
+ * `stream` is populated depending on which path the test exercises;
+ * extending the real `BaseChatModel` would pull in too much surface.
  */
+type StubModel = {
+  invoke?: (messages: BaseMessage[], config?: unknown) => Promise<AIMessage>;
+  stream?: (
+    messages: BaseMessage[],
+    config?: unknown
+  ) => AsyncGenerator<AIMessageChunk>;
+};
+
 function buildCapturingModel(): {
   invokeMessages: BaseMessage[][];
-  streamMessages: BaseMessage[][];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  model: any;
+  model: StubModel;
   } {
   const invokeMessages: BaseMessage[][] = [];
-  const streamMessages: BaseMessage[][] = [];
-
   const responseMsg = new AIMessage({ content: 'ok' });
-
-  const model = {
+  const model: StubModel = {
     invoke: jest.fn(async (messages: BaseMessage[]): Promise<AIMessage> => {
       invokeMessages.push(messages);
       return responseMsg;
     }),
-  } as Record<string, unknown>;
-
-  return { invokeMessages, streamMessages, model };
+  };
+  return { invokeMessages, model };
 }
 
 function buildStreamingCapturingModel(): {
   streamMessages: BaseMessage[][];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  model: any;
+  model: StubModel;
   } {
   const streamMessages: BaseMessage[][] = [];
-  const model = {
+  const model: StubModel = {
     stream: jest.fn(async function* (
       messages: BaseMessage[]
     ): AsyncGenerator<AIMessageChunk> {
       streamMessages.push(messages);
       yield new AIMessageChunk({ content: 'ok' });
     }),
-  } as Record<string, unknown>;
+  };
   return { streamMessages, model };
 }
 
@@ -330,5 +334,109 @@ describe('tryFallbackProviders applies the same lazy annotation transform', () =
 
     jest.dontMock('@/llm/init');
     jest.resetModules();
+  });
+});
+
+describe('cross-run hydration through ToolNode + attemptInvoke', () => {
+  it('annotates run 2 refs but leaves hydrated run 1 ToolMessages untouched', async () => {
+    /**
+     * Smoke test for the headline scenario: ToolMessages produced in
+     * run 1 are persisted with clean content + `_refKey`/`_refScope`
+     * metadata. When those messages are hydrated into run 2's state
+     * and run 2 produces its own tool output, the annotation transform
+     * must (a) annotate run 2's fresh tool message because its
+     * `_refScope` is live in run 2's registry, and (b) leave run 1's
+     * tool message clean because run 1's scope is not in run 2's
+     * registry. Same `tool0turn0` key collides across runs without any
+     * confusion.
+     */
+    const echo = tool(async (input) => (input as { command: string }).command, {
+      name: 'echo',
+      description: 'echoes its command back',
+      schema: z.object({ command: z.string() }),
+    }) as unknown as StructuredToolInterface;
+
+    /* Run 1 */
+    const run1Node = new ToolNode({
+      tools: [echo],
+      toolOutputReferences: { enabled: true },
+    });
+    const run1Result = (await run1Node.invoke(
+      {
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'r1c1', name: 'echo', args: { command: 'run-1-output' } },
+            ],
+          }),
+        ],
+      },
+      { configurable: { run_id: 'run-1' } }
+    )) as { messages: ToolMessage[] };
+
+    const run1ToolMsg = run1Result.messages[0];
+    expect(run1ToolMsg.content).toBe('run-1-output');
+    expect(run1ToolMsg.additional_kwargs._refKey).toBe('tool0turn0');
+    expect(run1ToolMsg.additional_kwargs._refScope).toBe('run-1');
+
+    /* Run 2 - fresh ToolNode and registry, simulating a new session */
+    const run2Node = new ToolNode({
+      tools: [echo],
+      toolOutputReferences: { enabled: true },
+    });
+    const run2Result = (await run2Node.invoke(
+      {
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [
+              { id: 'r2c1', name: 'echo', args: { command: 'run-2-output' } },
+            ],
+          }),
+        ],
+      },
+      { configurable: { run_id: 'run-2' } }
+    )) as { messages: ToolMessage[] };
+
+    const run2ToolMsg = run2Result.messages[0];
+    expect(run2ToolMsg.content).toBe('run-2-output');
+    expect(run2ToolMsg.additional_kwargs._refKey).toBe('tool0turn0');
+    expect(run2ToolMsg.additional_kwargs._refScope).toBe('run-2');
+
+    /* Hydrate run 1's message + run 2's message into a single state */
+    const hydrated: BaseMessage[] = [
+      new HumanMessage('first request'),
+      run1ToolMsg,
+      new HumanMessage('second request'),
+      run2ToolMsg,
+    ];
+
+    /* attemptInvoke with run 2's registry */
+    const context = {
+      getOrCreateToolOutputRegistry: () =>
+        run2Node._unsafeGetToolOutputRegistry(),
+    } as unknown as Parameters<typeof attemptInvoke>[0]['context'];
+
+    const { invokeMessages, model } = buildCapturingModel();
+    await attemptInvoke(
+      {
+        model: model as t.ChatModel,
+        messages: hydrated,
+        provider: Providers.ANTHROPIC,
+        context,
+      },
+      { configurable: { run_id: 'run-2' } }
+    );
+
+    const sent = invokeMessages[0];
+    /* Run 1's hydrated tool message stays clean — its scope is stale */
+    expect(sent[1].content).toBe('run-1-output');
+    /* Run 2's tool message gets annotated — its scope is live */
+    expect(sent[3].content).toBe('[ref: tool0turn0]\nrun-2-output');
+
+    /* Persisted state is unchanged */
+    expect(hydrated[1].content).toBe('run-1-output');
+    expect(hydrated[3].content).toBe('run-2-output');
   });
 });

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -26,7 +26,10 @@ import { initializeModel } from '@/llm/init';
  * stating it explicitly here surfaces the contract at the call site —
  * a developer reading `attemptInvoke` doesn't have to chase the
  * upstream handler's parameter list to discover that
- * `context?.getOrCreateToolOutputRegistry?.()` is a real thing.
+ * `context?.getOrCreateToolOutputRegistry()` is a real thing. Single
+ * optional chain only — the method itself is required on the
+ * `StandardGraph` branch of the intersection, so the second `?.` is
+ * unnecessary at the call site.
  *
  * `NonNullable<...>` strips `undefined` from the upstream parameter
  * type so the intersection doesn't collapse to `never` on the

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -3,6 +3,7 @@ import { AIMessageChunk } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type * as t from '@/types';
 import { manualToolStreamProviders } from '@/llm/providers';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
@@ -12,19 +13,34 @@ import { GraphEvents, Providers } from '@/common';
 import { initializeModel } from '@/llm/init';
 
 /**
- * Context passed to `attemptInvoke` for the default stream handler.
- * Matches the subset of Graph that `ChatModelStreamHandler.handle` needs.
+ * Context passed to `attemptInvoke`. Matches the subset of Graph that
+ * `ChatModelStreamHandler.handle` needs *plus* the explicit
+ * `getOrCreateToolOutputRegistry()` accessor that `attemptInvoke`
+ * itself calls to pull the run-scoped tool-output registry off the
+ * graph and project each relevant ToolMessage into a transient
+ * annotated copy before the provider call.
  *
- * `attemptInvoke` additionally calls `context?.getOrCreateToolOutputRegistry?.()`
- * (if defined) to pull the run-scoped tool output registry off the graph
- * so it can project each relevant `ToolMessage` into a transient
- * annotated copy right before sending to the provider — annotations
- * never persist back into graph state.
+ * The intersection is intentional: `Parameters<...>[3]` resolves
+ * indirectly through the stream handler's signature (which returns
+ * `StandardGraph` and already exposes the accessor since #117), but
+ * stating it explicitly here surfaces the contract at the call site —
+ * a developer reading `attemptInvoke` doesn't have to chase the
+ * upstream handler's parameter list to discover that
+ * `context?.getOrCreateToolOutputRegistry?.()` is a real thing.
+ *
+ * `NonNullable<...>` strips `undefined` from the upstream parameter
+ * type so the intersection doesn't collapse to `never` on the
+ * undefined branch; callers express optionality via `context?:
+ * InvokeContext` on the function signature instead.
  *
  * Callers without a registry (e.g. summarization) simply pass no
  * `context` and the transform safely no-ops.
  */
-export type InvokeContext = Parameters<ChatModelStreamHandler['handle']>[3];
+export type InvokeContext = NonNullable<
+  Parameters<ChatModelStreamHandler['handle']>[3]
+> & {
+  getOrCreateToolOutputRegistry?(): ToolOutputReferenceRegistry | undefined;
+};
 
 /**
  * Per-chunk callback for custom stream processing.

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -5,6 +5,7 @@ import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { manualToolStreamProviders } from '@/llm/providers';
+import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { modifyDeltaProperties } from '@/messages';
 import { ChatModelStreamHandler } from '@/stream';
 import { GraphEvents, Providers } from '@/common';
@@ -13,6 +14,15 @@ import { initializeModel } from '@/llm/init';
 /**
  * Context passed to `attemptInvoke` for the default stream handler.
  * Matches the subset of Graph that `ChatModelStreamHandler.handle` needs.
+ *
+ * `attemptInvoke` additionally calls `context?.getOrCreateToolOutputRegistry?.()`
+ * (if defined) to pull the run-scoped tool output registry off the graph
+ * so it can project each relevant `ToolMessage` into a transient
+ * annotated copy right before sending to the provider — annotations
+ * never persist back into graph state.
+ *
+ * Callers without a registry (e.g. summarization) simply pass no
+ * `context` and the transform safely no-ops.
  */
 export type InvokeContext = Parameters<ChatModelStreamHandler['handle']>[3];
 
@@ -47,8 +57,19 @@ export async function attemptInvoke(
   },
   config?: RunnableConfig
 ): Promise<Partial<t.BaseGraphState>> {
+  /**
+   * Pull the run-scoped tool output registry off the graph (when one
+   * exists) and project ToolMessages carrying ref metadata into a
+   * transient annotated copy. The original `messages` array stays
+   * untouched so the graph state never sees `[ref: …]` / `_ref`
+   * payload.
+   */
+  const registry = context?.getOrCreateToolOutputRegistry();
+  const runId = config?.configurable?.run_id as string | undefined;
+  const messagesForProvider = annotateMessagesForLLM(messages, registry, runId);
+
   if (model.stream) {
-    const stream = await model.stream(messages, config);
+    const stream = await model.stream(messagesForProvider, config);
     let finalChunk: AIMessageChunk | undefined;
 
     if (onChunk) {
@@ -83,7 +104,7 @@ export async function attemptInvoke(
     return { messages: [finalChunk as AIMessageChunk] };
   }
 
-  const finalMessage = await model.invoke(messages, config);
+  const finalMessage = await model.invoke(messagesForProvider, config);
   if ((finalMessage.tool_calls?.length ?? 0) > 0) {
     finalMessage.tool_calls = finalMessage.tool_calls?.filter(
       (tool_call: ToolCall) => !!tool_call.name

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -66,7 +66,9 @@ Referencing previous tool outputs:
 - Every successful tool result is tagged with a reference key of the form \`tool<idx>turn<turn>\` (e.g., \`tool0turn0\`). The key appears either as a \`[ref: tool0turn0]\` prefix line or, when the output is a JSON object, as a \`_ref\` field on the object.
 - To pipe a previous tool output into this tool, embed the placeholder \`{{tool<idx>turn<turn>}}\` literally anywhere in the \`command\` string (or any string arg). It will be substituted with the stored output verbatim before the command runs.
 - The substituted value is the original output string (no \`[ref: …]\` prefix, no \`_ref\` key), so it is safe to pipe directly into \`jq\`, \`grep\`, \`awk\`, etc.
-- Example: \`echo '{{tool0turn0}}' | jq '.foo'\` takes the full output of the first tool from the first turn and pipes it into jq.
+- Example (simple ASCII output): \`echo '{{tool0turn0}}' | jq '.foo'\` takes the full output of the first tool from the first turn and pipes it into jq.
+- For payloads that may contain quotes, parentheses, backticks, or arbitrary bytes (random/binary data, JSON with embedded quotes, multi-line strings), prefer a quoted-delimiter heredoc over \`echo '…'\`. The heredoc body is not interpreted by the shell, so substituted payloads pass through unchanged.
+- Heredoc example: \`wc -c << 'EOF'\\n{{tool0turn0}}\\nEOF\` (the quotes around \`'EOF'\` disable interpolation inside the body).
 - Unknown reference keys are left in place and surfaced as \`[unresolved refs: …]\` after the output.
 `.trim();
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -36,7 +36,6 @@ import { executeHooks } from '@/hooks';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import {
   buildReferenceKey,
-  annotateToolOutputWithReference,
   ToolOutputReferenceRegistry,
 } from '@/tools/toolOutputReferences';
 
@@ -429,21 +428,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const isError = toolMsg.status === 'error';
         if (isError) {
           /**
-           * Error ToolMessages bypass registration/annotation but must
-           * still carry the unresolved-refs hint so the LLM can
-           * self-correct when its reference key caused the failure.
+           * Error ToolMessages bypass registration but still stamp the
+           * unresolved-refs hint into `additional_kwargs` so the lazy
+           * annotation transform surfaces it to the LLM, letting the
+           * model self-correct when its reference key caused the
+           * failure. Persisted `content` stays clean.
            */
-          if (
-            unresolvedRefs.length > 0 &&
-            typeof toolMsg.content === 'string'
-          ) {
-            toolMsg.content = this.applyOutputReference(
-              runId,
-              toolMsg.content,
-              toolMsg.content,
-              undefined,
-              unresolvedRefs
-            );
+          if (unresolvedRefs.length > 0) {
+            toolMsg.additional_kwargs = {
+              ...toolMsg.additional_kwargs,
+              _unresolvedRefs: unresolvedRefs,
+            };
           }
           return toolMsg;
         }
@@ -454,35 +449,35 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               rawContent,
               this.maxToolResultChars
             );
-            toolMsg.content = this.applyOutputReference(
+            toolMsg.content = llmContent;
+            const refMeta = this.recordOutputReference(
               runId,
-              llmContent,
               rawContent,
               refKey,
               unresolvedRefs
             );
+            if (refMeta != null) {
+              toolMsg.additional_kwargs = {
+                ...toolMsg.additional_kwargs,
+                ...refMeta,
+              };
+            }
           } else {
             /**
              * Non-string content (multi-part content blocks — text +
              * image). Known limitation: we cannot register under a
              * reference key because there's no canonical serialized
              * form. Warn once per tool per run when the caller
-             * intended to register.
-             *
-             * Still surface unresolved-ref warnings so the LLM gets
-             * the self-correction signal that the string and error
-             * paths already emit. Prepended as a leading text block
-             * to keep the original content ordering intact.
+             * intended to register. The unresolved-refs hint is still
+             * stamped as metadata; the lazy transform prepends a text
+             * block at request time so the LLM gets the self-correction
+             * signal.
              */
-            if (unresolvedRefs.length > 0 && Array.isArray(toolMsg.content)) {
-              const warningBlock = {
-                type: 'text',
-                text: `[unresolved refs: ${unresolvedRefs.join(', ')}]`,
+            if (unresolvedRefs.length > 0) {
+              toolMsg.additional_kwargs = {
+                ...toolMsg.additional_kwargs,
+                _unresolvedRefs: unresolvedRefs,
               };
-              toolMsg.content = [
-                warningBlock,
-                ...toolMsg.content,
-              ] as typeof toolMsg.content;
             }
             if (
               refKey != null &&
@@ -504,9 +499,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         rawContent,
         this.maxToolResultChars
       );
-      const content = this.applyOutputReference(
+      const refMeta = this.recordOutputReference(
         runId,
-        truncated,
         rawContent,
         refKey,
         unresolvedRefs
@@ -514,8 +508,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return new ToolMessage({
         status: 'success',
         name: tool.name,
-        content,
+        content: truncated,
         tool_call_id: call.id!,
+        ...(refMeta != null && {
+          additional_kwargs: refMeta as Record<string, unknown>,
+        }),
       });
     } catch (_e: unknown) {
       const e = _e as Error;
@@ -561,64 +558,61 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           });
         }
       }
-      let errorContent = `Error: ${e.message}\n Please fix your mistakes.`;
-      if (unresolvedRefs.length > 0) {
-        errorContent = this.applyOutputReference(
-          runId,
-          errorContent,
-          errorContent,
-          undefined,
-          unresolvedRefs
-        );
-      }
+      const errorContent = `Error: ${e.message}\n Please fix your mistakes.`;
+      const refMeta =
+        unresolvedRefs.length > 0
+          ? this.recordOutputReference(
+            runId,
+            errorContent,
+            undefined,
+            unresolvedRefs
+          )
+          : undefined;
       return new ToolMessage({
         status: 'error',
         content: errorContent,
         name: call.name,
         tool_call_id: call.id ?? '',
+        ...(refMeta != null && {
+          additional_kwargs: refMeta as Record<string, unknown>,
+        }),
       });
     }
   }
 
   /**
-   * Finalizes the LLM-visible content for a tool call and (when a
-   * `refKey` is provided) registers the full, raw output under that
-   * key.
+   * Registers the full, raw output under `refKey` (when provided) and
+   * builds the per-message ref metadata stamped onto the resulting
+   * `ToolMessage.additional_kwargs`. The metadata is read at LLM-
+   * request time by `annotateMessagesForLLM` to produce a transient
+   * annotated copy of the message — the persisted `content` itself
+   * stays clean.
    *
-   * @param llmContent  The content string the LLM will see. This is
-   *   the already-truncated, post-hook view; the annotation is
-   *   applied on top of it.
    * @param registryContent  The full, untruncated output to store in
    *   the registry so `{{tool<i>turn<n>}}` substitutions deliver the
    *   complete payload. Ignored when `refKey` is undefined.
    * @param refKey  Precomputed `tool<i>turn<n>` key, or undefined when
    *   the output is not to be registered (errors, disabled feature,
    *   unavailable batch/turn).
-   * @param unresolved  Placeholder keys that did not resolve; appended
-   *   as `[unresolved refs: …]` so the LLM can self-correct.
-   *
-   * `refKey` is passed in (rather than built from `this.currentTurn`)
-   * so parallel `invoke()` calls on the same ToolNode cannot race on
-   * the shared turn field.
+   * @param unresolved  Placeholder keys that did not resolve; surfaced
+   *   to the LLM lazily so it can self-correct.
+   * @returns A `ToolMessageRefMetadata` object when there is anything
+   *   to stamp, otherwise `undefined`.
    */
-  private applyOutputReference(
+  private recordOutputReference(
     runId: string | undefined,
-    llmContent: string,
     registryContent: string,
     refKey: string | undefined,
     unresolved: string[]
-  ): string {
+  ): t.ToolMessageRefMetadata | undefined {
     if (this.toolOutputRegistry != null && refKey != null) {
       this.toolOutputRegistry.set(runId, refKey, registryContent);
     }
-    /**
-     * `annotateToolOutputWithReference` handles both the ref-key and
-     * unresolved-refs cases together so JSON-object outputs stay
-     * parseable: unresolved refs land in an `_unresolved_refs` field
-     * instead of as a trailing text line that would break
-     * `JSON.parse` for downstream consumers.
-     */
-    return annotateToolOutputWithReference(llmContent, refKey, unresolved);
+    if (refKey == null && unresolved.length === 0) return undefined;
+    const meta: t.ToolMessageRefMetadata = {};
+    if (refKey != null) meta._refKey = refKey;
+    if (unresolved.length > 0) meta._unresolvedRefs = unresolved;
+    return meta;
   }
 
   /**
@@ -1054,25 +1048,30 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         if (result.status === 'error') {
           contentString = `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`;
           /**
-           * Error results bypass registration/annotation but must still
-           * carry the unresolved-refs hint so the LLM can self-correct
-           * when its reference key caused the failure.
+           * Error results bypass registration but stamp the
+           * unresolved-refs hint into `additional_kwargs` so the lazy
+           * annotation transform surfaces it to the LLM at request
+           * time, letting the model self-correct when its reference
+           * key caused the failure. Persisted `content` stays clean.
            */
           const unresolved = unresolvedByCallId.get(result.toolCallId) ?? [];
-          if (unresolved.length > 0) {
-            contentString = this.applyOutputReference(
-              registryRunId,
-              contentString,
-              contentString,
-              undefined,
-              unresolved
-            );
-          }
+          const errorRefMeta =
+            unresolved.length > 0
+              ? this.recordOutputReference(
+                registryRunId,
+                contentString,
+                undefined,
+                unresolved
+              )
+              : undefined;
           toolMessage = new ToolMessage({
             status: 'error',
             content: contentString,
             name: toolName,
             tool_call_id: result.toolCallId,
+            ...(errorRefMeta != null && {
+              additional_kwargs: errorRefMeta as Record<string, unknown>,
+            }),
           });
 
           if (hasFailureHook) {
@@ -1145,9 +1144,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             turn != null
               ? buildReferenceKey(batchIndex, turn)
               : undefined;
-          contentString = this.applyOutputReference(
+          const successRefMeta = this.recordOutputReference(
             registryRunId,
-            contentString,
             registryRaw,
             refKey,
             unresolved
@@ -1159,6 +1157,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             content: contentString,
             artifact: result.artifact,
             tool_call_id: result.toolCallId,
+            ...(successRefMeta != null && {
+              additional_kwargs: successRefMeta as Record<string, unknown>,
+            }),
           });
         }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -610,7 +610,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
     if (refKey == null && unresolved.length === 0) return undefined;
     const meta: t.ToolMessageRefMetadata = {};
-    if (refKey != null) meta._refKey = refKey;
+    if (refKey != null) {
+      meta._refKey = refKey;
+      /**
+       * Stamp the registry scope alongside the key so the lazy
+       * annotation transform can look up the right bucket. Anonymous
+       * invocations get a synthetic per-batch scope (`\0anon-<n>`)
+       * that `attemptInvoke` cannot derive from
+       * `config.configurable.run_id` — without this, anonymous-run
+       * refs would silently fail registry lookup and the LLM would
+       * never see `[ref: …]` markers for outputs that were registered.
+       */
+      if (runId != null) meta._refScope = runId;
+    }
     if (unresolved.length > 0) meta._unresolvedRefs = unresolved;
     return meta;
   }

--- a/src/tools/__tests__/BashExecutor.test.ts
+++ b/src/tools/__tests__/BashExecutor.test.ts
@@ -27,6 +27,19 @@ describe('buildBashExecutionToolDescription', () => {
     expect(composed).toContain('{{tool<idx>turn<turn>}}');
   });
 
+  it('nudges the model toward heredoc when payloads may contain shell metacharacters', () => {
+    /**
+     * Real-world failure observed against ClickHouse + bash piping:
+     * the model emitted `echo '{{ref}}' | wc -c` and the substituted
+     * binary payload contained literal single quotes, breaking the
+     * shell. The model self-corrected to a heredoc on retry. Surface
+     * the heredoc pattern upfront so the round-trip isn't burned to
+     * rediscover it.
+     */
+    expect(BashToolOutputReferencesGuide).toContain('heredoc');
+    expect(BashToolOutputReferencesGuide).toContain('<< \'EOF\'');
+  });
+
   it('separates base and guide with a blank line', () => {
     const composed = buildBashExecutionToolDescription({
       enableToolOutputReferences: true,

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -18,6 +18,10 @@ import { ToolOutputReferenceRegistry } from '../toolOutputReferences';
 function getRefKey(msg: ToolMessage): string | undefined {
   return (msg.additional_kwargs as { _refKey?: string } | undefined)?._refKey;
 }
+function getRefScope(msg: ToolMessage): string | undefined {
+  return (msg.additional_kwargs as { _refScope?: string } | undefined)
+    ?._refScope;
+}
 function getUnresolvedRefs(msg: ToolMessage): string[] {
   return (
     (msg.additional_kwargs as { _unresolvedRefs?: string[] } | undefined)
@@ -127,6 +131,13 @@ describe('ToolNode tool output references', () => {
 
       expect(msg.content).toBe('hello world');
       expect(getRefKey(msg)).toBe('tool0turn0');
+      /**
+       * `_refScope` is what lets `annotateMessagesForLLM` recover the
+       * registry bucket at request time without re-deriving it from
+       * `config.configurable.run_id` (which fails for anonymous
+       * batches). For named runs it equals the run_id.
+       */
+      expect(getRefScope(msg)).toBe('test-run');
       expect(getUnresolvedRefs(msg)).toEqual([]);
     });
 
@@ -611,6 +622,19 @@ describe('ToolNode tool output references', () => {
       expect(resA.messages[0].content).toBe('out-A');
       expect(getRefKey(resB.messages[0])).toBe('tool0turn0');
       expect(resB.messages[0].content).toBe('out-B');
+
+      /**
+       * Each anonymous invocation stamps a distinct synthetic
+       * `_refScope` so the lazy annotation transform can later look
+       * up the right registry bucket — `config.configurable.run_id`
+       * is undefined for both calls and would collapse them to the
+       * same `\0anon` bucket without this stamping.
+       */
+      const scopeA = getRefScope(resA.messages[0]);
+      const scopeB = getRefScope(resB.messages[0]);
+      expect(scopeA).toMatch(/^\0anon-\d+$/);
+      expect(scopeB).toMatch(/^\0anon-\d+$/);
+      expect(scopeA).not.toBe(scopeB);
     });
 
     it('clears state on every batch when run_id is absent (anonymous caller)', async () => {

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -7,10 +7,23 @@ import type * as t from '@/types';
 import * as events from '@/utils/events';
 import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
-import {
-  ToolOutputReferenceRegistry,
-  TOOL_OUTPUT_REF_KEY,
-} from '../toolOutputReferences';
+import { ToolOutputReferenceRegistry } from '../toolOutputReferences';
+
+/**
+ * Reads the lazy ref-metadata stamped onto a `ToolMessage` by ToolNode.
+ * The metadata replaces the durable `[ref: …]` content mutation that the
+ * earlier eager-annotation design used; the LLM-facing annotation is
+ * applied at request time by `annotateMessagesForLLM` instead.
+ */
+function getRefKey(msg: ToolMessage): string | undefined {
+  return (msg.additional_kwargs as { _refKey?: string } | undefined)?._refKey;
+}
+function getUnresolvedRefs(msg: ToolMessage): string[] {
+  return (
+    (msg.additional_kwargs as { _unresolvedRefs?: string[] } | undefined)
+      ?._unresolvedRefs ?? []
+  );
+}
 
 /**
  * Captures the `command` arg each time the tool is invoked and returns
@@ -98,7 +111,7 @@ describe('ToolNode tool output references', () => {
   });
 
   describe('enabled', () => {
-    it('annotates string outputs with a [ref: …] prefix line', async () => {
+    it('keeps string outputs clean and stamps the ref key as metadata', async () => {
       const t1 = createEchoTool({
         capturedArgs: [],
         outputs: ['hello world'],
@@ -112,10 +125,12 @@ describe('ToolNode tool output references', () => {
         { id: 'c1', name: 'echo', command: 'run' },
       ]);
 
-      expect(msg.content).toBe('[ref: tool0turn0]\nhello world');
+      expect(msg.content).toBe('hello world');
+      expect(getRefKey(msg)).toBe('tool0turn0');
+      expect(getUnresolvedRefs(msg)).toEqual([]);
     });
 
-    it('injects _ref into JSON-object string outputs', async () => {
+    it('keeps JSON-object string outputs unmodified and stamps ref metadata', async () => {
       const t1 = createEchoTool({
         capturedArgs: [],
         outputs: ['{"a":1,"b":"x"}'],
@@ -130,11 +145,13 @@ describe('ToolNode tool output references', () => {
       ]);
 
       const parsed = JSON.parse(msg.content as string);
-      expect(parsed[TOOL_OUTPUT_REF_KEY]).toBe('tool0turn0');
       expect(parsed.a).toBe(1);
+      expect(parsed.b).toBe('x');
+      expect(parsed._ref).toBeUndefined();
+      expect(getRefKey(msg)).toBe('tool0turn0');
     });
 
-    it('uses the [ref: …] prefix for JSON array outputs', async () => {
+    it('keeps JSON array outputs unmodified and stamps ref metadata', async () => {
       const t1 = createEchoTool({ capturedArgs: [], outputs: ['[1,2,3]'] });
       const node = new ToolNode({
         tools: [t1],
@@ -145,7 +162,8 @@ describe('ToolNode tool output references', () => {
         { id: 'c1', name: 'echo', command: 'run' },
       ]);
 
-      expect(msg.content).toBe('[ref: tool0turn0]\n[1,2,3]');
+      expect(msg.content).toBe('[1,2,3]');
+      expect(getRefKey(msg)).toBe('tool0turn0');
     });
 
     it('registers the un-annotated output for piping into later calls', async () => {
@@ -192,9 +210,9 @@ describe('ToolNode tool output references', () => {
         { id: 'b3c1', name: 'echo', command: '{{tool0turn1}}' },
       ]);
 
-      expect(m0.content).toContain('[ref: tool0turn0]');
-      expect(m1.content).toContain('[ref: tool0turn1]');
-      expect(m2.content).toContain('[ref: tool0turn2]');
+      expect(getRefKey(m0)).toBe('tool0turn0');
+      expect(getRefKey(m1)).toBe('tool0turn1');
+      expect(getRefKey(m2)).toBe('tool0turn2');
       expect(capturedArgs[2]).toBe('two');
     });
 
@@ -221,8 +239,8 @@ describe('ToolNode tool output references', () => {
         { id: 'c2', name: 'beta', command: 'b' },
       ]);
 
-      expect(messages[0].content).toContain('[ref: tool0turn0]');
-      expect(messages[1].content).toContain('[ref: tool1turn0]');
+      expect(getRefKey(messages[0])).toBe('tool0turn0');
+      expect(getRefKey(messages[1])).toBe('tool1turn0');
     });
 
     it('reports unresolved placeholders after the output', async () => {
@@ -242,7 +260,8 @@ describe('ToolNode tool output references', () => {
       ]);
 
       expect(capturedArgs[0]).toBe('see {{tool9turn9}}');
-      expect(msg.content).toContain('[unresolved refs: tool9turn9]');
+      expect(msg.content).toBe('done');
+      expect(getUnresolvedRefs(msg)).toEqual(['tool9turn9']);
     });
 
     it('stores the raw untruncated output in the registry, independent of the LLM-visible truncation', async () => {
@@ -343,10 +362,10 @@ describe('ToolNode tool output references', () => {
         messages: ToolMessage[];
       }>;
 
-      expect(resA.messages[0].content).toContain('[ref: tool0turn0]');
-      expect(resA.messages[0].content).toContain('output-A');
-      expect(resB.messages[0].content).toContain('[ref: tool0turn1]');
-      expect(resB.messages[0].content).toContain('output-B');
+      expect(getRefKey(resA.messages[0])).toBe('tool0turn0');
+      expect(resA.messages[0].content).toBe('output-A');
+      expect(getRefKey(resB.messages[0])).toBe('tool0turn1');
+      expect(resB.messages[0].content).toBe('output-B');
 
       const registry = node._unsafeGetToolOutputRegistry()!;
       expect(registry.get('concurrent-run', 'tool0turn0')).toBe('output-A');
@@ -417,7 +436,7 @@ describe('ToolNode tool output references', () => {
         { id: 'c1', name: 'boom', command: 'x' },
       ]);
 
-      expect((msg.content as string).startsWith('[ref:')).toBe(false);
+      expect(getRefKey(msg)).toBeUndefined();
       expect(
         node._unsafeGetToolOutputRegistry()!.get('test-run', 'tool0turn0')
       ).toBeUndefined();
@@ -445,7 +464,8 @@ describe('ToolNode tool output references', () => {
       ]);
 
       expect(msg.content).toContain('Error: nope');
-      expect(msg.content).toContain('[unresolved refs: tool9turn9]');
+      expect(msg.content as string).not.toContain('[unresolved refs:');
+      expect(getUnresolvedRefs(msg)).toEqual(['tool9turn9']);
     });
 
     it('surfaces unresolved refs on tool-returned error ToolMessages', async () => {
@@ -473,8 +493,8 @@ describe('ToolNode tool output references', () => {
         { id: 'c1', name: 'errReturn', command: 'see {{tool9turn9}}' },
       ]);
 
-      expect(msg.content).toContain('handled failure');
-      expect(msg.content).toContain('[unresolved refs: tool9turn9]');
+      expect(msg.content).toBe('handled failure');
+      expect(getUnresolvedRefs(msg)).toEqual(['tool9turn9']);
     });
 
     it('isolates state between overlapping runs on the same ToolNode', async () => {
@@ -584,13 +604,13 @@ describe('ToolNode tool output references', () => {
         messages: ToolMessage[];
       }>;
 
-      // Each invocation produces its own annotated output — neither's
+      // Each invocation stamps its own ref metadata — neither's
       // registered tool0turn0 was clobbered by the other's sync-prefix
       // reset.
-      expect(resA.messages[0].content).toContain('[ref: tool0turn0]');
-      expect(resA.messages[0].content).toContain('out-A');
-      expect(resB.messages[0].content).toContain('[ref: tool0turn0]');
-      expect(resB.messages[0].content).toContain('out-B');
+      expect(getRefKey(resA.messages[0])).toBe('tool0turn0');
+      expect(resA.messages[0].content).toBe('out-A');
+      expect(getRefKey(resB.messages[0])).toBe('tool0turn0');
+      expect(resB.messages[0].content).toBe('out-B');
     });
 
     it('clears state on every batch when run_id is absent (anonymous caller)', async () => {
@@ -616,9 +636,7 @@ describe('ToolNode tool output references', () => {
       })) as { messages: ToolMessage[] };
 
       expect(capturedArgs[1]).toBe('echo {{tool0turn0}}');
-      expect(result.messages[0].content).toContain(
-        '[unresolved refs: tool0turn0]'
-      );
+      expect(getUnresolvedRefs(result.messages[0])).toEqual(['tool0turn0']);
     });
 
     it('lets two ToolNodes sharing a registry resolve each other\'s refs', async () => {
@@ -728,7 +746,7 @@ describe('ToolNode tool output references', () => {
       expect(JSON.parse(stepCompletedArgs[1]).command).toBe('echo STORED');
     });
 
-    it('prepends unresolved-refs warning to non-string ToolMessage content', async () => {
+    it('records unresolved refs as metadata on non-string ToolMessage content (content untouched)', async () => {
       const complexTool = tool(
         async () =>
           new ToolMessage({
@@ -760,12 +778,13 @@ describe('ToolNode tool output references', () => {
 
       expect(Array.isArray(msg.content)).toBe(true);
       const blocks = msg.content as Array<{ type: string; text?: string }>;
+      // Multi-part content is untouched at storage time — the lazy
+      // transform handles the unresolved-refs warning at request time.
+      expect(blocks).toHaveLength(2);
       expect(blocks[0].type).toBe('text');
-      expect(blocks[0].text).toContain('[unresolved refs: tool9turn9]');
-      // Original blocks follow the warning.
-      expect(blocks[1].type).toBe('text');
-      expect(blocks[1].text).toBe('data');
-      expect(blocks[2].type).toBe('image_url');
+      expect(blocks[0].text).toBe('data');
+      expect(blocks[1].type).toBe('image_url');
+      expect(getUnresolvedRefs(msg)).toEqual(['tool9turn9']);
     });
 
     it('resets the registry and turn counter when the runId changes', async () => {
@@ -800,10 +819,9 @@ describe('ToolNode tool output references', () => {
       )) as { messages: ToolMessage[] };
 
       expect(capturedArgs[1]).toBe('echo {{tool0turn0}}');
-      expect(resultB.messages[0].content).toContain('[ref: tool0turn0]');
-      expect(resultB.messages[0].content).toContain(
-        '[unresolved refs: tool0turn0]'
-      );
+      expect(resultB.messages[0].content).toBe('from-run-B');
+      expect(getRefKey(resultB.messages[0])).toBe('tool0turn0');
+      expect(getUnresolvedRefs(resultB.messages[0])).toEqual(['tool0turn0']);
     });
   });
 
@@ -836,7 +854,7 @@ describe('ToolNode tool output references', () => {
       }) as unknown as StructuredToolInterface;
     }
 
-    it('annotates the output the host returns', async () => {
+    it('keeps host-returned output clean and stamps the ref key as metadata', async () => {
       const node = new ToolNode({
         tools: [createSchemaStub('echo')],
         eventDrivenMode: true,
@@ -858,7 +876,8 @@ describe('ToolNode tool output references', () => {
         { configurable: { run_id: 'run-host' } }
       )) as { messages: ToolMessage[] };
 
-      expect(result.messages[0].content).toBe('[ref: tool0turn0]\nhost-output');
+      expect(result.messages[0].content).toBe('host-output');
+      expect(getRefKey(result.messages[0])).toBe('tool0turn0');
       expect(
         node._unsafeGetToolOutputRegistry()!.get('run-host', 'tool0turn0')
       ).toBe('host-output');
@@ -963,9 +982,10 @@ describe('ToolNode tool output references', () => {
       })) as { messages: ToolMessage[] };
 
       expect(result.messages[0].content).toContain('Error: host failure');
-      expect(result.messages[0].content).toContain(
-        '[unresolved refs: tool9turn9]'
+      expect(result.messages[0].content as string).not.toContain(
+        '[unresolved refs:'
       );
+      expect(getUnresolvedRefs(result.messages[0])).toEqual(['tool9turn9']);
     });
 
     it('reports unresolved refs even when the host succeeds', async () => {
@@ -995,9 +1015,8 @@ describe('ToolNode tool output references', () => {
         ],
       })) as { messages: ToolMessage[] };
 
-      expect(result.messages[0].content).toContain(
-        '[unresolved refs: tool9turn9]'
-      );
+      expect(result.messages[0].content).toBe('done');
+      expect(getUnresolvedRefs(result.messages[0])).toEqual(['tool9turn9']);
     });
 
     it('registers the post-hook output when PostToolUse replaces it', async () => {
@@ -1035,9 +1054,8 @@ describe('ToolNode tool output references', () => {
         { configurable: { run_id: 'run-posthook' } }
       )) as { messages: ToolMessage[] };
 
-      expect(result.messages[0].content).toBe(
-        '[ref: tool0turn0]\nhooked-output'
-      );
+      expect(result.messages[0].content).toBe('hooked-output');
+      expect(getRefKey(result.messages[0])).toBe('tool0turn0');
       expect(
         node._unsafeGetToolOutputRegistry()!.get('run-posthook', 'tool0turn0')
       ).toBe('hooked-output');
@@ -1252,9 +1270,10 @@ describe('ToolNode tool output references', () => {
       // call attempts `{{tool0turn0}}` — which points at the direct
       // call running *in the same batch*. Correct behavior: the
       // placeholder stays unresolved (cross-batch only), and the
-      // event args received by the host must carry the literal
-      // template string plus the LLM-visible `[unresolved refs:…]`
-      // trailer.
+      // event args received by the host carry the literal template
+      // string. The unresolved-refs hint is stamped into the resulting
+      // ToolMessage's `additional_kwargs._unresolvedRefs` so the lazy
+      // annotation transform surfaces it to the LLM at request time.
       await node.invoke(
         {
           messages: [

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -140,7 +140,14 @@ describe('annotateMessagesForLLM', () => {
     expect(tm.additional_kwargs).toEqual(originalKwargs);
   });
 
-  it('strips ref metadata from the projected ToolMessage so annotation is not double-applied', () => {
+  it('passes original additional_kwargs through by reference on the projection', () => {
+    /**
+     * The projected ToolMessage shares its `additional_kwargs` with the
+     * original — LangChain's provider serializers don't transmit
+     * `additional_kwargs` to provider APIs, and the projected array
+     * never round-trips back into graph state, so a defensive clone
+     * here would be wasted work.
+     */
     const registry = new ToolOutputReferenceRegistry();
     registry.set('r1', 'tool0turn0', 'raw');
     const tm = makeToolMessage({
@@ -153,8 +160,7 @@ describe('annotateMessagesForLLM', () => {
     });
     const out = annotateMessagesForLLM([tm], registry, 'r1');
     const projected = out[0] as ToolMessage;
-    expect(projected.additional_kwargs._refKey).toBeUndefined();
-    expect(projected.additional_kwargs._unresolvedRefs).toBeUndefined();
+    expect(projected.additional_kwargs).toBe(tm.additional_kwargs);
     expect(projected.additional_kwargs.someOtherField).toBe('preserved');
   });
 

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -207,6 +207,39 @@ describe('annotateMessagesForLLM', () => {
     );
   });
 
+  it('uses _refScope for the registry lookup when present, ignoring runId', () => {
+    /**
+     * Anonymous ToolNode batches register under a synthetic scope
+     * (`\0anon-<n>`) that `config.configurable.run_id` cannot recover.
+     * The transform must follow the message-stamped `_refScope`
+     * instead of the config-derived runId.
+     */
+    const registry = new ToolOutputReferenceRegistry();
+    const anonScope = '\0anon-3';
+    registry.set(anonScope, 'tool0turn0', 'raw');
+
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _refKey: 'tool0turn0',
+        _refScope: anonScope,
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, undefined);
+    expect(out[0].content).toBe('[ref: tool0turn0]\noutput');
+  });
+
+  it('falls back to runId when _refScope is absent (legacy / pre-scope messages)', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('[ref: tool0turn0]\noutput');
+  });
+
   it('treats stale _refKey but live unresolved as unresolved-only', () => {
     const registry = new ToolOutputReferenceRegistry();
     const tm = makeToolMessage({

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -287,6 +287,60 @@ describe('annotateMessagesForLLM', () => {
     expect(out[0].content).toBe('[ref: tool0turn0]\noutput');
   });
 
+  it('coerces a non-array _unresolvedRefs to empty without throwing', () => {
+    /**
+     * Defensive against malformed hydrated messages:
+     * `additional_kwargs._unresolvedRefs` is untyped at the LangChain
+     * layer, so a persisted message could carry a string/object/null
+     * by mistake. The transform must not crash the run on
+     * `.length` / `.join` — coerce to an empty list and proceed.
+     */
+    const registry = new ToolOutputReferenceRegistry();
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _unresolvedRefs: 'tool9turn9' as unknown as string[],
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('output');
+    expect(out[0]).toBe(tm);
+  });
+
+  it('filters non-string entries out of _unresolvedRefs', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _unresolvedRefs: [
+          'tool9turn9',
+          42,
+          null,
+          { not: 'a string' },
+          'tool8turn8',
+        ] as unknown as string[],
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe(
+      'output\n[unresolved refs: tool9turn9, tool8turn8]'
+    );
+  });
+
+  it('ignores a non-string _refKey rather than poisoning the registry lookup', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _refKey: { malformed: true } as unknown as string,
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('output');
+    expect(out[0]).toBe(tm);
+  });
+
   it('treats stale _refKey but live unresolved as unresolved-only', () => {
     const registry = new ToolOutputReferenceRegistry();
     const tm = makeToolMessage({

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -36,6 +36,32 @@ describe('annotateMessagesForLLM', () => {
     expect(out).toBe(messages);
   });
 
+  it('does not iterate any message when the feature is disabled (registry undefined)', () => {
+    /**
+     * Hard guarantee: when the host hasn't enabled
+     * `RunConfig.toolOutputReferences`, calling
+     * `annotateMessagesForLLM` must short-circuit at O(1) without
+     * touching a single ToolMessage. We assert by spying on
+     * `_getType` — the first per-message call inside the loop — and
+     * confirming it was never invoked.
+     */
+    const messages = [
+      makeToolMessage({ content: 'a' }),
+      makeToolMessage({ content: 'b' }),
+      makeToolMessage({
+        content: 'c',
+        additional_kwargs: { _refKey: 'tool0turn0' },
+      }),
+    ];
+    const spies = messages.map((m) => jest.spyOn(m, '_getType'));
+    const out = annotateMessagesForLLM(messages, undefined, undefined);
+    expect(out).toBe(messages);
+    for (const spy of spies) {
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    }
+  });
+
   it('returns the input array reference when no ToolMessage carries metadata', () => {
     const registry = new ToolOutputReferenceRegistry();
     registry.set('r1', 'tool0turn0', 'stored');
@@ -62,15 +88,26 @@ describe('annotateMessagesForLLM', () => {
     expect(out[0]).not.toBe(tm);
   });
 
-  it('skips annotation when _refKey is stale (not in the registry)', () => {
+  it('leaves content untouched but strips framework metadata when _refKey is stale', () => {
+    /**
+     * Stale `_refKey` (not in registry) doesn't trigger annotation,
+     * but the message still gets projected so framework keys are
+     * removed from `additional_kwargs` before the bytes leave for the
+     * provider. This protects against custom or future serializers
+     * that transmit `additional_kwargs`.
+     */
     const registry = new ToolOutputReferenceRegistry();
     const tm = makeToolMessage({
       content: 'output',
-      additional_kwargs: { _refKey: 'tool0turn0' },
+      additional_kwargs: { _refKey: 'tool0turn0', userField: 'preserved' },
     });
     const out = annotateMessagesForLLM([tm], registry, 'r1');
     expect(out[0].content).toBe('output');
-    expect(out[0]).toBe(tm);
+    expect(out[0]).not.toBe(tm);
+    const projectedKwargs = (out[0] as ToolMessage).additional_kwargs;
+    expect(projectedKwargs._refKey).toBeUndefined();
+    expect(projectedKwargs.userField).toBe('preserved');
+    expect(tm.additional_kwargs._refKey).toBe('tool0turn0');
   });
 
   it('always applies _unresolvedRefs even when there is no registry entry', () => {
@@ -232,7 +269,7 @@ describe('annotateMessagesForLLM', () => {
     expect(out[2]).not.toBe(tm);
   });
 
-  it('returns same array when only stale _refKey is present and no unresolvedRefs', () => {
+  it('projects (to strip metadata) but does not annotate when only stale _refKey is present', () => {
     const registry = new ToolOutputReferenceRegistry();
     registry.set('r1', 'tool1turn0', 'somethingelse');
     const tm = makeToolMessage({
@@ -240,6 +277,23 @@ describe('annotateMessagesForLLM', () => {
       additional_kwargs: { _refKey: 'tool0turn0' },
     });
     const messages = [tm];
+    const out = annotateMessagesForLLM(messages, registry, 'r1');
+    expect(out).not.toBe(messages);
+    expect(out[0].content).toBe('output');
+    expect((out[0] as ToolMessage).additional_kwargs._refKey).toBeUndefined();
+  });
+
+  it('returns the input array reference-equal when no ToolMessage carries any framework metadata', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'stored');
+    const messages = [
+      new HumanMessage('hi'),
+      makeToolMessage({
+        content: 'output',
+        additional_kwargs: { unrelated: 'value' },
+      }),
+      new AIMessage('answer'),
+    ];
     const out = annotateMessagesForLLM(messages, registry, 'r1');
     expect(out).toBe(messages);
   });
@@ -299,7 +353,8 @@ describe('annotateMessagesForLLM', () => {
      * `additional_kwargs._unresolvedRefs` is untyped at the LangChain
      * layer, so a persisted message could carry a string/object/null
      * by mistake. The transform must not crash the run on
-     * `.length` / `.join` — coerce to an empty list and proceed.
+     * `.length` / `.join` — coerce to an empty list, strip the
+     * malformed key, and proceed.
      */
     const registry = new ToolOutputReferenceRegistry();
     const tm = makeToolMessage({
@@ -310,7 +365,9 @@ describe('annotateMessagesForLLM', () => {
     });
     const out = annotateMessagesForLLM([tm], registry, 'r1');
     expect(out[0].content).toBe('output');
-    expect(out[0]).toBe(tm);
+    expect(
+      (out[0] as ToolMessage).additional_kwargs._unresolvedRefs
+    ).toBeUndefined();
   });
 
   it('filters non-string entries out of _unresolvedRefs', () => {
@@ -344,7 +401,7 @@ describe('annotateMessagesForLLM', () => {
     });
     const out = annotateMessagesForLLM([tm], registry, 'r1');
     expect(out[0].content).toBe('output');
-    expect(out[0]).toBe(tm);
+    expect((out[0] as ToolMessage).additional_kwargs._refKey).toBeUndefined();
   });
 
   it('treats stale _refKey but live unresolved as unresolved-only', () => {

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -196,7 +196,13 @@ describe('annotateMessagesForLLM', () => {
     expect(tm.additional_kwargs._refScope).toBe('r1');
   });
 
-  it('drops additional_kwargs entirely when only framework keys were present', () => {
+  it('leaves additional_kwargs empty when stripping removed every framework key', () => {
+    /**
+     * `stripFrameworkRefMetadata` returns `undefined` when no non-
+     * framework keys remain, and the LangChain `ToolMessage`
+     * constructor normalizes that to `{}` — so the projected message
+     * exposes an empty object, not the original kwargs.
+     */
     const registry = new ToolOutputReferenceRegistry();
     registry.set('r1', 'tool0turn0', 'raw');
     const tm = makeToolMessage({

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -4,6 +4,7 @@ import {
   annotateMessagesForLLM,
   ToolOutputReferenceRegistry,
   TOOL_OUTPUT_REF_KEY,
+  TOOL_OUTPUT_UNRESOLVED_KEY,
 } from '../toolOutputReferences';
 
 function makeToolMessage(fields: {
@@ -96,6 +97,32 @@ describe('annotateMessagesForLLM', () => {
     expect(parsed.b).toBe('x');
   });
 
+  it('injects both _ref and _unresolved_refs into JSON-object content', () => {
+    /**
+     * Combined path: when a ToolMessage carries both a live `_refKey`
+     * and unresolved-ref hints, JSON-object content should receive
+     * both `_ref` and `_unresolved_refs` fields rather than falling
+     * back to the prefix/trailer form. Exercises
+     * `annotateToolOutputWithReference`'s collision-detection logic
+     * through the projection entry point.
+     */
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', '{"a":1}');
+    const tm = makeToolMessage({
+      content: '{"a":1,"b":"x"}',
+      additional_kwargs: {
+        _refKey: 'tool0turn0',
+        _unresolvedRefs: ['tool9turn9'],
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const parsed = JSON.parse(out[0].content as string);
+    expect(parsed[TOOL_OUTPUT_REF_KEY]).toBe('tool0turn0');
+    expect(parsed[TOOL_OUTPUT_UNRESOLVED_KEY]).toEqual(['tool9turn9']);
+    expect(parsed.a).toBe(1);
+    expect(parsed.b).toBe('x');
+  });
+
   it('uses [ref: …] prefix for non-JSON string content', () => {
     const registry = new ToolOutputReferenceRegistry();
     registry.set('r1', 'tool0turn0', 'raw');
@@ -140,13 +167,13 @@ describe('annotateMessagesForLLM', () => {
     expect(tm.additional_kwargs).toEqual(originalKwargs);
   });
 
-  it('passes original additional_kwargs through by reference on the projection', () => {
+  it('strips framework ref metadata from the projected additional_kwargs but preserves other fields', () => {
     /**
-     * The projected ToolMessage shares its `additional_kwargs` with the
-     * original — LangChain's provider serializers don't transmit
-     * `additional_kwargs` to provider APIs, and the projected array
-     * never round-trips back into graph state, so a defensive clone
-     * here would be wasted work.
+     * Defensive: even though LangChain's standard provider serializers
+     * do not transmit `additional_kwargs`, a custom adapter or future
+     * LangChain change could. Strip our three framework-owned keys on
+     * the projection so the metadata never reaches the wire under any
+     * serializer behavior. Non-framework fields stay put.
      */
     const registry = new ToolOutputReferenceRegistry();
     registry.set('r1', 'tool0turn0', 'raw');
@@ -154,14 +181,34 @@ describe('annotateMessagesForLLM', () => {
       content: 'output',
       additional_kwargs: {
         _refKey: 'tool0turn0',
+        _refScope: 'r1',
         _unresolvedRefs: ['tool9turn9'],
         someOtherField: 'preserved',
       },
     });
     const out = annotateMessagesForLLM([tm], registry, 'r1');
     const projected = out[0] as ToolMessage;
-    expect(projected.additional_kwargs).toBe(tm.additional_kwargs);
+    expect(projected.additional_kwargs._refKey).toBeUndefined();
+    expect(projected.additional_kwargs._refScope).toBeUndefined();
+    expect(projected.additional_kwargs._unresolvedRefs).toBeUndefined();
     expect(projected.additional_kwargs.someOtherField).toBe('preserved');
+    expect(tm.additional_kwargs._refKey).toBe('tool0turn0');
+    expect(tm.additional_kwargs._refScope).toBe('r1');
+  });
+
+  it('drops additional_kwargs entirely when only framework keys were present', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _refKey: 'tool0turn0',
+        _refScope: 'r1',
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const projected = out[0] as ToolMessage;
+    expect(projected.additional_kwargs).toEqual({});
   });
 
   it('passes through non-ToolMessages unchanged in the projected array', () => {

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -12,12 +12,14 @@ function makeToolMessage(fields: {
   name?: string;
   tool_call_id?: string;
   status?: 'success' | 'error';
+  artifact?: unknown;
   additional_kwargs?: Record<string, unknown>;
 }): ToolMessage {
   return new ToolMessage({
     name: fields.name ?? 'echo',
     tool_call_id: fields.tool_call_id ?? 'tc1',
     status: fields.status ?? 'success',
+    artifact: fields.artifact,
     additional_kwargs: fields.additional_kwargs,
     content: fields.content,
   });
@@ -188,6 +190,31 @@ describe('annotateMessagesForLLM', () => {
     expect(blocks[1].type).toBe('text');
     expect(blocks[1].text).toBe('data');
     expect(blocks[2].type).toBe('image_url');
+  });
+
+  it('preserves artifact on the projected ToolMessage', () => {
+    /**
+     * Hosts attach `artifact` to ToolMessages via the
+     * `content_and_artifact` response format (e.g. code execution
+     * sessions, MCP tools that return structured side-data). The
+     * projection must round-trip the artifact untouched so downstream
+     * consumers (audit logs, code-session tracking) keep working.
+     */
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const artifact = {
+      session_id: 'abc',
+      files: [{ id: 'f1', name: 'a.txt' }],
+    };
+    const tm = makeToolMessage({
+      content: 'output',
+      artifact,
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const projected = out[0] as ToolMessage;
+    expect(projected.artifact).toBe(artifact);
+    expect(projected.content).toBe('[ref: tool0turn0]\noutput');
   });
 
   it('does not mutate the original ToolMessage instance or its content', () => {

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -1,0 +1,216 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { describe, it, expect } from '@jest/globals';
+import {
+  annotateMessagesForLLM,
+  ToolOutputReferenceRegistry,
+  TOOL_OUTPUT_REF_KEY,
+} from '../toolOutputReferences';
+
+function makeToolMessage(fields: {
+  content: ToolMessage['content'];
+  name?: string;
+  tool_call_id?: string;
+  status?: 'success' | 'error';
+  additional_kwargs?: Record<string, unknown>;
+}): ToolMessage {
+  return new ToolMessage({
+    name: fields.name ?? 'echo',
+    tool_call_id: fields.tool_call_id ?? 'tc1',
+    status: fields.status ?? 'success',
+    additional_kwargs: fields.additional_kwargs,
+    content: fields.content,
+  });
+}
+
+describe('annotateMessagesForLLM', () => {
+  it('returns the input array reference when registry is undefined', () => {
+    const messages = [
+      new HumanMessage('hi'),
+      makeToolMessage({
+        content: 'data',
+        additional_kwargs: { _refKey: 'tool0turn0' },
+      }),
+    ];
+    const out = annotateMessagesForLLM(messages, undefined, 'r1');
+    expect(out).toBe(messages);
+  });
+
+  it('returns the input array reference when no ToolMessage carries metadata', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'stored');
+    const messages = [
+      new HumanMessage('hi'),
+      makeToolMessage({ content: 'data' }),
+      new AIMessage('answer'),
+    ];
+    const out = annotateMessagesForLLM(messages, registry, 'r1');
+    expect(out).toBe(messages);
+  });
+
+  it('annotates string content when _refKey is live in the registry', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'stored-raw');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('[ref: tool0turn0]\noutput');
+    expect(tm.content).toBe('output');
+    expect(out).not.toBe([tm]);
+    expect(out[0]).not.toBe(tm);
+  });
+
+  it('skips annotation when _refKey is stale (not in the registry)', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('output');
+    expect(out[0]).toBe(tm);
+  });
+
+  it('always applies _unresolvedRefs even when there is no registry entry', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: { _unresolvedRefs: ['tool9turn9'] },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('output\n[unresolved refs: tool9turn9]');
+  });
+
+  it('injects _ref into JSON-object string content', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', '{"a":1}');
+    const tm = makeToolMessage({
+      content: '{"a":1,"b":"x"}',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const parsed = JSON.parse(out[0].content as string);
+    expect(parsed[TOOL_OUTPUT_REF_KEY]).toBe('tool0turn0');
+    expect(parsed.a).toBe(1);
+    expect(parsed.b).toBe('x');
+  });
+
+  it('uses [ref: …] prefix for non-JSON string content', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: 'plain output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('[ref: tool0turn0]\nplain output');
+  });
+
+  it('prepends an unresolved-refs warning text block to multi-part content', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    const tm = makeToolMessage({
+      content: [
+        { type: 'text', text: 'data' },
+        { type: 'image_url', image_url: { url: 'data:...' } },
+      ] as unknown as ToolMessage['content'],
+      additional_kwargs: { _unresolvedRefs: ['tool9turn9'] },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const blocks = out[0].content as Array<{ type: string; text?: string }>;
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].type).toBe('text');
+    expect(blocks[0].text).toBe('[unresolved refs: tool9turn9]');
+    expect(blocks[1].type).toBe('text');
+    expect(blocks[1].text).toBe('data');
+    expect(blocks[2].type).toBe('image_url');
+  });
+
+  it('does not mutate the original ToolMessage instance or its content', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const originalContent = tm.content;
+    const originalKwargs = { ...tm.additional_kwargs };
+    annotateMessagesForLLM([tm], registry, 'r1');
+    expect(tm.content).toBe(originalContent);
+    expect(tm.additional_kwargs).toEqual(originalKwargs);
+  });
+
+  it('strips ref metadata from the projected ToolMessage so annotation is not double-applied', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _refKey: 'tool0turn0',
+        _unresolvedRefs: ['tool9turn9'],
+        someOtherField: 'preserved',
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    const projected = out[0] as ToolMessage;
+    expect(projected.additional_kwargs._refKey).toBeUndefined();
+    expect(projected.additional_kwargs._unresolvedRefs).toBeUndefined();
+    expect(projected.additional_kwargs.someOtherField).toBe('preserved');
+  });
+
+  it('passes through non-ToolMessages unchanged in the projected array', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const human = new HumanMessage('hi');
+    const ai = new AIMessage('answer');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const out = annotateMessagesForLLM([human, ai, tm], registry, 'r1');
+    expect(out[0]).toBe(human);
+    expect(out[1]).toBe(ai);
+    expect(out[2]).not.toBe(tm);
+  });
+
+  it('returns same array when only stale _refKey is present and no unresolvedRefs', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool1turn0', 'somethingelse');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+    const messages = [tm];
+    const out = annotateMessagesForLLM(messages, registry, 'r1');
+    expect(out).toBe(messages);
+  });
+
+  it('annotates only the live ref when both ref and unresolved are present', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _refKey: 'tool0turn0',
+        _unresolvedRefs: ['tool9turn9'],
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe(
+      '[ref: tool0turn0]\noutput\n[unresolved refs: tool9turn9]'
+    );
+  });
+
+  it('treats stale _refKey but live unresolved as unresolved-only', () => {
+    const registry = new ToolOutputReferenceRegistry();
+    const tm = makeToolMessage({
+      content: 'output',
+      additional_kwargs: {
+        _refKey: 'tool0turn0',
+        _unresolvedRefs: ['tool9turn9'],
+      },
+    });
+    const out = annotateMessagesForLLM([tm], registry, 'r1');
+    expect(out[0].content).toBe('output\n[unresolved refs: tool9turn9]');
+  });
+});

--- a/src/tools/__tests__/annotateMessagesForLLM.test.ts
+++ b/src/tools/__tests__/annotateMessagesForLLM.test.ts
@@ -404,6 +404,39 @@ describe('annotateMessagesForLLM', () => {
     expect((out[0] as ToolMessage).additional_kwargs._refKey).toBeUndefined();
   });
 
+  it('skips a ToolMessage whose additional_kwargs is a primitive without throwing', () => {
+    /**
+     * The `in` operator throws `TypeError` on primitives, so without
+     * a runtime object guard, a hydrated ToolMessage carrying e.g.
+     * `additional_kwargs: 'not-an-object'` (from a buggy serializer)
+     * would crash `attemptInvoke` before the provider call. Verify
+     * we skip that message and process subsequent live-ref messages
+     * normally.
+     */
+    const registry = new ToolOutputReferenceRegistry();
+    registry.set('r1', 'tool0turn0', 'raw');
+
+    const malformed = new ToolMessage({
+      name: 'echo',
+      tool_call_id: 'mal',
+      status: 'success',
+      content: 'malformed-output',
+    });
+    /* Force a primitive past LangChain's typed setter via a cast. */
+    (malformed as unknown as { additional_kwargs: unknown }).additional_kwargs =
+      'not-an-object' as unknown;
+
+    const live = makeToolMessage({
+      content: 'live-output',
+      additional_kwargs: { _refKey: 'tool0turn0' },
+    });
+
+    const out = annotateMessagesForLLM([malformed, live], registry, 'r1');
+    /* Malformed message passes through unchanged; live ref still annotates. */
+    expect(out[0]).toBe(malformed);
+    expect(out[1].content).toBe('[ref: tool0turn0]\nlive-output');
+  });
+
   it('treats stale _refKey but live unresolved as unresolved-only', () => {
     const registry = new ToolOutputReferenceRegistry();
     const tm = makeToolMessage({

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -24,7 +24,6 @@
 
 import { ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
-import type { ToolMessageRefMetadata } from '@/types/messages';
 import {
   calculateMaxTotalToolOutputSize,
   HARD_MAX_TOOL_RESULT_CHARS,
@@ -634,11 +633,18 @@ export function annotateMessagesForLLM(
   for (let i = 0; i < messages.length; i++) {
     const m = messages[i];
     if (m._getType() !== 'tool') continue;
-    const meta = m.additional_kwargs as
-      | (ToolMessageRefMetadata & Record<string, unknown>)
-      | undefined;
-    const refKey = meta?._refKey;
-    const unresolved = meta?._unresolvedRefs ?? [];
+    /**
+     * `additional_kwargs` is untyped at the LangChain layer
+     * (`Record<string, unknown>`), so persisted or client-supplied
+     * ToolMessages can carry arbitrary shapes under our framework
+     * keys. Treat them as untrusted input and coerce defensively
+     * before any array operation — a malformed field on a single
+     * hydrated message must not crash `attemptInvoke` before the
+     * provider call.
+     */
+    const meta = m.additional_kwargs as Record<string, unknown> | undefined;
+    const refKey = readRefKey(meta);
+    const unresolved = readUnresolvedRefs(meta);
     if (refKey == null && unresolved.length === 0) continue;
 
     /**
@@ -649,7 +655,7 @@ export function annotateMessagesForLLM(
      * recover. Falling back to `runId` keeps backward compatibility
      * with messages stamped before this field existed.
      */
-    const lookupScope = meta?._refScope ?? runId;
+    const lookupScope = readRefScope(meta) ?? runId;
     const liveRef =
       refKey != null && registry.has(lookupScope, refKey) ? refKey : undefined;
     if (liveRef == null && unresolved.length === 0) continue;
@@ -679,6 +685,50 @@ export function annotateMessagesForLLM(
   }
 
   return out ?? messages;
+}
+
+/**
+ * Reads `_refKey` defensively from untyped `additional_kwargs`. Returns
+ * undefined for non-string values so a malformed field cannot poison
+ * the registry lookup or downstream string operations.
+ */
+function readRefKey(
+  meta: Record<string, unknown> | undefined
+): string | undefined {
+  const v = meta?._refKey;
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Reads `_refScope` defensively from untyped `additional_kwargs`.
+ * Mirrors {@link readRefKey} — non-string scopes are dropped (the
+ * caller falls back to the run-derived scope) rather than passed into
+ * the registry as a malformed key.
+ */
+function readRefScope(
+  meta: Record<string, unknown> | undefined
+): string | undefined {
+  const v = meta?._refScope;
+  return typeof v === 'string' ? v : undefined;
+}
+
+/**
+ * Reads `_unresolvedRefs` defensively from untyped `additional_kwargs`.
+ * Returns an empty array for any non-array value, and filters out
+ * non-string entries from a real array. Without this guard, a hydrated
+ * ToolMessage carrying e.g. `_unresolvedRefs: 'tool0turn0'` would crash
+ * `attemptInvoke` on the eventual `.length` / `.join(...)` call.
+ */
+function readUnresolvedRefs(
+  meta: Record<string, unknown> | undefined
+): string[] {
+  const v = meta?._unresolvedRefs;
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === 'string') out.push(item);
+  }
+  return out;
 }
 
 /**

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -22,6 +22,9 @@
  * complete, verbatim output with no injected fields.
  */
 
+import { ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ToolMessageRefMetadata } from '@/types/messages';
 import {
   calculateMaxTotalToolOutputSize,
   HARD_MAX_TOOL_RESULT_CHARS,
@@ -241,6 +244,16 @@ export class ToolOutputReferenceRegistry {
   /** Returns the stored value for `key` in `runId`'s bucket, or `undefined`. */
   get(runId: string | undefined, key: string): string | undefined {
     return this.runStates.get(this.keyFor(runId))?.entries.get(key);
+  }
+
+  /**
+   * Returns `true` when `key` is currently stored in `runId`'s bucket.
+   * Used by {@link annotateMessagesForLLM} to gate transient annotation
+   * on whether the registry still owns the referenced output (a stale
+   * `_refKey` from a prior run silently no-ops here).
+   */
+  has(runId: string | undefined, key: string): boolean {
+    return this.runStates.get(this.keyFor(runId))?.entries.has(key) ?? false;
   }
 
   /** Total number of registered outputs across every run bucket. */
@@ -587,4 +600,107 @@ function arraysShallowEqual(a: unknown, b: readonly string[]): boolean {
     }
   }
   return true;
+}
+
+/**
+ * Lazy projection that, given a registry and a runId, returns a new
+ * `messages` array where each `ToolMessage` carrying a live `_refKey`
+ * (and/or unresolved-ref metadata) has its `content` annotated for the
+ * LLM. The original input array and its messages are never mutated.
+ *
+ * Annotation is gated on registry presence: a stale `_refKey` from a
+ * prior run (e.g. one that survived in persisted history) silently
+ * no-ops, exactly matching the "refs are run-scoped" mental model.
+ * `_unresolvedRefs` is always meaningful and is not gated.
+ *
+ * When neither a registry nor any ToolMessage in the batch carries
+ * relevant metadata, the input array is returned unchanged (reference-
+ * equal) so the common case is allocation-free.
+ */
+export function annotateMessagesForLLM(
+  messages: BaseMessage[],
+  registry: ToolOutputReferenceRegistry | undefined,
+  runId: string | undefined
+): BaseMessage[] {
+  if (registry == null) return messages;
+
+  const out = messages.map((m) => {
+    if (m._getType() !== 'tool') return m;
+    const meta = m.additional_kwargs as
+      | (ToolMessageRefMetadata & Record<string, unknown>)
+      | undefined;
+    const refKey = meta?._refKey;
+    const unresolved = meta?._unresolvedRefs ?? [];
+    if (refKey == null && unresolved.length === 0) return m;
+
+    const liveRef =
+      refKey != null && registry.has(runId, refKey) ? refKey : undefined;
+
+    if (liveRef == null && unresolved.length === 0) return m;
+
+    const tm = m as ToolMessage;
+    const cleanedKwargs = stripRefMetadata(meta);
+    if (typeof tm.content === 'string') {
+      const annotated = annotateToolOutputWithReference(
+        tm.content,
+        liveRef,
+        unresolved
+      );
+      return new ToolMessage({
+        id: tm.id,
+        name: tm.name,
+        status: tm.status,
+        artifact: tm.artifact,
+        tool_call_id: tm.tool_call_id,
+        response_metadata: tm.response_metadata,
+        additional_kwargs: cleanedKwargs,
+        content: annotated,
+      });
+    }
+    if (Array.isArray(tm.content) && unresolved.length > 0) {
+      const warningBlock = {
+        type: 'text' as const,
+        text: `[unresolved refs: ${unresolved.join(', ')}]`,
+      };
+      return new ToolMessage({
+        id: tm.id,
+        name: tm.name,
+        status: tm.status,
+        artifact: tm.artifact,
+        tool_call_id: tm.tool_call_id,
+        response_metadata: tm.response_metadata,
+        additional_kwargs: cleanedKwargs,
+        content: [
+          warningBlock,
+          ...tm.content,
+        ] as unknown as ToolMessage['content'],
+      });
+    }
+    return m;
+  });
+
+  for (let i = 0; i < out.length; i++) {
+    if (out[i] !== messages[i]) return out;
+  }
+  return messages;
+}
+
+/**
+ * Returns a copy of `meta` with the framework-owned ref keys stripped.
+ * Used by {@link annotateMessagesForLLM} so the projected ToolMessage
+ * does not round-trip the metadata back into state with annotation
+ * already applied. Returns `undefined` when no other keys remain.
+ */
+function stripRefMetadata(
+  meta: (ToolMessageRefMetadata & Record<string, unknown>) | undefined
+): Record<string, unknown> | undefined {
+  if (meta == null) return undefined;
+  const rest: Record<string, unknown> = {};
+  let hasOther = false;
+  for (const [k, v] of Object.entries(meta)) {
+    if (k === '_refKey' || k === '_unresolvedRefs') continue;
+    rest[k] = v;
+    hasOther = true;
+  }
+  return hasOther ? rest : undefined;
 }

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -691,6 +691,15 @@ export function annotateMessagesForLLM(
         type: 'text' as const,
         text: `[unresolved refs: ${unresolved.join(', ')}]`,
       };
+      /**
+       * `as unknown as ToolMessage['content']` is unavoidable here:
+       * LangChain's content union (`MessageContentComplex[] |
+       * DataContentBlock[] | string`) does not accept a freshly built
+       * mixed array literal even though the structural shape is valid
+       * at runtime. The double-cast is structurally safe — we
+       * preserve every block from `tm.content` and prepend a single
+       * `{ type: 'text', text }` block that all providers accept.
+       */
       nextContent = [
         warningBlock,
         ...tm.content,

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -641,8 +641,17 @@ export function annotateMessagesForLLM(
     const unresolved = meta?._unresolvedRefs ?? [];
     if (refKey == null && unresolved.length === 0) continue;
 
+    /**
+     * Prefer the message-stamped `_refScope` for the registry lookup.
+     * For named runs it equals the current `runId`; for anonymous
+     * invocations it carries the per-batch synthetic scope minted by
+     * ToolNode (`\0anon-<n>`), which `runId` from config cannot
+     * recover. Falling back to `runId` keeps backward compatibility
+     * with messages stamped before this field existed.
+     */
+    const lookupScope = meta?._refScope ?? runId;
     const liveRef =
-      refKey != null && registry.has(runId, refKey) ? refKey : undefined;
+      refKey != null && registry.has(lookupScope, refKey) ? refKey : undefined;
     if (liveRef == null && unresolved.length === 0) continue;
 
     const tm = m as ToolMessage;

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -603,18 +603,25 @@ function arraysShallowEqual(a: unknown, b: readonly string[]): boolean {
 
 /**
  * Lazy projection that, given a registry and a runId, returns a new
- * `messages` array where each `ToolMessage` carrying a live `_refKey`
- * (and/or unresolved-ref metadata) has its `content` annotated for the
- * LLM. The original input array and its messages are never mutated.
+ * `messages` array where each `ToolMessage` carrying ref metadata is
+ * projected into a transient copy with annotated content (when the ref
+ * is live in the registry) and with the framework-owned `additional_
+ * kwargs` keys (`_refKey`, `_refScope`, `_unresolvedRefs`) stripped
+ * regardless of whether annotation applied. The original input array
+ * and its messages are never mutated.
  *
  * Annotation is gated on registry presence: a stale `_refKey` from a
  * prior run (e.g. one that survived in persisted history) silently
- * no-ops, exactly matching the "refs are run-scoped" mental model.
+ * no-ops on the *content* side. The strip-metadata side still runs so
+ * stale framework keys never leak onto the wire under any custom or
+ * future provider serializer that might transmit `additional_kwargs`.
  * `_unresolvedRefs` is always meaningful and is not gated.
  *
- * When neither a registry nor any ToolMessage in the batch carries
- * relevant metadata, the input array is returned unchanged (reference-
- * equal) so the common case is allocation-free.
+ * **Feature-disabled fast path:** when the host hasn't enabled the
+ * tool-output-reference feature, the registry is `undefined` and this
+ * function returns the input array reference-equal *without iterating
+ * a single message*. The loop is exclusive to the feature-enabled
+ * code path.
  */
 export function annotateMessagesForLLM(
   messages: BaseMessage[],
@@ -625,9 +632,8 @@ export function annotateMessagesForLLM(
 
   /**
    * Lazy-allocate the output array so the common case (no ToolMessage
-   * needs annotation — refs are stale or absent) returns the input
-   * reference-equal with zero allocations beyond the per-message
-   * predicate checks.
+   * carries framework metadata) returns the input reference-equal with
+   * zero allocations beyond the per-message predicate checks.
    */
   let out: BaseMessage[] | undefined;
   for (let i = 0; i < messages.length; i++) {
@@ -643,9 +649,13 @@ export function annotateMessagesForLLM(
      * provider call.
      */
     const meta = m.additional_kwargs as Record<string, unknown> | undefined;
+    const hasRefKey = meta != null && '_refKey' in meta;
+    const hasRefScope = meta != null && '_refScope' in meta;
+    const hasUnresolvedField = meta != null && '_unresolvedRefs' in meta;
+    if (!hasRefKey && !hasRefScope && !hasUnresolvedField) continue;
+
     const refKey = readRefKey(meta);
     const unresolved = readUnresolvedRefs(meta);
-    if (refKey == null && unresolved.length === 0) continue;
 
     /**
      * Prefer the message-stamped `_refScope` for the registry lookup.
@@ -658,30 +668,40 @@ export function annotateMessagesForLLM(
     const lookupScope = readRefScope(meta) ?? runId;
     const liveRef =
       refKey != null && registry.has(lookupScope, refKey) ? refKey : undefined;
-    if (liveRef == null && unresolved.length === 0) continue;
+    const annotates = liveRef != null || unresolved.length > 0;
 
     const tm = m as ToolMessage;
-    let projected: ToolMessage | undefined;
+    let nextContent: ToolMessage['content'] = tm.content;
 
-    if (typeof tm.content === 'string') {
-      projected = cloneToolMessageWithContent(
-        tm,
-        annotateToolOutputWithReference(tm.content, liveRef, unresolved)
+    if (annotates && typeof tm.content === 'string') {
+      nextContent = annotateToolOutputWithReference(
+        tm.content,
+        liveRef,
+        unresolved
       );
-    } else if (Array.isArray(tm.content) && unresolved.length > 0) {
+    } else if (
+      annotates &&
+      Array.isArray(tm.content) &&
+      unresolved.length > 0
+    ) {
       const warningBlock = {
         type: 'text' as const,
         text: `[unresolved refs: ${unresolved.join(', ')}]`,
       };
-      projected = cloneToolMessageWithContent(tm, [
+      nextContent = [
         warningBlock,
         ...tm.content,
-      ] as unknown as ToolMessage['content']);
+      ] as unknown as ToolMessage['content'];
     }
 
-    if (projected == null) continue;
+    /**
+     * Project unconditionally: even when no annotation applies (stale
+     * `_refKey` or non-annotatable content), `cloneToolMessageWithContent`
+     * runs `stripFrameworkRefMetadata` on `additional_kwargs` so the
+     * framework-owned keys never reach the wire.
+     */
     out ??= messages.slice();
-    out[i] = projected;
+    out[i] = cloneToolMessageWithContent(tm, nextContent);
   }
 
   return out ?? messages;

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -642,16 +642,19 @@ export function annotateMessagesForLLM(
     /**
      * `additional_kwargs` is untyped at the LangChain layer
      * (`Record<string, unknown>`), so persisted or client-supplied
-     * ToolMessages can carry arbitrary shapes under our framework
-     * keys. Treat them as untrusted input and coerce defensively
-     * before any array operation — a malformed field on a single
-     * hydrated message must not crash `attemptInvoke` before the
-     * provider call.
+     * ToolMessages can carry arbitrary shapes — including primitives
+     * (a malformed serializer might write a string, or `null`).
+     * Guard with a runtime object check before the `in` probes
+     * because the `in` operator throws `TypeError` on primitives.
+     * A single malformed message must never crash the provider call
+     * path; skip its annotation/strip and continue.
      */
-    const meta = m.additional_kwargs as Record<string, unknown> | undefined;
-    const hasRefKey = meta != null && '_refKey' in meta;
-    const hasRefScope = meta != null && '_refScope' in meta;
-    const hasUnresolvedField = meta != null && '_unresolvedRefs' in meta;
+    const rawMeta = m.additional_kwargs as unknown;
+    if (rawMeta == null || typeof rawMeta !== 'object') continue;
+    const meta = rawMeta as Record<string, unknown>;
+    const hasRefKey = '_refKey' in meta;
+    const hasRefScope = '_refScope' in meta;
+    const hasUnresolvedField = '_unresolvedRefs' in meta;
     if (!hasRefKey && !hasRefScope && !hasUnresolvedField) continue;
 
     const refKey = readRefKey(meta);

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -624,83 +624,78 @@ export function annotateMessagesForLLM(
 ): BaseMessage[] {
   if (registry == null) return messages;
 
-  const out = messages.map((m) => {
-    if (m._getType() !== 'tool') return m;
+  /**
+   * Lazy-allocate the output array so the common case (no ToolMessage
+   * needs annotation — refs are stale or absent) returns the input
+   * reference-equal with zero allocations beyond the per-message
+   * predicate checks.
+   */
+  let out: BaseMessage[] | undefined;
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
+    if (m._getType() !== 'tool') continue;
     const meta = m.additional_kwargs as
       | (ToolMessageRefMetadata & Record<string, unknown>)
       | undefined;
     const refKey = meta?._refKey;
     const unresolved = meta?._unresolvedRefs ?? [];
-    if (refKey == null && unresolved.length === 0) return m;
+    if (refKey == null && unresolved.length === 0) continue;
 
     const liveRef =
       refKey != null && registry.has(runId, refKey) ? refKey : undefined;
-
-    if (liveRef == null && unresolved.length === 0) return m;
+    if (liveRef == null && unresolved.length === 0) continue;
 
     const tm = m as ToolMessage;
-    const cleanedKwargs = stripRefMetadata(meta);
+    let projected: ToolMessage | undefined;
+
     if (typeof tm.content === 'string') {
-      const annotated = annotateToolOutputWithReference(
-        tm.content,
-        liveRef,
-        unresolved
-      );
-      return new ToolMessage({
+      projected = new ToolMessage({
         id: tm.id,
         name: tm.name,
         status: tm.status,
         artifact: tm.artifact,
         tool_call_id: tm.tool_call_id,
         response_metadata: tm.response_metadata,
-        additional_kwargs: cleanedKwargs,
-        content: annotated,
+        /**
+         * Pass the original `additional_kwargs` through by reference.
+         * LangChain's provider serializers do not transmit
+         * `additional_kwargs` to provider HTTP APIs, and the projected
+         * array is discarded after the request — so the metadata
+         * never reaches the wire and never round-trips back into
+         * graph state. Skipping a clone here avoids an O(n) walk plus
+         * a fresh object per annotated ToolMessage.
+         */
+        additional_kwargs: tm.additional_kwargs,
+        content: annotateToolOutputWithReference(
+          tm.content,
+          liveRef,
+          unresolved
+        ),
       });
-    }
-    if (Array.isArray(tm.content) && unresolved.length > 0) {
+    } else if (Array.isArray(tm.content) && unresolved.length > 0) {
       const warningBlock = {
         type: 'text' as const,
         text: `[unresolved refs: ${unresolved.join(', ')}]`,
       };
-      return new ToolMessage({
+      projected = new ToolMessage({
         id: tm.id,
         name: tm.name,
         status: tm.status,
         artifact: tm.artifact,
         tool_call_id: tm.tool_call_id,
         response_metadata: tm.response_metadata,
-        additional_kwargs: cleanedKwargs,
+        additional_kwargs: tm.additional_kwargs,
         content: [
           warningBlock,
           ...tm.content,
         ] as unknown as ToolMessage['content'],
       });
     }
-    return m;
-  });
 
-  for (let i = 0; i < out.length; i++) {
-    if (out[i] !== messages[i]) return out;
+    if (projected == null) continue;
+    out ??= messages.slice();
+    out[i] = projected;
   }
-  return messages;
-}
 
-/**
- * Returns a copy of `meta` with the framework-owned ref keys stripped.
- * Used by {@link annotateMessagesForLLM} so the projected ToolMessage
- * does not round-trip the metadata back into state with annotation
- * already applied. Returns `undefined` when no other keys remain.
- */
-function stripRefMetadata(
-  meta: (ToolMessageRefMetadata & Record<string, unknown>) | undefined
-): Record<string, unknown> | undefined {
-  if (meta == null) return undefined;
-  const rest: Record<string, unknown> = {};
-  let hasOther = false;
-  for (const [k, v] of Object.entries(meta)) {
-    if (k === '_refKey' || k === '_unresolvedRefs') continue;
-    rest[k] = v;
-    hasOther = true;
-  }
-  return hasOther ? rest : undefined;
+  return out ?? messages;
 }

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -658,47 +658,19 @@ export function annotateMessagesForLLM(
     let projected: ToolMessage | undefined;
 
     if (typeof tm.content === 'string') {
-      projected = new ToolMessage({
-        id: tm.id,
-        name: tm.name,
-        status: tm.status,
-        artifact: tm.artifact,
-        tool_call_id: tm.tool_call_id,
-        response_metadata: tm.response_metadata,
-        /**
-         * Pass the original `additional_kwargs` through by reference.
-         * LangChain's provider serializers do not transmit
-         * `additional_kwargs` to provider HTTP APIs, and the projected
-         * array is discarded after the request — so the metadata
-         * never reaches the wire and never round-trips back into
-         * graph state. Skipping a clone here avoids an O(n) walk plus
-         * a fresh object per annotated ToolMessage.
-         */
-        additional_kwargs: tm.additional_kwargs,
-        content: annotateToolOutputWithReference(
-          tm.content,
-          liveRef,
-          unresolved
-        ),
-      });
+      projected = cloneToolMessageWithContent(
+        tm,
+        annotateToolOutputWithReference(tm.content, liveRef, unresolved)
+      );
     } else if (Array.isArray(tm.content) && unresolved.length > 0) {
       const warningBlock = {
         type: 'text' as const,
         text: `[unresolved refs: ${unresolved.join(', ')}]`,
       };
-      projected = new ToolMessage({
-        id: tm.id,
-        name: tm.name,
-        status: tm.status,
-        artifact: tm.artifact,
-        tool_call_id: tm.tool_call_id,
-        response_metadata: tm.response_metadata,
-        additional_kwargs: tm.additional_kwargs,
-        content: [
-          warningBlock,
-          ...tm.content,
-        ] as unknown as ToolMessage['content'],
-      });
+      projected = cloneToolMessageWithContent(tm, [
+        warningBlock,
+        ...tm.content,
+      ] as unknown as ToolMessage['content']);
     }
 
     if (projected == null) continue;
@@ -707,4 +679,65 @@ export function annotateMessagesForLLM(
   }
 
   return out ?? messages;
+}
+
+/**
+ * Builds a fresh `ToolMessage` that mirrors `tm`'s identity fields with
+ * the supplied `content`. Every `ToolMessage` field but `content` is
+ * carried over so the projection is structurally identical to the
+ * original from a LangChain serializer's perspective.
+ *
+ * `additional_kwargs` is rebuilt with the framework-owned ref keys
+ * stripped. Defensive: LangChain's standard provider serializers do not
+ * transmit `additional_kwargs` to provider HTTP APIs, but a custom
+ * adapter or future LangChain change could. Stripping keeps the
+ * implementation correct under any serializer behavior at the cost of a
+ * shallow object spread per annotated message.
+ */
+function cloneToolMessageWithContent(
+  tm: ToolMessage,
+  content: ToolMessage['content']
+): ToolMessage {
+  return new ToolMessage({
+    id: tm.id,
+    name: tm.name,
+    status: tm.status,
+    artifact: tm.artifact,
+    tool_call_id: tm.tool_call_id,
+    response_metadata: tm.response_metadata,
+    additional_kwargs: stripFrameworkRefMetadata(tm.additional_kwargs),
+    content,
+  });
+}
+
+/**
+ * Returns a copy of `kwargs` with `_refKey`, `_refScope`, and
+ * `_unresolvedRefs` removed. Returns the input reference-equal when
+ * none of those keys are present so the no-strip path stays cheap;
+ * returns `undefined` when stripping leaves the object empty so the
+ * caller can drop the field entirely.
+ */
+function stripFrameworkRefMetadata(
+  kwargs: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (kwargs == null) return undefined;
+  if (
+    !('_refKey' in kwargs) &&
+    !('_refScope' in kwargs) &&
+    !('_unresolvedRefs' in kwargs)
+  ) {
+    return kwargs;
+  }
+  const { _refKey, _refScope, _unresolvedRefs, ...rest } = kwargs as Record<
+    string,
+    unknown
+  > & {
+    _refKey?: unknown;
+    _refScope?: unknown;
+    _unresolvedRefs?: unknown;
+  };
+  void _refKey;
+  void _refScope;
+  void _unresolvedRefs;
+  return Object.keys(rest).length === 0 ? undefined : rest;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 // src/types/index.ts
 export * from './graph';
 export * from './llm';
+export * from './messages';
 export * from './run';
 export * from './skill';
 export * from './stream';

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -2,3 +2,20 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { BaseMessage } from '@langchain/core/messages';
 export type AnthropicMessages = Array<AnthropicMessage | BaseMessage>;
 export type AnthropicMessage = Anthropic.MessageParam;
+
+/**
+ * Per-message ref metadata stamped onto a `ToolMessage` at execution
+ * time. Read by `annotateMessagesForLLM` to apply transient annotation
+ * to a copy of the message right before it goes on the wire to the
+ * provider. Never read after the run-scoped registry has been cleared.
+ *
+ * Lives in `ToolMessage.additional_kwargs`. LangChain's provider
+ * serializers don't transmit `additional_kwargs` to provider APIs, so
+ * the metadata never leaks even if you forget to clean it.
+ */
+export interface ToolMessageRefMetadata {
+  /** Key under which this message's untruncated output was registered. */
+  _refKey?: string;
+  /** Placeholders the model used that could not be resolved this batch. */
+  _unresolvedRefs?: string[];
+}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -16,6 +16,16 @@ export type AnthropicMessage = Anthropic.MessageParam;
 export interface ToolMessageRefMetadata {
   /** Key under which this message's untruncated output was registered. */
   _refKey?: string;
+  /**
+   * Registry bucket scope under which `_refKey` was stored. For named
+   * runs this equals `config.configurable.run_id`; for anonymous
+   * invocations (no `run_id`) ToolNode mints a per-batch synthetic
+   * scope (`\0anon-<n>`) so concurrent batches don't collide. Stamping
+   * the scope on the message itself lets `annotateMessagesForLLM`
+   * recover it without re-deriving from config — which is impossible
+   * for the anonymous case, since the scope is internal to ToolNode.
+   */
+  _refScope?: string;
   /** Placeholders the model used that could not be resolved this batch. */
   _unresolvedRefs?: string[];
 }


### PR DESCRIPTION
## Summary

Move `_ref` annotation from a *durable mutation of `ToolMessage.content`* to a *transient projection applied at LLM request time*. Annotations exist only in the bytes sent to the provider HTTP API; they're never present in the in-memory state that becomes persisted/streamed content.

Builds on #114. From hosts' perspective the only observable changes are silent improvements: persisted ToolMessage content is now clean, streamed tool-output events are now clean, and no host-side migration is required. The `RunConfig.toolOutputReferences.enabled` flag and the model-facing `{{tool<i>turn<n>}}` substitution semantics are unchanged.

### What changed

- **`ToolNode`** stamps `additional_kwargs._refKey` / `_unresolvedRefs` on each ToolMessage and leaves `content` clean (truncated only). The new `recordOutputReference` replaces the old `applyOutputReference` content-mutator.
- **`annotateMessagesForLLM`** (new utility) projects each ToolMessage carrying live ref metadata into a transient annotated copy at request time. Stale `_refKey` values from prior runs silently no-op via a registry-presence gate. `_unresolvedRefs` is always meaningful and is not gated. Returns the input array reference-equal when nothing was projected (allocation-free common path).
- **`attemptInvoke`** pulls the run-scoped registry off the graph via the typed `InvokeContext` and applies the transform before each provider call (streaming and non-streaming). `tryFallbackProviders` reuses `attemptInvoke` so fallback paths inherit the transform. Summarization passes no `context` and the transform safely no-ops there.
- **`Graph.getOrCreateToolOutputRegistry`** is now `public` so the typed context can read it.

### Files

- `src/types/messages.ts` — new `ToolMessageRefMetadata` interface
- `src/tools/toolOutputReferences.ts` — new `annotateMessagesForLLM`, new `has(runId, key)` on the registry
- `src/tools/ToolNode.ts` — demoted helper + 6 call-site updates (success/error in runTool & dispatchToolEvents, multi-part content path)
- `src/llm/invoke.ts` — single transform call before each provider request
- `src/graphs/Graph.ts` — registry getter promoted to `public`

### Tests

- Migrated `ToolNode.outputReferences.test.ts` (32 tests) to assert clean content + `additional_kwargs._refKey` / `_unresolvedRefs` metadata
- Added `annotateMessagesForLLM.test.ts` (14 tests) — registry-gating, JSON `_ref` injection, unresolved-only annotation, multi-part warnings, no-mutation guarantees, array reference identity
- Added `invoke.test.ts` (6 tests) — wire-format integration: streaming/non-streaming, summarization no-op, stale `_refKey` skip, unresolved-refs always applied, `tryFallbackProviders` parity

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest src/tools src/llm/invoke.test.ts` → 477 pass / 23 skipped, 0 failures
- [x] Full unit-test run → 1263 pass; the 28 pre-existing failures are integration suites missing API keys (confirmed identical on `origin/dev`)
- [x] `npx eslint` on changed files clean (one pre-existing warning at `ToolNode.ts:669` unrelated to this change)
- [ ] Smoke test: cross-run scenario where ToolMessages from a prior run hydrate into a new run, verify the new run's annotated request body has refs only for keys live in the new run's registry