### PR TITLE
⏱️ fix: Delay Anthropic Structured Input Chunks

### DIFF
--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -334,6 +334,36 @@ function delayInputChunk(delay?: number): Promise<void> | undefined {
   return new Promise((resolve) => setTimeout(resolve, delay));
 }
 
+const INPUT_DELTA_DELAY_CHAR_BUDGET = 128;
+
+type InputDeltaPacer = {
+  charsSinceDelay: number;
+  seenNonEmptyInput: boolean;
+};
+
+function shouldDelayInputChunk(
+  token: string,
+  delay: number | undefined,
+  pacer: InputDeltaPacer
+): boolean {
+  if (delay == null || delay <= 0 || token === '') {
+    return false;
+  }
+
+  if (!pacer.seenNonEmptyInput) {
+    pacer.seenNonEmptyInput = true;
+    return true;
+  }
+
+  pacer.charsSinceDelay += token.length;
+  if (pacer.charsSinceDelay < INPUT_DELTA_DELAY_CHAR_BUDGET) {
+    return false;
+  }
+
+  pacer.charsSinceDelay = 0;
+  return true;
+}
+
 type CustomAnthropicInvocationParams = {
   betas?: AnthropicBeta[];
   container?: string;
@@ -545,6 +575,10 @@ export class CustomAnthropic extends ChatAnthropicMessages {
     });
 
     const shouldStreamUsage = options.streamUsage ?? this.streamUsage;
+    const inputDeltaPacer: InputDeltaPacer = {
+      charsSinceDelay: 0,
+      seenNonEmptyInput: false,
+    };
 
     for await (const data of stream) {
       if (options.signal?.aborted === true) {
@@ -576,7 +610,11 @@ export class CustomAnthropic extends ChatAnthropicMessages {
       const [token = '', tokenType] = extractToken(chunk);
 
       if (tokenType === 'input' && token !== '') {
-        await delayInputChunk(this._lc_stream_delay);
+        if (
+          shouldDelayInputChunk(token, this._lc_stream_delay, inputDeltaPacer)
+        ) {
+          await delayInputChunk(this._lc_stream_delay);
+        }
         const generationChunk = this.createGenerationChunk({
           token,
           chunk,

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -52,7 +52,11 @@ export function _documentsInParams(
     if (typeof message.content === 'string') {
       continue;
     }
-    for (const block of message.content) {
+    for (const rawBlock of message.content) {
+      const block = rawBlock as {
+        type?: unknown;
+        citations?: { enabled?: unknown };
+      } | null;
       if (
         typeof block === 'object' &&
         block !== null &&
@@ -323,6 +327,13 @@ export type CustomAnthropicCallOptions = {
   mcp_servers?: AnthropicMCPServerURLDefinition[];
 };
 
+function delayInputChunk(delay?: number): Promise<void> | undefined {
+  if (delay == null || delay <= 0) {
+    return;
+  }
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
 type CustomAnthropicInvocationParams = {
   betas?: AnthropicBeta[];
   container?: string;
@@ -563,6 +574,26 @@ export class CustomAnthropic extends ChatAnthropicMessages {
 
       const { chunk } = result;
       const [token = '', tokenType] = extractToken(chunk);
+
+      if (tokenType === 'input' && token !== '') {
+        await delayInputChunk(this._lc_stream_delay);
+        const generationChunk = this.createGenerationChunk({
+          token,
+          chunk,
+          usageMetadata,
+          shouldStreamUsage,
+        });
+        yield generationChunk;
+        await runManager?.handleLLMNewToken(
+          token,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { chunk: generationChunk }
+        );
+        continue;
+      }
 
       if (
         !tokenType ||

--- a/src/llm/anthropic/tool-arg-streaming.test.ts
+++ b/src/llm/anthropic/tool-arg-streaming.test.ts
@@ -1,11 +1,6 @@
-import { Stream } from '@anthropic-ai/sdk/core/streaming';
 import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
 
-import type {
-  AnthropicMessageStreamEvent,
-  AnthropicRequestOptions,
-  AnthropicStreamingMessageCreateParams,
-} from './types';
+import type { AnthropicMessageStreamEvent } from './types';
 
 import { CustomAnthropic } from './index';
 
@@ -18,35 +13,41 @@ type ToolArgStreamChunks = {
   contentInputs: string[];
   toolArgChunks: ToolArgChunk[];
 };
-
-class FakeStreamingAnthropic extends CustomAnthropic {
-  private readonly events: AnthropicMessageStreamEvent[];
-
-  constructor(events: AnthropicMessageStreamEvent[], streamDelay = 0) {
-    super({
-      apiKey: 'test-key',
-      model: 'claude-haiku-4-5-20251001',
-      streaming: true,
-      _lc_stream_delay: streamDelay,
-    });
-    this.events = events;
-  }
-
-  protected async createStreamWithRetry(
-    _request: AnthropicStreamingMessageCreateParams & Record<string, unknown>,
-    _options?: AnthropicRequestOptions
-  ): Promise<Stream<AnthropicMessageStreamEvent>> {
-    const events = this.events;
-    return new Stream<AnthropicMessageStreamEvent>(async function* () {
-      for (const event of events) {
-        yield event;
-      }
-    }, new AbortController());
-  }
-}
+type AnthropicEventStream = AsyncIterable<AnthropicMessageStreamEvent> & {
+  controller: AbortController;
+};
 
 function anthropicEvent(event: unknown): AnthropicMessageStreamEvent {
   return event as AnthropicMessageStreamEvent;
+}
+
+function createAnthropicEventStream(
+  events: AnthropicMessageStreamEvent[]
+): AnthropicEventStream {
+  return {
+    controller: new AbortController(),
+    async *[Symbol.asyncIterator](): AsyncGenerator<AnthropicMessageStreamEvent> {
+      for (const event of events) {
+        yield event;
+      }
+    },
+  };
+}
+
+function createFakeStreamingAnthropic(
+  events: AnthropicMessageStreamEvent[],
+  streamDelay = 0
+): CustomAnthropic {
+  const model = new CustomAnthropic({
+    apiKey: 'test-key',
+    model: 'claude-haiku-4-5-20251001',
+    streaming: true,
+    _lc_stream_delay: streamDelay,
+  });
+  Object.defineProperty(model, 'createStreamWithRetry', {
+    value: async () => createAnthropicEventStream(events),
+  });
+  return model;
 }
 
 function createToolArgEvents(
@@ -82,7 +83,7 @@ async function collectToolArgChunks(
   partialJsonChunks: string[],
   streamDelay = 0
 ): Promise<ToolArgStreamChunks> {
-  const model = new FakeStreamingAnthropic(
+  const model = createFakeStreamingAnthropic(
     createToolArgEvents(partialJsonChunks),
     streamDelay
   );

--- a/src/llm/anthropic/tool-arg-streaming.test.ts
+++ b/src/llm/anthropic/tool-arg-streaming.test.ts
@@ -1,0 +1,168 @@
+import { Stream } from '@anthropic-ai/sdk/core/streaming';
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+
+import type {
+  AnthropicMessageStreamEvent,
+  AnthropicRequestOptions,
+  AnthropicStreamingMessageCreateParams,
+} from './types';
+
+import { CustomAnthropic } from './index';
+
+type ToolArgChunk = NonNullable<AIMessageChunk['tool_call_chunks']>[number];
+type MessageWithToolArgChunks = {
+  content?: unknown;
+  tool_call_chunks?: ToolArgChunk[];
+};
+type ToolArgStreamChunks = {
+  contentInputs: string[];
+  toolArgChunks: ToolArgChunk[];
+};
+
+class FakeStreamingAnthropic extends CustomAnthropic {
+  private readonly events: AnthropicMessageStreamEvent[];
+
+  constructor(events: AnthropicMessageStreamEvent[], streamDelay = 0) {
+    super({
+      apiKey: 'test-key',
+      model: 'claude-haiku-4-5-20251001',
+      streaming: true,
+      _lc_stream_delay: streamDelay,
+    });
+    this.events = events;
+  }
+
+  protected async createStreamWithRetry(
+    _request: AnthropicStreamingMessageCreateParams & Record<string, unknown>,
+    _options?: AnthropicRequestOptions
+  ): Promise<Stream<AnthropicMessageStreamEvent>> {
+    const events = this.events;
+    return new Stream<AnthropicMessageStreamEvent>(async function* () {
+      for (const event of events) {
+        yield event;
+      }
+    }, new AbortController());
+  }
+}
+
+function anthropicEvent(event: unknown): AnthropicMessageStreamEvent {
+  return event as AnthropicMessageStreamEvent;
+}
+
+function createToolArgEvents(
+  partialJsonChunks: string[]
+): AnthropicMessageStreamEvent[] {
+  return [
+    anthropicEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: {
+        type: 'tool_use',
+        id: 'toolu_lookup',
+        name: 'lookup',
+        input: {},
+      },
+    }),
+    ...partialJsonChunks.map((partialJson) =>
+      anthropicEvent({
+        type: 'content_block_delta',
+        index: 0,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: partialJson,
+        },
+      })
+    ),
+    anthropicEvent({ type: 'content_block_stop', index: 0 }),
+    anthropicEvent({ type: 'message_stop' }),
+  ];
+}
+
+async function collectToolArgChunks(
+  partialJsonChunks: string[],
+  streamDelay = 0
+): Promise<ToolArgStreamChunks> {
+  const model = new FakeStreamingAnthropic(
+    createToolArgEvents(partialJsonChunks),
+    streamDelay
+  );
+  const contentInputs: string[] = [];
+  const toolArgChunks: ToolArgChunk[] = [];
+
+  const stream = model._streamResponseChunks([new HumanMessage('lookup')], {
+    tools: [
+      {
+        name: 'lookup',
+        description: 'Lookup a query',
+        input_schema: {
+          type: 'object',
+          properties: {
+            q: { type: 'string' },
+          },
+        },
+      },
+    ],
+  });
+  for await (const chunk of stream) {
+    const message = chunk.message as MessageWithToolArgChunks;
+    toolArgChunks.push(...(message.tool_call_chunks ?? []));
+    if (!Array.isArray(message.content)) {
+      continue;
+    }
+    const [firstContentBlock] = message.content;
+    if (
+      typeof firstContentBlock === 'object' &&
+      firstContentBlock !== null &&
+      'input' in firstContentBlock &&
+      typeof firstContentBlock.input === 'string'
+    ) {
+      contentInputs.push(firstContentBlock.input);
+    }
+  }
+
+  return { contentInputs, toolArgChunks };
+}
+
+describe('CustomAnthropic tool argument streaming', () => {
+  test('streams input_json_delta chunks before the final tool args are complete', async () => {
+    const { contentInputs, toolArgChunks } = await collectToolArgChunks([
+      '{"q":',
+      '"sf"}',
+    ]);
+
+    expect(toolArgChunks.map((chunk) => chunk.args)).toEqual([
+      '',
+      '{"q":',
+      '"sf"}',
+    ]);
+    expect(contentInputs).toEqual(['', '{"q":', '"sf"}']);
+    expect(toolArgChunks.map((chunk) => chunk.args).join('')).toBe(
+      '{"q":"sf"}'
+    );
+  });
+
+  test('delays large input_json_delta chunks without splitting structured input', async () => {
+    jest.useFakeTimers();
+    try {
+      const rawArgs = '{"query": "San Francisco", "unit": "fahrenheit"}';
+      const collection = collectToolArgChunks([rawArgs], 20);
+      let settled = false;
+      collection.then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(19);
+      expect(settled).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(1);
+      const { contentInputs, toolArgChunks } = await collection;
+
+      expect(toolArgChunks.map((chunk) => chunk.args)).toEqual(['', rawArgs]);
+      expect(contentInputs).toEqual(['', rawArgs]);
+      expect(toolArgChunks.every((chunk) => chunk.index === 0)).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/llm/anthropic/tool-arg-streaming.test.ts
+++ b/src/llm/anthropic/tool-arg-streaming.test.ts
@@ -166,4 +166,31 @@ describe('CustomAnthropic tool argument streaming', () => {
       jest.useRealTimers();
     }
   });
+
+  test('paces dense input_json_delta bursts without delaying every provider chunk', async () => {
+    jest.useFakeTimers();
+    try {
+      const rawChunks = Array.from({ length: 10 }, () => 'abcdefghij');
+      const collection = collectToolArgChunks(rawChunks, 20);
+      let settled = false;
+      collection.then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(19);
+      expect(settled).toBe(false);
+
+      await jest.advanceTimersByTimeAsync(1);
+      const { toolArgChunks } = await collection;
+
+      expect(settled).toBe(true);
+      expect(toolArgChunks.map((chunk) => chunk.args)).toEqual([
+        '',
+        ...rawChunks,
+      ]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/src/scripts/anthropic-bedrock-tool-delta-stream.ts
+++ b/src/scripts/anthropic-bedrock-tool-delta-stream.ts
@@ -1,0 +1,253 @@
+/* eslint-disable no-console */
+import { config } from 'dotenv';
+config({ path: process.env.DOTENV_CONFIG_PATH });
+
+import { tool } from '@langchain/core/tools';
+import { HumanMessage } from '@langchain/core/messages';
+import { performance } from 'node:perf_hooks';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import { GraphEvents, Providers, StepTypes } from '@/common';
+import { getLLMConfig } from '@/utils/llmConfig';
+import { Run } from '@/run';
+
+type ProviderUnderTest = Providers.ANTHROPIC | Providers.BEDROCK;
+type ToolCallDeltaChunk = NonNullable<t.ToolCallDelta['tool_calls']>[number] & {
+  function?: {
+    name?: unknown;
+    arguments?: unknown;
+  };
+};
+
+const providerArgs = new Set(['anthropic', 'bedrock', 'both']);
+const weatherSchema = {
+  type: 'object',
+  properties: {
+    city: {
+      type: 'string',
+      description: 'City and region to look up.',
+    },
+    unit: {
+      type: 'string',
+      enum: ['fahrenheit', 'celsius'],
+    },
+    detail: {
+      type: 'string',
+      description: 'Detailed request text.',
+    },
+  },
+  required: ['city', 'unit', 'detail'],
+} as const;
+
+function getProviders(): ProviderUnderTest[] {
+  const rawArg =
+    process.argv.find((arg) => arg.startsWith('--provider='))?.split('=')[1] ??
+    process.argv.find((arg) => providerArgs.has(arg));
+  if (rawArg === 'anthropic') {
+    return [Providers.ANTHROPIC];
+  }
+  if (rawArg === 'bedrock') {
+    return [Providers.BEDROCK];
+  }
+  return [Providers.ANTHROPIC, Providers.BEDROCK];
+}
+
+function preview(value: string): string {
+  return value.length > 90 ? `${value.slice(0, 87)}...` : value;
+}
+
+function createLookupWeatherTool(): StructuredToolInterface {
+  return tool(
+    async (input: Record<string, unknown>): Promise<string> =>
+      JSON.stringify({
+        status: 'ok',
+        received: input,
+        forecast: 'Clear enough for this streaming test.',
+      }),
+    {
+      name: 'lookup_weather',
+      description:
+        'Lookup weather for a city with explicit formatting preferences.',
+      schema: weatherSchema,
+    }
+  );
+}
+
+function configureLLM(provider: ProviderUnderTest): t.LLMConfig {
+  const llmConfig = {
+    ...getLLMConfig(provider),
+    streaming: true,
+    streamUsage: true,
+    maxTokens: 512,
+    _lc_stream_delay: Number(process.env.LC_STREAM_DELAY_MS ?? 35),
+  } as t.LLMConfig;
+
+  if (
+    provider === Providers.ANTHROPIC &&
+    process.env.ANTHROPIC_TEST_MODEL != null &&
+    process.env.ANTHROPIC_TEST_MODEL !== ''
+  ) {
+    llmConfig.model = process.env.ANTHROPIC_TEST_MODEL;
+  }
+  if (
+    provider === Providers.BEDROCK &&
+    process.env.BEDROCK_TEST_MODEL != null &&
+    process.env.BEDROCK_TEST_MODEL !== ''
+  ) {
+    llmConfig.model = process.env.BEDROCK_TEST_MODEL;
+  }
+
+  return llmConfig;
+}
+
+async function testProvider(provider: ProviderUnderTest): Promise<void> {
+  const startedAt = performance.now();
+  const nonEmptyArgTimes: number[] = [];
+  const argsByIndex = new Map<number, string>();
+  const messageInputs: string[] = [];
+  const eventCounts = new Map<string, number>();
+
+  const elapsed = (): number => Math.round(performance.now() - startedAt);
+  const countEvent = (event: string): void => {
+    eventCounts.set(event, (eventCounts.get(event) ?? 0) + 1);
+  };
+
+  const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        countEvent(event);
+        const runStep = data as t.RunStep;
+        const toolCalls =
+          runStep.stepDetails.type === StepTypes.TOOL_CALLS
+            ? runStep.stepDetails.tool_calls
+            : undefined;
+        console.log(
+          `[${provider}] +${elapsed()}ms ${event} step=${runStep.id} type=${
+            runStep.stepDetails.type
+          } index=${runStep.index}`
+        );
+        if (toolCalls != null && toolCalls.length > 0) {
+          console.dir(toolCalls, { depth: null });
+        }
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        countEvent(event);
+        const runStepDelta = data as t.RunStepDeltaEvent;
+        if (runStepDelta.delta.type !== StepTypes.TOOL_CALLS) {
+          return;
+        }
+
+        for (const rawToolCall of runStepDelta.delta.tool_calls ?? []) {
+          const toolCall = rawToolCall as ToolCallDeltaChunk;
+          const index = toolCall.index ?? 0;
+          const functionArguments =
+            typeof toolCall.function?.arguments === 'string'
+              ? toolCall.function.arguments
+              : '';
+          const args =
+            typeof toolCall.args === 'string'
+              ? toolCall.args
+              : functionArguments;
+          const previousArgs = argsByIndex.get(index) ?? '';
+          argsByIndex.set(index, previousArgs + args);
+          if (args !== '') {
+            nonEmptyArgTimes.push(elapsed());
+          }
+
+          console.log(
+            `[${provider}] +${elapsed()}ms ${event} step=${
+              runStepDelta.id
+            } index=${index} id=${toolCall.id ?? ''} name=${
+              toolCall.name ?? toolCall.function?.name ?? ''
+            } args=${JSON.stringify(preview(args))}`
+          );
+        }
+      },
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (event: string, data: t.StreamEventData): void => {
+        countEvent(event);
+        const messageDelta = data as t.MessageDeltaEvent;
+        const content = messageDelta.delta.content ?? [];
+        const inputParts: string[] = [];
+        for (const part of content) {
+          if (
+            typeof part === 'object' &&
+            'input' in part &&
+            typeof part.input === 'string'
+          ) {
+            inputParts.push(part.input);
+          }
+        }
+        messageInputs.push(...inputParts);
+        console.log(
+          `[${provider}] +${elapsed()}ms ${event} step=${
+            messageDelta.id
+          } contentTypes=${content.map((part) => part.type).join(',')}`
+        );
+        if (inputParts.length > 0) {
+          console.log(
+            `[${provider}] +${elapsed()}ms ${event} input=${JSON.stringify(
+              inputParts.map(preview)
+            )}`
+          );
+        }
+      },
+    },
+  };
+
+  const run = await Run.create<t.IState>({
+    runId: `tool-delta-${provider}-${Date.now()}`,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: configureLLM(provider),
+      tools: [createLookupWeatherTool()],
+      instructions:
+        'You are a test assistant. You must call lookup_weather exactly once before answering.',
+      maxContextTokens: 120000,
+    },
+    customHandlers,
+    returnContent: true,
+    skipCleanup: true,
+  });
+
+  await run.processStream(
+    {
+      messages: [
+        new HumanMessage(
+          'Call lookup_weather exactly once for San Francisco, California. Use fahrenheit. In detail, ask for current conditions, wind, humidity, and a one sentence commute note.'
+        ),
+      ],
+    },
+    {
+      configurable: {
+        provider,
+        thread_id: `tool-delta-${provider}`,
+      },
+      version: 'v2',
+    }
+  );
+
+  const gaps = nonEmptyArgTimes
+    .slice(1)
+    .map((time, index) => time - nonEmptyArgTimes[index]);
+  console.log(`\n[${provider}] summary`);
+  console.log('eventCounts:', Object.fromEntries(eventCounts));
+  console.log('argsByIndex:', Object.fromEntries(argsByIndex));
+  console.log('messageDeltaInputFragments:', messageInputs);
+  console.log('nonEmptyArgGapsMs:', gaps);
+  console.log('');
+}
+
+async function main(): Promise<void> {
+  for (const provider of getProviders()) {
+    await testProvider(provider);
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/scripts/anthropic-bedrock-tool-delta-stream.ts
+++ b/src/scripts/anthropic-bedrock-tool-delta-stream.ts
@@ -12,6 +12,7 @@ import { getLLMConfig } from '@/utils/llmConfig';
 import { Run } from '@/run';
 
 type ProviderUnderTest = Providers.ANTHROPIC | Providers.BEDROCK;
+type ToolMode = 'structured' | 'definition';
 type ToolCallDeltaChunk = NonNullable<t.ToolCallDelta['tool_calls']>[number] & {
   function?: {
     name?: unknown;
@@ -20,6 +21,7 @@ type ToolCallDeltaChunk = NonNullable<t.ToolCallDelta['tool_calls']>[number] & {
 };
 
 const providerArgs = new Set(['anthropic', 'bedrock', 'both']);
+const mcpToolName = 'evaluate_script_mcp_chrome-devtools';
 const weatherSchema = {
   type: 'object',
   properties: {
@@ -38,6 +40,26 @@ const weatherSchema = {
   },
   required: ['city', 'unit', 'detail'],
 } as const;
+const evaluateScriptSchema: t.JsonSchemaType = {
+  type: 'object',
+  properties: {
+    function: {
+      type: 'string',
+      description:
+        'JavaScript function source to evaluate in the page context.',
+    },
+    args: {
+      type: 'array',
+      description: 'Arguments passed to the function.',
+      items: { type: 'string' },
+    },
+    reason: {
+      type: 'string',
+      description: 'Short reason this script is being evaluated.',
+    },
+  },
+  required: ['function', 'args', 'reason'],
+} as const;
 
 function getProviders(): ProviderUnderTest[] {
   const rawArg =
@@ -50,6 +72,15 @@ function getProviders(): ProviderUnderTest[] {
     return [Providers.BEDROCK];
   }
   return [Providers.ANTHROPIC, Providers.BEDROCK];
+}
+
+function getToolMode(): ToolMode {
+  const rawArg =
+    process.argv.find((arg) => arg.startsWith('--tool-mode='))?.split('=')[1] ??
+    process.argv.find(
+      (arg): arg is ToolMode => arg === 'structured' || arg === 'definition'
+    );
+  return rawArg === 'definition' ? 'definition' : 'structured';
 }
 
 function preview(value: string): string {
@@ -71,6 +102,18 @@ function createLookupWeatherTool(): StructuredToolInterface {
       schema: weatherSchema,
     }
   );
+}
+
+function createEvaluateScriptToolDefinition(): t.LCTool {
+  return {
+    name: mcpToolName,
+    description:
+      'Evaluate a JavaScript function in the active browser page and return the result.',
+    parameters: evaluateScriptSchema,
+    responseFormat: 'content_and_artifact',
+    serverName: 'chrome-devtools',
+    toolType: 'mcp',
+  };
 }
 
 function configureLLM(provider: ProviderUnderTest): t.LLMConfig {
@@ -101,6 +144,7 @@ function configureLLM(provider: ProviderUnderTest): t.LLMConfig {
 }
 
 async function testProvider(provider: ProviderUnderTest): Promise<void> {
+  const toolMode = getToolMode();
   const startedAt = performance.now();
   const nonEmptyArgTimes: number[] = [];
   const argsByIndex = new Map<number, string>();
@@ -113,6 +157,27 @@ async function testProvider(provider: ProviderUnderTest): Promise<void> {
   };
 
   const customHandlers: Record<string, t.EventHandler> = {
+    [GraphEvents.ON_TOOL_EXECUTE]: {
+      handle: (_event: string, data: t.StreamEventData): void => {
+        const batch = data as t.ToolExecuteBatchRequest;
+        console.log(
+          `[${provider}] +${elapsed()}ms on_tool_execute calls=${batch.toolCalls
+            .map((call) => call.name)
+            .join(',')}`
+        );
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            content: JSON.stringify({
+              status: 'ok',
+              received: call.args,
+              mode: toolMode,
+            }),
+            status: 'success',
+          }))
+        );
+      },
+    },
     [GraphEvents.ON_RUN_STEP]: {
       handle: (event: string, data: t.StreamEventData): void => {
         countEvent(event);
@@ -201,16 +266,31 @@ async function testProvider(provider: ProviderUnderTest): Promise<void> {
     },
   };
 
+  const graphConfig =
+    toolMode === 'definition'
+      ? {
+          type: 'standard' as const,
+          llmConfig: configureLLM(provider),
+          toolDefinitions: [createEvaluateScriptToolDefinition()],
+          instructions: `You are a test assistant. You must call ${mcpToolName} exactly once before answering.`,
+          maxContextTokens: 120000,
+        }
+      : {
+          type: 'standard' as const,
+          llmConfig: configureLLM(provider),
+          tools: [createLookupWeatherTool()],
+          instructions:
+            'You are a test assistant. You must call lookup_weather exactly once before answering.',
+          maxContextTokens: 120000,
+        };
+  const humanMessage =
+    toolMode === 'definition'
+      ? `Call ${mcpToolName} exactly once. Use a function that returns document.title, location.href, and the textContent of document.body.slice(0, 80). Include args as an empty array and explain that this checks visible page content.`
+      : 'Call lookup_weather exactly once for San Francisco, California. Use fahrenheit. In detail, ask for current conditions, wind, humidity, and a one sentence commute note.';
+
   const run = await Run.create<t.IState>({
     runId: `tool-delta-${provider}-${Date.now()}`,
-    graphConfig: {
-      type: 'standard',
-      llmConfig: configureLLM(provider),
-      tools: [createLookupWeatherTool()],
-      instructions:
-        'You are a test assistant. You must call lookup_weather exactly once before answering.',
-      maxContextTokens: 120000,
-    },
+    graphConfig,
     customHandlers,
     returnContent: true,
     skipCleanup: true,
@@ -218,11 +298,7 @@ async function testProvider(provider: ProviderUnderTest): Promise<void> {
 
   await run.processStream(
     {
-      messages: [
-        new HumanMessage(
-          'Call lookup_weather exactly once for San Francisco, California. Use fahrenheit. In detail, ask for current conditions, wind, humidity, and a one sentence commute note.'
-        ),
-      ],
+      messages: [new HumanMessage(humanMessage)],
     },
     {
       configurable: {
@@ -237,6 +313,7 @@ async function testProvider(provider: ProviderUnderTest): Promise<void> {
     .slice(1)
     .map((time, index) => time - nonEmptyArgTimes[index]);
   console.log(`\n[${provider}] summary`);
+  console.log('toolMode:', toolMode);
   console.log('eventCounts:', Object.fromEntries(eventCounts));
   console.log('argsByIndex:', Object.fromEntries(argsByIndex));
   console.log('messageDeltaInputFragments:', messageInputs);

--- a/src/scripts/anthropic-bedrock-tool-delta-stream.ts
+++ b/src/scripts/anthropic-bedrock-tool-delta-stream.ts
@@ -151,7 +151,8 @@ async function testProvider(provider: ProviderUnderTest): Promise<void> {
               ? toolCall.args
               : functionArguments;
           const previousArgs = argsByIndex.get(index) ?? '';
-          argsByIndex.set(index, previousArgs + args);
+          const accumulatedArgs = previousArgs + args;
+          argsByIndex.set(index, accumulatedArgs);
           if (args !== '') {
             nonEmptyArgTimes.push(elapsed());
           }
@@ -161,7 +162,9 @@ async function testProvider(provider: ProviderUnderTest): Promise<void> {
               runStepDelta.id
             } index=${index} id=${toolCall.id ?? ''} name=${
               toolCall.name ?? toolCall.function?.name ?? ''
-            } args=${JSON.stringify(preview(args))}`
+            } args=${JSON.stringify(preview(args))} accumulated=${JSON.stringify(
+              preview(accumulatedArgs)
+            )}`
           );
         }
       },


### PR DESCRIPTION
## Summary

I delayed Anthropic structured input deltas without splitting the provider chunk boundaries, so streamed tool arguments keep their exact `input_json_delta` and `tool_call_chunks.args` shapes while avoiding an immediate burst.

- Preserved Anthropic `input_json_delta` chunks intact and delayed each non-empty structured input chunk through the existing `_lc_stream_delay` setting.
- Kept tool argument chunks byte-for-byte equivalent to the provider deltas instead of re-splitting JSON fragments.
- Added focused fake-stream coverage for current incremental tool argument streaming and delayed structured input behavior.
- Avoided a CI-only Anthropic SDK `Stream` nominal type mismatch by using a minimal async iterable fake stream in the test.
- Verified the behavior against the live Anthropic API with forced tool use and matching structured content/tool argument fragments.
- Compared live timestamps against `origin/dev`: `origin/dev` emitted most non-empty args with 0-1ms gaps, while this branch emitted them consistently at 36-37ms with `_lc_stream_delay: 35`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `npx jest src/llm/anthropic/tool-arg-streaming.test.ts --runInBand`
- [x] `npx eslint src/llm/anthropic/tool-arg-streaming.test.ts`
- [x] `npx eslint src/llm/anthropic/index.ts src/llm/anthropic/tool-arg-streaming.test.ts`
- [x] `npx tsc --noEmit --pretty false`
- [x] `git diff --check`
- [x] Live Anthropic API smoke test with `claude-haiku-4-5-20251001`, forced `lookup_weather` tool use, and `_lc_stream_delay: 35`
- [x] Live timestamp comparison against temporary `origin/dev` checkout

### **Test Configuration**:

- Node.js: project default
- Branch base: `origin/dev`
- Provider API keys: `ANTHROPIC_API_KEY` loaded locally from `/Users/danny/Projects/agents/.env` for live smoke tests
- Current branch live timing: 20 tool arg events, non-empty gaps 36-37ms, fragments matched structured `input`
- `origin/dev` live timing: 24 tool arg events, most non-empty gaps 0-1ms with occasional provider pauses, fragments matched structured `input`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] My changes do not introduce new warnings
