### PR TITLE
🪡 fix: Preserve DeepSeek Same-Run Reasoning

### DIFF
--- a/src/llm/openai/deepseek.test.ts
+++ b/src/llm/openai/deepseek.test.ts
@@ -207,8 +207,19 @@ describe('ChatDeepSeek', () => {
       ]
     );
     const chunks = [];
+    const callbackTokens: string[] = [];
 
-    for await (const chunk of await model.stream([new HumanMessage('hi')])) {
+    const stream = await model.stream([new HumanMessage('hi')], {
+      callbacks: [
+        {
+          handleLLMNewToken(token: string): void {
+            callbackTokens.push(token);
+          },
+        },
+      ],
+    });
+
+    for await (const chunk of stream) {
       chunks.push(chunk);
     }
 
@@ -220,6 +231,9 @@ describe('ChatDeepSeek', () => {
     );
 
     expect(streamedText).toBe('prefix visible');
+    expect(callbackTokens.join('')).toBe('prefix visible');
+    expect(callbackTokens.join('')).not.toContain('hidden');
+    expect(callbackTokens.join('')).not.toContain('think');
     expect(hasHiddenReasoning).toBe(true);
   });
 });

--- a/src/llm/openai/deepseek.test.ts
+++ b/src/llm/openai/deepseek.test.ts
@@ -1,5 +1,6 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type { OpenAIClient } from '@langchain/openai';
 
 import { ChatDeepSeek } from './index';
@@ -44,6 +45,14 @@ class CapturingChatDeepSeek extends ChatDeepSeek {
     }
 
     return createCompletion();
+  }
+
+  streamChunksWithSignal(
+    signal: AbortSignal
+  ): AsyncGenerator<ChatGenerationChunk> {
+    return this._streamResponseChunks([new HumanMessage('hi')], {
+      signal,
+    } as this['ParsedCallOptions']);
   }
 }
 
@@ -150,6 +159,12 @@ function getReasoningAssistantMessage(
   return request.messages[0] as ReasoningAssistantMessageParam;
 }
 
+async function drainStream(stream: AsyncIterable<unknown>): Promise<void> {
+  for await (const chunk of stream) {
+    void chunk;
+  }
+}
+
 describe('ChatDeepSeek', () => {
   it('passes reasoning_content back on same-run streaming tool continuations', async () => {
     const model = new CapturingChatDeepSeek({
@@ -235,5 +250,62 @@ describe('ChatDeepSeek', () => {
     expect(callbackTokens.join('')).not.toContain('hidden');
     expect(callbackTokens.join('')).not.toContain('think');
     expect(hasHiddenReasoning).toBe(true);
+  });
+
+  it('keeps multiple raw think fallback blocks hidden from content and callbacks', async () => {
+    const model = new CapturingChatDeepSeek(
+      {
+        apiKey: 'test-key',
+        model: 'deepseek-v4-pro',
+        streaming: true,
+      },
+      [
+        createContentChunk(
+          'before<think>hidden one</think>visible<think>hidden two</think>done'
+        ),
+      ]
+    );
+    const chunks = [];
+    const callbackTokens: string[] = [];
+
+    const stream = await model.stream([new HumanMessage('hi')], {
+      callbacks: [
+        {
+          handleLLMNewToken(token: string): void {
+            callbackTokens.push(token);
+          },
+        },
+      ],
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    const streamedText = chunks
+      .map((chunk) => (typeof chunk.content === 'string' ? chunk.content : ''))
+      .join('');
+    const reasoningContent = chunks
+      .map((chunk) => chunk.additional_kwargs.reasoning_content)
+      .filter((content): content is string => typeof content === 'string');
+
+    expect(streamedText).toBe('beforevisibledone');
+    expect(callbackTokens.join('')).toBe('beforevisibledone');
+    expect(reasoningContent).toEqual(['hidden one', 'hidden two']);
+  });
+
+  it('throws AbortError when a DeepSeek stream is canceled', async () => {
+    const controller = new AbortController();
+    const model = new CapturingChatDeepSeek({
+      apiKey: 'test-key',
+      model: 'deepseek-v4-pro',
+      streaming: true,
+    });
+
+    controller.abort();
+
+    await expect(
+      drainStream(model.streamChunksWithSignal(controller.signal))
+    ).rejects.toThrow('AbortError');
   });
 });

--- a/src/llm/openai/deepseek.test.ts
+++ b/src/llm/openai/deepseek.test.ts
@@ -1,6 +1,6 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
-import type { BaseMessage } from '@langchain/core/messages';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { BaseMessage } from '@langchain/core/messages';
 import type { OpenAIClient } from '@langchain/openai';
 
 import { ChatDeepSeek } from './index';
@@ -21,7 +21,8 @@ class CapturingChatDeepSeek extends ChatDeepSeek {
 
   constructor(
     fields: ConstructorParameters<typeof ChatDeepSeek>[0],
-    private readonly streamChunks = createCompletionStreamChunks()
+    private readonly streamChunks = createCompletionStreamChunks(),
+    private readonly completion = createCompletion()
   ) {
     super(fields);
   }
@@ -44,7 +45,7 @@ class CapturingChatDeepSeek extends ChatDeepSeek {
       return createCompletionStream(this.streamChunks);
     }
 
-    return createCompletion();
+    return this.completion;
   }
 
   streamChunksWithSignal(
@@ -127,7 +128,13 @@ async function* createCompletionStream(
   }
 }
 
-function createCompletion(): OpenAIChatCompletion {
+function createCompletion(
+  usage: OpenAIClient.Completions.CompletionUsage = {
+    prompt_tokens: 1,
+    completion_tokens: 1,
+    total_tokens: 2,
+  }
+): OpenAIChatCompletion {
   return {
     id: 'chatcmpl-deepseek-test',
     object: 'chat.completion',
@@ -145,11 +152,7 @@ function createCompletion(): OpenAIChatCompletion {
         logprobs: null,
       },
     ],
-    usage: {
-      prompt_tokens: 1,
-      completion_tokens: 1,
-      total_tokens: 2,
-    },
+    usage,
   };
 }
 
@@ -292,6 +295,102 @@ describe('ChatDeepSeek', () => {
     expect(streamedText).toBe('beforevisibledone');
     expect(callbackTokens.join('')).toBe('beforevisibledone');
     expect(reasoningContent).toEqual(['hidden one', 'hidden two']);
+  });
+
+  it('emits trailing unfinished raw think fallback as reasoning content', async () => {
+    const model = new CapturingChatDeepSeek(
+      {
+        apiKey: 'test-key',
+        model: 'deepseek-v4-pro',
+        streaming: true,
+      },
+      [createContentChunk('<think>truncated')]
+    );
+    const chunks = [];
+    const callbackTokens: string[] = [];
+
+    const stream = await model.stream([new HumanMessage('hi')], {
+      callbacks: [
+        {
+          handleLLMNewToken(token: string): void {
+            callbackTokens.push(token);
+          },
+        },
+      ],
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    const streamedText = chunks
+      .map((chunk) => (typeof chunk.content === 'string' ? chunk.content : ''))
+      .join('');
+    const reasoningContent = chunks
+      .map((chunk) => chunk.additional_kwargs.reasoning_content)
+      .filter((content): content is string => typeof content === 'string');
+
+    expect(streamedText).toBe('');
+    expect(callbackTokens.join('')).toBe('');
+    expect(reasoningContent).toEqual(['truncated']);
+  });
+
+  it('preserves detailed usage metadata in non-streaming responses', async () => {
+    const model = new CapturingChatDeepSeek(
+      {
+        apiKey: 'test-key',
+        model: 'deepseek-v4-pro',
+        streaming: false,
+      },
+      createCompletionStreamChunks(),
+      createCompletion({
+        prompt_tokens: 11,
+        completion_tokens: 7,
+        total_tokens: 18,
+        prompt_tokens_details: {
+          audio_tokens: 2,
+          cached_tokens: 3,
+        },
+        completion_tokens_details: {
+          audio_tokens: 4,
+          reasoning_tokens: 5,
+        },
+      })
+    );
+
+    const response = await model.invoke([new HumanMessage('hi')]);
+
+    expect(response.usage_metadata).toEqual({
+      input_tokens: 11,
+      output_tokens: 7,
+      total_tokens: 18,
+      input_token_details: {
+        audio: 2,
+        cache_read: 3,
+      },
+      output_token_details: {
+        audio: 4,
+        reasoning: 5,
+      },
+    });
+  });
+
+  it('does not serialize non-streaming requests when aborted before generation', async () => {
+    const controller = new AbortController();
+    const model = new CapturingChatDeepSeek({
+      apiKey: 'test-key',
+      model: 'deepseek-v4-pro',
+      streaming: false,
+    });
+
+    controller.abort();
+
+    await expect(
+      model.invoke([new HumanMessage('hi')], {
+        signal: controller.signal,
+      })
+    ).rejects.toThrow();
+    expect(model.requests).toHaveLength(0);
   });
 
   it('throws AbortError when a DeepSeek stream is canceled', async () => {

--- a/src/llm/openai/deepseek.test.ts
+++ b/src/llm/openai/deepseek.test.ts
@@ -1,0 +1,225 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { OpenAIClient } from '@langchain/openai';
+
+import { ChatDeepSeek } from './index';
+
+type DeepSeekRequest =
+  | OpenAIClient.Chat.ChatCompletionCreateParamsStreaming
+  | OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming;
+type OpenAIChatCompletion = OpenAIClient.Chat.Completions.ChatCompletion;
+type OpenAIChatCompletionChunk =
+  OpenAIClient.Chat.Completions.ChatCompletionChunk;
+type ReasoningAssistantMessageParam =
+  OpenAIClient.Chat.Completions.ChatCompletionAssistantMessageParam & {
+    reasoning_content?: string;
+  };
+
+class CapturingChatDeepSeek extends ChatDeepSeek {
+  readonly requests: DeepSeekRequest[] = [];
+
+  constructor(
+    fields: ConstructorParameters<typeof ChatDeepSeek>[0],
+    private readonly streamChunks = createCompletionStreamChunks()
+  ) {
+    super(fields);
+  }
+
+  async completionWithRetry(
+    request: OpenAIClient.Chat.ChatCompletionCreateParamsStreaming,
+    requestOptions?: OpenAIClient.RequestOptions
+  ): Promise<AsyncIterable<OpenAIChatCompletionChunk>>;
+  async completionWithRetry(
+    request: OpenAIClient.Chat.ChatCompletionCreateParamsNonStreaming,
+    requestOptions?: OpenAIClient.RequestOptions
+  ): Promise<OpenAIChatCompletion>;
+  async completionWithRetry(
+    request: DeepSeekRequest,
+    _requestOptions?: OpenAIClient.RequestOptions
+  ): Promise<AsyncIterable<OpenAIChatCompletionChunk> | OpenAIChatCompletion> {
+    this.requests.push(request);
+
+    if (request.stream === true) {
+      return createCompletionStream(this.streamChunks);
+    }
+
+    return createCompletion();
+  }
+}
+
+function createToolContextMessages(): BaseMessage[] {
+  return [
+    new AIMessage({
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_1',
+          name: 'web_search',
+          args: { query: 'trending news today' },
+          type: 'tool_call',
+        },
+      ],
+      additional_kwargs: {
+        reasoning_content: 'Need current news from the web.',
+      },
+    }),
+    new ToolMessage({
+      content: 'Search results',
+      tool_call_id: 'call_1',
+    }),
+  ];
+}
+
+function createCompletionStreamChunks(): OpenAIChatCompletionChunk[] {
+  return [
+    createContentChunk('ok'),
+    {
+      id: 'chatcmpl-deepseek-test',
+      object: 'chat.completion.chunk',
+      created: 0,
+      model: 'deepseek-v4-pro',
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    },
+  ];
+}
+
+function createContentChunk(content: string): OpenAIChatCompletionChunk {
+  return {
+    id: 'chatcmpl-deepseek-test',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'deepseek-v4-pro',
+    choices: [
+      {
+        index: 0,
+        delta: {
+          role: 'assistant',
+          content,
+        },
+        finish_reason: null,
+        logprobs: null,
+      },
+    ],
+  };
+}
+
+async function* createCompletionStream(
+  chunks: OpenAIChatCompletionChunk[]
+): AsyncGenerator<OpenAIChatCompletionChunk> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
+function createCompletion(): OpenAIChatCompletion {
+  return {
+    id: 'chatcmpl-deepseek-test',
+    object: 'chat.completion',
+    created: 0,
+    model: 'deepseek-v4-pro',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: 'ok',
+          refusal: null,
+        },
+        finish_reason: 'stop',
+        logprobs: null,
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+  };
+}
+
+function getReasoningAssistantMessage(
+  request: DeepSeekRequest
+): ReasoningAssistantMessageParam {
+  return request.messages[0] as ReasoningAssistantMessageParam;
+}
+
+describe('ChatDeepSeek', () => {
+  it('passes reasoning_content back on same-run streaming tool continuations', async () => {
+    const model = new CapturingChatDeepSeek({
+      apiKey: 'test-key',
+      model: 'deepseek-v4-pro',
+      streaming: true,
+    });
+    const chunks = [];
+
+    for await (const chunk of await model.stream(createToolContextMessages())) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(2);
+    expect(model.requests).toHaveLength(1);
+    expect(getReasoningAssistantMessage(model.requests[0])).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'Need current news from the web.',
+      })
+    );
+  });
+
+  it('passes reasoning_content back on same-run non-streaming tool continuations', async () => {
+    const model = new CapturingChatDeepSeek({
+      apiKey: 'test-key',
+      model: 'deepseek-v4-pro',
+      streaming: false,
+    });
+
+    await model.invoke(createToolContextMessages());
+
+    expect(model.requests).toHaveLength(1);
+    expect(getReasoningAssistantMessage(model.requests[0])).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'Need current news from the web.',
+      })
+    );
+  });
+
+  it('keeps raw think fallback content out of streamed assistant content', async () => {
+    const model = new CapturingChatDeepSeek(
+      {
+        apiKey: 'test-key',
+        model: 'deepseek-v4-pro',
+        streaming: true,
+      },
+      [
+        createContentChunk('prefix <thi'),
+        createContentChunk('nk>hidden'),
+        createContentChunk('</think>visible'),
+      ]
+    );
+    const chunks = [];
+
+    for await (const chunk of await model.stream([new HumanMessage('hi')])) {
+      chunks.push(chunk);
+    }
+
+    const streamedText = chunks
+      .map((chunk) => (typeof chunk.content === 'string' ? chunk.content : ''))
+      .join('');
+    const hasHiddenReasoning = chunks.some(
+      (chunk) => chunk.additional_kwargs.reasoning_content === 'hidden'
+    );
+
+    expect(streamedText).toBe('prefix visible');
+    expect(hasHiddenReasoning).toBe(true);
+  });
+});

--- a/src/llm/openai/deepseek.test.ts
+++ b/src/llm/openai/deepseek.test.ts
@@ -297,6 +297,48 @@ describe('ChatDeepSeek', () => {
     expect(reasoningContent).toEqual(['hidden one', 'hidden two']);
   });
 
+  it('keeps cross-chunk multiple raw think fallback blocks hidden from content and callbacks', async () => {
+    const model = new CapturingChatDeepSeek(
+      {
+        apiKey: 'test-key',
+        model: 'deepseek-v4-pro',
+        streaming: true,
+      },
+      [
+        createContentChunk('before<think>hidden one</thi'),
+        createContentChunk('nk>visible<thi'),
+        createContentChunk('nk>hidden two</think>done'),
+      ]
+    );
+    const chunks = [];
+    const callbackTokens: string[] = [];
+
+    const stream = await model.stream([new HumanMessage('hi')], {
+      callbacks: [
+        {
+          handleLLMNewToken(token: string): void {
+            callbackTokens.push(token);
+          },
+        },
+      ],
+    });
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    const streamedText = chunks
+      .map((chunk) => (typeof chunk.content === 'string' ? chunk.content : ''))
+      .join('');
+    const reasoningContent = chunks
+      .map((chunk) => chunk.additional_kwargs.reasoning_content)
+      .filter((content): content is string => typeof content === 'string');
+
+    expect(streamedText).toBe('beforevisibledone');
+    expect(callbackTokens.join('')).toBe('beforevisibledone');
+    expect(reasoningContent).toEqual(['hidden one', 'hidden two']);
+  });
+
   it('emits trailing unfinished raw think fallback as reasoning content', async () => {
     const model = new CapturingChatDeepSeek(
       {
@@ -406,5 +448,32 @@ describe('ChatDeepSeek', () => {
     await expect(
       drainStream(model.streamChunksWithSignal(controller.signal))
     ).rejects.toThrow('AbortError');
+  });
+
+  it('throws AbortError when a DeepSeek stream is canceled mid-stream', async () => {
+    const controller = new AbortController();
+    const model = new CapturingChatDeepSeek(
+      {
+        apiKey: 'test-key',
+        model: 'deepseek-v4-pro',
+        streaming: true,
+      },
+      [createContentChunk('first '), createContentChunk('second')]
+    );
+    const stream = model.streamChunksWithSignal(controller.signal);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual(
+      expect.objectContaining({
+        done: false,
+        value: expect.objectContaining({
+          text: 'first ',
+        }),
+      })
+    );
+
+    controller.abort();
+
+    await expect(iterator.next()).rejects.toThrow('AbortError');
   });
 });

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1404,8 +1404,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
   ): AsyncGenerator<ChatGenerationChunk> {
     const stream = this._streamResponseChunksFromReasoningMessages(
       messages,
-      options,
-      runManager
+      options
     );
     const thinkStartTag = '<think>';
     const thinkEndTag = '</think>';
@@ -1420,13 +1419,13 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
       const reasoningContent =
         chunk.message.additional_kwargs.reasoning_content;
       if (reasoningContent != null && reasoningContent !== '') {
-        yield chunk;
+        yield* this._yieldDeepSeekStreamChunk(chunk, runManager);
         continue;
       }
 
       const text = chunk.text;
       if (text === '') {
-        yield chunk;
+        yield* this._yieldDeepSeekStreamChunk(chunk, runManager);
         continue;
       }
 
@@ -1440,7 +1439,10 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
           tokensBuffer.substring(thinkIndex + thinkStartTag.length) || '';
 
         if (beforeThink !== '') {
-          yield this._createDeepSeekStreamChunk(chunk, beforeThink);
+          yield* this._yieldDeepSeekStreamChunk(
+            this._createDeepSeekStreamChunk(chunk, beforeThink),
+            runManager
+          );
         }
       }
 
@@ -1452,19 +1454,25 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
           thinkEndIndex + thinkEndTag.length
         );
 
-        yield this._createDeepSeekStreamChunk(
-          chunk,
-          '',
-          {
-            ...chunk.message.additional_kwargs,
-            reasoning_content: thoughtContent,
-          },
-          ''
+        yield* this._yieldDeepSeekStreamChunk(
+          this._createDeepSeekStreamChunk(
+            chunk,
+            '',
+            {
+              ...chunk.message.additional_kwargs,
+              reasoning_content: thoughtContent,
+            },
+            ''
+          ),
+          runManager
         );
 
         tokensBuffer = afterThink || '';
         if (tokensBuffer !== '') {
-          yield this._createDeepSeekStreamChunk(chunk, tokensBuffer);
+          yield* this._yieldDeepSeekStreamChunk(
+            this._createDeepSeekStreamChunk(chunk, tokensBuffer),
+            runManager
+          );
           tokensBuffer = '';
         }
       } else if (isThinking) {
@@ -1479,26 +1487,32 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
         if (splitIndex !== -1) {
           const safeToYield = tokensBuffer.substring(0, splitIndex);
           if (safeToYield !== '') {
-            yield this._createDeepSeekStreamChunk(
-              chunk,
-              '',
-              {
-                ...chunk.message.additional_kwargs,
-                reasoning_content: safeToYield,
-              },
-              ''
+            yield* this._yieldDeepSeekStreamChunk(
+              this._createDeepSeekStreamChunk(
+                chunk,
+                '',
+                {
+                  ...chunk.message.additional_kwargs,
+                  reasoning_content: safeToYield,
+                },
+                ''
+              ),
+              runManager
             );
           }
           tokensBuffer = tokensBuffer.substring(splitIndex);
         } else if (tokensBuffer !== '') {
-          yield this._createDeepSeekStreamChunk(
-            chunk,
-            '',
-            {
-              ...chunk.message.additional_kwargs,
-              reasoning_content: tokensBuffer,
-            },
-            ''
+          yield* this._yieldDeepSeekStreamChunk(
+            this._createDeepSeekStreamChunk(
+              chunk,
+              '',
+              {
+                ...chunk.message.additional_kwargs,
+                reasoning_content: tokensBuffer,
+              },
+              ''
+            ),
+            runManager
           );
           tokensBuffer = '';
         }
@@ -1514,11 +1528,17 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
         if (splitIndex !== -1) {
           const safeToYield = tokensBuffer.substring(0, splitIndex);
           if (safeToYield !== '') {
-            yield this._createDeepSeekStreamChunk(chunk, safeToYield);
+            yield* this._yieldDeepSeekStreamChunk(
+              this._createDeepSeekStreamChunk(chunk, safeToYield),
+              runManager
+            );
           }
           tokensBuffer = tokensBuffer.substring(splitIndex);
         } else if (tokensBuffer !== '') {
-          yield this._createDeepSeekStreamChunk(chunk, tokensBuffer);
+          yield* this._yieldDeepSeekStreamChunk(
+            this._createDeepSeekStreamChunk(chunk, tokensBuffer),
+            runManager
+          );
           tokensBuffer = '';
         }
       }
@@ -1529,30 +1549,35 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     }
 
     if (isThinking) {
-      yield new ChatGenerationChunk({
-        message: new AIMessageChunk({
-          content: '',
-          additional_kwargs: {
-            reasoning_content: tokensBuffer,
-          },
+      yield* this._yieldDeepSeekStreamChunk(
+        new ChatGenerationChunk({
+          message: new AIMessageChunk({
+            content: '',
+            additional_kwargs: {
+              reasoning_content: tokensBuffer,
+            },
+          }),
+          text: '',
         }),
-        text: '',
-      });
+        runManager
+      );
       return;
     }
 
-    yield new ChatGenerationChunk({
-      message: new AIMessageChunk({
-        content: tokensBuffer,
+    yield* this._yieldDeepSeekStreamChunk(
+      new ChatGenerationChunk({
+        message: new AIMessageChunk({
+          content: tokensBuffer,
+        }),
+        text: tokensBuffer,
       }),
-      text: tokensBuffer,
-    });
+      runManager
+    );
   }
 
   protected async *_streamResponseChunksFromReasoningMessages(
     messages: BaseMessage[],
-    options: this['ParsedCallOptions'],
-    runManager?: CallbackManagerForLLMRun
+    options: this['ParsedCallOptions']
   ): AsyncGenerator<ChatGenerationChunk> {
     const params = {
       ...this.invocationParams(options, { streaming: true }),
@@ -1626,14 +1651,6 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
       });
 
       yield generationChunk;
-      await runManager?.handleLLMNewToken(
-        generationChunk.text,
-        newTokenIndices,
-        undefined,
-        undefined,
-        undefined,
-        { chunk: generationChunk }
-      );
     }
 
     if (usage != null) {
@@ -1648,20 +1665,13 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
           usage_metadata: usageMetadata,
         }),
         text: '',
-      });
-
-      yield generationChunk;
-      await runManager?.handleLLMNewToken(
-        generationChunk.text,
-        {
+        generationInfo: {
           prompt: 0,
           completion: 0,
         },
-        undefined,
-        undefined,
-        undefined,
-        { chunk: generationChunk }
-      );
+      });
+
+      yield generationChunk;
     }
 
     if (options.signal?.aborted === true) {
@@ -1688,6 +1698,34 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
       text,
       generationInfo: chunk.generationInfo,
     });
+  }
+
+  protected async *_yieldDeepSeekStreamChunk(
+    chunk: ChatGenerationChunk,
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield chunk;
+    await runManager?.handleLLMNewToken(
+      chunk.text,
+      this._getDeepSeekTokenIndices(chunk),
+      undefined,
+      undefined,
+      undefined,
+      { chunk }
+    );
+  }
+
+  protected _getDeepSeekTokenIndices(
+    chunk: ChatGenerationChunk
+  ): { prompt: number; completion: number } | undefined {
+    const prompt = chunk.generationInfo?.prompt;
+    const completion = chunk.generationInfo?.completion;
+
+    if (typeof prompt === 'number' && typeof completion === 'number') {
+      return { prompt, completion };
+    }
+
+    return undefined;
   }
 }
 

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -141,6 +141,50 @@ type OpenAIChatCompletionRetry = (
   AsyncIterable<OpenAIChatCompletionStreamItem> | OpenAIChatCompletion
 >;
 
+function createUsageMetadata(
+  usage?: OpenAIClient.Completions.CompletionUsage
+): UsageMetadata {
+  const usageMetadata: UsageMetadata = {
+    input_tokens: usage?.prompt_tokens ?? 0,
+    output_tokens: usage?.completion_tokens ?? 0,
+    total_tokens: usage?.total_tokens ?? 0,
+  };
+
+  if (usage == null) {
+    return usageMetadata;
+  }
+
+  const inputTokenDetails: UsageMetadata['input_token_details'] = {};
+  const outputTokenDetails: UsageMetadata['output_token_details'] = {};
+  const audioInputTokens = usage.prompt_tokens_details?.audio_tokens;
+  const cachedInputTokens = usage.prompt_tokens_details?.cached_tokens;
+  const audioOutputTokens = usage.completion_tokens_details?.audio_tokens;
+  const reasoningOutputTokens =
+    usage.completion_tokens_details?.reasoning_tokens;
+
+  if (audioInputTokens != null) {
+    inputTokenDetails.audio = audioInputTokens;
+  }
+  if (cachedInputTokens != null) {
+    inputTokenDetails.cache_read = cachedInputTokens;
+  }
+  if (audioOutputTokens != null) {
+    outputTokenDetails.audio = audioOutputTokens;
+  }
+  if (reasoningOutputTokens != null) {
+    outputTokenDetails.reasoning = reasoningOutputTokens;
+  }
+
+  if (Object.keys(inputTokenDetails).length > 0) {
+    usageMetadata.input_token_details = inputTokenDetails;
+  }
+  if (Object.keys(outputTokenDetails).length > 0) {
+    usageMetadata.output_token_details = outputTokenDetails;
+  }
+
+  return usageMetadata;
+}
+
 function getExposedOpenAIClient(
   completions: OpenAIClientDelegate,
   responses: OpenAIClientDelegate,
@@ -1242,6 +1286,78 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     return 'LibreChatDeepSeek';
   }
 
+  protected _convertDeepSeekMessages(
+    messages: BaseMessage[]
+  ): OpenAICompletionParam[] {
+    return _convertMessagesToOpenAIParams(messages, this.model, {
+      includeReasoningContent: true,
+    });
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const params = this.invocationParams(options);
+
+    if (params.stream === true) {
+      return super._generate(messages, options, runManager);
+    }
+
+    const messagesMapped = this._convertDeepSeekMessages(messages);
+    const response = await this.completionWithRetry(
+      {
+        ...params,
+        stream: false,
+        messages: messagesMapped,
+      },
+      {
+        signal: options.signal,
+        ...options.options,
+      }
+    );
+
+    const usageMetadata = createUsageMetadata(response.usage);
+
+    const generations: ChatGeneration[] = response.choices.map((part) => {
+      const text = part.message.content ?? '';
+      const generation: ChatGeneration = {
+        text,
+        message: this._convertCompletionsMessageToBaseMessage(
+          part.message,
+          response
+        ),
+      };
+      generation.generationInfo = {
+        finish_reason: part.finish_reason,
+        ...(part.logprobs != null ? { logprobs: part.logprobs } : {}),
+      };
+      if (isAIMessage(generation.message)) {
+        generation.message.usage_metadata = usageMetadata;
+      }
+      generation.message = new AIMessage(
+        Object.fromEntries(
+          Object.entries(generation.message).filter(
+            ([key]) => !key.startsWith('lc_')
+          )
+        )
+      );
+      return generation;
+    });
+
+    return {
+      generations,
+      llmOutput: {
+        tokenUsage: {
+          promptTokens: usageMetadata.input_tokens,
+          completionTokens: usageMetadata.output_tokens,
+          totalTokens: usageMetadata.total_tokens,
+        },
+      },
+    };
+  }
+
   _getClientOptions(
     options?: OpenAICoreRequestOptions
   ): OpenAICoreRequestOptions {
@@ -1276,9 +1392,302 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      super._streamResponseChunks(messages, options, runManager),
+      this._streamResponseChunksWithReasoning(messages, options, runManager),
       this._lc_stream_delay
     );
+  }
+
+  protected async *_streamResponseChunksWithReasoning(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    const stream = this._streamResponseChunksFromReasoningMessages(
+      messages,
+      options,
+      runManager
+    );
+    const thinkStartTag = '<think>';
+    const thinkEndTag = '</think>';
+    let tokensBuffer = '';
+    let isThinking = false;
+
+    for await (const chunk of stream) {
+      if (options.signal?.aborted === true) {
+        return;
+      }
+
+      const reasoningContent =
+        chunk.message.additional_kwargs.reasoning_content;
+      if (reasoningContent != null && reasoningContent !== '') {
+        yield chunk;
+        continue;
+      }
+
+      const text = chunk.text;
+      if (text === '') {
+        yield chunk;
+        continue;
+      }
+
+      tokensBuffer += text;
+
+      if (!isThinking && tokensBuffer.includes(thinkStartTag)) {
+        isThinking = true;
+        const thinkIndex = tokensBuffer.indexOf(thinkStartTag);
+        const beforeThink = tokensBuffer.substring(0, thinkIndex);
+        tokensBuffer =
+          tokensBuffer.substring(thinkIndex + thinkStartTag.length) || '';
+
+        if (beforeThink !== '') {
+          yield this._createDeepSeekStreamChunk(chunk, beforeThink);
+        }
+      }
+
+      if (isThinking && tokensBuffer.includes(thinkEndTag)) {
+        isThinking = false;
+        const thinkEndIndex = tokensBuffer.indexOf(thinkEndTag);
+        const thoughtContent = tokensBuffer.substring(0, thinkEndIndex);
+        const afterThink = tokensBuffer.substring(
+          thinkEndIndex + thinkEndTag.length
+        );
+
+        yield this._createDeepSeekStreamChunk(
+          chunk,
+          '',
+          {
+            ...chunk.message.additional_kwargs,
+            reasoning_content: thoughtContent,
+          },
+          ''
+        );
+
+        tokensBuffer = afterThink || '';
+        if (tokensBuffer !== '') {
+          yield this._createDeepSeekStreamChunk(chunk, tokensBuffer);
+          tokensBuffer = '';
+        }
+      } else if (isThinking) {
+        let splitIndex = -1;
+        for (let i = thinkEndTag.length - 1; i >= 1; i--) {
+          if (tokensBuffer.endsWith(thinkEndTag.substring(0, i))) {
+            splitIndex = tokensBuffer.length - i;
+            break;
+          }
+        }
+
+        if (splitIndex !== -1) {
+          const safeToYield = tokensBuffer.substring(0, splitIndex);
+          if (safeToYield !== '') {
+            yield this._createDeepSeekStreamChunk(
+              chunk,
+              '',
+              {
+                ...chunk.message.additional_kwargs,
+                reasoning_content: safeToYield,
+              },
+              ''
+            );
+          }
+          tokensBuffer = tokensBuffer.substring(splitIndex);
+        } else if (tokensBuffer !== '') {
+          yield this._createDeepSeekStreamChunk(
+            chunk,
+            '',
+            {
+              ...chunk.message.additional_kwargs,
+              reasoning_content: tokensBuffer,
+            },
+            ''
+          );
+          tokensBuffer = '';
+        }
+      } else {
+        let splitIndex = -1;
+        for (let i = thinkStartTag.length - 1; i >= 1; i--) {
+          if (tokensBuffer.endsWith(thinkStartTag.substring(0, i))) {
+            splitIndex = tokensBuffer.length - i;
+            break;
+          }
+        }
+
+        if (splitIndex !== -1) {
+          const safeToYield = tokensBuffer.substring(0, splitIndex);
+          if (safeToYield !== '') {
+            yield this._createDeepSeekStreamChunk(chunk, safeToYield);
+          }
+          tokensBuffer = tokensBuffer.substring(splitIndex);
+        } else if (tokensBuffer !== '') {
+          yield this._createDeepSeekStreamChunk(chunk, tokensBuffer);
+          tokensBuffer = '';
+        }
+      }
+    }
+
+    if (tokensBuffer === '') {
+      return;
+    }
+
+    if (isThinking) {
+      yield new ChatGenerationChunk({
+        message: new AIMessageChunk({
+          content: '',
+          additional_kwargs: {
+            reasoning_content: tokensBuffer,
+          },
+        }),
+        text: '',
+      });
+      return;
+    }
+
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content: tokensBuffer,
+      }),
+      text: tokensBuffer,
+    });
+  }
+
+  protected async *_streamResponseChunksFromReasoningMessages(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    const params = {
+      ...this.invocationParams(options, { streaming: true }),
+      stream: true as const,
+    };
+    const messagesMapped = this._convertDeepSeekMessages(messages);
+    const streamIterable = await this.completionWithRetry(
+      {
+        ...params,
+        messages: messagesMapped,
+      },
+      {
+        signal: options.signal,
+        ...options.options,
+      }
+    );
+
+    let defaultRole:
+      | OpenAIClient.Chat.Completions.ChatCompletionRole
+      | undefined;
+    let usage: OpenAIClient.Completions.CompletionUsage | undefined;
+
+    for await (const data of streamIterable) {
+      if (options.signal?.aborted === true) {
+        return;
+      }
+
+      if (data.usage != null) {
+        usage = data.usage;
+      }
+
+      if (data.choices.length === 0) {
+        continue;
+      }
+
+      const choice = data.choices[0];
+      const { delta } = choice;
+      const messageChunk = this._convertCompletionsDeltaToBaseMessageChunk(
+        delta,
+        data,
+        defaultRole
+      );
+      defaultRole = delta.role ?? defaultRole;
+
+      if (typeof messageChunk.content !== 'string') {
+        continue;
+      }
+
+      const messageText = messageChunk.content;
+      const newTokenIndices = {
+        prompt: options.promptIndex ?? 0,
+        completion: choice.index,
+      };
+      const generationInfo = { ...newTokenIndices };
+      if (choice.finish_reason != null) {
+        Object.assign(generationInfo, {
+          finish_reason: choice.finish_reason,
+          system_fingerprint: data.system_fingerprint,
+          model_name: data.model,
+          service_tier: data.service_tier,
+        });
+      }
+      if (this.logprobs === true) {
+        Object.assign(generationInfo, { logprobs: choice.logprobs });
+      }
+
+      const generationChunk = new ChatGenerationChunk({
+        message: messageChunk,
+        text: messageText,
+        generationInfo,
+      });
+
+      yield generationChunk;
+      await runManager?.handleLLMNewToken(
+        generationChunk.text,
+        newTokenIndices,
+        undefined,
+        undefined,
+        undefined,
+        { chunk: generationChunk }
+      );
+    }
+
+    if (usage != null) {
+      const usageMetadata = createUsageMetadata(usage);
+
+      const generationChunk = new ChatGenerationChunk({
+        message: new AIMessageChunk({
+          content: '',
+          response_metadata: {
+            usage: { ...usage },
+          },
+          usage_metadata: usageMetadata,
+        }),
+        text: '',
+      });
+
+      yield generationChunk;
+      await runManager?.handleLLMNewToken(
+        generationChunk.text,
+        {
+          prompt: 0,
+          completion: 0,
+        },
+        undefined,
+        undefined,
+        undefined,
+        { chunk: generationChunk }
+      );
+    }
+
+    if (options.signal?.aborted === true) {
+      return;
+    }
+  }
+
+  protected _createDeepSeekStreamChunk(
+    chunk: ChatGenerationChunk,
+    content: string,
+    additionalKwargs?: AIMessageChunk['additional_kwargs'],
+    text = content
+  ): ChatGenerationChunk {
+    const message = chunk.message as AIMessageChunk;
+    return new ChatGenerationChunk({
+      message: new AIMessageChunk({
+        content,
+        additional_kwargs: additionalKwargs ?? message.additional_kwargs,
+        response_metadata: message.response_metadata,
+        tool_calls: message.tool_calls,
+        tool_call_chunks: message.tool_call_chunks,
+        id: message.id,
+      }),
+      text,
+      generationInfo: chunk.generationInfo,
+    });
   }
 }
 

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -156,6 +156,8 @@ function createUsageMetadata(
 
   const inputTokenDetails: UsageMetadata['input_token_details'] = {};
   const outputTokenDetails: UsageMetadata['output_token_details'] = {};
+  let hasInputTokenDetails = false;
+  let hasOutputTokenDetails = false;
   const audioInputTokens = usage.prompt_tokens_details?.audio_tokens;
   const cachedInputTokens = usage.prompt_tokens_details?.cached_tokens;
   const audioOutputTokens = usage.completion_tokens_details?.audio_tokens;
@@ -164,21 +166,25 @@ function createUsageMetadata(
 
   if (audioInputTokens != null) {
     inputTokenDetails.audio = audioInputTokens;
+    hasInputTokenDetails = true;
   }
   if (cachedInputTokens != null) {
     inputTokenDetails.cache_read = cachedInputTokens;
+    hasInputTokenDetails = true;
   }
   if (audioOutputTokens != null) {
     outputTokenDetails.audio = audioOutputTokens;
+    hasOutputTokenDetails = true;
   }
   if (reasoningOutputTokens != null) {
     outputTokenDetails.reasoning = reasoningOutputTokens;
+    hasOutputTokenDetails = true;
   }
 
-  if (Object.keys(inputTokenDetails).length > 0) {
+  if (hasInputTokenDetails) {
     usageMetadata.input_token_details = inputTokenDetails;
   }
-  if (Object.keys(outputTokenDetails).length > 0) {
+  if (hasOutputTokenDetails) {
     usageMetadata.output_token_details = outputTokenDetails;
   }
 
@@ -1299,6 +1305,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
+    options.signal?.throwIfAborted();
     const params = this.invocationParams(options);
 
     if (params.stream === true) {
@@ -1397,6 +1404,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     );
   }
 
+  /** Parses raw `<think>` fallback tags across chunks and emits sanitized DeepSeek stream chunks. */
   protected async *_streamResponseChunksWithReasoning(
     messages: BaseMessage[],
     options: this['ParsedCallOptions'],
@@ -1437,16 +1445,9 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
           if (thinkEndIndex !== -1) {
             const thoughtContent = tokensBuffer.substring(0, thinkEndIndex);
             if (thoughtContent !== '') {
-              yield* this._yieldDeepSeekStreamChunk(
-                this._createDeepSeekStreamChunk(
-                  chunk,
-                  '',
-                  {
-                    ...chunk.message.additional_kwargs,
-                    reasoning_content: thoughtContent,
-                  },
-                  ''
-                ),
+              yield* this._yieldDeepSeekReasoningText(
+                chunk,
+                thoughtContent,
                 runManager
               );
             }
@@ -1465,16 +1466,9 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
           if (splitIndex !== -1) {
             const safeToYield = tokensBuffer.substring(0, splitIndex);
             if (safeToYield !== '') {
-              yield* this._yieldDeepSeekStreamChunk(
-                this._createDeepSeekStreamChunk(
-                  chunk,
-                  '',
-                  {
-                    ...chunk.message.additional_kwargs,
-                    reasoning_content: safeToYield,
-                  },
-                  ''
-                ),
+              yield* this._yieldDeepSeekReasoningText(
+                chunk,
+                safeToYield,
                 runManager
               );
             }
@@ -1482,16 +1476,9 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
             break;
           }
 
-          yield* this._yieldDeepSeekStreamChunk(
-            this._createDeepSeekStreamChunk(
-              chunk,
-              '',
-              {
-                ...chunk.message.additional_kwargs,
-                reasoning_content: tokensBuffer,
-              },
-              ''
-            ),
+          yield* this._yieldDeepSeekReasoningText(
+            chunk,
+            tokensBuffer,
             runManager
           );
           tokensBuffer = '';
@@ -1681,7 +1668,21 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     additionalKwargs?: AIMessageChunk['additional_kwargs'],
     text = content
   ): ChatGenerationChunk {
-    const message = chunk.message as AIMessageChunk;
+    if (!(chunk.message instanceof AIMessageChunk)) {
+      return new ChatGenerationChunk({
+        message: new AIMessageChunk({
+          content,
+          additional_kwargs:
+            additionalKwargs ?? chunk.message.additional_kwargs,
+          response_metadata: chunk.message.response_metadata,
+          id: chunk.message.id,
+        }),
+        text,
+        generationInfo: chunk.generationInfo,
+      });
+    }
+
+    const message = chunk.message;
     return new ChatGenerationChunk({
       message: new AIMessageChunk({
         content,
@@ -1694,6 +1695,32 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
       text,
       generationInfo: chunk.generationInfo,
     });
+  }
+
+  protected _createDeepSeekReasoningStreamChunk(
+    chunk: ChatGenerationChunk,
+    reasoningContent: string
+  ): ChatGenerationChunk {
+    return this._createDeepSeekStreamChunk(
+      chunk,
+      '',
+      {
+        ...chunk.message.additional_kwargs,
+        reasoning_content: reasoningContent,
+      },
+      ''
+    );
+  }
+
+  protected async *_yieldDeepSeekReasoningText(
+    chunk: ChatGenerationChunk,
+    reasoningContent: string,
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    yield* this._yieldDeepSeekStreamChunk(
+      this._createDeepSeekReasoningStreamChunk(chunk, reasoningContent),
+      runManager
+    );
   }
 
   protected async *_yieldDeepSeekStreamChunk(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1413,7 +1413,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
 
     for await (const chunk of stream) {
       if (options.signal?.aborted === true) {
-        return;
+        throw new Error('AbortError');
       }
 
       const reasoningContent =
@@ -1431,77 +1431,57 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
 
       tokensBuffer += text;
 
-      if (!isThinking && tokensBuffer.includes(thinkStartTag)) {
-        isThinking = true;
-        const thinkIndex = tokensBuffer.indexOf(thinkStartTag);
-        const beforeThink = tokensBuffer.substring(0, thinkIndex);
-        tokensBuffer =
-          tokensBuffer.substring(thinkIndex + thinkStartTag.length) || '';
+      while (tokensBuffer !== '') {
+        if (isThinking) {
+          const thinkEndIndex = tokensBuffer.indexOf(thinkEndTag);
+          if (thinkEndIndex !== -1) {
+            const thoughtContent = tokensBuffer.substring(0, thinkEndIndex);
+            if (thoughtContent !== '') {
+              yield* this._yieldDeepSeekStreamChunk(
+                this._createDeepSeekStreamChunk(
+                  chunk,
+                  '',
+                  {
+                    ...chunk.message.additional_kwargs,
+                    reasoning_content: thoughtContent,
+                  },
+                  ''
+                ),
+                runManager
+              );
+            }
 
-        if (beforeThink !== '') {
-          yield* this._yieldDeepSeekStreamChunk(
-            this._createDeepSeekStreamChunk(chunk, beforeThink),
-            runManager
+            tokensBuffer = tokensBuffer.substring(
+              thinkEndIndex + thinkEndTag.length
+            );
+            isThinking = false;
+            continue;
+          }
+
+          const splitIndex = this._getDeepSeekPartialTagSplitIndex(
+            tokensBuffer,
+            thinkEndTag
           );
-        }
-      }
-
-      if (isThinking && tokensBuffer.includes(thinkEndTag)) {
-        isThinking = false;
-        const thinkEndIndex = tokensBuffer.indexOf(thinkEndTag);
-        const thoughtContent = tokensBuffer.substring(0, thinkEndIndex);
-        const afterThink = tokensBuffer.substring(
-          thinkEndIndex + thinkEndTag.length
-        );
-
-        yield* this._yieldDeepSeekStreamChunk(
-          this._createDeepSeekStreamChunk(
-            chunk,
-            '',
-            {
-              ...chunk.message.additional_kwargs,
-              reasoning_content: thoughtContent,
-            },
-            ''
-          ),
-          runManager
-        );
-
-        tokensBuffer = afterThink || '';
-        if (tokensBuffer !== '') {
-          yield* this._yieldDeepSeekStreamChunk(
-            this._createDeepSeekStreamChunk(chunk, tokensBuffer),
-            runManager
-          );
-          tokensBuffer = '';
-        }
-      } else if (isThinking) {
-        let splitIndex = -1;
-        for (let i = thinkEndTag.length - 1; i >= 1; i--) {
-          if (tokensBuffer.endsWith(thinkEndTag.substring(0, i))) {
-            splitIndex = tokensBuffer.length - i;
+          if (splitIndex !== -1) {
+            const safeToYield = tokensBuffer.substring(0, splitIndex);
+            if (safeToYield !== '') {
+              yield* this._yieldDeepSeekStreamChunk(
+                this._createDeepSeekStreamChunk(
+                  chunk,
+                  '',
+                  {
+                    ...chunk.message.additional_kwargs,
+                    reasoning_content: safeToYield,
+                  },
+                  ''
+                ),
+                runManager
+              );
+            }
+            tokensBuffer = tokensBuffer.substring(splitIndex);
             break;
           }
-        }
 
-        if (splitIndex !== -1) {
-          const safeToYield = tokensBuffer.substring(0, splitIndex);
-          if (safeToYield !== '') {
-            yield* this._yieldDeepSeekStreamChunk(
-              this._createDeepSeekStreamChunk(
-                chunk,
-                '',
-                {
-                  ...chunk.message.additional_kwargs,
-                  reasoning_content: safeToYield,
-                },
-                ''
-              ),
-              runManager
-            );
-          }
-          tokensBuffer = tokensBuffer.substring(splitIndex);
-        } else if (tokensBuffer !== '') {
           yield* this._yieldDeepSeekStreamChunk(
             this._createDeepSeekStreamChunk(
               chunk,
@@ -1515,16 +1495,30 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
             runManager
           );
           tokensBuffer = '';
-        }
-      } else {
-        let splitIndex = -1;
-        for (let i = thinkStartTag.length - 1; i >= 1; i--) {
-          if (tokensBuffer.endsWith(thinkStartTag.substring(0, i))) {
-            splitIndex = tokensBuffer.length - i;
-            break;
-          }
+          break;
         }
 
+        const thinkStartIndex = tokensBuffer.indexOf(thinkStartTag);
+        if (thinkStartIndex !== -1) {
+          const beforeThink = tokensBuffer.substring(0, thinkStartIndex);
+          if (beforeThink !== '') {
+            yield* this._yieldDeepSeekStreamChunk(
+              this._createDeepSeekStreamChunk(chunk, beforeThink),
+              runManager
+            );
+          }
+
+          tokensBuffer = tokensBuffer.substring(
+            thinkStartIndex + thinkStartTag.length
+          );
+          isThinking = true;
+          continue;
+        }
+
+        const splitIndex = this._getDeepSeekPartialTagSplitIndex(
+          tokensBuffer,
+          thinkStartTag
+        );
         if (splitIndex !== -1) {
           const safeToYield = tokensBuffer.substring(0, splitIndex);
           if (safeToYield !== '') {
@@ -1534,13 +1528,15 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
             );
           }
           tokensBuffer = tokensBuffer.substring(splitIndex);
-        } else if (tokensBuffer !== '') {
-          yield* this._yieldDeepSeekStreamChunk(
-            this._createDeepSeekStreamChunk(chunk, tokensBuffer),
-            runManager
-          );
-          tokensBuffer = '';
+          break;
         }
+
+        yield* this._yieldDeepSeekStreamChunk(
+          this._createDeepSeekStreamChunk(chunk, tokensBuffer),
+          runManager
+        );
+        tokensBuffer = '';
+        break;
       }
     }
 
@@ -1602,7 +1598,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
 
     for await (const data of streamIterable) {
       if (options.signal?.aborted === true) {
-        return;
+        throw new Error('AbortError');
       }
 
       if (data.usage != null) {
@@ -1675,7 +1671,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     }
 
     if (options.signal?.aborted === true) {
-      return;
+      throw new Error('AbortError');
     }
   }
 
@@ -1726,6 +1722,19 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     }
 
     return undefined;
+  }
+
+  protected _getDeepSeekPartialTagSplitIndex(
+    text: string,
+    tag: string
+  ): number {
+    for (let i = tag.length - 1; i >= 1; i--) {
+      if (text.endsWith(tag.substring(0, i))) {
+        return text.length - i;
+      }
+    }
+
+    return -1;
   }
 }
 


### PR DESCRIPTION
## Summary

I fixed DeepSeek same-run tool continuations so `reasoning_content` is serialized back to the API after a reasoning model emits tool calls.

- Route ChatDeepSeek streaming and non-streaming follow-up requests through LibreChat's OpenAI message converter with `includeReasoningContent` enabled.
- Preserve DeepSeek's raw `<think>` fallback parsing, usage metadata, generation info, and stream delay behavior while using the patched request serializer.
- Add unit coverage for streaming request serialization, non-streaming request serialization, and split raw `<think>` fallback chunks.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx eslint src/llm/openai/index.ts src/llm/openai/deepseek.test.ts`
- `npx tsc --noEmit --pretty false`
- `npx jest src/llm/openai/deepseek.test.ts src/llm/openai/utils/messages.test.ts`
- `npx jest src/specs/deepseek.simple.test.ts --runInBand`
- `npm run build`

### **Test Configuration**:

- Live DeepSeek API key loaded from local environment.
- Model exercised by the live spec: `deepseek-v4-pro`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes