### PR TITLE
fix: keep agent prompt cache prefix stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.74",
+  "version": "3.1.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.74",
+      "version": "3.1.75",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.74",
+  "version": "3.1.75",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -20,6 +20,16 @@ import { addCacheControl } from '@/messages/cache';
 import { DEFAULT_RESERVE_RATIO } from '@/messages';
 import { toJsonSchema } from '@/utils/schema';
 
+type AgentSystemTextBlock = {
+  type: 'text';
+  text: string;
+  cache_control?: { type: 'ephemeral' };
+};
+
+type AgentSystemContentBlock =
+  | AgentSystemTextBlock
+  | { cachePoint: { type: 'default' } };
+
 /**
  * Encapsulates agent-specific state that can vary between agents in a multi-agent system
  */
@@ -597,14 +607,14 @@ export class AgentContext {
 
         const summaryMsg = usePromptCache
           ? new HumanMessage({
-              content: [
-                {
-                  type: 'text',
-                  text: wrappedSummary,
-                  cache_control: { type: 'ephemeral' },
-                },
-              ],
-            })
+            content: [
+              {
+                type: 'text',
+                text: wrappedSummary,
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          })
           : new HumanMessage(wrappedSummary);
         body = [summaryMsg, ...messages];
       } else {
@@ -652,7 +662,7 @@ export class AgentContext {
     }
 
     if (usePromptCache) {
-      const content: Array<Record<string, unknown>> = [];
+      const content: AgentSystemContentBlock[] = [];
       if (stableInstructions) {
         content.push({
           type: 'text',
@@ -667,7 +677,7 @@ export class AgentContext {
     }
 
     if (this.hasBedrockPromptCache() && stableInstructions) {
-      const content: Array<Record<string, unknown>> = [
+      const content: AgentSystemContentBlock[] = [
         { type: 'text', text: stableInstructions },
         { cachePoint: { type: 'default' } },
       ];

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -249,7 +249,7 @@ export class AgentContext {
   private summaryTokenCount: number = 0;
   /**
    * Where the summary should be injected:
-   * - `'system_prompt'`: cross-run summary, included in `buildInstructionsString`
+   * - `'system_prompt'`: cross-run summary, included in the dynamic system tail
    * - `'user_message'`: mid-run compaction, injected as HumanMessage on clean slate
    * - `'none'`: no summary present
    */
@@ -417,7 +417,8 @@ export class AgentContext {
 
   /**
    * Gets the system runnable, creating it lazily if needed.
-   * Includes instructions, additional instructions, and programmatic-only tools documentation.
+   * Includes stable instructions, dynamic additional instructions, and
+   * programmatic-only tools documentation.
    * Only rebuilds when marked stale (via markToolsAsDiscovered).
    */
   get systemRunnable():
@@ -431,8 +432,10 @@ export class AgentContext {
       return this.cachedSystemRunnable;
     }
 
-    const instructionsString = this.buildInstructionsString();
-    this.cachedSystemRunnable = this.buildSystemRunnable(instructionsString);
+    this.cachedSystemRunnable = this.buildSystemRunnable({
+      stableInstructions: this.buildStableInstructionsString(),
+      dynamicInstructions: this.buildDynamicInstructionsString(),
+    });
     this.systemRunnableStale = false;
     return this.cachedSystemRunnable;
   }
@@ -443,17 +446,19 @@ export class AgentContext {
    */
   initializeSystemRunnable(): void {
     if (this.systemRunnableStale || this.cachedSystemRunnable === undefined) {
-      const instructionsString = this.buildInstructionsString();
-      this.cachedSystemRunnable = this.buildSystemRunnable(instructionsString);
+      this.cachedSystemRunnable = this.buildSystemRunnable({
+        stableInstructions: this.buildStableInstructionsString(),
+        dynamicInstructions: this.buildDynamicInstructionsString(),
+      });
       this.systemRunnableStale = false;
     }
   }
 
   /**
-   * Builds the raw instructions string (without creating SystemMessage).
+   * Builds the cacheable instructions string (without creating SystemMessage).
    * Includes agent identity preamble and handoff context when available.
    */
-  private buildInstructionsString(): string {
+  private buildStableInstructionsString(): string {
     const parts: string[] = [];
 
     const identityPreamble = this.buildIdentityPreamble();
@@ -465,6 +470,22 @@ export class AgentContext {
       parts.push(this.instructions);
     }
 
+    const programmaticToolsDoc = this.buildProgrammaticOnlyToolsInstructions();
+    if (programmaticToolsDoc) {
+      parts.push(programmaticToolsDoc);
+    }
+
+    return parts.join('\n\n');
+  }
+
+  /**
+   * Builds the dynamic system-tail string (without creating SystemMessage).
+   * Keep this out of prompt-cache-marked content so volatile context does not
+   * invalidate the stable prefix.
+   */
+  private buildDynamicInstructionsString(): string {
+    const parts: string[] = [];
+
     if (
       this.additionalInstructions != null &&
       this.additionalInstructions !== ''
@@ -472,14 +493,10 @@ export class AgentContext {
       parts.push(this.additionalInstructions);
     }
 
-    const programmaticToolsDoc = this.buildProgrammaticOnlyToolsInstructions();
-    if (programmaticToolsDoc) {
-      parts.push(programmaticToolsDoc);
-    }
-
-    // Cross-run summary: include in system prompt so the model has context
-    // from the prior run.  Mid-run summaries are injected as a HumanMessage
-    // on the post-compaction clean slate instead (see buildSystemRunnable).
+    // Cross-run summary: include in the system tail so the model has context
+    // from the prior run without invalidating the cacheable prefix. Mid-run
+    // summaries are injected as a HumanMessage on the post-compaction clean
+    // slate instead (see buildSystemRunnable).
     if (
       this._summaryLocation === 'system_prompt' &&
       this.summaryText != null &&
@@ -523,9 +540,13 @@ export class AgentContext {
    * Build system runnable from pre-built instructions string.
    * Only called when content has actually changed.
    */
-  private buildSystemRunnable(
-    instructionsString: string
-  ):
+  private buildSystemRunnable({
+    stableInstructions,
+    dynamicInstructions,
+  }: {
+    stableInstructions: string;
+    dynamicInstructions: string;
+  }):
     | Runnable<
         BaseMessage[],
         (BaseMessage | SystemMessage)[],
@@ -537,35 +558,17 @@ export class AgentContext {
       this.summaryText != null &&
       this.summaryText !== '';
 
-    if (!instructionsString && !hasMidRunSummary) {
+    if (!stableInstructions && !dynamicInstructions && !hasMidRunSummary) {
       this.systemMessageTokens = 0;
       return undefined;
     }
 
-    let finalInstructions: string | BaseMessageFields = instructionsString;
-
-    let usePromptCache = false;
-    if (this.provider === Providers.ANTHROPIC) {
-      const anthropicOptions = this.clientOptions as
-        | t.AnthropicClientOptions
-        | undefined;
-      if (anthropicOptions?.promptCache === true) {
-        usePromptCache = true;
-        finalInstructions = {
-          content: [
-            {
-              type: 'text',
-              text: instructionsString,
-              cache_control: { type: 'ephemeral' },
-            },
-          ],
-        };
-      }
-    }
-
-    const systemMessage = instructionsString
-      ? new SystemMessage(finalInstructions)
-      : undefined;
+    const usePromptCache = this.hasAnthropicPromptCache();
+    const systemMessage = this.buildSystemMessage({
+      stableInstructions,
+      dynamicInstructions,
+      usePromptCache,
+    });
 
     if (this.tokenCounter) {
       this.systemMessageTokens = systemMessage
@@ -594,14 +597,14 @@ export class AgentContext {
 
         const summaryMsg = usePromptCache
           ? new HumanMessage({
-            content: [
-              {
-                type: 'text',
-                text: wrappedSummary,
-                cache_control: { type: 'ephemeral' },
-              },
-            ],
-          })
+              content: [
+                {
+                  type: 'text',
+                  text: wrappedSummary,
+                  cache_control: { type: 'ephemeral' },
+                },
+              ],
+            })
           : new HumanMessage(wrappedSummary);
         body = [summaryMsg, ...messages];
       } else {
@@ -613,6 +616,72 @@ export class AgentContext {
       }
       return [...prefix, ...body];
     }).withConfig({ runName: 'prompt' });
+  }
+
+  private hasAnthropicPromptCache(): boolean {
+    if (this.provider !== Providers.ANTHROPIC) {
+      return false;
+    }
+    const anthropicOptions = this.clientOptions as
+      | t.AnthropicClientOptions
+      | undefined;
+    return anthropicOptions?.promptCache === true;
+  }
+
+  private hasBedrockPromptCache(): boolean {
+    if (this.provider !== Providers.BEDROCK) {
+      return false;
+    }
+    const bedrockOptions = this.clientOptions as
+      | t.BedrockAnthropicClientOptions
+      | undefined;
+    return bedrockOptions?.promptCache === true;
+  }
+
+  private buildSystemMessage({
+    stableInstructions,
+    dynamicInstructions,
+    usePromptCache,
+  }: {
+    stableInstructions: string;
+    dynamicInstructions: string;
+    usePromptCache: boolean;
+  }): SystemMessage | undefined {
+    if (!stableInstructions && !dynamicInstructions) {
+      return undefined;
+    }
+
+    if (usePromptCache) {
+      const content: Array<Record<string, unknown>> = [];
+      if (stableInstructions) {
+        content.push({
+          type: 'text',
+          text: stableInstructions,
+          cache_control: { type: 'ephemeral' },
+        });
+      }
+      if (dynamicInstructions) {
+        content.push({ type: 'text', text: dynamicInstructions });
+      }
+      return new SystemMessage({ content } as BaseMessageFields);
+    }
+
+    if (this.hasBedrockPromptCache() && stableInstructions) {
+      const content: Array<Record<string, unknown>> = [
+        { type: 'text', text: stableInstructions },
+        { cachePoint: { type: 'default' } },
+      ];
+      if (dynamicInstructions) {
+        content.push({ type: 'text', text: dynamicInstructions });
+      }
+      return new SystemMessage({ content } as BaseMessageFields);
+    }
+
+    return new SystemMessage(
+      [stableInstructions, dynamicInstructions]
+        .filter((part) => part !== '')
+        .join('\n\n')
+    );
   }
 
   /**

--- a/src/agents/__tests__/AgentContext.anthropic.live.test.ts
+++ b/src/agents/__tests__/AgentContext.anthropic.live.test.ts
@@ -8,14 +8,16 @@
 import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
 
-import { HumanMessage } from '@langchain/core/messages';
 import { describe, expect, it } from '@jest/globals';
-import type { UsageMetadata } from '@langchain/core/messages';
 import type * as t from '@/types';
-import { ModelEndHandler } from '@/events';
-import { AgentContext } from '../AgentContext';
-import { GraphEvents, Providers } from '@/common';
-import { Run } from '@/run';
+import { Providers } from '@/common';
+import {
+  runLiveTurn,
+  assertSystemPayloadShape,
+  buildDynamicInstructions,
+  buildStableInstructions,
+  waitForCachePropagation,
+} from './promptCacheLiveHelpers';
 
 const shouldRunLive =
   process.env.RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS === '1' &&
@@ -26,26 +28,7 @@ const describeIfLive = shouldRunLive ? describe : describe.skip;
 
 const modelName =
   process.env.ANTHROPIC_PROMPT_CACHE_MODEL ?? 'claude-sonnet-4-5';
-
-function buildStableInstructions(nonce: string): string {
-  const records = Array.from(
-    { length: 360 },
-    (_, index) =>
-      `Stable cache record ${index}: nonce ${nonce}; keep this reference in the cacheable prefix and do not use it as the dynamic marker.`
-  );
-  return [
-    'You are a prompt-cache verification assistant.',
-    'When asked for the dynamic marker, answer with only the marker value from the Dynamic Marker line.',
-    ...records,
-  ].join('\n');
-}
-
-function buildDynamicInstructions(marker: string): string {
-  return [
-    `Dynamic Marker: ${marker}`,
-    'The Dynamic Marker line is runtime context and must remain outside the cached prefix.',
-  ].join('\n');
-}
+const providerLabel = 'Anthropic';
 
 function createClientOptions(): t.AnthropicClientOptions {
   return {
@@ -63,128 +46,48 @@ function createClientOptions(): t.AnthropicClientOptions {
   };
 }
 
-async function assertSystemPayloadShape({
-  stableInstructions,
-  dynamicInstructions,
-}: {
-  stableInstructions: string;
-  dynamicInstructions: string;
-}): Promise<void> {
-  const ctx = AgentContext.fromConfig({
-    agentId: 'live-cache-shape-check',
-    provider: Providers.ANTHROPIC,
-    clientOptions: createClientOptions(),
-    instructions: stableInstructions,
-    additional_instructions: dynamicInstructions,
-  });
-
-  const messages = await ctx.systemRunnable!.invoke([
-    new HumanMessage('What is the dynamic marker?'),
-  ]);
-
-  expect(messages[0].content).toEqual([
-    {
-      type: 'text',
-      text: stableInstructions,
-      cache_control: { type: 'ephemeral' },
-    },
-    {
-      type: 'text',
-      text: dynamicInstructions,
-    },
-  ]);
-}
-
-function latestUsage(
-  collectedUsage: UsageMetadata[],
-  label: string
-): UsageMetadata {
-  if (collectedUsage.length === 0) {
-    throw new Error(`Missing Anthropic usage metadata for ${label}`);
-  }
-  return collectedUsage[collectedUsage.length - 1];
-}
-
-function collectText(parts: t.MessageContentComplex[] | undefined): string {
-  return (parts ?? []).reduce((text, part) => {
-    if (part.type === 'text') {
-      return text + part.text;
-    }
-    return text;
-  }, '');
-}
-
-async function waitForCachePropagation(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-}
-
-async function runLiveTurn({
-  runId,
-  threadId,
-  stableInstructions,
-  dynamicInstructions,
-}: {
-  runId: string;
-  threadId: string;
-  stableInstructions: string;
-  dynamicInstructions: string;
-}): Promise<{
-  text: string;
-  usage: UsageMetadata;
-}> {
-  const collectedUsage: UsageMetadata[] = [];
-  const run = await Run.create<t.IState>({
-    runId,
-    graphConfig: {
-      type: 'standard',
-      llmConfig: {
-        provider: Providers.ANTHROPIC,
-        ...createClientOptions(),
-      },
-      instructions: stableInstructions,
-      additional_instructions: dynamicInstructions,
-    },
-    returnContent: true,
-    skipCleanup: true,
-    customHandlers: {
-      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
-    },
-  });
-
-  const config = {
-    configurable: { thread_id: threadId },
-    streamMode: 'values',
-    version: 'v2' as const,
-  };
-
-  const contentParts = await run.processStream(
-    {
-      messages: [
-        new HumanMessage('What is the dynamic marker? Reply with only it.'),
-      ],
-    },
-    config
-  );
-
-  return {
-    text: collectText(contentParts),
-    usage: latestUsage(collectedUsage, runId),
-  };
-}
-
 describeIfLive('AgentContext Anthropic prompt cache live API', () => {
   it('caches only the stable system prefix while dynamic tail changes', async () => {
     const nonce = `agent-cache-live-${Date.now()}`;
-    const stableInstructions = buildStableInstructions(nonce);
-    const firstDynamicInstructions = buildDynamicInstructions('alpha');
-    const secondDynamicInstructions = buildDynamicInstructions('bravo');
+    const clientOptions = createClientOptions();
+    const stableInstructions = buildStableInstructions({
+      nonce,
+      providerLabel,
+    });
+    const firstDynamicInstructions = buildDynamicInstructions({
+      marker: 'alpha',
+      tailDescription:
+        'The Dynamic Marker line is runtime context and must remain outside the cached prefix.',
+    });
+    const secondDynamicInstructions = buildDynamicInstructions({
+      marker: 'bravo',
+      tailDescription:
+        'The Dynamic Marker line is runtime context and must remain outside the cached prefix.',
+    });
 
     await assertSystemPayloadShape({
+      agentId: 'live-cache-shape-check',
+      provider: Providers.ANTHROPIC,
+      clientOptions,
       stableInstructions,
       dynamicInstructions: firstDynamicInstructions,
+      expectedContent: [
+        {
+          type: 'text',
+          text: stableInstructions,
+          cache_control: { type: 'ephemeral' },
+        },
+        {
+          type: 'text',
+          text: firstDynamicInstructions,
+        },
+      ],
     });
 
     const first = await runLiveTurn({
+      provider: Providers.ANTHROPIC,
+      providerLabel,
+      clientOptions,
       runId: `${nonce}-first`,
       threadId: `${nonce}-thread`,
       stableInstructions,
@@ -198,6 +101,9 @@ describeIfLive('AgentContext Anthropic prompt cache live API', () => {
     await waitForCachePropagation();
 
     const second = await runLiveTurn({
+      provider: Providers.ANTHROPIC,
+      providerLabel,
+      clientOptions,
       runId: `${nonce}-second`,
       threadId: `${nonce}-thread`,
       stableInstructions,

--- a/src/agents/__tests__/AgentContext.anthropic.live.test.ts
+++ b/src/agents/__tests__/AgentContext.anthropic.live.test.ts
@@ -10,7 +10,6 @@ dotenvConfig();
 
 import { describe, expect, it } from '@jest/globals';
 import type * as t from '@/types';
-import { Providers } from '@/common';
 import {
   runLiveTurn,
   assertSystemPayloadShape,
@@ -18,6 +17,7 @@ import {
   buildStableInstructions,
   waitForCachePropagation,
 } from './promptCacheLiveHelpers';
+import { Providers } from '@/common';
 
 const shouldRunLive =
   process.env.RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS === '1' &&

--- a/src/agents/__tests__/AgentContext.anthropic.live.test.ts
+++ b/src/agents/__tests__/AgentContext.anthropic.live.test.ts
@@ -1,0 +1,204 @@
+// src/agents/__tests__/AgentContext.anthropic.live.test.ts
+/**
+ * Live Anthropic prompt-cache verification.
+ *
+ * Run with:
+ * RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- AgentContext.anthropic.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import { HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it } from '@jest/globals';
+import type { UsageMetadata } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { ModelEndHandler } from '@/events';
+import { AgentContext } from '../AgentContext';
+import { GraphEvents, Providers } from '@/common';
+import { Run } from '@/run';
+
+const shouldRunLive =
+  process.env.RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS === '1' &&
+  process.env.ANTHROPIC_API_KEY != null &&
+  process.env.ANTHROPIC_API_KEY !== '';
+
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+
+const modelName =
+  process.env.ANTHROPIC_PROMPT_CACHE_MODEL ?? 'claude-3-haiku-20240307';
+
+function buildStableInstructions(nonce: string): string {
+  const records = Array.from(
+    { length: 360 },
+    (_, index) =>
+      `Stable cache record ${index}: nonce ${nonce}; keep this reference in the cacheable prefix and do not use it as the dynamic marker.`
+  );
+  return [
+    'You are a prompt-cache verification assistant.',
+    'When asked for the dynamic marker, answer with only the marker value from the Dynamic Marker line.',
+    ...records,
+  ].join('\n');
+}
+
+function buildDynamicInstructions(marker: string): string {
+  return [
+    `Dynamic Marker: ${marker}`,
+    'The Dynamic Marker line is runtime context and must remain outside the cached prefix.',
+  ].join('\n');
+}
+
+function createClientOptions(): t.AnthropicClientOptions {
+  return {
+    modelName,
+    temperature: 0,
+    maxTokens: 8,
+    streaming: true,
+    streamUsage: true,
+    promptCache: true,
+    clientOptions: {
+      defaultHeaders: {
+        'anthropic-beta': 'prompt-caching-2024-07-31',
+      },
+    },
+  };
+}
+
+async function assertSystemPayloadShape({
+  stableInstructions,
+  dynamicInstructions,
+}: {
+  stableInstructions: string;
+  dynamicInstructions: string;
+}): Promise<void> {
+  const ctx = AgentContext.fromConfig({
+    agentId: 'live-cache-shape-check',
+    provider: Providers.ANTHROPIC,
+    clientOptions: createClientOptions(),
+    instructions: stableInstructions,
+    additional_instructions: dynamicInstructions,
+  });
+
+  const messages = await ctx.systemRunnable!.invoke([
+    new HumanMessage('What is the dynamic marker?'),
+  ]);
+
+  expect(messages[0].content).toEqual([
+    {
+      type: 'text',
+      text: stableInstructions,
+      cache_control: { type: 'ephemeral' },
+    },
+    {
+      type: 'text',
+      text: dynamicInstructions,
+    },
+  ]);
+}
+
+function latestUsage(
+  collectedUsage: UsageMetadata[],
+  label: string
+): UsageMetadata {
+  if (collectedUsage.length === 0) {
+    throw new Error(`Missing Anthropic usage metadata for ${label}`);
+  }
+  return collectedUsage[collectedUsage.length - 1];
+}
+
+function collectText(parts: t.MessageContentComplex[] | undefined): string {
+  return (parts ?? []).reduce((text, part) => {
+    if (part.type === 'text') {
+      return text + part.text;
+    }
+    return text;
+  }, '');
+}
+
+async function runLiveTurn({
+  runId,
+  threadId,
+  stableInstructions,
+  dynamicInstructions,
+}: {
+  runId: string;
+  threadId: string;
+  stableInstructions: string;
+  dynamicInstructions: string;
+}): Promise<{
+  text: string;
+  usage: UsageMetadata;
+}> {
+  const collectedUsage: UsageMetadata[] = [];
+  const run = await Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.ANTHROPIC,
+        ...createClientOptions(),
+      },
+      instructions: stableInstructions,
+      additional_instructions: dynamicInstructions,
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers: {
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
+    },
+  });
+
+  const config = {
+    configurable: { thread_id: threadId },
+    streamMode: 'values',
+    version: 'v2' as const,
+  };
+
+  const contentParts = await run.processStream(
+    {
+      messages: [
+        new HumanMessage('What is the dynamic marker? Reply with only it.'),
+      ],
+    },
+    config
+  );
+
+  return {
+    text: collectText(contentParts),
+    usage: latestUsage(collectedUsage, runId),
+  };
+}
+
+describeIfLive('AgentContext Anthropic prompt cache live API', () => {
+  it('caches only the stable system prefix while dynamic tail changes', async () => {
+    const nonce = `agent-cache-live-${Date.now()}`;
+    const stableInstructions = buildStableInstructions(nonce);
+    const firstDynamicInstructions = buildDynamicInstructions('alpha');
+    const secondDynamicInstructions = buildDynamicInstructions('bravo');
+
+    await assertSystemPayloadShape({
+      stableInstructions,
+      dynamicInstructions: firstDynamicInstructions,
+    });
+
+    const first = await runLiveTurn({
+      runId: `${nonce}-first`,
+      threadId: `${nonce}-thread`,
+      stableInstructions,
+      dynamicInstructions: firstDynamicInstructions,
+    });
+
+    expect(first.text.toLowerCase()).toContain('alpha');
+    expect(first.usage.input_token_details?.cache_creation).toBeGreaterThan(0);
+    expect(first.usage.input_token_details?.cache_read ?? 0).toBe(0);
+
+    const second = await runLiveTurn({
+      runId: `${nonce}-second`,
+      threadId: `${nonce}-thread`,
+      stableInstructions,
+      dynamicInstructions: secondDynamicInstructions,
+    });
+
+    expect(second.text.toLowerCase()).toContain('bravo');
+    expect(second.usage.input_token_details?.cache_read).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/src/agents/__tests__/AgentContext.bedrock.live.test.ts
+++ b/src/agents/__tests__/AgentContext.bedrock.live.test.ts
@@ -1,9 +1,11 @@
-// src/agents/__tests__/AgentContext.anthropic.live.test.ts
+// src/agents/__tests__/AgentContext.bedrock.live.test.ts
 /**
- * Live Anthropic prompt-cache verification.
+ * Live Bedrock prompt-cache verification.
  *
  * Run with:
- * RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- AgentContext.anthropic.live.test.ts --runInBand
+ * RUN_BEDROCK_PROMPT_CACHE_LIVE_TESTS=1 BEDROCK_AWS_REGION=... BEDROCK_AWS_ACCESS_KEY_ID=... BEDROCK_AWS_SECRET_ACCESS_KEY=... npm test -- AgentContext.bedrock.live.test.ts --runInBand
+ *
+ * Standard AWS credential env vars or AWS_PROFILE can also be used.
  */
 import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
@@ -17,24 +19,42 @@ import { AgentContext } from '../AgentContext';
 import { GraphEvents, Providers } from '@/common';
 import { Run } from '@/run';
 
+const accessKeyId =
+  process.env.BEDROCK_AWS_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID;
+const secretAccessKey =
+  process.env.BEDROCK_AWS_SECRET_ACCESS_KEY ??
+  process.env.AWS_SECRET_ACCESS_KEY;
+const sessionToken =
+  process.env.BEDROCK_AWS_SESSION_TOKEN ?? process.env.AWS_SESSION_TOKEN;
+const hasCredentialPair =
+  accessKeyId != null &&
+  accessKeyId !== '' &&
+  secretAccessKey != null &&
+  secretAccessKey !== '';
+const hasAmbientCredentials =
+  process.env.AWS_PROFILE != null ||
+  process.env.AWS_WEB_IDENTITY_TOKEN_FILE != null;
+
 const shouldRunLive =
-  process.env.RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS === '1' &&
-  process.env.ANTHROPIC_API_KEY != null &&
-  process.env.ANTHROPIC_API_KEY !== '';
+  process.env.RUN_BEDROCK_PROMPT_CACHE_LIVE_TESTS === '1' &&
+  (hasCredentialPair || hasAmbientCredentials);
 
 const describeIfLive = shouldRunLive ? describe : describe.skip;
 
-const modelName =
-  process.env.ANTHROPIC_PROMPT_CACHE_MODEL ?? 'claude-sonnet-4-5';
+const model =
+  process.env.BEDROCK_PROMPT_CACHE_MODEL ??
+  'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+const region =
+  process.env.BEDROCK_AWS_REGION ?? process.env.AWS_REGION ?? 'us-east-1';
 
 function buildStableInstructions(nonce: string): string {
   const records = Array.from(
     { length: 360 },
     (_, index) =>
-      `Stable cache record ${index}: nonce ${nonce}; keep this reference in the cacheable prefix and do not use it as the dynamic marker.`
+      `Stable Bedrock cache record ${index}: nonce ${nonce}; keep this reference in the cacheable prefix and do not use it as the dynamic marker.`
   );
   return [
-    'You are a prompt-cache verification assistant.',
+    'You are a Bedrock prompt-cache verification assistant.',
     'When asked for the dynamic marker, answer with only the marker value from the Dynamic Marker line.',
     ...records,
   ].join('\n');
@@ -43,23 +63,33 @@ function buildStableInstructions(nonce: string): string {
 function buildDynamicInstructions(marker: string): string {
   return [
     `Dynamic Marker: ${marker}`,
-    'The Dynamic Marker line is runtime context and must remain outside the cached prefix.',
+    'The Dynamic Marker line is runtime context and must remain after the Bedrock cache point.',
   ].join('\n');
 }
 
-function createClientOptions(): t.AnthropicClientOptions {
+function getCredentials():
+  | t.BedrockAnthropicClientOptions['credentials']
+  | undefined {
+  if (!hasCredentialPair) {
+    return undefined;
+  }
+
   return {
-    modelName,
-    temperature: 0,
+    accessKeyId,
+    secretAccessKey,
+    ...(sessionToken != null && sessionToken !== '' ? { sessionToken } : {}),
+  };
+}
+
+function createClientOptions(): t.BedrockAnthropicClientOptions {
+  return {
+    model,
+    region,
     maxTokens: 8,
     streaming: true,
     streamUsage: true,
     promptCache: true,
-    clientOptions: {
-      defaultHeaders: {
-        'anthropic-beta': 'prompt-caching-2024-07-31',
-      },
-    },
+    ...(getCredentials() != null ? { credentials: getCredentials() } : {}),
   };
 }
 
@@ -71,8 +101,8 @@ async function assertSystemPayloadShape({
   dynamicInstructions: string;
 }): Promise<void> {
   const ctx = AgentContext.fromConfig({
-    agentId: 'live-cache-shape-check',
-    provider: Providers.ANTHROPIC,
+    agentId: 'live-bedrock-cache-shape-check',
+    provider: Providers.BEDROCK,
     clientOptions: createClientOptions(),
     instructions: stableInstructions,
     additional_instructions: dynamicInstructions,
@@ -86,7 +116,9 @@ async function assertSystemPayloadShape({
     {
       type: 'text',
       text: stableInstructions,
-      cache_control: { type: 'ephemeral' },
+    },
+    {
+      cachePoint: { type: 'default' },
     },
     {
       type: 'text',
@@ -100,7 +132,7 @@ function latestUsage(
   label: string
 ): UsageMetadata {
   if (collectedUsage.length === 0) {
-    throw new Error(`Missing Anthropic usage metadata for ${label}`);
+    throw new Error(`Missing Bedrock usage metadata for ${label}`);
   }
   return collectedUsage[collectedUsage.length - 1];
 }
@@ -112,10 +144,6 @@ function collectText(parts: t.MessageContentComplex[] | undefined): string {
     }
     return text;
   }, '');
-}
-
-async function waitForCachePropagation(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 2000));
 }
 
 async function runLiveTurn({
@@ -138,7 +166,7 @@ async function runLiveTurn({
     graphConfig: {
       type: 'standard',
       llmConfig: {
-        provider: Providers.ANTHROPIC,
+        provider: Providers.BEDROCK,
         ...createClientOptions(),
       },
       instructions: stableInstructions,
@@ -172,9 +200,9 @@ async function runLiveTurn({
   };
 }
 
-describeIfLive('AgentContext Anthropic prompt cache live API', () => {
+describeIfLive('AgentContext Bedrock prompt cache live API', () => {
   it('caches only the stable system prefix while dynamic tail changes', async () => {
-    const nonce = `agent-cache-live-${Date.now()}`;
+    const nonce = `agent-bedrock-cache-live-${Date.now()}`;
     const stableInstructions = buildStableInstructions(nonce);
     const firstDynamicInstructions = buildDynamicInstructions('alpha');
     const secondDynamicInstructions = buildDynamicInstructions('bravo');
@@ -195,8 +223,6 @@ describeIfLive('AgentContext Anthropic prompt cache live API', () => {
     expect(first.usage.input_token_details?.cache_creation).toBeGreaterThan(0);
     expect(first.usage.input_token_details?.cache_read ?? 0).toBe(0);
 
-    await waitForCachePropagation();
-
     const second = await runLiveTurn({
       runId: `${nonce}-second`,
       threadId: `${nonce}-thread`,
@@ -206,5 +232,5 @@ describeIfLive('AgentContext Anthropic prompt cache live API', () => {
 
     expect(second.text.toLowerCase()).toContain('bravo');
     expect(second.usage.input_token_details?.cache_read).toBeGreaterThan(0);
-  }, 120_000);
+  }, 180_000);
 });

--- a/src/agents/__tests__/AgentContext.bedrock.live.test.ts
+++ b/src/agents/__tests__/AgentContext.bedrock.live.test.ts
@@ -12,7 +12,6 @@ dotenvConfig();
 
 import { describe, expect, it } from '@jest/globals';
 import type * as t from '@/types';
-import { Providers } from '@/common';
 import {
   runLiveTurn,
   assertSystemPayloadShape,
@@ -20,6 +19,7 @@ import {
   buildStableInstructions,
   waitForCachePropagation,
 } from './promptCacheLiveHelpers';
+import { Providers } from '@/common';
 
 const accessKeyId =
   process.env.BEDROCK_AWS_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID;

--- a/src/agents/__tests__/AgentContext.bedrock.live.test.ts
+++ b/src/agents/__tests__/AgentContext.bedrock.live.test.ts
@@ -10,14 +10,16 @@
 import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
 
-import { HumanMessage } from '@langchain/core/messages';
 import { describe, expect, it } from '@jest/globals';
-import type { UsageMetadata } from '@langchain/core/messages';
 import type * as t from '@/types';
-import { ModelEndHandler } from '@/events';
-import { AgentContext } from '../AgentContext';
-import { GraphEvents, Providers } from '@/common';
-import { Run } from '@/run';
+import { Providers } from '@/common';
+import {
+  runLiveTurn,
+  assertSystemPayloadShape,
+  buildDynamicInstructions,
+  buildStableInstructions,
+  waitForCachePropagation,
+} from './promptCacheLiveHelpers';
 
 const accessKeyId =
   process.env.BEDROCK_AWS_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID;
@@ -46,26 +48,7 @@ const model =
   'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
 const region =
   process.env.BEDROCK_AWS_REGION ?? process.env.AWS_REGION ?? 'us-east-1';
-
-function buildStableInstructions(nonce: string): string {
-  const records = Array.from(
-    { length: 360 },
-    (_, index) =>
-      `Stable Bedrock cache record ${index}: nonce ${nonce}; keep this reference in the cacheable prefix and do not use it as the dynamic marker.`
-  );
-  return [
-    'You are a Bedrock prompt-cache verification assistant.',
-    'When asked for the dynamic marker, answer with only the marker value from the Dynamic Marker line.',
-    ...records,
-  ].join('\n');
-}
-
-function buildDynamicInstructions(marker: string): string {
-  return [
-    `Dynamic Marker: ${marker}`,
-    'The Dynamic Marker line is runtime context and must remain after the Bedrock cache point.',
-  ].join('\n');
-}
+const providerLabel = 'Bedrock';
 
 function getCredentials():
   | t.BedrockAnthropicClientOptions['credentials']
@@ -82,6 +65,7 @@ function getCredentials():
 }
 
 function createClientOptions(): t.BedrockAnthropicClientOptions {
+  const credentials = getCredentials();
   return {
     model,
     region,
@@ -89,130 +73,54 @@ function createClientOptions(): t.BedrockAnthropicClientOptions {
     streaming: true,
     streamUsage: true,
     promptCache: true,
-    ...(getCredentials() != null ? { credentials: getCredentials() } : {}),
-  };
-}
-
-async function assertSystemPayloadShape({
-  stableInstructions,
-  dynamicInstructions,
-}: {
-  stableInstructions: string;
-  dynamicInstructions: string;
-}): Promise<void> {
-  const ctx = AgentContext.fromConfig({
-    agentId: 'live-bedrock-cache-shape-check',
-    provider: Providers.BEDROCK,
-    clientOptions: createClientOptions(),
-    instructions: stableInstructions,
-    additional_instructions: dynamicInstructions,
-  });
-
-  const messages = await ctx.systemRunnable!.invoke([
-    new HumanMessage('What is the dynamic marker?'),
-  ]);
-
-  expect(messages[0].content).toEqual([
-    {
-      type: 'text',
-      text: stableInstructions,
-    },
-    {
-      cachePoint: { type: 'default' },
-    },
-    {
-      type: 'text',
-      text: dynamicInstructions,
-    },
-  ]);
-}
-
-function latestUsage(
-  collectedUsage: UsageMetadata[],
-  label: string
-): UsageMetadata {
-  if (collectedUsage.length === 0) {
-    throw new Error(`Missing Bedrock usage metadata for ${label}`);
-  }
-  return collectedUsage[collectedUsage.length - 1];
-}
-
-function collectText(parts: t.MessageContentComplex[] | undefined): string {
-  return (parts ?? []).reduce((text, part) => {
-    if (part.type === 'text') {
-      return text + part.text;
-    }
-    return text;
-  }, '');
-}
-
-async function runLiveTurn({
-  runId,
-  threadId,
-  stableInstructions,
-  dynamicInstructions,
-}: {
-  runId: string;
-  threadId: string;
-  stableInstructions: string;
-  dynamicInstructions: string;
-}): Promise<{
-  text: string;
-  usage: UsageMetadata;
-}> {
-  const collectedUsage: UsageMetadata[] = [];
-  const run = await Run.create<t.IState>({
-    runId,
-    graphConfig: {
-      type: 'standard',
-      llmConfig: {
-        provider: Providers.BEDROCK,
-        ...createClientOptions(),
-      },
-      instructions: stableInstructions,
-      additional_instructions: dynamicInstructions,
-    },
-    returnContent: true,
-    skipCleanup: true,
-    customHandlers: {
-      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
-    },
-  });
-
-  const config = {
-    configurable: { thread_id: threadId },
-    streamMode: 'values',
-    version: 'v2' as const,
-  };
-
-  const contentParts = await run.processStream(
-    {
-      messages: [
-        new HumanMessage('What is the dynamic marker? Reply with only it.'),
-      ],
-    },
-    config
-  );
-
-  return {
-    text: collectText(contentParts),
-    usage: latestUsage(collectedUsage, runId),
+    ...(credentials != null ? { credentials } : {}),
   };
 }
 
 describeIfLive('AgentContext Bedrock prompt cache live API', () => {
   it('caches only the stable system prefix while dynamic tail changes', async () => {
     const nonce = `agent-bedrock-cache-live-${Date.now()}`;
-    const stableInstructions = buildStableInstructions(nonce);
-    const firstDynamicInstructions = buildDynamicInstructions('alpha');
-    const secondDynamicInstructions = buildDynamicInstructions('bravo');
+    const clientOptions = createClientOptions();
+    const stableInstructions = buildStableInstructions({
+      nonce,
+      providerLabel,
+    });
+    const firstDynamicInstructions = buildDynamicInstructions({
+      marker: 'alpha',
+      tailDescription:
+        'The Dynamic Marker line is runtime context and must remain after the Bedrock cache point.',
+    });
+    const secondDynamicInstructions = buildDynamicInstructions({
+      marker: 'bravo',
+      tailDescription:
+        'The Dynamic Marker line is runtime context and must remain after the Bedrock cache point.',
+    });
 
     await assertSystemPayloadShape({
+      agentId: 'live-bedrock-cache-shape-check',
+      provider: Providers.BEDROCK,
+      clientOptions,
       stableInstructions,
       dynamicInstructions: firstDynamicInstructions,
+      expectedContent: [
+        {
+          type: 'text',
+          text: stableInstructions,
+        },
+        {
+          cachePoint: { type: 'default' },
+        },
+        {
+          type: 'text',
+          text: firstDynamicInstructions,
+        },
+      ],
     });
 
     const first = await runLiveTurn({
+      provider: Providers.BEDROCK,
+      providerLabel,
+      clientOptions,
       runId: `${nonce}-first`,
       threadId: `${nonce}-thread`,
       stableInstructions,
@@ -223,7 +131,12 @@ describeIfLive('AgentContext Bedrock prompt cache live API', () => {
     expect(first.usage.input_token_details?.cache_creation).toBeGreaterThan(0);
     expect(first.usage.input_token_details?.cache_read ?? 0).toBe(0);
 
+    await waitForCachePropagation();
+
     const second = await runLiveTurn({
+      provider: Providers.BEDROCK,
+      providerLabel,
+      clientOptions,
       runId: `${nonce}-second`,
       threadId: `${nonce}-thread`,
       stableInstructions,

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -6,6 +6,10 @@ import { addBedrockCacheControl } from '@/messages/cache';
 import type * as t from '@/types';
 
 describe('AgentContext', () => {
+  type TestSystemContentBlock =
+    | { type: 'text'; text: string; cache_control?: { type: 'ephemeral' } }
+    | { cachePoint: { type: 'default' } };
+
   type ContextOptions = {
     agentConfig?: Partial<t.AgentInputs>;
     tokenCounter?: t.TokenCounter;
@@ -86,7 +90,7 @@ describe('AgentContext', () => {
       });
 
       const result = await ctx.systemRunnable!.invoke([]);
-      const content = result[0].content as Array<Record<string, unknown>>;
+      const content = result[0].content as TestSystemContentBlock[];
       expect(content).toHaveLength(2);
       expect(content[0]).toMatchObject({
         type: 'text',
@@ -97,6 +101,22 @@ describe('AgentContext', () => {
         type: 'text',
         text: 'Dynamic instructions',
       });
+    });
+
+    it('omits Anthropic cache control when only dynamic system text exists', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: { model: 'claude-3-5-sonnet', promptCache: true },
+          instructions: undefined,
+          additional_instructions: 'Dynamic only',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = result[0].content as TestSystemContentBlock[];
+      expect(content).toEqual([{ type: 'text', text: 'Dynamic only' }]);
+      expect(content[0]).not.toHaveProperty('cache_control');
     });
 
     it('keeps cross-run summaries in the dynamic Anthropic system tail', async () => {
@@ -110,7 +130,7 @@ describe('AgentContext', () => {
       ctx.setInitialSummary('Prior summary', 13);
 
       const result = await ctx.systemRunnable!.invoke([]);
-      const content = result[0].content as Array<Record<string, unknown>>;
+      const content = result[0].content as TestSystemContentBlock[];
       expect(content).toHaveLength(2);
       expect(content[0]).toHaveProperty('cache_control');
       expect(content[1]).toEqual({
@@ -133,12 +153,29 @@ describe('AgentContext', () => {
       });
 
       const result = await ctx.systemRunnable!.invoke([]);
-      const content = result[0].content as Array<Record<string, unknown>>;
+      const content = result[0].content as TestSystemContentBlock[];
       expect(content).toEqual([
         { type: 'text', text: 'Stable instructions' },
         { cachePoint: { type: 'default' } },
         { type: 'text', text: 'Dynamic instructions' },
       ]);
+    });
+
+    it('uses plain Bedrock system text when only dynamic system text exists', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.BEDROCK,
+          clientOptions: {
+            model: 'anthropic.claude-3-5-sonnet',
+            promptCache: true,
+          },
+          instructions: undefined,
+          additional_instructions: 'Dynamic only',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      expect(result[0].content).toBe('Dynamic only');
     });
 
     it('preserves the Bedrock system cache point through message cache-control pass', async () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -178,6 +178,26 @@ describe('AgentContext', () => {
       expect(result[0].content).toBe('Dynamic only');
     });
 
+    it('keeps non-cache providers as plain system text with promptCache-like options', async () => {
+      const clientOptions: t.OpenAIClientOptions & { promptCache: true } = {
+        modelName: 'gpt-4o-mini',
+        promptCache: true,
+      };
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.OPENAI,
+          clientOptions,
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      expect(result[0].content).toBe(
+        'Stable instructions\n\nDynamic instructions'
+      );
+    });
+
     it('preserves the Bedrock system cache point through message cache-control pass', async () => {
       const ctx = createBasicContext({
         agentConfig: {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1,6 +1,8 @@
 // src/agents/__tests__/AgentContext.test.ts
+import { HumanMessage } from '@langchain/core/messages';
 import { AgentContext } from '../AgentContext';
 import { Providers } from '@/common';
+import { addBedrockCacheControl } from '@/messages/cache';
 import type * as t from '@/types';
 
 describe('AgentContext', () => {
@@ -59,14 +61,108 @@ describe('AgentContext', () => {
       expect(ctx.systemRunnable).toBeUndefined();
     });
 
-    it('includes additional_instructions in system message', () => {
+    it('keeps additional_instructions after stable instructions', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           instructions: 'Base instructions',
           additional_instructions: 'Additional instructions',
         },
       });
-      expect(ctx.systemRunnable).toBeDefined();
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      expect(result[0].content).toBe(
+        'Base instructions\n\nAdditional instructions'
+      );
+    });
+
+    it('marks only stable system text for Anthropic prompt caching', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: { model: 'claude-3-5-sonnet', promptCache: true },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = result[0].content as Array<Record<string, unknown>>;
+      expect(content).toHaveLength(2);
+      expect(content[0]).toMatchObject({
+        type: 'text',
+        text: 'Stable instructions',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(content[1]).toEqual({
+        type: 'text',
+        text: 'Dynamic instructions',
+      });
+    });
+
+    it('keeps cross-run summaries in the dynamic Anthropic system tail', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: { model: 'claude-3-5-sonnet', promptCache: true },
+          instructions: 'Stable instructions',
+        },
+      });
+      ctx.setInitialSummary('Prior summary', 13);
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = result[0].content as Array<Record<string, unknown>>;
+      expect(content).toHaveLength(2);
+      expect(content[0]).toHaveProperty('cache_control');
+      expect(content[1]).toEqual({
+        type: 'text',
+        text: '## Conversation Summary\n\nPrior summary',
+      });
+    });
+
+    it('places the Bedrock cache point before dynamic system text', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.BEDROCK,
+          clientOptions: {
+            model: 'anthropic.claude-3-5-sonnet',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      const content = result[0].content as Array<Record<string, unknown>>;
+      expect(content).toEqual([
+        { type: 'text', text: 'Stable instructions' },
+        { cachePoint: { type: 'default' } },
+        { type: 'text', text: 'Dynamic instructions' },
+      ]);
+    });
+
+    it('preserves the Bedrock system cache point through message cache-control pass', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.BEDROCK,
+          clientOptions: {
+            model: 'anthropic.claude-3-5-sonnet',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Hello'),
+      ]);
+      const finalMessages = addBedrockCacheControl(result);
+      expect(finalMessages[0].content).toEqual([
+        { type: 'text', text: 'Stable instructions' },
+        { cachePoint: { type: 'default' } },
+        { type: 'text', text: 'Dynamic instructions' },
+      ]);
     });
   });
 

--- a/src/agents/__tests__/promptCacheLiveHelpers.ts
+++ b/src/agents/__tests__/promptCacheLiveHelpers.ts
@@ -1,0 +1,165 @@
+import { expect } from '@jest/globals';
+import { HumanMessage } from '@langchain/core/messages';
+import type { UsageMetadata } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { ModelEndHandler } from '@/events';
+import { AgentContext } from '../AgentContext';
+import { GraphEvents, Providers } from '@/common';
+import { Run } from '@/run';
+
+type LivePromptCacheProvider = Providers.ANTHROPIC | Providers.BEDROCK;
+
+type PromptCacheExpectedSystemBlock =
+  | { type: 'text'; text: string; cache_control?: { type: 'ephemeral' } }
+  | { cachePoint: { type: 'default' } };
+
+type LivePromptCacheClientOptions =
+  | t.ClientOptions
+  | t.BedrockAnthropicClientOptions;
+
+export function buildStableInstructions({
+  nonce,
+  providerLabel,
+}: {
+  nonce: string;
+  providerLabel: string;
+}): string {
+  const records = Array.from(
+    { length: 360 },
+    (_, index) =>
+      `Stable ${providerLabel} cache record ${index}: nonce ${nonce}; keep this reference in the cacheable prefix and do not use it as the dynamic marker.`
+  );
+  return [
+    `You are a ${providerLabel} prompt-cache verification assistant.`,
+    'When asked for the dynamic marker, answer with only the marker value from the Dynamic Marker line.',
+    ...records,
+  ].join('\n');
+}
+
+export function buildDynamicInstructions({
+  marker,
+  tailDescription,
+}: {
+  marker: string;
+  tailDescription: string;
+}): string {
+  return [`Dynamic Marker: ${marker}`, tailDescription].join('\n');
+}
+
+export function waitForCachePropagation(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 2000));
+}
+
+export async function assertSystemPayloadShape({
+  agentId,
+  provider,
+  clientOptions,
+  stableInstructions,
+  dynamicInstructions,
+  expectedContent,
+}: {
+  agentId: string;
+  provider: LivePromptCacheProvider;
+  clientOptions: LivePromptCacheClientOptions;
+  stableInstructions: string;
+  dynamicInstructions: string;
+  expectedContent: PromptCacheExpectedSystemBlock[];
+}): Promise<void> {
+  const ctx = AgentContext.fromConfig({
+    agentId,
+    provider,
+    clientOptions,
+    instructions: stableInstructions,
+    additional_instructions: dynamicInstructions,
+  });
+
+  const messages = await ctx.systemRunnable!.invoke([
+    new HumanMessage('What is the dynamic marker?'),
+  ]);
+
+  expect(messages[0].content).toEqual(expectedContent);
+}
+
+function latestUsage({
+  collectedUsage,
+  label,
+  providerLabel,
+}: {
+  collectedUsage: UsageMetadata[];
+  label: string;
+  providerLabel: string;
+}): UsageMetadata {
+  if (collectedUsage.length === 0) {
+    throw new Error(`Missing ${providerLabel} usage metadata for ${label}`);
+  }
+  return collectedUsage[collectedUsage.length - 1];
+}
+
+function collectText(parts: t.MessageContentComplex[] | undefined): string {
+  return (parts ?? []).reduce((text, part) => {
+    if (part.type === 'text') {
+      return text + part.text;
+    }
+    return text;
+  }, '');
+}
+
+export async function runLiveTurn({
+  provider,
+  providerLabel,
+  clientOptions,
+  runId,
+  threadId,
+  stableInstructions,
+  dynamicInstructions,
+}: {
+  provider: LivePromptCacheProvider;
+  providerLabel: string;
+  clientOptions: LivePromptCacheClientOptions;
+  runId: string;
+  threadId: string;
+  stableInstructions: string;
+  dynamicInstructions: string;
+}): Promise<{
+  text: string;
+  usage: UsageMetadata;
+}> {
+  const collectedUsage: UsageMetadata[] = [];
+  const run = await Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider,
+        ...clientOptions,
+      } as t.LLMConfig,
+      instructions: stableInstructions,
+      additional_instructions: dynamicInstructions,
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers: {
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
+    },
+  });
+
+  const config = {
+    configurable: { thread_id: threadId },
+    streamMode: 'values',
+    version: 'v2' as const,
+  };
+
+  const contentParts = await run.processStream(
+    {
+      messages: [
+        new HumanMessage('What is the dynamic marker? Reply with only it.'),
+      ],
+    },
+    config
+  );
+
+  return {
+    text: collectText(contentParts),
+    usage: latestUsage({ collectedUsage, label: runId, providerLabel }),
+  };
+}

--- a/src/agents/__tests__/promptCacheLiveHelpers.ts
+++ b/src/agents/__tests__/promptCacheLiveHelpers.ts
@@ -2,9 +2,9 @@ import { expect } from '@jest/globals';
 import { HumanMessage } from '@langchain/core/messages';
 import type { UsageMetadata } from '@langchain/core/messages';
 import type * as t from '@/types';
-import { ModelEndHandler } from '@/events';
-import { AgentContext } from '../AgentContext';
 import { GraphEvents, Providers } from '@/common';
+import { AgentContext } from '../AgentContext';
+import { ModelEndHandler } from '@/events';
 import { Run } from '@/run';
 
 type LivePromptCacheProvider = Providers.ANTHROPIC | Providers.BEDROCK;

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -1,8 +1,9 @@
 import {
   AIMessage,
   BaseMessage,
-  ToolMessage,
   HumanMessage,
+  SystemMessage,
+  ToolMessage,
   MessageContentComplex,
 } from '@langchain/core/messages';
 import type Anthropic from '@anthropic-ai/sdk';
@@ -404,7 +405,43 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     expect(first[1]).toEqual({ cachePoint: { type: 'default' } });
   });
 
-  it('works with the example from the langchain pr (with multi-turn behavior)', () => {
+  it('preserves LangChain system message content unchanged', () => {
+    const systemContent = [
+      { type: ContentTypes.TEXT, text: 'Stable system text' },
+      { cachePoint: { type: 'default' } },
+      { type: ContentTypes.TEXT, text: 'Dynamic system text' },
+    ] as MessageContentComplex[];
+    const messages: BaseMessage[] = [
+      new SystemMessage({ content: systemContent }),
+      new HumanMessage('Hello'),
+      new AIMessage('Hi'),
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    expect(result[0]).toBe(messages[0]);
+    expect(result[0].content).toEqual(systemContent);
+  });
+
+  it('preserves serialized system message content unchanged', () => {
+    const systemContent = [
+      { type: ContentTypes.TEXT, text: 'Stable system text' },
+      { cachePoint: { type: 'default' } },
+      { type: ContentTypes.TEXT, text: 'Dynamic system text' },
+    ] as MessageContentComplex[];
+    const messages: TestMsg[] = [
+      { role: 'system', content: systemContent },
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi' },
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    expect(result[0]).toBe(messages[0]);
+    expect(result[0].content).toEqual(systemContent);
+  });
+
+  it('skips serialized system messages while adding cache points to non-system turns', () => {
     const messages: TestMsg[] = [
       {
         role: 'system',
@@ -429,7 +466,7 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
       type: ContentTypes.TEXT,
       text: 'You\'re an advanced AI assistant.',
     });
-    expect(system[1]).toEqual({ cachePoint: { type: 'default' } });
+    expect(system).toHaveLength(1);
     expect(user[0]).toEqual({
       type: ContentTypes.TEXT,
       text: 'What is the capital of France?',

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -441,6 +441,70 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     expect(result[0].content).toEqual(systemContent);
   });
 
+  it('strips Anthropic cache_control from LangChain system messages without moving cache points', () => {
+    const systemContent = [
+      {
+        type: ContentTypes.TEXT,
+        text: 'Stable system text',
+        cache_control: { type: 'ephemeral' },
+      } as MessageContentComplex,
+      { cachePoint: { type: 'default' } },
+      {
+        type: ContentTypes.TEXT,
+        text: 'Dynamic system text',
+        cache_control: { type: 'ephemeral' },
+      } as MessageContentComplex,
+    ] as MessageContentComplex[];
+    const messages: BaseMessage[] = [
+      new SystemMessage({ content: systemContent }),
+      new HumanMessage('Hello'),
+      new AIMessage('Hi'),
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    expect(result[0]).not.toBe(messages[0]);
+    expect(result[0].content).toEqual([
+      { type: ContentTypes.TEXT, text: 'Stable system text' },
+      { cachePoint: { type: 'default' } },
+      { type: ContentTypes.TEXT, text: 'Dynamic system text' },
+    ]);
+    expect(systemContent[0]).toHaveProperty('cache_control');
+    expect(systemContent[2]).toHaveProperty('cache_control');
+  });
+
+  it('strips Anthropic cache_control from serialized system messages without moving cache points', () => {
+    const systemContent = [
+      {
+        type: ContentTypes.TEXT,
+        text: 'Stable system text',
+        cache_control: { type: 'ephemeral' },
+      } as MessageContentComplex,
+      { cachePoint: { type: 'default' } },
+      {
+        type: ContentTypes.TEXT,
+        text: 'Dynamic system text',
+        cache_control: { type: 'ephemeral' },
+      } as MessageContentComplex,
+    ] as MessageContentComplex[];
+    const messages: TestMsg[] = [
+      { role: 'system', content: systemContent },
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi' },
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    expect(result[0]).not.toBe(messages[0]);
+    expect(result[0].content).toEqual([
+      { type: ContentTypes.TEXT, text: 'Stable system text' },
+      { cachePoint: { type: 'default' } },
+      { type: ContentTypes.TEXT, text: 'Dynamic system text' },
+    ]);
+    expect(systemContent[0]).toHaveProperty('cache_control');
+    expect(systemContent[2]).toHaveProperty('cache_control');
+  });
+
   it('skips serialized system messages while adding cache points to non-system turns', () => {
     const messages: TestMsg[] = [
       {

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -14,6 +14,10 @@ type MessageWithContent = {
   content?: string | MessageContentComplex[];
 };
 
+type MessageContentWithCacheControl = MessageContentComplex & {
+  cache_control?: unknown;
+};
+
 /**
  * Deep clones a message's content to prevent mutation of the original.
  */
@@ -99,6 +103,24 @@ function cloneMessage<T extends MessageWithContent>(
   }
 
   return cloned;
+}
+
+function stripAnthropicCacheControlFromBlocks(
+  content: MessageContentComplex[]
+): { content: MessageContentComplex[]; modified: boolean } {
+  let modified = false;
+  const strippedContent = content.map((block) => {
+    if (!('cache_control' in block)) {
+      return block;
+    }
+
+    const cloned: MessageContentWithCacheControl = { ...block };
+    delete cloned.cache_control;
+    modified = true;
+    return cloned;
+  });
+
+  return { content: strippedContent, modified };
 }
 
 /**
@@ -320,7 +342,16 @@ export function addBedrockCacheControl<
         ? originalMessage.role
         : undefined;
 
-    if (messageType === 'system' || messageRole === 'system') {
+    const isSystemMessage =
+      messageType === 'system' || messageRole === 'system';
+    if (isSystemMessage) {
+      const systemContent = originalMessage.content;
+      if (Array.isArray(systemContent)) {
+        const stripped = stripAnthropicCacheControlFromBlocks(systemContent);
+        if (stripped.modified) {
+          updatedMessages[i] = cloneMessage(originalMessage, stripped.content);
+        }
+      }
       continue;
     }
 

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -50,22 +50,22 @@ function cloneMessage<T extends MessageWithContent>(
 
     const msgType = message.getType();
     switch (msgType) {
-      case 'ai':
-        return new AIMessage({
-          ...baseParams,
-          tool_calls: (message as unknown as AIMessage).tool_calls,
-        }) as unknown as T;
-      case 'human':
-        return new HumanMessage(baseParams) as unknown as T;
-      case 'system':
-        return new SystemMessage(baseParams) as unknown as T;
-      case 'tool':
-        return new ToolMessage({
-          ...baseParams,
-          tool_call_id: (message as unknown as ToolMessage).tool_call_id,
-        }) as unknown as T;
-      default:
-        break;
+    case 'ai':
+      return new AIMessage({
+        ...baseParams,
+        tool_calls: (message as unknown as AIMessage).tool_calls,
+      }) as unknown as T;
+    case 'human':
+      return new HumanMessage(baseParams) as unknown as T;
+    case 'system':
+      return new SystemMessage(baseParams) as unknown as T;
+    case 'tool':
+      return new ToolMessage({
+        ...baseParams,
+        tool_call_id: (message as unknown as ToolMessage).tool_call_id,
+      }) as unknown as T;
+    default:
+      break;
     }
   }
 
@@ -310,19 +310,21 @@ export function addBedrockCacheControl<
 
   for (let i = updatedMessages.length - 1; i >= 0; i--) {
     const originalMessage = updatedMessages[i];
-    const isToolMessage =
+    const messageType =
       'getType' in originalMessage &&
-      typeof originalMessage.getType === 'function' &&
-      originalMessage.getType() === 'tool';
-    const isSystemMessage =
-      'getType' in originalMessage &&
-      typeof originalMessage.getType === 'function' &&
-      originalMessage.getType() === 'system';
+      typeof originalMessage.getType === 'function'
+        ? originalMessage.getType()
+        : undefined;
+    const messageRole =
+      'role' in originalMessage && typeof originalMessage.role === 'string'
+        ? originalMessage.role
+        : undefined;
 
-    if (isSystemMessage) {
+    if (messageType === 'system' || messageRole === 'system') {
       continue;
     }
 
+    const isToolMessage = messageType === 'tool' || messageRole === 'tool';
     const content = originalMessage.content;
     const hasArrayContent = Array.isArray(content);
     const isEmptyString = typeof content === 'string' && content === '';

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -50,22 +50,22 @@ function cloneMessage<T extends MessageWithContent>(
 
     const msgType = message.getType();
     switch (msgType) {
-    case 'ai':
-      return new AIMessage({
-        ...baseParams,
-        tool_calls: (message as unknown as AIMessage).tool_calls,
-      }) as unknown as T;
-    case 'human':
-      return new HumanMessage(baseParams) as unknown as T;
-    case 'system':
-      return new SystemMessage(baseParams) as unknown as T;
-    case 'tool':
-      return new ToolMessage({
-        ...baseParams,
-        tool_call_id: (message as unknown as ToolMessage).tool_call_id,
-      }) as unknown as T;
-    default:
-      break;
+      case 'ai':
+        return new AIMessage({
+          ...baseParams,
+          tool_calls: (message as unknown as AIMessage).tool_calls,
+        }) as unknown as T;
+      case 'human':
+        return new HumanMessage(baseParams) as unknown as T;
+      case 'system':
+        return new SystemMessage(baseParams) as unknown as T;
+      case 'tool':
+        return new ToolMessage({
+          ...baseParams,
+          tool_call_id: (message as unknown as ToolMessage).tool_call_id,
+        }) as unknown as T;
+      default:
+        break;
     }
   }
 
@@ -314,6 +314,14 @@ export function addBedrockCacheControl<
       'getType' in originalMessage &&
       typeof originalMessage.getType === 'function' &&
       originalMessage.getType() === 'tool';
+    const isSystemMessage =
+      'getType' in originalMessage &&
+      typeof originalMessage.getType === 'function' &&
+      originalMessage.getType() === 'system';
+
+    if (isSystemMessage) {
+      continue;
+    }
 
     const content = originalMessage.content;
     const hasArrayContent = Array.isArray(content);

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -123,6 +123,22 @@ function stripAnthropicCacheControlFromBlocks(
   return { content: strippedContent, modified };
 }
 
+function sanitizeBedrockSystemMessage<T extends MessageWithContent>(
+  message: T
+): T {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return message;
+  }
+
+  const stripped = stripAnthropicCacheControlFromBlocks(content);
+  if (!stripped.modified) {
+    return message;
+  }
+
+  return cloneMessage(message, stripped.content);
+}
+
 /**
  * Anthropic API: Adds cache control to the appropriate user messages in the payload.
  * Strips ALL existing cache control (both Anthropic and Bedrock formats) from all messages,
@@ -345,13 +361,7 @@ export function addBedrockCacheControl<
     const isSystemMessage =
       messageType === 'system' || messageRole === 'system';
     if (isSystemMessage) {
-      const systemContent = originalMessage.content;
-      if (Array.isArray(systemContent)) {
-        const stripped = stripAnthropicCacheControlFromBlocks(systemContent);
-        if (stripped.modified) {
-          updatedMessages[i] = cloneMessage(originalMessage, stripped.content);
-        }
-      }
+      updatedMessages[i] = sanitizeBedrockSystemMessage(originalMessage);
       continue;
     }
 

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -502,7 +502,7 @@ export interface AgentInputs {
   summarizationEnabled?: boolean;
   summarizationConfig?: SummarizationConfig;
   /** Cross-run summary from a previous run, forwarded from formatAgentMessages.
-   *  Injected into the system message via AgentContext.buildInstructionsString(). */
+   *  Injected into the dynamic system tail via AgentContext. */
   initialSummary?: { text: string; tokenCount: number };
   contextPruningConfig?: ContextPruningConfig;
   maxToolResultChars?: number;

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -471,10 +471,12 @@ export interface AgentInputs {
   toolMap?: ToolMap;
   tools?: GraphTools;
   provider: Providers;
+  /** Stable/cacheable system instructions. */
   instructions?: string;
   streamBuffer?: number;
   maxContextTokens?: number;
   clientOptions?: ClientOptions;
+  /** Dynamic system tail appended after stable instructions without provider cache markers. */
   additional_instructions?: string;
   reasoningKey?: 'reasoning_content' | 'reasoning';
   /** Format content blocks as strings (for legacy compatibility i.e. Ollama/Azure Serverless) */

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -75,7 +75,9 @@ export interface AgentStateChannels {
   messages: BaseMessage[];
   next: string;
   [key: string]: unknown;
+  /** Stable/cacheable system instructions. */
   instructions?: string;
+  /** Dynamic system tail appended after stable instructions. */
   additional_instructions?: string;
 }
 


### PR DESCRIPTION
## Summary
- split AgentContext system content into a stable cacheable prefix and dynamic additional_instructions tail
- keep Anthropic cache_control only on stable system text and place Bedrock cache points before dynamic text
- treat cross-run summaries as dynamic system tail while preserving mid-run compaction as HumanMessage
- add opt-in live Anthropic and Bedrock prompt-cache tests that verify cache creation/read behavior across dynamic tails
- bump @librechat/agents to 3.1.75

## Tests
- npm test -- src/agents/__tests__/AgentContext.test.ts --runInBand
- RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS=1 RUN_BEDROCK_PROMPT_CACHE_LIVE_TESTS=1 npm test -- src/agents/__tests__/AgentContext.anthropic.live.test.ts src/agents/__tests__/AgentContext.bedrock.live.test.ts src/agents/__tests__/AgentContext.test.ts --runInBand
- npm run build
- npm pack --json

## Optional live verification
- RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- AgentContext.anthropic.live.test.ts --runInBand
- RUN_BEDROCK_PROMPT_CACHE_LIVE_TESTS=1 BEDROCK_AWS_REGION=... BEDROCK_AWS_ACCESS_KEY_ID=... BEDROCK_AWS_SECRET_ACCESS_KEY=... npm test -- AgentContext.bedrock.live.test.ts --runInBand