### PR TITLE
fix(anthropic): drop whitespace-only text blocks before send

### DIFF
--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -611,7 +611,12 @@ function _formatContent(message: BaseMessage) {
     return contentBlocks.filter(
       (block) =>
         block !== null &&
-        !(block.type === 'text' && 'text' in block && block.text === '')
+        !(
+          block.type === 'text' &&
+          'text' in block &&
+          typeof block.text === 'string' &&
+          block.text.trim() === ''
+        )
     );
   }
 }

--- a/src/llm/anthropic/utils/server-tool-inputs.test.ts
+++ b/src/llm/anthropic/utils/server-tool-inputs.test.ts
@@ -346,4 +346,81 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     expect(textBlocks).toHaveLength(1);
     expect(textBlocks[0].text).toBe('Here are the results.');
   });
+
+  /**
+   * Regression for LibreChat discussion #12806.
+   *
+   * Anthropic web_search responses can include text blocks whose text is
+   * whitespace-only (e.g. ' ', '\n', '\t') alongside server_tool_use and
+   * web_search_tool_result blocks. On follow-up turns the API rejects these
+   * with: "messages: text content blocks must contain non-whitespace text".
+   *
+   * The empty-string check alone is insufficient — the filter must drop any
+   * text block whose trimmed content is empty.
+   */
+  it.each([
+    ['single space', ' '],
+    ['newline', '\n'],
+    ['tab', '\t'],
+    ['multiple spaces', '   '],
+    ['mixed whitespace', ' \n\t '],
+  ])(
+    'filters whitespace-only text blocks from array content (%s)',
+    (_label, whitespace) => {
+      const messageHistory: BaseMessage[] = [
+        new HumanMessage('search for X'),
+        new AIMessage({
+          content: [
+            { type: 'text', text: whitespace },
+            {
+              type: 'server_tool_use',
+              id: 'srvtoolu_1',
+              name: 'web_search',
+              input: { query: 'X' },
+            },
+            {
+              type: 'web_search_tool_result',
+              tool_use_id: 'srvtoolu_1',
+              content: [
+                {
+                  type: 'web_search_result',
+                  url: 'https://example.com',
+                  title: 'Result',
+                  encrypted_content: 'abc',
+                  page_age: '1d',
+                },
+              ],
+            },
+            { type: 'text', text: 'Here are the results.' },
+          ],
+          tool_calls: [
+            {
+              id: 'srvtoolu_1',
+              name: 'web_search',
+              args: { query: 'X' },
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new HumanMessage('follow up'),
+      ];
+
+      const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+      const assistantContent = messages[1].content as any[];
+
+      const whitespaceTextBlocks = assistantContent.filter(
+        (b: any) =>
+          b.type === 'text' &&
+          typeof b.text === 'string' &&
+          b.text.trim() === ''
+      );
+      expect(whitespaceTextBlocks).toHaveLength(0);
+
+      const textBlocks = assistantContent.filter(
+        (b: any) => b.type === 'text'
+      );
+      expect(textBlocks).toHaveLength(1);
+      expect(textBlocks[0].text).toBe('Here are the results.');
+    }
+  );
 });

--- a/src/specs/anthropic.simple.test.ts
+++ b/src/specs/anthropic.simple.test.ts
@@ -376,6 +376,67 @@ describe(`${capitalizeFirstLetter(provider)} Streaming Tests`, () => {
     );
   });
 
+  test(`${capitalizeFirstLetter(provider)}: follow-up after assistant message with only whitespace text content`, async () => {
+    /**
+     * Regression for LibreChat discussion #12806.
+     *
+     * The Anthropic API has two distinct rejection rules (verified against
+     * the live API):
+     *   1. Strict empty `text: ''`  → rejected anywhere
+     *      "messages: text content blocks must be non-empty"
+     *   2. Whitespace-only `text: ' '` / '\n' / '\t' → rejected when the
+     *      assistant message has no other accepted blocks (no tool blocks,
+     *      no non-whitespace text)
+     *      "messages: text content blocks must contain non-whitespace text"
+     *
+     * Anthropic responses for some prompts include a whitespace-only text
+     * block as the sole text content. Re-sending that history on a
+     * follow-up turn triggers rule 2.
+     *
+     * The wire-send filter in `_formatContent` must drop any text block
+     * whose trimmed content is empty. The previous filter used strict
+     * `text === ''` only, which caught rule 1 but not rule 2.
+     */
+    const llmConfig = getLLMConfig(provider);
+    const customHandlers1 = setupCustomHandlers();
+
+    const followUpRun = await Run.create<t.IState>({
+      runId: 'repro-12806-followup',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        instructions: 'You are a friendly AI assistant.',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: customHandlers1,
+    });
+
+    // Build history with an assistant message whose entire content array
+    // is a single whitespace-only text block. This is the precise shape
+    // the API rejects under rule 2 above.
+    conversationHistory = [
+      new HumanMessage('hi'),
+      new (require('@langchain/core/messages').AIMessage)({
+        content: [{ type: 'text', text: ' ' }],
+      }),
+      new HumanMessage('please respond with a short greeting'),
+    ];
+
+    // With the fix: `_formatContent` drops the whitespace text block,
+    // the assistant content becomes an empty array, and the API accepts.
+    // Without the fix: the whitespace block is forwarded and the API
+    // rejects with "messages: text content blocks must contain non-whitespace text".
+    const finalContentParts = await followUpRun.processStream(
+      { messages: conversationHistory },
+      config
+    );
+    expect(finalContentParts).toBeDefined();
+    const finalMessages = followUpRun.getRunMessages();
+    expect(finalMessages).toBeDefined();
+    expect(finalMessages?.length).toBeGreaterThan(0);
+  });
+
   test('should handle errors appropriately', async () => {
     // Test error scenarios
     await expect(async () => {


### PR DESCRIPTION
## Summary

Fixes [LibreChat discussion #12806](https://github.com/danny-avila/LibreChat/discussions/12806) — Claude + web_search + a follow-up turn fails with:

```
messages: text content blocks must contain non-whitespace text
```

## Root cause

\`_formatContent\` in \`src/llm/anthropic/utils/message_inputs.ts\` filters empty text blocks before sending the payload to the Anthropic API, but the check only catches strict \`text === ''\`. Blocks with whitespace-only text (\`' '\`, \`'\n'\`, \`'\t'\`, etc.) are passed through. The Anthropic API rejects those when the message has no other non-whitespace text content.

I confirmed the API rules by hitting \`messages.create\` directly:

| Content shape | API result |
|---|---|
| \`[text:'']\` (anywhere) | rejected — \"text content blocks must be non-empty\" |
| \`[text:' ']\` (only block) | rejected — \"text content blocks must contain non-whitespace text\" |
| \`[text:' ', text:'real']\` | accepted |
| \`[text:'\n']\` (only block) | rejected — \"text content blocks must contain non-whitespace text\" |

The reporter's exact error message corresponds to row 2/4 — Anthropic returned a web_search response whose only text block was whitespace, so re-sending the history triggers the rejection.

## The fix

Broaden the existing filter to drop any text block whose trimmed content is empty. One-liner change in \`message_inputs.ts:611\`:

\`\`\`diff
-        !(block.type === 'text' && 'text' in block && block.text === '')
+        !(
+          block.type === 'text' &&
+          'text' in block &&
+          typeof block.text === 'string' &&
+          block.text.trim() === ''
+        )
\`\`\`

Whitespace-only text blocks have no semantic value — Anthropic's web_search responses can include them as artifacts between \`server_tool_use\` and \`web_search_tool_result\` blocks. Dropping them is safe and preserves all citation-relevant blocks (per the existing comment at lines 568–574).

## Why the reporter saw it gated by Custom Instructions OR cache OFF

The condition for the bug to manifest is: the assistant message that's about to be re-sent contains only whitespace text alongside its tool blocks. The reporter's environment hits this. The \`addCacheControl\` path at \`graphs/Graph.ts:879\`–\`888\` is gated to run only when \`promptCache === true\` AND \`!systemRunnable\`, which probably correlates with whatever response shape avoids the trigger in their setup. The fix resolves the failure mode regardless of cache state or system prompt.

## Test plan

- [x] New regression cases in \`server-tool-inputs.test.ts\` (5 whitespace variants: space, newline, tab, multiple spaces, mixed) all pass with the fix and previously failed.
- [x] Existing \`'filters out empty text blocks from array content'\` test (strict empty case) still passes — no regression on the original behavior.
- [x] All 11 cases in \`server-tool-inputs.test.ts\` green: \`npx jest src/llm/anthropic/utils/server-tool-inputs.test.ts\`.
- [x] Live e2e against \`claude-opus-4-7\`, \`claude-sonnet-4-6\`, \`claude-haiku-4-5\`, \`claude-opus-4-1-20250805\`, \`claude-sonnet-4-20250514\` — turn 1 and turn 2 both succeed with the fix in place.
- [x] Direct API probes confirm the rejection rules above.