### PR TITLE
🧰 fix: Clarify Tool Output Reference Content Mode

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -172,9 +172,10 @@ export abstract class Graph<
      * ToolNodes compiled from this graph captured the registry
      * instance at construction time, so simply dropping the Graph's
      * own reference would leave their captured reference — and every
-     * stored `tool<i>turn<n>` entry, plus up to `maxTotalSize` of raw
-     * output — alive across subsequent `processStream()` calls. Wipe
-     * the registry's contents first so subsequent runs start fresh.
+     * stored `tool<i>turn<n>` entry, plus up to `maxTotalSize` of
+     * retained output — alive across subsequent `processStream()`
+     * calls. Wipe the registry's contents first so subsequent runs
+     * start fresh.
      */
     this._toolOutputRegistry?.clear();
     this._toolOutputRegistry = undefined;
@@ -582,6 +583,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,
         maxToolResultChars: agentContext?.maxToolResultChars,
+        toolOutputReferences: this.toolOutputReferences,
         toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
         errorHandler: (data, metadata) =>
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
@@ -614,6 +616,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       sessions: this.sessions,
       maxContextTokens: agentContext?.maxContextTokens,
       maxToolResultChars: agentContext?.maxToolResultChars,
+      toolOutputReferences: this.toolOutputReferences,
       toolOutputRegistry: this.getOrCreateToolOutputRegistry(),
     });
   }

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -70,9 +70,10 @@ Usage:
 export const BashToolOutputReferencesGuide = `
 Referencing previous tool outputs:
 - Every successful tool result is tagged with a reference key of the form \`tool<idx>turn<turn>\` (e.g., \`tool0turn0\`). The key appears either as a \`[ref: tool0turn0]\` prefix line or, when the output is a JSON object, as a \`_ref\` field on the object.
-- To pipe a previous tool output into this tool, embed the placeholder \`{{tool<idx>turn<turn>}}\` literally anywhere in the \`command\` string (or any string arg). It will be substituted with the stored output verbatim before the command runs.
-- The substituted value is the original output string (no \`[ref: …]\` prefix, no \`_ref\` key), so it is safe to pipe directly into \`jq\`, \`grep\`, \`awk\`, etc.
-- Example (simple ASCII output): \`echo '{{tool0turn0}}' | jq '.foo'\` takes the full output of the first tool from the first turn and pipes it into jq.
+- To pipe a previous tool output into this tool, embed the placeholder \`{{tool<idx>turn<turn>}}\` literally anywhere in the \`command\` string (or any string arg). It will be substituted with the stored output before the command runs.
+- By default, the substituted value is the full post-hook output string (subject to registry size caps), even when the LLM-visible tool result was truncated. It excludes the \`[ref: …]\` prefix and \`_ref\` key so it can be piped directly into \`jq\`, \`grep\`, \`awk\`, etc.
+- If the host configured \`toolOutputReferences.referenceContent = "visible"\`, substitutions use the LLM-visible truncated content instead.
+- Example (simple ASCII output): \`echo '{{tool0turn0}}' | jq '.foo'\` takes the stored output of the first tool from the first turn and pipes it into jq.
 - For payloads that may contain quotes, parentheses, backticks, or arbitrary bytes (random/binary data, JSON with embedded quotes, multi-line strings), prefer a quoted-delimiter heredoc over \`echo '…'\`. The heredoc body is not interpreted by the shell, so substituted payloads pass through unchanged.
 - Heredoc example: \`wc -c << 'EOF'\\n{{tool0turn0}}\\nEOF\` (the quotes around \`'EOF'\` disable interpolation inside the body).
 - Unknown reference keys are left in place and surfaced as \`[unresolved refs: …]\` after the output.

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -171,6 +171,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private maxToolResultChars: number;
   /** Hook registry for PreToolUse/PostToolUse lifecycle hooks */
   private hookRegistry?: HookRegistry;
+  /** Which output snapshot gets stored for later `{{…}}` substitutions. */
+  private toolOutputReferenceContent: t.ToolOutputReferenceContent = 'raw';
   /**
    * Registry of tool outputs keyed by `tool<idx>turn<turn>`.
    *
@@ -227,16 +229,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
     this.hookRegistry = hookRegistry;
+    this.toolOutputReferenceContent =
+      toolOutputReferences?.referenceContent ?? 'raw';
     /**
      * Precedence: an explicitly passed `toolOutputRegistry` instance
      * wins over a config object so a host (`Graph`) can share one
      * registry across many ToolNodes. When only the config is
      * provided (direct ToolNode usage), build a local registry so
-     * the feature still works without graph-level plumbing. Registry
-     * caps are intentionally decoupled from `maxToolResultChars`:
-     * the registry stores the raw untruncated output so a later
-     * `{{…}}` substitution pipes the full payload into the next
-     * tool, even when the LLM saw a truncated preview.
+     * the feature still works without graph-level plumbing. The
+     * registry retains whichever snapshot `referenceContent` selects:
+     * raw for full parser/piping inputs, or visible for stricter
+     * deployments that treat truncation as a data boundary.
      */
     if (toolOutputRegistry != null) {
       this.toolOutputRegistry = toolOutputRegistry;
@@ -260,6 +263,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     | ToolOutputReferenceRegistry
     | undefined {
     return this.toolOutputRegistry;
+  }
+
+  private getReferenceContent(raw: string, visible: string): string {
+    if (this.toolOutputReferenceContent === 'visible') {
+      return visible;
+    }
+    return raw;
   }
 
   /**
@@ -472,7 +482,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             toolMsg.content = llmContent;
             const refMeta = this.recordOutputReference(
               runId,
-              rawContent,
+              this.getReferenceContent(rawContent, llmContent),
               refKey,
               unresolvedRefs
             );
@@ -521,7 +531,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       );
       const refMeta = this.recordOutputReference(
         runId,
-        rawContent,
+        this.getReferenceContent(rawContent, truncated),
         refKey,
         unresolvedRefs
       );
@@ -601,16 +611,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
-   * Registers the full, raw output under `refKey` (when provided) and
+   * Registers the selected output snapshot under `refKey` (when provided) and
    * builds the per-message ref metadata stamped onto the resulting
    * `ToolMessage.additional_kwargs`. The metadata is read at LLM-
    * request time by `annotateMessagesForLLM` to produce a transient
    * annotated copy of the message — the persisted `content` itself
    * stays clean.
    *
-   * @param registryContent  The full, untruncated output to store in
-   *   the registry so `{{tool<i>turn<n>}}` substitutions deliver the
-   *   complete payload. Ignored when `refKey` is undefined.
+   * @param registryContent  The output snapshot to store in the
+   *   registry for `{{tool<i>turn<n>}}` substitutions. This is either
+   *   the full post-hook raw output or the LLM-visible content,
+   *   depending on `toolOutputReferences.referenceContent`. Ignored
+   *   when `refKey` is undefined.
    * @param refKey  Precomputed `tool<i>turn<n>` key, or undefined when
    *   the output is not to be registered (errors, disabled feature,
    *   unavailable batch/turn).
@@ -697,10 +709,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const request = requestMap.get(result.toolCallId);
+      const requestName = request?.name;
       if (
-        !request?.name ||
-        (!CODE_EXECUTION_TOOLS.has(request.name) &&
-          request.name !== Constants.SKILL_TOOL)
+        requestName == null ||
+        requestName === '' ||
+        (!CODE_EXECUTION_TOOLS.has(requestName) &&
+          requestName !== Constants.SKILL_TOOL)
       ) {
         continue;
       }
@@ -1140,13 +1154,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             });
           }
         } else {
-          let registryRaw =
+          let rawContent =
             typeof result.content === 'string'
               ? result.content
               : JSON.stringify(result.content);
           contentString = truncateToolResultContent(
-            registryRaw,
+            rawContent,
             this.maxToolResultChars
+          );
+          let registryContent = this.getReferenceContent(
+            rawContent,
+            contentString
           );
 
           if (hasPostHook) {
@@ -1172,10 +1190,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 typeof hookResult.updatedOutput === 'string'
                   ? hookResult.updatedOutput
                   : JSON.stringify(hookResult.updatedOutput);
-              registryRaw = replaced;
               contentString = truncateToolResultContent(
                 replaced,
                 this.maxToolResultChars
+              );
+              rawContent = replaced;
+              registryContent = this.getReferenceContent(
+                rawContent,
+                contentString
               );
             }
           }
@@ -1190,7 +1212,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               : undefined;
           const successRefMeta = this.recordOutputReference(
             registryRunId,
-            registryRaw,
+            registryContent,
             refKey,
             unresolved
           );

--- a/src/tools/__tests__/ToolNode.outputReferences.test.ts
+++ b/src/tools/__tests__/ToolNode.outputReferences.test.ts
@@ -275,7 +275,7 @@ describe('ToolNode tool output references', () => {
       expect(getUnresolvedRefs(msg)).toEqual(['tool9turn9']);
     });
 
-    it('stores the raw untruncated output in the registry, independent of the LLM-visible truncation', async () => {
+    it('stores the raw untruncated output in the registry by default for downstream substitution', async () => {
       const raw = 'X'.repeat(8_000);
       const capturedArgs: string[] = [];
       const t1 = createEchoTool({
@@ -309,6 +309,45 @@ describe('ToolNode tool output references', () => {
           ._unsafeGetToolOutputRegistry()!
           .get('raw-preservation', 'tool0turn0')
       ).toBe(raw);
+    });
+
+    it('can store truncated LLM-visible output when referenceContent is visible', async () => {
+      const raw = 'X'.repeat(8_000);
+      const capturedArgs: string[] = [];
+      const t1 = createEchoTool({
+        capturedArgs,
+        outputs: [raw, 'second'],
+      });
+      const node = new ToolNode({
+        tools: [t1],
+        maxToolResultChars: 200,
+        toolOutputReferences: {
+          enabled: true,
+          referenceContent: 'visible',
+        },
+      });
+
+      const [first] = await invokeBatch(
+        node,
+        [{ id: 'c1', name: 'echo', command: 'first' }],
+        'visible-preservation'
+      );
+
+      expect((first.content as string).length).toBeLessThan(raw.length);
+      expect(first.content).toContain('truncated');
+
+      await invokeBatch(
+        node,
+        [{ id: 'c2', name: 'echo', command: 'echo {{tool0turn0}}' }],
+        'visible-preservation'
+      );
+
+      const stored = node
+        ._unsafeGetToolOutputRegistry()!
+        .get('visible-preservation', 'tool0turn0');
+      expect(stored).toBe(first.content);
+      expect(capturedArgs[1]).toBe(`echo ${stored}`);
+      expect(capturedArgs[1]).not.toBe(`echo ${raw}`);
     });
 
     it('uses each batch\'s own turn when ToolNode is invoked concurrently within a run', async () => {
@@ -971,6 +1010,159 @@ describe('ToolNode tool output references', () => {
 
       expect(capturedRequests).toHaveLength(1);
       expect(capturedRequests[0].args).toEqual({ command: 'see FIRST' });
+    });
+
+    it('stores raw untruncated host output by default for downstream substitution', async () => {
+      const raw = 'Y'.repeat(8_000);
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        maxToolResultChars: 200,
+        toolCallStepIds: new Map([
+          ['ec1', 'step_ec1'],
+          ['ec2', 'step_ec2'],
+        ]),
+        toolOutputReferences: { enabled: true },
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'ec1', content: raw, status: 'success' },
+      ]);
+      const first = (await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id: 'ec1', name: 'echo', args: { command: 'a' } }],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-host-raw' } }
+      )) as { messages: ToolMessage[] };
+
+      const firstContent = first.messages[0].content as string;
+      expect(firstContent.length).toBeLessThan(raw.length);
+      expect(firstContent).toContain('truncated');
+
+      jest.restoreAllMocks();
+      const capturedRequests: t.ToolCallRequest[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const batch = data as t.ToolExecuteBatchRequest;
+          capturedRequests.push(...batch.toolCalls);
+          batch.resolve([
+            { toolCallId: 'ec2', content: 'SECOND', status: 'success' },
+          ]);
+        });
+
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                {
+                  id: 'ec2',
+                  name: 'echo',
+                  args: { command: 'see {{tool0turn0}}' },
+                },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-host-raw' } }
+      );
+
+      expect(
+        node._unsafeGetToolOutputRegistry()!.get('run-host-raw', 'tool0turn0')
+      ).toBe(raw);
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0].args).toEqual({ command: `see ${raw}` });
+    });
+
+    it('can store truncated LLM-visible host output when referenceContent is visible', async () => {
+      const raw = 'Y'.repeat(8_000);
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'agent-x',
+        maxToolResultChars: 200,
+        toolCallStepIds: new Map([
+          ['ec1', 'step_ec1'],
+          ['ec2', 'step_ec2'],
+        ]),
+        toolOutputReferences: {
+          enabled: true,
+          referenceContent: 'visible',
+        },
+      });
+
+      mockEventDispatch([
+        { toolCallId: 'ec1', content: raw, status: 'success' },
+      ]);
+      const first = (await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id: 'ec1', name: 'echo', args: { command: 'a' } }],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-host-trunc' } }
+      )) as { messages: ToolMessage[] };
+
+      const firstContent = first.messages[0].content as string;
+      expect(firstContent.length).toBeLessThan(raw.length);
+      expect(firstContent).toContain('truncated');
+
+      jest.restoreAllMocks();
+      const capturedRequests: t.ToolCallRequest[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const batch = data as t.ToolExecuteBatchRequest;
+          capturedRequests.push(...batch.toolCalls);
+          batch.resolve([
+            { toolCallId: 'ec2', content: 'SECOND', status: 'success' },
+          ]);
+        });
+
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                {
+                  id: 'ec2',
+                  name: 'echo',
+                  args: { command: 'see {{tool0turn0}}' },
+                },
+              ],
+            }),
+          ],
+        },
+        { configurable: { run_id: 'run-host-trunc' } }
+      );
+
+      const stored = node
+        ._unsafeGetToolOutputRegistry()!
+        .get('run-host-trunc', 'tool0turn0');
+      expect(stored).toBe(firstContent);
+      expect(capturedRequests).toHaveLength(1);
+      expect(capturedRequests[0].args).toEqual({ command: `see ${stored}` });
+      expect(
+        (capturedRequests[0].args as { command: string }).command.length
+      ).toBeLessThan(raw.length);
     });
 
     it('surfaces unresolved refs on host-returned error results', async () => {

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -12,14 +12,14 @@
  * {@link ToolOutputReferenceRegistry.resolve} walks the args and
  * substitutes the placeholders immediately before invocation.
  *
- * The registry stores the *raw, untruncated* tool output so a later
- * `{{…}}` substitution pipes the full payload into the next tool —
- * even when the LLM only saw a head+tail-truncated preview in
- * `ToolMessage.content`. Outputs are stored without any annotation
- * (the `_ref` key or the `[ref: ...]` prefix seen by the LLM is
- * strictly a UX signal attached to `ToolMessage.content`). Keeping the
- * registry pristine means downstream bash/jq piping receives the
- * complete, verbatim output with no injected fields.
+ * ToolNode stores an un-annotated output snapshot in the registry.
+ * By default that snapshot is the full post-hook raw output (subject
+ * to registry caps) so parser/piping tools can consume complete
+ * payloads even when `ToolMessage.content` is truncated for the LLM.
+ * Hosts can set `RunConfig.toolOutputReferences.referenceContent` to
+ * `'visible'` when substitutions should use the LLM-visible content
+ * instead. The `_ref` key or `[ref: ...]` prefix seen by the LLM is
+ * strictly a UX signal attached to `ToolMessage.content`.
  */
 
 import { ToolMessage } from '@langchain/core/messages';
@@ -165,11 +165,9 @@ export class ToolOutputReferenceRegistry {
     /**
      * Per-output default is the same ~400 KB budget as the standard
      * tool-result truncation (`HARD_MAX_TOOL_RESULT_CHARS`). This
-     * keeps a single `{{…}}` substitution at a size that is safe to
-     * pass through typical shell `ARG_MAX` limits and matches what
-     * the LLM would otherwise have seen. Hosts that want larger per-
-     * output payloads (API consumers, long JSON streams) can raise
-     * the cap explicitly up to the 5 MB total budget.
+     * keeps a single `{{…}}` substitution at a size that is safer for
+     * typical shell `ARG_MAX` limits. Hosts that need larger parser
+     * inputs can raise the cap explicitly up to the 5 MB total budget.
      */
     const perOutput =
       options.maxOutputSize != null && options.maxOutputSize > 0
@@ -183,11 +181,11 @@ export class ToolOutputReferenceRegistry {
      * upper bound on its computed default, but the user-provided
      * branch was bypassing it.
      */
-    const totalRaw =
+    const totalLimit =
       options.maxTotalSize != null && options.maxTotalSize > 0
         ? Math.min(options.maxTotalSize, HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE)
         : calculateMaxTotalToolOutputSize(perOutput);
-    this.maxTotalSize = totalRaw;
+    this.maxTotalSize = totalLimit;
     /**
      * The per-output cap can never exceed the per-run aggregate cap:
      * if a single entry were allowed to be larger than `maxTotalSize`,
@@ -196,7 +194,7 @@ export class ToolOutputReferenceRegistry {
      * `maxTotalSize` into a hard upper bound on *any* state the
      * registry retains per run.
      */
-    this.maxOutputSize = Math.min(perOutput, totalRaw);
+    this.maxOutputSize = Math.min(perOutput, totalLimit);
     this.maxActiveRuns =
       options.maxActiveRuns != null && options.maxActiveRuns > 0
         ? options.maxActiveRuns

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -14,7 +14,7 @@ export type AnthropicMessage = Anthropic.MessageParam;
  * the metadata never leaks even if you forget to clean it.
  */
 export interface ToolMessageRefMetadata {
-  /** Key under which this message's untruncated output was registered. */
+  /** Key under which this message's selected output snapshot was registered. */
   _refKey?: string;
   /**
    * Registry bucket scope under which `_refKey` was stored. For named

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -153,7 +153,9 @@ export type RunConfig = {
    * `true`, tool outputs are registered under stable keys
    * (`tool<idx>turn<turn>`) and subsequent tool calls can pipe previous
    * outputs into their arguments via `{{tool<idx>turn<turn>}}`
-   * placeholders. Disabled by default so existing runs are unaffected.
+   * placeholders. The default reference content is the raw post-hook
+   * output for full-payload parser/piping tools. Disabled by default
+   * so existing runs are unaffected.
    */
   toolOutputReferences?: ToolOutputReferencesConfig;
 };

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -260,6 +260,8 @@ export type ToolExecuteResult = {
 /** Map of tool names to tool definitions */
 export type LCToolRegistry = Map<string, LCTool>;
 
+export type ToolOutputReferenceContent = 'raw' | 'visible';
+
 /**
  * Run-scoped configuration for tool output references.
  *
@@ -270,11 +272,14 @@ export type LCToolRegistry = Map<string, LCTool>;
  * substitutes it with the stored output immediately before invoking
  * the tool.
  *
- * The registry stores the *raw, untruncated* tool output (subject to
- * its own size caps) so a later substitution can pipe the full payload
- * into the next tool even when the LLM only saw a head+tail-truncated
- * preview in `ToolMessage.content`. Size limits are decoupled from the
- * LLM-visible truncation budget and default to 5 MB total.
+ * By default, the registry stores the full post-hook output, subject
+ * to registry size caps but independent of `ToolMessage.content`
+ * truncation. This is the core parser/piping use case: downstream
+ * tools can consume complete JSON, CSV, logs, or command output even
+ * when the model only saw a truncated preview. Set
+ * `referenceContent: 'visible'` when a deployment wants substitutions
+ * to stay within the same data boundary as the LLM-visible tool
+ * message.
  *
  * Known limitations:
  *  - Tools that return a `ToolMessage` with array-type content
@@ -282,25 +287,35 @@ export type LCToolRegistry = Map<string, LCTool>;
  *    registered and cannot be cited via `{{tool<i>turn<n>}}`. A
  *    warning is logged so the missing reference is visible.
  *  - When a `PostToolUse` hook replaces `ToolMessage.content`, the
- *    *post-hook* content is what gets stored in the registry (and
- *    what the model sees), so `{{…}}` substitutions deliver the
- *    hooked output rather than the raw tool return. This matches the
- *    hook's "authoritative" role for output shaping.
+ *    *post-hook* content becomes the source for both the registry
+ *    snapshot and the model-visible message, so `{{…}}`
+ *    substitutions deliver the hooked output rather than the raw tool
+ *    return. In raw mode the full replacement is stored; in visible
+ *    mode the truncated visible replacement is stored.
  */
 export type ToolOutputReferencesConfig = {
   /** Enable the registry and placeholder substitution. Defaults to `false`. */
   enabled?: boolean;
   /**
+   * Which successful output snapshot is stored for later
+   * substitutions. Defaults to `'raw'` to preserve the feature's
+   * full-output parser/piping behavior.
+   *
+   * - `'raw'`: stores the full post-hook output, subject only to
+   *   registry size caps. Later `{{…}}` substitutions may include data
+   *   not present in truncated `ToolMessage.content`.
+   * - `'visible'`: stores the LLM-visible `ToolMessage.content` after
+   *   truncation, plus any additional registry clipping.
+   */
+  referenceContent?: ToolOutputReferenceContent;
+  /**
    * Maximum characters stored (and substituted) per registered output.
-   * Applied to the *raw* output before storage. Defaults to
-   * `HARD_MAX_TOOL_RESULT_CHARS` (~400 KB) — matching the
-   * LLM-visible tool-result truncation budget, which is also a safe
-   * payload size for shell `ARG_MAX` limits when a `{{…}}` expansion
-   * gets piped into a bash `command`. Hosts that want to preserve
-   * fuller fidelity (for example for non-bash API consumers) can
-   * raise this up to `maxTotalSize` (defaults to 5 MB) — be aware
-   * that large single-output substitutions may exceed shell
-   * argument-size limits on typical Linux/macOS.
+   * Applied to whichever snapshot `referenceContent` selects. Defaults
+   * to `HARD_MAX_TOOL_RESULT_CHARS` (~400 KB), keeping `{{…}}`
+   * expansion at a size that is safer for shell `ARG_MAX` limits.
+   * Hosts that need larger parser inputs can raise this up to
+   * `maxTotalSize`; be aware that large single-output substitutions
+   * may exceed shell argument-size limits on typical Linux/macOS.
    */
   maxOutputSize?: number;
   /**

--- a/src/utils/truncation.ts
+++ b/src/utils/truncation.ts
@@ -14,11 +14,10 @@ export const HARD_MAX_TOOL_RESULT_CHARS = 400_000;
 
 /**
  * Absolute hard cap on the aggregate size (characters) of all registered
- * tool outputs kept for `{{tool<i>turn<n>}}` substitution. Set at 5 MB
- * because the registry stores *raw, untruncated* tool output — full
- * fidelity for piping into downstream bash/jq — so the budget needs
- * enough headroom to keep a handful of large responses without
- * ballooning unbounded.
+ * tool outputs kept for `{{tool<i>turn<n>}}` substitution. The
+ * registry can store full post-hook outputs for parser/piping use
+ * cases, so this cap prevents a run from retaining unbounded
+ * substitution payloads when hosts raise per-output limits.
  */
 export const HARD_MAX_TOTAL_TOOL_OUTPUT_SIZE = 5_000_000;
 


### PR DESCRIPTION
## Summary

I clarified tool output reference behavior so full raw output remains the default parser/piping path while adding an explicit visible-content mode for stricter deployments.

- Preserved raw post-hook output as the default reference snapshot so downstream parser tools can consume full JSON, CSV, logs, and command output even when `ToolMessage.content` is truncated.
- Added `toolOutputReferences.referenceContent` with `raw` and `visible` modes to make the substitution boundary explicit.
- Threaded the reference-content policy through graph-created ToolNodes so direct, event-driven, and multi-agent execution use the same setting.
- Updated Bash/tool-reference guidance and type comments to document the intended full-output behavior and the visible-content escape hatch.
- Expanded ToolNode regression coverage for raw-default and visible-mode substitutions across direct and event-driven tool paths.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Ran `npx tsc --noEmit`.
- Ran `npm test -- src/tools/__tests__/ToolNode.outputReferences.test.ts --runInBand`.
- Pre-commit hooks ran `prettier --write` and `eslint --fix` for staged files.

### **Test Configuration**:

- Node.js: `v20.19.5`
- npm: `10.8.2`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes