### PR TITLE
📡 fix: Skip Custom OpenAI SSE Events

### DIFF
--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -1,4 +1,8 @@
-import { AIMessage, AIMessageChunk } from '@langchain/core/messages';
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+} from '@langchain/core/messages';
 import type { OpenAIChatInput, OpenAIClient } from '@langchain/openai';
 import type { ChatOpenRouterCallOptions } from '@/llm/openrouter';
 import type { CustomAnthropicInput } from '@/llm/anthropic';
@@ -68,6 +72,27 @@ type StreamingCompletionDelegate = {
 };
 type StreamingCompletionBackedModel = {
   completions: StreamingCompletionDelegate;
+};
+type OpenAIStreamEvent = {
+  event: string;
+  data?: unknown;
+};
+type OpenAIStreamItem =
+  | OpenAIClient.Chat.Completions.ChatCompletionChunk
+  | OpenAIStreamEvent;
+type MockableCompletionCreate = (
+  request: unknown,
+  options?: unknown
+) => Promise<AsyncIterable<OpenAIStreamItem>>;
+type MockableCompletionClient = {
+  chat: {
+    completions: {
+      create: MockableCompletionCreate;
+    };
+  };
+};
+type MockableCompletionDelegate = OpenAIResponsesDelegate & {
+  client?: MockableCompletionClient;
 };
 type OpenRouterReasoningStreamDelta =
   OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice.Delta & {
@@ -250,6 +275,74 @@ describe('custom chat model class smoke tests', () => {
     expect(xai._lc_stream_delay).toBe(7);
     expect(xai.exposedClient).toBeInstanceOf(CustomOpenAIClient);
     expect(xaiRequestOptions.baseURL).toBe('https://xai.test/v1');
+  });
+
+  it('skips custom OpenAI-compatible SSE events during streaming', async () => {
+    const model = new ChatOpenAI({
+      model: 'hermes-agent',
+      apiKey: 'test-key',
+      streaming: true,
+    });
+    const completions = (
+      model as unknown as { completions: MockableCompletionDelegate }
+    ).completions;
+    completions._getClientOptions(undefined);
+    const client = completions.client;
+    if (client == null) {
+      throw new Error('Expected OpenAI completions client');
+    }
+
+    const createChunk = (
+      content: string,
+      finishReason: OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['finish_reason'] = null
+    ): OpenAIClient.Chat.Completions.ChatCompletionChunk => ({
+      id: 'chatcmpl-hermes-test',
+      object: 'chat.completion.chunk',
+      created: 0,
+      model: 'hermes-agent',
+      choices: [
+        {
+          index: 0,
+          delta: { content },
+          finish_reason: finishReason,
+        },
+      ],
+    });
+    async function* streamChunks(): AsyncGenerator<OpenAIStreamItem> {
+      yield createChunk('Hello ');
+      yield {
+        event: 'hermes.tool.progress',
+        data: {
+          tool: 'execute_code',
+          toolCallId: 'call_1',
+          status: 'running',
+        },
+      };
+      yield {
+        event: 'message',
+        data: createChunk('world', 'stop'),
+      };
+    }
+
+    const createMock = jest.fn(async () =>
+      streamChunks()
+    ) as MockableCompletionCreate;
+    client.chat.completions.create = createMock;
+
+    const chunks: AIMessageChunk[] = [];
+    const stream = await model.stream([new HumanMessage('use a tool')]);
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    const text = chunks
+      .map((chunk) => (typeof chunk.content === 'string' ? chunk.content : ''))
+      .join('');
+    expect(text).toBe('Hello world');
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ stream: true }),
+      expect.any(Object)
+    );
   });
 
   it('keeps Moonshot reasoning content in completion requests', async () => {

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -118,6 +118,7 @@ type OpenRouterReasoningStreamChoice = Omit<
 > & {
   delta: OpenRouterReasoningStreamDelta;
 };
+type OpenAIStreamModel = ChatOpenAI | AzureChatOpenAI;
 
 const baseAzureFields = {
   azureOpenAIApiKey: 'test-azure-key',
@@ -133,6 +134,83 @@ const baseBedrockFields = {
     secretAccessKey: 'test-secret-key',
   },
 };
+
+const createOpenAIStreamChunk = (
+  content: string,
+  finishReason: OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['finish_reason'] = null
+): OpenAIClient.Chat.Completions.ChatCompletionChunk => ({
+  id: 'chatcmpl-hermes-test',
+  object: 'chat.completion.chunk',
+  created: 0,
+  model: 'hermes-agent',
+  choices: [
+    {
+      index: 0,
+      delta: { content },
+      finish_reason: finishReason,
+    },
+  ],
+});
+
+async function* createOpenAIStreamWithCustomEvents(): AsyncGenerator<OpenAIStreamItem> {
+  yield createOpenAIStreamChunk('Hello ');
+  yield {
+    event: 'hermes.tool.progress',
+    data: {
+      tool: 'execute_code',
+      toolCallId: 'call_1',
+      status: 'running',
+    },
+  };
+  yield {
+    event: 'hermes.tool.progress',
+    data: null,
+  };
+  yield {
+    event: 'message',
+    data: createOpenAIStreamChunk('world', 'stop'),
+  };
+}
+
+function mockCompletionStream(
+  model: OpenAIStreamModel
+): MockableCompletionCreate {
+  const completions = (
+    model as unknown as { completions: MockableCompletionDelegate }
+  ).completions;
+  completions._getClientOptions(undefined);
+  const client = completions.client;
+  if (client == null) {
+    throw new Error('Expected OpenAI completions client');
+  }
+
+  const createMock = jest.fn(async () =>
+    createOpenAIStreamWithCustomEvents()
+  ) as MockableCompletionCreate;
+  client.chat.completions.create = createMock;
+  return createMock;
+}
+
+async function expectCustomSSEEventsSkipped(
+  model: OpenAIStreamModel
+): Promise<void> {
+  const createMock = mockCompletionStream(model);
+  const chunks: AIMessageChunk[] = [];
+  const stream = await model.stream([new HumanMessage('use a tool')]);
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+
+  const text = chunks
+    .map((chunk) => (typeof chunk.content === 'string' ? chunk.content : ''))
+    .join('');
+  expect(chunks).toHaveLength(2);
+  expect(text).toBe('Hello world');
+  expect(createMock).toHaveBeenCalledWith(
+    expect.objectContaining({ stream: true }),
+    expect.any(Object)
+  );
+}
 
 describe('custom chat model class smoke tests', () => {
   it('keeps the custom OpenAI client, stream delay, and reasoning precedence', () => {
@@ -277,71 +355,21 @@ describe('custom chat model class smoke tests', () => {
     expect(xaiRequestOptions.baseURL).toBe('https://xai.test/v1');
   });
 
-  it('skips custom OpenAI-compatible SSE events during streaming', async () => {
-    const model = new ChatOpenAI({
-      model: 'hermes-agent',
-      apiKey: 'test-key',
-      streaming: true,
-    });
-    const completions = (
-      model as unknown as { completions: MockableCompletionDelegate }
-    ).completions;
-    completions._getClientOptions(undefined);
-    const client = completions.client;
-    if (client == null) {
-      throw new Error('Expected OpenAI completions client');
-    }
+  it('skips custom OpenAI-compatible SSE events during OpenAI streaming', async () => {
+    await expectCustomSSEEventsSkipped(
+      new ChatOpenAI({
+        model: 'hermes-agent',
+        apiKey: 'test-key',
+        streaming: true,
+      })
+    );
+  });
 
-    const createChunk = (
-      content: string,
-      finishReason: OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['finish_reason'] = null
-    ): OpenAIClient.Chat.Completions.ChatCompletionChunk => ({
-      id: 'chatcmpl-hermes-test',
-      object: 'chat.completion.chunk',
-      created: 0,
-      model: 'hermes-agent',
-      choices: [
-        {
-          index: 0,
-          delta: { content },
-          finish_reason: finishReason,
-        },
-      ],
-    });
-    async function* streamChunks(): AsyncGenerator<OpenAIStreamItem> {
-      yield createChunk('Hello ');
-      yield {
-        event: 'hermes.tool.progress',
-        data: {
-          tool: 'execute_code',
-          toolCallId: 'call_1',
-          status: 'running',
-        },
-      };
-      yield {
-        event: 'message',
-        data: createChunk('world', 'stop'),
-      };
-    }
-
-    const createMock = jest.fn(async () =>
-      streamChunks()
-    ) as MockableCompletionCreate;
-    client.chat.completions.create = createMock;
-
-    const chunks: AIMessageChunk[] = [];
-    const stream = await model.stream([new HumanMessage('use a tool')]);
-    for await (const chunk of stream) {
-      chunks.push(chunk);
-    }
-
-    const text = chunks
-      .map((chunk) => (typeof chunk.content === 'string' ? chunk.content : ''))
-      .join('');
-    expect(text).toBe('Hello world');
-    expect(createMock).toHaveBeenCalledWith(
-      expect.objectContaining({ stream: true }),
-      expect.any(Object)
+  it('skips custom OpenAI-compatible SSE events during Azure streaming', async () => {
+    await expectCustomSSEEventsSkipped(
+      new AzureChatOpenAI({
+        ...baseAzureFields,
+      })
     );
   });
 

--- a/src/llm/custom-chat-models.smoke.test.ts
+++ b/src/llm/custom-chat-models.smoke.test.ts
@@ -83,7 +83,9 @@ type OpenAIStreamItem =
 type MockableCompletionCreate = (
   request: unknown,
   options?: unknown
-) => Promise<AsyncIterable<OpenAIStreamItem>>;
+) => Promise<
+  AsyncIterable<OpenAIStreamItem> | OpenAIClient.Chat.Completions.ChatCompletion
+>;
 type MockableCompletionClient = {
   chat: {
     completions: {
@@ -187,6 +189,24 @@ function mockCompletionStream(
   const createMock = jest.fn(async () =>
     createOpenAIStreamWithCustomEvents()
   ) as MockableCompletionCreate;
+  client.chat.completions.create = createMock;
+  return createMock;
+}
+
+function mockCompletion(
+  model: ChatOpenAI,
+  response: OpenAIClient.Chat.Completions.ChatCompletion
+): MockableCompletionCreate {
+  const completions = (
+    model as unknown as { completions: MockableCompletionDelegate }
+  ).completions;
+  completions._getClientOptions(undefined);
+  const client = completions.client;
+  if (client == null) {
+    throw new Error('Expected OpenAI completions client');
+  }
+
+  const createMock = jest.fn(async () => response) as MockableCompletionCreate;
   client.chat.completions.create = createMock;
   return createMock;
 }
@@ -370,6 +390,39 @@ describe('custom chat model class smoke tests', () => {
       new AzureChatOpenAI({
         ...baseAzureFields,
       })
+    );
+  });
+
+  it('passes non-streaming OpenAI completions through unchanged', async () => {
+    const model = new ChatOpenAI({
+      model: 'hermes-agent',
+      apiKey: 'test-key',
+    });
+    const createMock = mockCompletion(model, {
+      id: 'chatcmpl-nonstream-test',
+      object: 'chat.completion',
+      created: 0,
+      model: 'hermes-agent',
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop',
+          logprobs: null,
+          message: {
+            role: 'assistant',
+            content: 'plain response',
+            refusal: null,
+          },
+        },
+      ],
+    });
+
+    const response = await model.invoke([new HumanMessage('no stream')]);
+
+    expect(response.content).toBe('plain response');
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ stream: false }),
+      expect.any(Object)
     );
   });
 

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -128,6 +128,18 @@ type OpenAIChatCompletionStreamItem =
       event: string;
       data?: unknown;
     };
+type OpenAIChatCompletionRequest =
+  | OpenAIClient.Chat.ChatCompletionCreateParamsStreaming
+  | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming;
+type OpenAIChatCompletionResult =
+  | AsyncIterable<OpenAIChatCompletionChunk>
+  | OpenAIChatCompletion;
+type OpenAIChatCompletionRetry = (
+  request: OpenAIChatCompletionRequest,
+  requestOptions?: OpenAICoreRequestOptions
+) => Promise<
+  AsyncIterable<OpenAIChatCompletionStreamItem> | OpenAIChatCompletion
+>;
 
 function getExposedOpenAIClient(
   completions: OpenAIClientDelegate,
@@ -199,6 +211,7 @@ function isOpenAIChatCompletionChunk(
     return false;
   }
 
+  // Intentionally loose: downstream handlers already tolerate empty choices.
   const { choices } = value as { choices?: unknown };
   return Array.isArray(choices);
 }
@@ -228,6 +241,24 @@ async function* filterOpenAIChatCompletionStream(
     }
     yield chunk;
   }
+}
+
+async function completionWithFilteredOpenAIStream(
+  request: OpenAIChatCompletionRequest,
+  requestOptions: OpenAICoreRequestOptions | undefined,
+  completionWithRetry: OpenAIChatCompletionRetry
+): Promise<OpenAIChatCompletionResult> {
+  if (request.stream !== true) {
+    return (await completionWithRetry(
+      request,
+      requestOptions
+    )) as OpenAIChatCompletion;
+  }
+
+  const stream = await completionWithRetry(request, requestOptions);
+  return filterOpenAIChatCompletionStream(
+    stream as AsyncIterable<OpenAIChatCompletionStreamItem>
+  );
 }
 
 function attachLibreChatDeltaFields(
@@ -471,12 +502,11 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
       | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
-    if (request.stream === true) {
-      const stream = await super.completionWithRetry(request, requestOptions);
-      return filterOpenAIChatCompletionStream(stream);
-    }
-
-    return super.completionWithRetry(request, requestOptions);
+    return completionWithFilteredOpenAIStream(
+      request,
+      requestOptions,
+      super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
+    );
   }
 
   protected _convertCompletionsDeltaToBaseMessageChunk(
@@ -917,12 +947,11 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
       | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
     requestOptions?: OpenAICoreRequestOptions
   ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
-    if (request.stream === true) {
-      const stream = await super.completionWithRetry(request, requestOptions);
-      return filterOpenAIChatCompletionStream(stream);
-    }
-
-    return super.completionWithRetry(request, requestOptions);
+    return completionWithFilteredOpenAIStream(
+      request,
+      requestOptions,
+      super.completionWithRetry.bind(this) as OpenAIChatCompletionRetry
+    );
   }
 }
 

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -119,6 +119,15 @@ type OpenAIClientDelegate = {
     options: OpenAICoreRequestOptions | undefined
   ): OpenAICoreRequestOptions;
 };
+type OpenAIChatCompletion = OpenAIClient.Chat.Completions.ChatCompletion;
+type OpenAIChatCompletionChunk =
+  OpenAIClient.Chat.Completions.ChatCompletionChunk;
+type OpenAIChatCompletionStreamItem =
+  | OpenAIChatCompletionChunk
+  | {
+      event: string;
+      data?: unknown;
+    };
 
 function getExposedOpenAIClient(
   completions: OpenAIClientDelegate,
@@ -177,6 +186,48 @@ function getGatedReasoningParams(
     return;
   }
   return getReasoningParams(baseReasoning, options);
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+function isOpenAIChatCompletionChunk(
+  value: unknown
+): value is OpenAIChatCompletionChunk {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  const { choices } = value as { choices?: unknown };
+  return Array.isArray(choices);
+}
+
+function getOpenAIChatCompletionChunk(
+  value: OpenAIChatCompletionStreamItem
+): OpenAIChatCompletionChunk | undefined {
+  if (isOpenAIChatCompletionChunk(value)) {
+    return value;
+  }
+
+  const { data } = value;
+  if (isOpenAIChatCompletionChunk(data)) {
+    return data;
+  }
+
+  return undefined;
+}
+
+async function* filterOpenAIChatCompletionStream(
+  stream: AsyncIterable<OpenAIChatCompletionStreamItem>
+): AsyncGenerator<OpenAIChatCompletionChunk> {
+  for await (const item of stream) {
+    const chunk = getOpenAIChatCompletionChunk(item);
+    if (chunk == null) {
+      continue;
+    }
+    yield chunk;
+  }
 }
 
 function attachLibreChatDeltaFields(
@@ -404,6 +455,28 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     options?: OpenAICoreRequestOptions
   ): OpenAICoreRequestOptions {
     return getCustomOpenAIClientOptions(this, options);
+  }
+
+  async completionWithRetry(
+    request: OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIChatCompletionChunk>>;
+  async completionWithRetry(
+    request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<OpenAIChatCompletion>;
+  async completionWithRetry(
+    request:
+      | OpenAIClient.Chat.ChatCompletionCreateParamsStreaming
+      | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
+    if (request.stream === true) {
+      const stream = await super.completionWithRetry(request, requestOptions);
+      return filterOpenAIChatCompletionStream(stream);
+    }
+
+    return super.completionWithRetry(request, requestOptions);
   }
 
   protected _convertCompletionsDeltaToBaseMessageChunk(
@@ -828,6 +901,28 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
       };
     }
     return requestOptions;
+  }
+
+  async completionWithRetry(
+    request: OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIChatCompletionChunk>>;
+  async completionWithRetry(
+    request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<OpenAIChatCompletion>;
+  async completionWithRetry(
+    request:
+      | OpenAIClient.Chat.ChatCompletionCreateParamsStreaming
+      | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
+    requestOptions?: OpenAICoreRequestOptions
+  ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
+    if (request.stream === true) {
+      const stream = await super.completionWithRetry(request, requestOptions);
+      return filterOpenAIChatCompletionStream(stream);
+    }
+
+    return super.completionWithRetry(request, requestOptions);
   }
 }
 


### PR DESCRIPTION
## Summary

I fixed OpenAI-compatible streaming so named custom SSE events from providers such as Hermes Agent do not reach chat-completion chunk handlers as malformed chunks. This addresses danny-avila/LibreChat#12919.

- Added a chat-completion stream filter that keeps normal OpenAI chunks and wrapped message chunks while skipping named custom event payloads without `choices`.
- Applied the filter to both OpenAI and Azure OpenAI completions delegates before inherited or LibreChat-specific stream handlers consume streamed data.
- Added a smoke regression that streams a Hermes-style `hermes.tool.progress` event between normal chunks and verifies the model still emits `Hello world` without throwing.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm ci`
- `npm test -- src/llm/custom-chat-models.smoke.test.ts --runInBand`
- `npx eslint src/llm/openai/index.ts src/llm/custom-chat-models.smoke.test.ts`
- `npm run build`
- `git diff --check`

### **Test Configuration**:

- Node.js v20.19.5
- npm 10.x

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes