### PR TITLE
fix: filter deferred/programmatic tools out of toolSchemaTokens accounting

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -703,9 +703,21 @@ export class AgentContext {
      * populated after `fromConfig()` kicks off the initial calculation, so
      * callers that mutate `graphTools` must re-trigger this method to
      * refresh `toolSchemaTokens`.
+     *
+     * Apply the same registry-based filter that `getToolsForBinding` uses on
+     * `this.tools` so accounting reflects what is actually bound: skip tools
+     * whose `allowed_callers` exclude `'direct'` and tools with
+     * `defer_loading: true` that haven't been discovered yet. Without this,
+     * `toolSchemaTokens` reports the worst-case ceiling (all registered
+     * tools) instead of the bound subset, which can trigger spurious
+     * `empty_messages` preflight rejections at low `maxContextTokens`.
      */
+    const filteredInstanceTools =
+      this.tools && this.toolRegistry
+        ? this.filterToolsForBinding(this.tools)
+        : (this.tools ?? []);
     const instanceTools: t.GraphTools = [
-      ...((this.tools as t.GenericTool[] | undefined) ?? []),
+      ...(filteredInstanceTools as t.GenericTool[]),
       ...((this.graphTools as t.GenericTool[] | undefined) ?? []),
     ];
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -919,8 +919,16 @@ export class AgentContext {
    */
   getTokenBudgetBreakdown(messages?: BaseMessage[]): t.TokenBudgetBreakdown {
     const maxContextTokens = this.maxContextTokens ?? 0;
-    const toolCount =
-      (this.tools?.length ?? 0) + this.getActiveToolDefinitions().length;
+    /**
+     * Derive `toolCount` from `getToolsForBinding()` so the diagnostic stays
+     * aligned with what is actually bound to the model — and with what
+     * `calculateInstructionTokens` counts into `toolSchemaTokens`. Using raw
+     * `this.tools.length` would inflate the count whenever the registry
+     * marks instance tools as deferred-undiscovered or non-`'direct'`,
+     * producing the same misleading "N tools" diagnostic this fix is meant
+     * to eliminate.
+     */
+    const toolCount = this.getToolsForBinding()?.length ?? 0;
     const messageCount = messages?.length ?? 0;
 
     let messageTokens = 0;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -681,10 +681,47 @@ export class AgentContext {
     if (!this.toolDefinitions) {
       return [];
     }
-    return this.toolDefinitions.filter(
-      (def) =>
+    /**
+     * Mirror `getEventDrivenToolsForBinding`'s gate: a definition is only
+     * bound to the model when its `allowed_callers` include `'direct'` and
+     * (if deferred) it has been discovered. Filtering by `defer_loading`
+     * alone left programmatic-only definitions counted in
+     * `toolSchemaTokens` even though they were never bound.
+     */
+    return this.toolDefinitions.filter((def) => {
+      const allowedCallers = def.allowed_callers ?? ['direct'];
+      if (!allowedCallers.includes('direct')) {
+        return false;
+      }
+      return (
         def.defer_loading !== true || this.discoveredToolNames.has(def.name)
-    );
+      );
+    });
+  }
+
+  /**
+   * Single source of truth for "which entries of `this.tools` should be
+   * treated as actually bound". Callers:
+   *   - `getToolsForBinding` (non-event-driven branch)
+   *   - `getEventDrivenToolsForBinding` (appends instance tools alongside
+   *     schema-only definitions)
+   *   - `calculateInstructionTokens` (counts schema bytes for accounting)
+   *
+   * In event-driven mode (`toolDefinitions` present) instance tools are
+   * appended unfiltered; outside event-driven mode they pass through
+   * `filterToolsForBinding`. Centralizing the decision here prevents the
+   * accounting/binding paths from drifting apart, which was the root
+   * cause of the original miscount.
+   */
+  private getEffectiveInstanceTools(): t.GraphTools | undefined {
+    if (!this.tools) {
+      return undefined;
+    }
+    const isEventDriven = (this.toolDefinitions?.length ?? 0) > 0;
+    if (isEventDriven || !this.toolRegistry) {
+      return this.tools;
+    }
+    return this.filterToolsForBinding(this.tools);
   }
 
   /**
@@ -704,27 +741,16 @@ export class AgentContext {
      * callers that mutate `graphTools` must re-trigger this method to
      * refresh `toolSchemaTokens`.
      *
-     * In the non-event-driven path, `getToolsForBinding` runs `this.tools`
-     * through `filterToolsForBinding` (skipping `defer_loading: true` tools
-     * not yet discovered, and tools whose `allowed_callers` exclude
-     * `'direct'`). Mirror that here so accounting reflects what is actually
-     * bound — without this, `toolSchemaTokens` reports the worst-case
-     * ceiling and can trigger spurious `empty_messages` preflight
-     * rejections at low `maxContextTokens`.
-     *
-     * In event-driven mode (`toolDefinitions` present), `getEventDriven-
-     * ToolsForBinding` appends `this.tools` unfiltered, so accounting must
-     * also leave them unfiltered to stay aligned. Deferred tools are
-     * instead represented through `toolDefinitions` and counted via
+     * Use `getEffectiveInstanceTools()` so accounting reflects exactly the
+     * subset that `getToolsForBinding` would emit — preventing the
+     * worst-case-ceiling miscount that triggered spurious `empty_messages`
+     * preflight rejections at low `maxContextTokens`. Deferred and
+     * non-`'direct'` `toolDefinitions` are excluded by
      * `getActiveToolDefinitions()` below.
      */
-    const isEventDriven = (this.toolDefinitions?.length ?? 0) > 0;
-    const filteredInstanceTools =
-      !isEventDriven && this.tools && this.toolRegistry
-        ? this.filterToolsForBinding(this.tools)
-        : (this.tools ?? []);
     const instanceTools: t.GraphTools = [
-      ...(filteredInstanceTools as t.GenericTool[]),
+      ...((this.getEffectiveInstanceTools() as t.GenericTool[] | undefined) ??
+        []),
       ...((this.graphTools as t.GenericTool[] | undefined) ?? []),
     ];
 
@@ -1041,10 +1067,7 @@ export class AgentContext {
       return this.getEventDrivenToolsForBinding();
     }
 
-    const filtered =
-      !this.tools || !this.toolRegistry
-        ? this.tools
-        : this.filterToolsForBinding(this.tools);
+    const filtered = this.getEffectiveInstanceTools();
 
     if (this.graphTools && this.graphTools.length > 0) {
       return [...(filtered ?? []), ...this.graphTools];
@@ -1059,21 +1082,9 @@ export class AgentContext {
       return this.graphTools ?? [];
     }
 
-    const defsToInclude = this.toolDefinitions.filter((def) => {
-      const allowedCallers = def.allowed_callers ?? ['direct'];
-      if (!allowedCallers.includes('direct')) {
-        return false;
-      }
-      if (
-        def.defer_loading === true &&
-        !this.discoveredToolNames.has(def.name)
-      ) {
-        return false;
-      }
-      return true;
-    });
-
-    const schemaTools = createSchemaOnlyTools(defsToInclude) as t.GraphTools;
+    const schemaTools = createSchemaOnlyTools(
+      this.getActiveToolDefinitions()
+    ) as t.GraphTools;
 
     const allTools = [...schemaTools];
 
@@ -1081,8 +1092,9 @@ export class AgentContext {
       allTools.push(...this.graphTools);
     }
 
-    if (this.tools && this.tools.length > 0) {
-      allTools.push(...this.tools);
+    const instanceTools = this.getEffectiveInstanceTools();
+    if (instanceTools && instanceTools.length > 0) {
+      allTools.push(...instanceTools);
     }
 
     return allTools;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -704,16 +704,23 @@ export class AgentContext {
      * callers that mutate `graphTools` must re-trigger this method to
      * refresh `toolSchemaTokens`.
      *
-     * Apply the same registry-based filter that `getToolsForBinding` uses on
-     * `this.tools` so accounting reflects what is actually bound: skip tools
-     * whose `allowed_callers` exclude `'direct'` and tools with
-     * `defer_loading: true` that haven't been discovered yet. Without this,
-     * `toolSchemaTokens` reports the worst-case ceiling (all registered
-     * tools) instead of the bound subset, which can trigger spurious
-     * `empty_messages` preflight rejections at low `maxContextTokens`.
+     * In the non-event-driven path, `getToolsForBinding` runs `this.tools`
+     * through `filterToolsForBinding` (skipping `defer_loading: true` tools
+     * not yet discovered, and tools whose `allowed_callers` exclude
+     * `'direct'`). Mirror that here so accounting reflects what is actually
+     * bound — without this, `toolSchemaTokens` reports the worst-case
+     * ceiling and can trigger spurious `empty_messages` preflight
+     * rejections at low `maxContextTokens`.
+     *
+     * In event-driven mode (`toolDefinitions` present), `getEventDriven-
+     * ToolsForBinding` appends `this.tools` unfiltered, so accounting must
+     * also leave them unfiltered to stay aligned. Deferred tools are
+     * instead represented through `toolDefinitions` and counted via
+     * `getActiveToolDefinitions()` below.
      */
+    const isEventDriven = (this.toolDefinitions?.length ?? 0) > 0;
     const filteredInstanceTools =
-      this.tools && this.toolRegistry
+      !isEventDriven && this.tools && this.toolRegistry
         ? this.filterToolsForBinding(this.tools)
         : (this.tools ?? []);
     const instanceTools: t.GraphTools = [

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -464,6 +464,47 @@ describe('AgentContext', () => {
       expect(ctxDiscovered.toolSchemaTokens).toBeGreaterThan(0);
     });
 
+    it('does not filter instance tools in event-driven mode (matches getEventDrivenToolsForBinding)', async () => {
+      // In event-driven mode, getEventDrivenToolsForBinding appends
+      // `this.tools` UNFILTERED. Accounting must do the same — otherwise we
+      // under-count and risk exceeding the model's context budget.
+      const activeDef: t.LCTool = {
+        name: 'active_def',
+        description: 'Always loaded',
+        parameters: { type: 'object', properties: {} },
+      };
+      const nativeTool = createMockTool('native_tool');
+      // Registry marks the native tool as deferred-undiscovered. In the
+      // non-event-driven path this would exclude it; in event-driven mode
+      // it is still bound and must still be counted.
+      const toolRegistry: t.LCToolRegistry = new Map([
+        ['native_tool', { name: 'native_tool', defer_loading: true }],
+      ]);
+
+      const ctxWithoutNative = createBasicContext({
+        agentConfig: {
+          toolDefinitions: [activeDef],
+          toolRegistry,
+        },
+        tokenCounter: mockTokenCounter,
+      });
+      const ctxWithNative = createBasicContext({
+        agentConfig: {
+          toolDefinitions: [activeDef],
+          tools: [nativeTool],
+          toolRegistry,
+        },
+        tokenCounter: mockTokenCounter,
+      });
+
+      await ctxWithoutNative.tokenCalculationPromise;
+      await ctxWithNative.tokenCalculationPromise;
+
+      expect(ctxWithNative.toolSchemaTokens).toBeGreaterThan(
+        ctxWithoutNative.toolSchemaTokens
+      );
+    });
+
     it('includes deferred toolDefinitions once discovered via discoveredTools input', async () => {
       const toolDefinitions: t.LCTool[] = [
         {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -629,6 +629,19 @@ describe('AgentContext', () => {
       expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(1);
     });
 
+    it('getTokenBudgetBreakdown toolCount includes graphTools', () => {
+      // graphTools (handoff/subagent) are bound to the model alongside
+      // instance tools. Now that toolCount derives from getToolsForBinding(),
+      // graphTools are reflected in the diagnostic just like they're
+      // counted in toolSchemaTokens. Locks in that alignment.
+      const ctx = createBasicContext({
+        agentConfig: { tools: [createMockTool('direct_tool')] },
+      });
+      ctx.graphTools = [createMockTool('handoff_tool')];
+
+      expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(2);
+    });
+
     it('toolSchemaTokens snapshot does not auto-update after markToolsAsDiscovered', async () => {
       const toolDefinitions: t.LCTool[] = [
         {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -549,6 +549,36 @@ describe('AgentContext', () => {
       expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(1);
     });
 
+    it('getTokenBudgetBreakdown toolCount excludes deferred-undiscovered instance tools', () => {
+      // Mirrors the toolDefinitions test for the instance-tools path so
+      // toolCount stays aligned with toolSchemaTokens (and with what
+      // getToolsForBinding actually emits) for non-event-driven runs.
+      const tools = [
+        createMockTool('active_tool'),
+        createMockTool('deferred_tool'),
+        createMockTool('programmatic_tool'),
+      ];
+      const toolRegistry: t.LCToolRegistry = new Map([
+        ['active_tool', { name: 'active_tool' }],
+        ['deferred_tool', { name: 'deferred_tool', defer_loading: true }],
+        [
+          'programmatic_tool',
+          {
+            name: 'programmatic_tool',
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]);
+
+      const ctx = createBasicContext({
+        agentConfig: { tools, toolRegistry },
+      });
+
+      expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(1);
+      ctx.markToolsAsDiscovered(['deferred_tool']);
+      expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(2);
+    });
+
     it('getTokenBudgetBreakdown toolCount reflects newly discovered deferred tools', () => {
       const toolDefinitions: t.LCTool[] = [
         {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -404,6 +404,40 @@ describe('AgentContext', () => {
       expect(ctxWithDeferred.toolSchemaTokens).toBe(ctxBase.toolSchemaTokens);
     });
 
+    it('excludes programmatic-only toolDefinitions from toolSchemaTokens', async () => {
+      // getEventDrivenToolsForBinding excludes definitions whose
+      // allowed_callers omit 'direct'. Accounting must mirror that — a
+      // programmatic-only definition is never bound to the model and
+      // shouldn't inflate toolSchemaTokens.
+      const activeDef: t.LCTool = {
+        name: 'active_tool',
+        description: 'Always loaded',
+        parameters: { type: 'object', properties: {} },
+      };
+      const programmaticDef: t.LCTool = {
+        name: 'programmatic_tool',
+        description: 'Only callable via code execution',
+        parameters: { type: 'object', properties: {} },
+        allowed_callers: ['code_execution'],
+      };
+
+      const ctxBase = createBasicContext({
+        agentConfig: { toolDefinitions: [activeDef] },
+        tokenCounter: mockTokenCounter,
+      });
+      const ctxWithProgrammatic = createBasicContext({
+        agentConfig: { toolDefinitions: [activeDef, programmaticDef] },
+        tokenCounter: mockTokenCounter,
+      });
+
+      await ctxBase.tokenCalculationPromise;
+      await ctxWithProgrammatic.tokenCalculationPromise;
+
+      expect(ctxWithProgrammatic.toolSchemaTokens).toBe(
+        ctxBase.toolSchemaTokens
+      );
+    });
+
     it('excludes deferred-undiscovered instance tools from toolSchemaTokens', async () => {
       const activeTool = createMockTool('active_tool');
       const deferredTool = createMockTool('deferred_tool');

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -404,6 +404,66 @@ describe('AgentContext', () => {
       expect(ctxWithDeferred.toolSchemaTokens).toBe(ctxBase.toolSchemaTokens);
     });
 
+    it('excludes deferred-undiscovered instance tools from toolSchemaTokens', async () => {
+      const activeTool = createMockTool('active_tool');
+      const deferredTool = createMockTool('deferred_tool');
+      const programmaticTool = createMockTool('programmatic_tool');
+      const toolRegistry: t.LCToolRegistry = new Map([
+        ['active_tool', { name: 'active_tool' }],
+        ['deferred_tool', { name: 'deferred_tool', defer_loading: true }],
+        [
+          'programmatic_tool',
+          {
+            name: 'programmatic_tool',
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]);
+
+      const ctxBase = createBasicContext({
+        agentConfig: { tools: [activeTool], toolRegistry },
+        tokenCounter: mockTokenCounter,
+      });
+      const ctxWithExcluded = createBasicContext({
+        agentConfig: {
+          tools: [activeTool, deferredTool, programmaticTool],
+          toolRegistry,
+        },
+        tokenCounter: mockTokenCounter,
+      });
+
+      await ctxBase.tokenCalculationPromise;
+      await ctxWithExcluded.tokenCalculationPromise;
+
+      expect(ctxWithExcluded.toolSchemaTokens).toBe(ctxBase.toolSchemaTokens);
+    });
+
+    it('includes deferred instance tools once discovered via discoveredTools input', async () => {
+      const tools = [createMockTool('deferred_tool')];
+      const toolRegistry: t.LCToolRegistry = new Map([
+        ['deferred_tool', { name: 'deferred_tool', defer_loading: true }],
+      ]);
+
+      const ctxUndiscovered = createBasicContext({
+        agentConfig: { tools, toolRegistry },
+        tokenCounter: mockTokenCounter,
+      });
+      const ctxDiscovered = createBasicContext({
+        agentConfig: {
+          tools,
+          toolRegistry,
+          discoveredTools: ['deferred_tool'],
+        },
+        tokenCounter: mockTokenCounter,
+      });
+
+      await ctxUndiscovered.tokenCalculationPromise;
+      await ctxDiscovered.tokenCalculationPromise;
+
+      expect(ctxUndiscovered.toolSchemaTokens).toBe(0);
+      expect(ctxDiscovered.toolSchemaTokens).toBeGreaterThan(0);
+    });
+
     it('includes deferred toolDefinitions once discovered via discoveredTools input', async () => {
       const toolDefinitions: t.LCTool[] = [
         {


### PR DESCRIPTION
## Summary

Fixes #121.

`AgentContext.calculateInstructionTokens` summed every entry in `this.tools` (and `this.graphTools`) regardless of whether it would be sent to the model, while `getToolsForBinding` filters `this.tools` through `filterToolsForBinding` (excluding `defer_loading: true && !discovered` and `allowed_callers` without `'direct'`). This made `toolSchemaTokens` report the worst-case ceiling instead of what was actually bound.

At low `maxContextTokens` the inflated ceiling triggered spurious `empty_messages` preflight rejections — e.g. `47705 tokens (99% of instructions) across 101 tools` reported as the budget killer when the real prompt was ~13K. Operators reading the error were misled into thinking they had to drastically trim MCP servers.

## Changes

- [src/agents/AgentContext.ts](src/agents/AgentContext.ts): apply `filterToolsForBinding` to `this.tools` inside `calculateInstructionTokens` so accounting matches what `getToolsForBinding` emits. `graphTools` (handoff/subagent) remains unfiltered to mirror the binding path exactly.
- [src/agents/__tests__/AgentContext.test.ts](src/agents/__tests__/AgentContext.test.ts): two regression tests covering the instance-tools path — one for deferred-undiscovered + non-`'direct'` callers being excluded, one for inclusion once discovered via `discoveredTools`. The existing `toolDefinitions` test (`excludes deferred-undiscovered toolDefinitions from toolSchemaTokens`) only covered the event-driven branch and didn't catch this.

## Test plan

- [x] `npx jest src/agents/__tests__/AgentContext.test.ts` — 56/56 pass (54 prior + 2 new)
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx eslint` on touched files — clean
- [x] Full test suite: only pre-existing live-API failures (openai/anthropic/google/vertexai/cache simple specs, summarization integration) — verified identical on `origin/main`