### PR TITLE
fix: Cross-provider tool-call ID + thinking-block compatibility

### DIFF
--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -3,6 +3,7 @@
 /**
  * This util file contains functions for converting LangChain messages to Anthropic messages.
  */
+import { createHash } from 'node:crypto';
 import {
   type BaseMessage,
   type SystemMessage,
@@ -92,12 +93,20 @@ function _formatImage(imageUrl: string) {
 
 const ANTHROPIC_TOOL_USE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const ANTHROPIC_TOOL_USE_ID_MAX_LENGTH = 64;
+const ANTHROPIC_TOOL_USE_ID_HASH_LENGTH = 10;
 
 /**
  * Normalize a tool-call ID to satisfy Anthropic's `^[a-zA-Z0-9_-]+$` and 64-char
  * constraints. Pure and deterministic — same input always yields the same output,
  * so paired `tool_use.id` and `tool_result.tool_use_id` stay matched without
  * needing a session map. IDs that already comply pass through unchanged.
+ *
+ * For non-compliant inputs we sanitize then append a short SHA-256 prefix of
+ * the original ID to preserve uniqueness when truncation would otherwise
+ * collapse distinct IDs to the same value (e.g. two long Responses-style IDs
+ * sharing a 64-char prefix). The hash is computed against the raw input so
+ * inputs that differ only after the truncation cutoff still produce distinct
+ * outputs.
  */
 export function normalizeAnthropicToolCallId(id: string): string;
 export function normalizeAnthropicToolCallId(
@@ -115,9 +124,14 @@ export function normalizeAnthropicToolCallId(
   ) {
     return id;
   }
-  return id
-    .replace(/[^a-zA-Z0-9_-]/g, '_')
-    .slice(0, ANTHROPIC_TOOL_USE_ID_MAX_LENGTH);
+  const sanitized = id.replace(/[^a-zA-Z0-9_-]/g, '_');
+  const hash = createHash('sha256')
+    .update(id)
+    .digest('hex')
+    .slice(0, ANTHROPIC_TOOL_USE_ID_HASH_LENGTH);
+  const prefixMaxLength =
+    ANTHROPIC_TOOL_USE_ID_MAX_LENGTH - ANTHROPIC_TOOL_USE_ID_HASH_LENGTH - 1;
+  return `${sanitized.slice(0, prefixMaxLength)}_${hash}`;
 }
 
 function _ensureMessageContents(

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -90,6 +90,36 @@ function _formatImage(imageUrl: string) {
   );
 }
 
+const ANTHROPIC_TOOL_USE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const ANTHROPIC_TOOL_USE_ID_MAX_LENGTH = 64;
+
+/**
+ * Normalize a tool-call ID to satisfy Anthropic's `^[a-zA-Z0-9_-]+$` and 64-char
+ * constraints. Pure and deterministic — same input always yields the same output,
+ * so paired `tool_use.id` and `tool_result.tool_use_id` stay matched without
+ * needing a session map. IDs that already comply pass through unchanged.
+ */
+export function normalizeAnthropicToolCallId(id: string): string;
+export function normalizeAnthropicToolCallId(
+  id: string | undefined
+): string | undefined;
+export function normalizeAnthropicToolCallId(
+  id: string | undefined
+): string | undefined {
+  if (id == null) {
+    return id;
+  }
+  if (
+    id.length <= ANTHROPIC_TOOL_USE_ID_MAX_LENGTH &&
+    ANTHROPIC_TOOL_USE_ID_PATTERN.test(id)
+  ) {
+    return id;
+  }
+  return id
+    .replace(/[^a-zA-Z0-9_-]/g, '_')
+    .slice(0, ANTHROPIC_TOOL_USE_ID_MAX_LENGTH);
+}
+
 function _ensureMessageContents(
   messages: BaseMessage[]
 ): (SystemMessage | HumanMessage | AIMessage)[] {
@@ -109,7 +139,9 @@ function _ensureMessageContents(
           (previousMessage.content as MessageContentComplex[]).push({
             type: 'tool_result',
             content: message.content,
-            tool_use_id: (message as ToolMessage).tool_call_id,
+            tool_use_id: normalizeAnthropicToolCallId(
+              (message as ToolMessage).tool_call_id
+            ),
           });
         } else {
           // If not, we create a new human message with the tool result.
@@ -119,7 +151,9 @@ function _ensureMessageContents(
                 {
                   type: 'tool_result',
                   content: message.content,
-                  tool_use_id: (message as ToolMessage).tool_call_id,
+                  tool_use_id: normalizeAnthropicToolCallId(
+                    (message as ToolMessage).tool_call_id
+                  ),
                 },
               ],
             })
@@ -135,7 +169,9 @@ function _ensureMessageContents(
                 ...(message.content != null
                   ? { content: _formatContent(message) }
                   : {}),
-                tool_use_id: (message as ToolMessage).tool_call_id,
+                tool_use_id: normalizeAnthropicToolCallId(
+                  (message as ToolMessage).tool_call_id
+                ),
               },
             ],
           })
@@ -154,11 +190,12 @@ export function _convertLangChainToolCallToAnthropic(
   if (toolCall.id === undefined) {
     throw new Error('Anthropic requires all tool calls to have an "id".');
   }
+  const isServerTool = toolCall.id.startsWith(
+    Constants.ANTHROPIC_SERVER_TOOL_PREFIX
+  );
   return {
-    type: toolCall.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
-      ? 'server_tool_use'
-      : 'tool_use',
-    id: toolCall.id,
+    type: isServerTool ? 'server_tool_use' : 'tool_use',
+    id: isServerTool ? toolCall.id : normalizeAnthropicToolCallId(toolCall.id),
     name: toolCall.name,
     input: toolCall.args,
   };

--- a/src/llm/anthropic/utils/tool-id-normalization.test.ts
+++ b/src/llm/anthropic/utils/tool-id-normalization.test.ts
@@ -16,20 +16,45 @@ describe('normalizeAnthropicToolCallId', () => {
     expect(normalizeAnthropicToolCallId('a-b_c-d')).toBe('a-b_c-d');
   });
 
-  it('replaces invalid characters with underscores', () => {
+  it('sanitizes invalid characters and appends a hash suffix', () => {
+    const out = normalizeAnthropicToolCallId(
+      'fc_67abc1234def567|call_abc123def456ghi789jkl0mnopqrs'
+    );
+    expect(/^[a-zA-Z0-9_-]+$/.test(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(64);
     expect(
-      normalizeAnthropicToolCallId(
-        'fc_67abc1234def567|call_abc123def456ghi789jkl0mnopqrs'
-      )
-    ).toBe('fc_67abc1234def567_call_abc123def456ghi789jkl0mnopqrs');
-    expect(normalizeAnthropicToolCallId('a.b@c#d')).toBe('a_b_c_d');
+      out.startsWith('fc_67abc1234def567_call_abc123def456ghi789jkl0mn')
+    ).toBe(true);
+    // Suffix is `_<10-hex-char hash>`
+    expect(out).toMatch(/_[0-9a-f]{10}$/);
   });
 
-  it('truncates IDs longer than 64 characters', () => {
+  it('produces compliant output for IDs of any length', () => {
     const long = 'fc_' + 'a'.repeat(80);
     const out = normalizeAnthropicToolCallId(long);
     expect(out).toHaveLength(64);
-    expect(out.startsWith('fc_aaa')).toBe(true);
+    expect(/^[a-zA-Z0-9_-]+$/.test(out)).toBe(true);
+  });
+
+  it('produces uniquely distinguishable outputs for IDs that share a 64-char prefix', () => {
+    const sharedPrefix = 'fc_' + 'a'.repeat(80);
+    const idA = sharedPrefix + '|call_unique_A';
+    const idB = sharedPrefix + '|call_unique_B';
+
+    const outA = normalizeAnthropicToolCallId(idA);
+    const outB = normalizeAnthropicToolCallId(idB);
+
+    expect(outA).not.toBe(outB);
+    expect(outA).toHaveLength(64);
+    expect(outB).toHaveLength(64);
+    expect(/^[a-zA-Z0-9_-]+$/.test(outA)).toBe(true);
+    expect(/^[a-zA-Z0-9_-]+$/.test(outB)).toBe(true);
+  });
+
+  it('disambiguates short IDs that sanitize to the same value', () => {
+    expect(normalizeAnthropicToolCallId('a|b')).not.toBe(
+      normalizeAnthropicToolCallId('a.b')
+    );
   });
 
   it('handles combined length and character violations', () => {

--- a/src/llm/anthropic/utils/tool-id-normalization.test.ts
+++ b/src/llm/anthropic/utils/tool-id-normalization.test.ts
@@ -1,0 +1,146 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  _convertLangChainToolCallToAnthropic,
+  _convertMessagesToAnthropicPayload,
+  normalizeAnthropicToolCallId,
+} from './message_inputs';
+
+describe('normalizeAnthropicToolCallId', () => {
+  it('returns valid IDs unchanged', () => {
+    expect(normalizeAnthropicToolCallId('toolu_01ABcdEFgh')).toBe(
+      'toolu_01ABcdEFgh'
+    );
+    expect(normalizeAnthropicToolCallId('call_abc123XYZ')).toBe(
+      'call_abc123XYZ'
+    );
+    expect(normalizeAnthropicToolCallId('a-b_c-d')).toBe('a-b_c-d');
+  });
+
+  it('replaces invalid characters with underscores', () => {
+    expect(
+      normalizeAnthropicToolCallId(
+        'fc_67abc1234def567|call_abc123def456ghi789jkl0mnopqrs'
+      )
+    ).toBe('fc_67abc1234def567_call_abc123def456ghi789jkl0mnopqrs');
+    expect(normalizeAnthropicToolCallId('a.b@c#d')).toBe('a_b_c_d');
+  });
+
+  it('truncates IDs longer than 64 characters', () => {
+    const long = 'fc_' + 'a'.repeat(80);
+    const out = normalizeAnthropicToolCallId(long);
+    expect(out).toHaveLength(64);
+    expect(out.startsWith('fc_aaa')).toBe(true);
+  });
+
+  it('handles combined length and character violations', () => {
+    const id = 'fc_' + 'x|'.repeat(100);
+    const out = normalizeAnthropicToolCallId(id);
+    expect(out).toHaveLength(64);
+    expect(/^[a-zA-Z0-9_-]+$/.test(out)).toBe(true);
+  });
+
+  it('is deterministic — same input always yields same output', () => {
+    const id = 'fc_a|b|c';
+    expect(normalizeAnthropicToolCallId(id)).toBe(
+      normalizeAnthropicToolCallId(id)
+    );
+  });
+
+  it('passes through undefined for the optional overload', () => {
+    expect(normalizeAnthropicToolCallId(undefined)).toBeUndefined();
+  });
+});
+
+describe('_convertMessagesToAnthropicPayload — cross-provider ID normalization', () => {
+  it('normalizes Responses-style IDs on tool_use AND matching tool_result', () => {
+    const responsesId = 'fc_67abc1234def567|call_abc123def456ghi789jkl0mnopqrs';
+
+    const payload = _convertMessagesToAnthropicPayload([
+      new HumanMessage('weather?'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: responsesId,
+            name: 'get_weather',
+            args: { location: 'Tokyo' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: responsesId,
+        content: '{"temp": 21}',
+      }),
+    ]);
+
+    const assistantMsg = payload.messages.find((m) => m.role === 'assistant')!;
+    const userToolResultMsg = payload.messages.find(
+      (m) =>
+        m.role === 'user' &&
+        Array.isArray(m.content) &&
+        (m.content as Array<{ type: string }>)[0]?.type === 'tool_result'
+    )!;
+
+    const toolUseBlock = (
+      assistantMsg.content as Array<{ type: string; id?: string }>
+    ).find((b) => b.type === 'tool_use')!;
+    const toolResultBlock = (
+      userToolResultMsg.content as Array<{
+        type: string;
+        tool_use_id?: string;
+      }>
+    ).find((b) => b.type === 'tool_result')!;
+
+    const expected = normalizeAnthropicToolCallId(responsesId);
+    expect(toolUseBlock.id).toBe(expected);
+    expect(toolResultBlock.tool_use_id).toBe(expected);
+    expect(toolUseBlock.id).toBe(toolResultBlock.tool_use_id);
+    expect(/^[a-zA-Z0-9_-]+$/.test(toolUseBlock.id!)).toBe(true);
+    expect(toolUseBlock.id!.length).toBeLessThanOrEqual(64);
+  });
+
+  it('passes through Anthropic-native IDs unchanged', () => {
+    const nativeId = 'toolu_01ABcdEFgh23ijKL';
+
+    const payload = _convertMessagesToAnthropicPayload([
+      new HumanMessage('hi'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: nativeId,
+            name: 'noop',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        tool_call_id: nativeId,
+        content: 'ok',
+      }),
+    ]);
+
+    const assistantMsg = payload.messages.find((m) => m.role === 'assistant')!;
+    const toolUseBlock = (
+      assistantMsg.content as Array<{ type: string; id?: string }>
+    ).find((b) => b.type === 'tool_use')!;
+
+    expect(toolUseBlock.id).toBe(nativeId);
+  });
+
+  it('does not normalize server tool IDs (srvtoolu_ prefix)', () => {
+    const serverId = 'srvtoolu_01abcXYZ';
+
+    const block = _convertLangChainToolCallToAnthropic({
+      id: serverId,
+      name: 'web_search',
+      args: { query: 'x' },
+      type: 'tool_call',
+    });
+
+    expect(block.type).toBe('server_tool_use');
+    expect(block.id).toBe(serverId);
+  });
+});

--- a/src/llm/anthropic/utils/tool-id-normalization.test.ts
+++ b/src/llm/anthropic/utils/tool-id-normalization.test.ts
@@ -74,6 +74,13 @@ describe('normalizeAnthropicToolCallId', () => {
   it('passes through undefined for the optional overload', () => {
     expect(normalizeAnthropicToolCallId(undefined)).toBeUndefined();
   });
+
+  it('handles empty string by producing a deterministic compliant output', () => {
+    const out = normalizeAnthropicToolCallId('');
+    expect(/^[a-zA-Z0-9_-]+$/.test(out)).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(64);
+    expect(out).toBe(normalizeAnthropicToolCallId(''));
+  });
 });
 
 describe('_convertMessagesToAnthropicPayload — cross-provider ID normalization', () => {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -34,7 +34,11 @@ import type { BindToolsInput } from '@langchain/core/language_models/chat_models
 import type { ChatGeneration, ChatResult } from '@langchain/core/outputs';
 import type { ChatXAIInput } from '@langchain/xai';
 import type * as t from '@langchain/openai';
-import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
+import {
+  isReasoningModel,
+  flattenAnthropicThinkingForOpenAI,
+  _convertMessagesToOpenAIParams,
+} from './utils';
 import { sleep } from '@/utils';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -589,12 +593,17 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
+    const normalizedMessages = flattenAnthropicThinkingForOpenAI(
+      messages,
+      this.model
+    );
     if (
       this.includeReasoningContent !== true &&
       this.includeReasoningDetails !== true
     ) {
-      return super._generate(messages, options, runManager);
+      return super._generate(normalizedMessages, options, runManager);
     }
+    messages = normalizedMessages;
 
     options.signal?.throwIfAborted();
     const usageMetadata: Partial<UsageMetadata> = {};
@@ -754,13 +763,22 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
+    const normalizedMessages = flattenAnthropicThinkingForOpenAI(
+      messages,
+      this.model
+    );
     if (
       this.includeReasoningContent !== true &&
       this.includeReasoningDetails !== true
     ) {
-      yield* super._streamResponseChunks(messages, options, runManager);
+      yield* super._streamResponseChunks(
+        normalizedMessages,
+        options,
+        runManager
+      );
       return;
     }
+    messages = normalizedMessages;
 
     const messagesMapped: OpenAICompletionParam[] =
       _convertMessagesToOpenAIParams(messages, this.model, {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1343,13 +1343,13 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     options.signal?.throwIfAborted();
     const params = this.invocationParams(options);
 
-    messages = flattenAnthropicThinkingForOpenAI(messages, this.model);
+    const normalized = flattenAnthropicThinkingForOpenAI(messages, this.model);
 
     if (params.stream === true) {
-      return super._generate(messages, options, runManager);
+      return super._generate(normalized, options, runManager);
     }
 
-    const messagesMapped = this._convertDeepSeekMessages(messages);
+    const messagesMapped = this._convertDeepSeekMessages(normalized);
     const response = await this.completionWithRetry(
       {
         ...params,

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1336,14 +1336,17 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
 }
 export class ChatDeepSeek extends OriginalChatDeepSeek {
   _lc_stream_delay?: number;
+  protected _claudeBackend?: boolean;
 
   constructor(
     fields?: ConstructorParameters<typeof OriginalChatDeepSeek>[0] & {
       _lc_stream_delay?: number;
+      claudeBackend?: boolean;
     }
   ) {
     super(fields);
     this._lc_stream_delay = fields?._lc_stream_delay;
+    this._claudeBackend = fields?.claudeBackend;
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -1358,6 +1361,7 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
   ): OpenAICompletionParam[] {
     return _convertMessagesToOpenAIParams(messages, this.model, {
       includeReasoningContent: true,
+      claudeBackend: this._claudeBackend,
     });
   }
 
@@ -1369,7 +1373,9 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     options.signal?.throwIfAborted();
     const params = this.invocationParams(options);
 
-    const normalized = flattenAnthropicThinkingForOpenAI(messages, this.model);
+    const normalized = flattenAnthropicThinkingForOpenAI(messages, this.model, {
+      claudeBackend: this._claudeBackend,
+    });
 
     if (params.stream === true) {
       return super._generate(normalized, options, runManager);
@@ -1463,7 +1469,9 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
       this._streamResponseChunksWithReasoning(
-        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        flattenAnthropicThinkingForOpenAI(messages, this.model, {
+          claudeBackend: this._claudeBackend,
+        }),
         options,
         runManager
       ),
@@ -1867,16 +1875,19 @@ export class ChatMoonshot extends ChatOpenAI {
 
 export class ChatXAI extends OriginalChatXAI {
   _lc_stream_delay?: number;
+  protected _claudeBackend?: boolean;
 
   constructor(
     fields?: Partial<ChatXAIInput> & {
       configuration?: { baseURL?: string };
       clientConfig?: { baseURL?: string };
       _lc_stream_delay?: number;
+      claudeBackend?: boolean;
     }
   ) {
     super(fields);
     this._lc_stream_delay = fields?._lc_stream_delay;
+    this._claudeBackend = fields?.claudeBackend;
     const customBaseURL =
       fields?.configuration?.baseURL ?? fields?.clientConfig?.baseURL;
     if (customBaseURL != null && customBaseURL) {
@@ -1932,7 +1943,9 @@ export class ChatXAI extends OriginalChatXAI {
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     return super._generate(
-      flattenAnthropicThinkingForOpenAI(messages, this.model),
+      flattenAnthropicThinkingForOpenAI(messages, this.model, {
+        claudeBackend: this._claudeBackend,
+      }),
       options,
       runManager
     );
@@ -1945,7 +1958,9 @@ export class ChatXAI extends OriginalChatXAI {
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
       super._streamResponseChunks(
-        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        flattenAnthropicThinkingForOpenAI(messages, this.model, {
+          claudeBackend: this._claudeBackend,
+        }),
         options,
         runManager
       ),

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -593,17 +593,12 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
-    const normalizedMessages = flattenAnthropicThinkingForOpenAI(
-      messages,
-      this.model
-    );
     if (
       this.includeReasoningContent !== true &&
       this.includeReasoningDetails !== true
     ) {
-      return super._generate(normalizedMessages, options, runManager);
+      return super._generate(messages, options, runManager);
     }
-    messages = normalizedMessages;
 
     options.signal?.throwIfAborted();
     const usageMetadata: Partial<UsageMetadata> = {};
@@ -763,22 +758,13 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
-    const normalizedMessages = flattenAnthropicThinkingForOpenAI(
-      messages,
-      this.model
-    );
     if (
       this.includeReasoningContent !== true &&
       this.includeReasoningDetails !== true
     ) {
-      yield* super._streamResponseChunks(
-        normalizedMessages,
-        options,
-        runManager
-      );
+      yield* super._streamResponseChunks(messages, options, runManager);
       return;
     }
-    messages = normalizedMessages;
 
     const messagesMapped: OpenAICompletionParam[] =
       _convertMessagesToOpenAIParams(messages, this.model, {
@@ -1170,13 +1156,29 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
     return this.getReasoningParams(options);
   }
 
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    return super._generate(
+      flattenAnthropicThinkingForOpenAI(messages, this.model),
+      options,
+      runManager
+    );
+  }
+
   async *_streamResponseChunks(
     messages: BaseMessage[],
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      super._streamResponseChunks(messages, options, runManager),
+      super._streamResponseChunks(
+        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        options,
+        runManager
+      ),
       this._lc_stream_delay
     );
   }
@@ -1280,13 +1282,28 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
     }
     return requestOptions;
   }
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    return super._generate(
+      flattenAnthropicThinkingForOpenAI(messages, this.model),
+      options,
+      runManager
+    );
+  }
   async *_streamResponseChunks(
     messages: BaseMessage[],
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      super._streamResponseChunks(messages, options, runManager),
+      super._streamResponseChunks(
+        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        options,
+        runManager
+      ),
       this._lc_stream_delay
     );
   }
@@ -1325,6 +1342,8 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
   ): Promise<ChatResult> {
     options.signal?.throwIfAborted();
     const params = this.invocationParams(options);
+
+    messages = flattenAnthropicThinkingForOpenAI(messages, this.model);
 
     if (params.stream === true) {
       return super._generate(messages, options, runManager);
@@ -1417,7 +1436,11 @@ export class ChatDeepSeek extends OriginalChatDeepSeek {
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      this._streamResponseChunksWithReasoning(messages, options, runManager),
+      this._streamResponseChunksWithReasoning(
+        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        options,
+        runManager
+      ),
       this._lc_stream_delay
     );
   }
@@ -1877,13 +1900,29 @@ export class ChatXAI extends OriginalChatXAI {
     return requestOptions;
   }
 
+  async _generate(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    return super._generate(
+      flattenAnthropicThinkingForOpenAI(messages, this.model),
+      options,
+      runManager
+    );
+  }
+
   async *_streamResponseChunks(
     messages: BaseMessage[],
     options: this['ParsedCallOptions'],
     runManager?: CallbackManagerForLLMRun
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
-      super._streamResponseChunks(messages, options, runManager),
+      super._streamResponseChunks(
+        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        options,
+        runManager
+      ),
       this._lc_stream_delay
     );
   }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -98,9 +98,19 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   includeReasoningContent?: boolean;
   includeReasoningDetails?: boolean;
   convertReasoningDetailsToContent?: boolean;
+  /**
+   * Override for the model-name heuristic used to detect Claude targets
+   * served via an OpenAI-shaped surface (e.g. OpenRouter's `anthropic/*`
+   * models). Set to `true` for aliased Claude deployments whose names lack
+   * the usual substrings; set to `false` to force flatten/drop on a
+   * Claude-named model that's actually a passthrough shim. When `undefined`,
+   * detection falls back to substring matching.
+   */
+  claudeBackend?: boolean;
 };
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
+  claudeBackend?: boolean;
 };
 type ReasoningCallOptions = {
   reasoning?: OpenAIClient.Reasoning;
@@ -521,6 +531,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   private includeReasoningContent?: boolean;
   private includeReasoningDetails?: boolean;
   private convertReasoningDetailsToContent?: boolean;
+  protected _claudeBackend?: boolean;
 
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
@@ -528,6 +539,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     this.includeReasoningDetails = fields?.includeReasoningDetails;
     this.convertReasoningDetailsToContent =
       fields?.convertReasoningDetailsToContent;
+    this._claudeBackend = fields?.claudeBackend;
   }
 
   protected _getReasoningParams(
@@ -610,6 +622,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
         includeReasoningContent: this.includeReasoningContent,
         includeReasoningDetails: this.includeReasoningDetails,
         convertReasoningDetailsToContent: this.convertReasoningDetailsToContent,
+        claudeBackend: this._claudeBackend,
       }
     );
 
@@ -771,6 +784,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
         includeReasoningContent: this.includeReasoningContent,
         includeReasoningDetails: this.includeReasoningDetails,
         convertReasoningDetailsToContent: this.convertReasoningDetailsToContent,
+        claudeBackend: this._claudeBackend,
       });
 
     const params = {
@@ -1094,12 +1108,14 @@ function withLibreChatOpenAIFields(
 
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   _lc_stream_delay?: number;
+  protected _claudeBackend?: boolean;
 
   constructor(
     fields?: LibreChatOpenAIFields & t.OpenAIChatInput['modelKwargs']
   ) {
     super(withLibreChatOpenAIFields(fields));
     this._lc_stream_delay = fields?._lc_stream_delay;
+    this._claudeBackend = fields?.claudeBackend;
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -1162,7 +1178,9 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     return super._generate(
-      flattenAnthropicThinkingForOpenAI(messages, this.model),
+      flattenAnthropicThinkingForOpenAI(messages, this.model, {
+        claudeBackend: this._claudeBackend,
+      }),
       options,
       runManager
     );
@@ -1175,7 +1193,9 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
       super._streamResponseChunks(
-        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        flattenAnthropicThinkingForOpenAI(messages, this.model, {
+          claudeBackend: this._claudeBackend,
+        }),
         options,
         runManager
       ),
@@ -1186,12 +1206,14 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
 
 export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   _lc_stream_delay?: number;
+  protected _claudeBackend?: boolean;
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
     this.completions = new LibreChatAzureOpenAICompletions(fields);
     this.responses = new LibreChatAzureOpenAIResponses(fields);
     this._lc_stream_delay = fields?._lc_stream_delay;
+    this._claudeBackend = fields?.claudeBackend;
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -1288,7 +1310,9 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
     runManager?: CallbackManagerForLLMRun
   ): Promise<ChatResult> {
     return super._generate(
-      flattenAnthropicThinkingForOpenAI(messages, this.model),
+      flattenAnthropicThinkingForOpenAI(messages, this.model, {
+        claudeBackend: this._claudeBackend,
+      }),
       options,
       runManager
     );
@@ -1300,7 +1324,9 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   ): AsyncGenerator<ChatGenerationChunk> {
     yield* delayStreamChunks(
       super._streamResponseChunks(
-        flattenAnthropicThinkingForOpenAI(messages, this.model),
+        flattenAnthropicThinkingForOpenAI(messages, this.model, {
+          claudeBackend: this._claudeBackend,
+        }),
         options,
         runManager
       ),

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -291,11 +291,18 @@ const completionsApiContentBlockConverter: StandardContentBlockConverter<{
  * Heuristic for detecting Claude served via an OpenAI-shaped surface (e.g.
  * OpenRouter's `anthropic/claude-*` models). Used to decide whether thinking
  * blocks pass through verbatim or get flattened to text for the request body.
+ *
+ * The match is case-insensitive — provider configs in the wild ship IDs like
+ * `Anthropic/Claude-Sonnet-4.5` and `CLAUDE-3-5-SONNET`, and misclassifying
+ * any of them as non-Claude would silently drop signed thinking blocks that
+ * Claude needs replayed unchanged for tool-call continuation.
  */
 export function isClaudeModel(model?: string): boolean {
-  return (
-    model?.includes('claude') === true || model?.includes('anthropic') === true
-  );
+  if (model == null) {
+    return false;
+  }
+  const normalized = model.toLowerCase();
+  return normalized.includes('claude') || normalized.includes('anthropic');
 }
 
 /**

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -326,36 +326,36 @@ export function flattenAnthropicThinkingForOpenAI(
       return msg;
     }
     let blockChanged = false;
-    const rewritten = msg.content
-      .map((block) => {
-        if (
-          block != null &&
-          typeof block === 'object' &&
-          'type' in block &&
-          (block as { type?: string }).type === 'thinking'
-        ) {
-          blockChanged = true;
-          const thinking = (block as { thinking?: string }).thinking ?? '';
-          if (!thinking) {
-            return null;
-          }
-          return {
+    const rewritten = msg.content.flatMap((block) => {
+      if (
+        block != null &&
+        typeof block === 'object' &&
+        'type' in block &&
+        (block as { type?: string }).type === 'thinking'
+      ) {
+        blockChanged = true;
+        const thinking = (block as { thinking?: string }).thinking ?? '';
+        if (!thinking) {
+          return [];
+        }
+        return [
+          {
             type: 'text' as const,
             text: `<thinking>${thinking}</thinking>`,
-          };
-        }
-        if (
-          block != null &&
-          typeof block === 'object' &&
-          'type' in block &&
-          (block as { type?: string }).type === 'redacted_thinking'
-        ) {
-          blockChanged = true;
-          return null;
-        }
-        return block;
-      })
-      .filter(<T>(b: T | null): b is T => b !== null);
+          },
+        ];
+      }
+      if (
+        block != null &&
+        typeof block === 'object' &&
+        'type' in block &&
+        (block as { type?: string }).type === 'redacted_thinking'
+      ) {
+        blockChanged = true;
+        return [];
+      }
+      return [block];
+    });
     if (!blockChanged) {
       return msg;
     }

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -317,7 +317,12 @@ export function flattenAnthropicThinkingForOpenAI(
   }
   let mutated = false;
   const out = messages.map((msg) => {
-    if (!Array.isArray(msg.content)) {
+    /**
+     * Thinking blocks only originate from AI messages. Skip non-AI types and
+     * messages with non-array content entirely so the rewrite work isn't
+     * spent producing values we'd then discard.
+     */
+    if (!isAIMessage(msg) || !Array.isArray(msg.content)) {
       return msg;
     }
     let blockChanged = false;
@@ -357,25 +362,22 @@ export function flattenAnthropicThinkingForOpenAI(
     mutated = true;
     const newContent: BaseMessage['content'] =
       rewritten.length === 0 ? '' : rewritten;
-    if (isAIMessage(msg)) {
-      return new AIMessage({
-        content: newContent,
-        additional_kwargs: msg.additional_kwargs,
-        response_metadata: msg.response_metadata,
-        ...(msg.name != null ? { name: msg.name } : {}),
-        ...(msg.id != null ? { id: msg.id } : {}),
-        ...(msg.tool_calls != null && msg.tool_calls.length > 0
-          ? { tool_calls: msg.tool_calls }
-          : {}),
-        ...(msg.invalid_tool_calls != null && msg.invalid_tool_calls.length > 0
-          ? { invalid_tool_calls: msg.invalid_tool_calls }
-          : {}),
-        ...(msg.usage_metadata != null
-          ? { usage_metadata: msg.usage_metadata }
-          : {}),
-      });
-    }
-    return msg;
+    return new AIMessage({
+      content: newContent,
+      additional_kwargs: msg.additional_kwargs,
+      response_metadata: msg.response_metadata,
+      ...(msg.name != null ? { name: msg.name } : {}),
+      ...(msg.id != null ? { id: msg.id } : {}),
+      ...(msg.tool_calls != null && msg.tool_calls.length > 0
+        ? { tool_calls: msg.tool_calls }
+        : {}),
+      ...(msg.invalid_tool_calls != null && msg.invalid_tool_calls.length > 0
+        ? { invalid_tool_calls: msg.invalid_tool_calls }
+        : {}),
+      ...(msg.usage_metadata != null
+        ? { usage_metadata: msg.usage_metadata }
+        : {}),
+    });
   });
   return mutated ? out : messages;
 }
@@ -774,53 +776,65 @@ export function _convertMessagesToOpenAIResponsesParams(
           ];
         }
 
+        const flattenedContent =
+          typeof content === 'string'
+            ? content
+            : content.flatMap((item) => {
+              if (item.type === 'text') {
+                const textItem = item as MessageContentComplex & {
+                    annotations?: unknown[];
+                  };
+                return {
+                  type: 'output_text',
+                  text: item.text,
+                  annotations: textItem.annotations ?? [],
+                };
+              }
+
+              if (item.type === 'output_text' || item.type === 'refusal') {
+                return item;
+              }
+
+              if (item.type === 'thinking') {
+                if (isClaudeTarget) {
+                  return item as ResponsesInputItem;
+                }
+                const thinkingText =
+                    (item as { thinking?: string }).thinking ?? '';
+                if (!thinkingText) {
+                  return [];
+                }
+                return {
+                  type: 'output_text',
+                  text: `<thinking>${thinkingText}</thinking>`,
+                  annotations: [],
+                };
+              }
+
+              if (item.type === 'redacted_thinking') {
+                return isClaudeTarget ? (item as ResponsesInputItem) : [];
+              }
+
+              return [];
+            });
+
+        /**
+         * Mirror the Chat Completions guard: if filtering reduced the assistant
+         * content to an empty array, fall back to '' so the request still
+         * validates against OpenAI's "at least one content part" requirement.
+         */
+        const assistantContent =
+          Array.isArray(flattenedContent) && flattenedContent.length === 0
+            ? ''
+            : flattenedContent;
+
         input.push({
           type: 'message',
           role: 'assistant',
           ...(lcMsg.id && !zdrEnabled && lcMsg.id.startsWith('msg_')
             ? { id: lcMsg.id }
             : {}),
-          content:
-            typeof content === 'string'
-              ? content
-              : content.flatMap((item) => {
-                if (item.type === 'text') {
-                  const textItem = item as MessageContentComplex & {
-                      annotations?: unknown[];
-                    };
-                  return {
-                    type: 'output_text',
-                    text: item.text,
-                    annotations: textItem.annotations ?? [],
-                  };
-                }
-
-                if (item.type === 'output_text' || item.type === 'refusal') {
-                  return item;
-                }
-
-                if (item.type === 'thinking') {
-                  if (isClaudeTarget) {
-                    return item as ResponsesInputItem;
-                  }
-                  const thinkingText =
-                      (item as { thinking?: string }).thinking ?? '';
-                  if (!thinkingText) {
-                    return [];
-                  }
-                  return {
-                    type: 'output_text',
-                    text: `<thinking>${thinkingText}</thinking>`,
-                    annotations: [],
-                  };
-                }
-
-                if (item.type === 'redacted_thinking') {
-                  return isClaudeTarget ? (item as ResponsesInputItem) : [];
-                }
-
-                return [];
-              }),
+          content: assistantContent,
         } as ResponsesInputItem);
 
         const functionCallIds = additional_kwargs[_FUNCTION_CALL_IDS_MAP_KEY];

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -417,15 +417,12 @@ export function _convertMessagesToOpenAIParams(
       role = 'developer';
     }
 
-    let hasAnthropicThinkingBlock: boolean = false;
-
     const filteredContent =
       typeof message.content === 'string'
         ? message.content
         : message.content
           .map((m) => {
             if ('type' in m && m.type === 'thinking') {
-              hasAnthropicThinkingBlock = true;
               if (isClaudeTarget) {
                 return m;
               }
@@ -439,7 +436,6 @@ export function _convertMessagesToOpenAIParams(
               };
             }
             if ('type' in m && m.type === 'redacted_thinking') {
-              hasAnthropicThinkingBlock = true;
               return isClaudeTarget ? m : null;
             }
             if (isDataContentBlock(m)) {
@@ -459,9 +455,7 @@ export function _convertMessagesToOpenAIParams(
      * the request still validates.
      */
     const content =
-      hasAnthropicThinkingBlock &&
-      Array.isArray(filteredContent) &&
-      filteredContent.length === 0
+      Array.isArray(filteredContent) && filteredContent.length === 0
         ? ''
         : filteredContent;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -483,7 +477,15 @@ export function _convertMessagesToOpenAIParams(
       completionParam.tool_calls = message.tool_calls.map(
         convertLangChainToolCallToOpenAI
       );
-      completionParam.content = hasAnthropicThinkingBlock ? content : '';
+      /**
+       * OpenAI's convention is for tool-call assistant messages to have empty
+       * content. Preserve the content array when non-empty — that covers
+       * pass-through thinking blocks for Claude targets AND
+       * `<thinking>...</thinking>` text blocks pre-flattened by the outer
+       * wrapper, which would otherwise be silently dropped on this turn.
+       */
+      completionParam.content =
+        Array.isArray(content) && content.length > 0 ? content : '';
       if (
         options?.includeReasoningDetails === true &&
         message.additional_kwargs.reasoning_details != null

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -327,7 +327,7 @@ export function _convertMessagesToOpenAIParams(
       model?.includes('claude') === true ||
       model?.includes('anthropic') === true;
 
-    const content =
+    const filteredContent =
       typeof message.content === 'string'
         ? message.content
         : message.content
@@ -359,6 +359,19 @@ export function _convertMessagesToOpenAIParams(
             return m;
           })
           .filter(<T>(m: T | null): m is T => m !== null);
+
+    /**
+     * Chat Completions requires assistant content arrays to contain at least
+     * one part — an empty array (which can result from filtering out
+     * thinking/redacted_thinking blocks) triggers a 400. Fall back to '' so
+     * the request still validates.
+     */
+    const content =
+      hasAnthropicThinkingBlock &&
+      Array.isArray(filteredContent) &&
+      filteredContent.length === 0
+        ? ''
+        : filteredContent;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const completionParam: Record<string, any> = {
       role,
@@ -378,11 +391,7 @@ export function _convertMessagesToOpenAIParams(
       completionParam.tool_calls = message.tool_calls.map(
         convertLangChainToolCallToOpenAI
       );
-      completionParam.content = hasAnthropicThinkingBlock
-        ? Array.isArray(content) && content.length === 0
-          ? ''
-          : content
-        : '';
+      completionParam.content = hasAnthropicThinkingBlock ? content : '';
       if (
         options?.includeReasoningDetails === true &&
         message.additional_kwargs.reasoning_details != null

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -287,6 +287,99 @@ const completionsApiContentBlockConverter: StandardContentBlockConverter<{
   },
 };
 
+/**
+ * Heuristic for detecting Claude served via an OpenAI-shaped surface (e.g.
+ * OpenRouter's `anthropic/claude-*` models). Used to decide whether thinking
+ * blocks pass through verbatim or get flattened to text for the request body.
+ */
+export function isClaudeModel(model?: string): boolean {
+  return (
+    model?.includes('claude') === true || model?.includes('anthropic') === true
+  );
+}
+
+/**
+ * Pre-process LangChain messages before they reach an OpenAI-bound request.
+ * Flattens Anthropic-style `thinking` content blocks into
+ * `<thinking>...</thinking>` text, drops empty thinking blocks, and drops
+ * `redacted_thinking` blocks entirely — preserving the reasoning narrative
+ * as in-band context for non-Claude OpenAI targets while satisfying OpenAI's
+ * content schema. Returns the same array reference unchanged when no
+ * rewriting was needed (Claude target, no thinking blocks present, or
+ * non-array content throughout).
+ */
+export function flattenAnthropicThinkingForOpenAI(
+  messages: BaseMessage[],
+  model?: string
+): BaseMessage[] {
+  if (isClaudeModel(model)) {
+    return messages;
+  }
+  let mutated = false;
+  const out = messages.map((msg) => {
+    if (!Array.isArray(msg.content)) {
+      return msg;
+    }
+    let blockChanged = false;
+    const rewritten = msg.content
+      .map((block) => {
+        if (
+          block != null &&
+          typeof block === 'object' &&
+          'type' in block &&
+          (block as { type?: string }).type === 'thinking'
+        ) {
+          blockChanged = true;
+          const thinking = (block as { thinking?: string }).thinking ?? '';
+          if (!thinking) {
+            return null;
+          }
+          return {
+            type: 'text' as const,
+            text: `<thinking>${thinking}</thinking>`,
+          };
+        }
+        if (
+          block != null &&
+          typeof block === 'object' &&
+          'type' in block &&
+          (block as { type?: string }).type === 'redacted_thinking'
+        ) {
+          blockChanged = true;
+          return null;
+        }
+        return block;
+      })
+      .filter(<T>(b: T | null): b is T => b !== null);
+    if (!blockChanged) {
+      return msg;
+    }
+    mutated = true;
+    const newContent: BaseMessage['content'] =
+      rewritten.length === 0 ? '' : rewritten;
+    if (isAIMessage(msg)) {
+      return new AIMessage({
+        content: newContent,
+        additional_kwargs: msg.additional_kwargs,
+        response_metadata: msg.response_metadata,
+        ...(msg.name != null ? { name: msg.name } : {}),
+        ...(msg.id != null ? { id: msg.id } : {}),
+        ...(msg.tool_calls != null && msg.tool_calls.length > 0
+          ? { tool_calls: msg.tool_calls }
+          : {}),
+        ...(msg.invalid_tool_calls != null && msg.invalid_tool_calls.length > 0
+          ? { invalid_tool_calls: msg.invalid_tool_calls }
+          : {}),
+        ...(msg.usage_metadata != null
+          ? { usage_metadata: msg.usage_metadata }
+          : {}),
+      });
+    }
+    return msg;
+  });
+  return mutated ? out : messages;
+}
+
 /** Options for converting messages to OpenAI params */
 export interface ConvertMessagesOptions {
   /** Include reasoning_content field for DeepSeek thinking mode with tool calls */
@@ -304,6 +397,17 @@ export function _convertMessagesToOpenAIParams(
   options?: ConvertMessagesOptions
 ): OpenAICompletionParam[] {
   let hasReasoningToolCallContext = false;
+  /**
+   * When the target is Claude served via an OpenAI-shaped surface (e.g.
+   * OpenRouter), thinking and redacted_thinking blocks are valid input and
+   * must pass through verbatim. For native OpenAI, those block types are
+   * rejected with a 400 — flatten thinking to a `<thinking>...</thinking>`
+   * text block so the reasoning narrative remains in-band, drop empty
+   * thinking blocks (some providers reject empty content), and drop
+   * redacted_thinking entirely (its payload is encrypted and useless to
+   * a non-Anthropic model).
+   */
+  const isClaudeTarget = isClaudeModel(model);
   // TODO: Function messages do not support array content, fix cast
   return messages.flatMap((message) => {
     let role = messageToOpenAIRole(message);
@@ -312,20 +416,6 @@ export function _convertMessagesToOpenAIParams(
     }
 
     let hasAnthropicThinkingBlock: boolean = false;
-
-    /**
-     * When the target is Claude served via an OpenAI-shaped surface (e.g.
-     * OpenRouter), thinking and redacted_thinking blocks are valid input and
-     * must pass through verbatim. For native OpenAI, those block types are
-     * rejected with a 400 — flatten thinking to a `<thinking>...</thinking>`
-     * text block so the reasoning narrative remains in-band, drop empty
-     * thinking blocks (some providers reject empty content), and drop
-     * redacted_thinking entirely (its payload is encrypted and useless to
-     * a non-Anthropic model).
-     */
-    const isClaudeTarget =
-      model?.includes('claude') === true ||
-      model?.includes('anthropic') === true;
 
     const filteredContent =
       typeof message.content === 'string'
@@ -397,12 +487,9 @@ export function _convertMessagesToOpenAIParams(
         message.additional_kwargs.reasoning_details != null
       ) {
         // For Claude via OpenRouter, convert reasoning_details to content blocks
-        const isClaudeModel =
-          model?.includes('claude') === true ||
-          model?.includes('anthropic') === true;
         if (
           options.convertReasoningDetailsToContent === true &&
-          isClaudeModel
+          isClaudeTarget
         ) {
           const reasoningDetails = message.additional_kwargs
             .reasoning_details as Record<string, unknown>[];
@@ -448,12 +535,9 @@ export function _convertMessagesToOpenAIParams(
           message.additional_kwargs.reasoning_details != null
         ) {
           // For Claude via OpenRouter, convert reasoning_details to content blocks
-          const isClaudeModel =
-            model?.includes('claude') === true ||
-            model?.includes('anthropic') === true;
           if (
             options.convertReasoningDetailsToContent === true &&
-            isClaudeModel
+            isClaudeTarget
           ) {
             const reasoningDetails = message.additional_kwargs
               .reasoning_details as Record<string, unknown>[];
@@ -565,6 +649,13 @@ export function _convertMessagesToOpenAIResponsesParams(
   model?: string,
   zdrEnabled?: boolean
 ): ResponsesInputItem[] {
+  /**
+   * Same cross-provider rationale as `_convertMessagesToOpenAIParams`: flatten
+   * thinking blocks to text for non-Claude targets so the reasoning narrative
+   * survives a handoff into the Responses API instead of being silently
+   * dropped by the content `flatMap` below.
+   */
+  const isClaudeTarget = isClaudeModel(model);
   return messages.flatMap(
     (lcMsg): ResponsesInputItem | ResponsesInputItem[] => {
       const additional_kwargs =
@@ -706,6 +797,26 @@ export function _convertMessagesToOpenAIResponsesParams(
 
                 if (item.type === 'output_text' || item.type === 'refusal') {
                   return item;
+                }
+
+                if (item.type === 'thinking') {
+                  if (isClaudeTarget) {
+                    return item as ResponsesInputItem;
+                  }
+                  const thinkingText =
+                      (item as { thinking?: string }).thinking ?? '';
+                  if (!thinkingText) {
+                    return [];
+                  }
+                  return {
+                    type: 'output_text',
+                    text: `<thinking>${thinkingText}</thinking>`,
+                    annotations: [],
+                  };
+                }
+
+                if (item.type === 'redacted_thinking') {
+                  return isClaudeTarget ? (item as ResponsesInputItem) : [];
                 }
 
                 return [];

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -306,6 +306,28 @@ export function isClaudeModel(model?: string): boolean {
 }
 
 /**
+ * Options for `flattenAnthropicThinkingForOpenAI` and the OpenAI converters.
+ *
+ * `claudeBackend` is an explicit override for the model-name heuristic in
+ * `isClaudeModel`: corporate gateways and self-hosted Claude deployments
+ * sometimes alias Claude under names without `claude`/`anthropic` substrings,
+ * which would otherwise be misclassified as non-Claude and have their
+ * `thinking` / `redacted_thinking` blocks rewritten or dropped — exactly the
+ * blocks Claude needs replayed unchanged for tool-call continuation. When
+ * provided, this flag wins over the heuristic in both directions.
+ */
+export interface ClaudeBackendOptions {
+  claudeBackend?: boolean;
+}
+
+function resolveClaudeTarget(
+  model: string | undefined,
+  options?: ClaudeBackendOptions
+): boolean {
+  return options?.claudeBackend ?? isClaudeModel(model);
+}
+
+/**
  * Pre-process LangChain messages before they reach an OpenAI-bound request.
  * Flattens Anthropic-style `thinking` content blocks into
  * `<thinking>...</thinking>` text, drops empty thinking blocks, and drops
@@ -317,9 +339,10 @@ export function isClaudeModel(model?: string): boolean {
  */
 export function flattenAnthropicThinkingForOpenAI(
   messages: BaseMessage[],
-  model?: string
+  model?: string,
+  options?: ClaudeBackendOptions
 ): BaseMessage[] {
-  if (isClaudeModel(model)) {
+  if (resolveClaudeTarget(model, options)) {
     return messages;
   }
   let mutated = false;
@@ -390,7 +413,7 @@ export function flattenAnthropicThinkingForOpenAI(
 }
 
 /** Options for converting messages to OpenAI params */
-export interface ConvertMessagesOptions {
+export interface ConvertMessagesOptions extends ClaudeBackendOptions {
   /** Include reasoning_content field for DeepSeek thinking mode with tool calls */
   includeReasoningContent?: boolean;
   /** Include reasoning_details field for OpenRouter/Gemini thinking mode with tool calls */
@@ -416,7 +439,7 @@ export function _convertMessagesToOpenAIParams(
    * redacted_thinking entirely (its payload is encrypted and useless to
    * a non-Anthropic model).
    */
-  const isClaudeTarget = isClaudeModel(model);
+  const isClaudeTarget = resolveClaudeTarget(model, options);
   // TODO: Function messages do not support array content, fix cast
   return messages.flatMap((message) => {
     let role = messageToOpenAIRole(message);
@@ -658,7 +681,8 @@ function _convertReasoningSummaryToOpenAIResponsesParams(
 export function _convertMessagesToOpenAIResponsesParams(
   messages: BaseMessage[],
   model?: string,
-  zdrEnabled?: boolean
+  zdrEnabled?: boolean,
+  options?: ClaudeBackendOptions
 ): ResponsesInputItem[] {
   /**
    * Same cross-provider rationale as `_convertMessagesToOpenAIParams`: flatten
@@ -666,7 +690,7 @@ export function _convertMessagesToOpenAIResponsesParams(
    * survives a handoff into the Responses API instead of being silently
    * dropped by the content `flatMap` below.
    */
-  const isClaudeTarget = isClaudeModel(model);
+  const isClaudeTarget = resolveClaudeTarget(model, options);
   return messages.flatMap(
     (lcMsg): ResponsesInputItem | ResponsesInputItem[] => {
       const additional_kwargs =

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -313,22 +313,52 @@ export function _convertMessagesToOpenAIParams(
 
     let hasAnthropicThinkingBlock: boolean = false;
 
+    /**
+     * When the target is Claude served via an OpenAI-shaped surface (e.g.
+     * OpenRouter), thinking and redacted_thinking blocks are valid input and
+     * must pass through verbatim. For native OpenAI, those block types are
+     * rejected with a 400 — flatten thinking to a `<thinking>...</thinking>`
+     * text block so the reasoning narrative remains in-band, drop empty
+     * thinking blocks (some providers reject empty content), and drop
+     * redacted_thinking entirely (its payload is encrypted and useless to
+     * a non-Anthropic model).
+     */
+    const isClaudeTarget =
+      model?.includes('claude') === true ||
+      model?.includes('anthropic') === true;
+
     const content =
       typeof message.content === 'string'
         ? message.content
-        : message.content.map((m) => {
-          if ('type' in m && m.type === 'thinking') {
-            hasAnthropicThinkingBlock = true;
+        : message.content
+          .map((m) => {
+            if ('type' in m && m.type === 'thinking') {
+              hasAnthropicThinkingBlock = true;
+              if (isClaudeTarget) {
+                return m;
+              }
+              const thinking = (m as { thinking?: string }).thinking ?? '';
+              if (!thinking) {
+                return null;
+              }
+              return {
+                type: 'text' as const,
+                text: `<thinking>${thinking}</thinking>`,
+              };
+            }
+            if ('type' in m && m.type === 'redacted_thinking') {
+              hasAnthropicThinkingBlock = true;
+              return isClaudeTarget ? m : null;
+            }
+            if (isDataContentBlock(m)) {
+              return convertToProviderContentBlock(
+                m,
+                completionsApiContentBlockConverter
+              );
+            }
             return m;
-          }
-          if (isDataContentBlock(m)) {
-            return convertToProviderContentBlock(
-              m,
-              completionsApiContentBlockConverter
-            );
-          }
-          return m;
-        });
+          })
+          .filter(<T>(m: T | null): m is T => m !== null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const completionParam: Record<string, any> = {
       role,
@@ -348,7 +378,11 @@ export function _convertMessagesToOpenAIParams(
       completionParam.tool_calls = message.tool_calls.map(
         convertLangChainToolCallToOpenAI
       );
-      completionParam.content = hasAnthropicThinkingBlock ? content : '';
+      completionParam.content = hasAnthropicThinkingBlock
+        ? Array.isArray(content) && content.length === 0
+          ? ''
+          : content
+        : '';
       if (
         options?.includeReasoningDetails === true &&
         message.additional_kwargs.reasoning_details != null

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -1,5 +1,9 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
-import { _convertMessagesToOpenAIParams } from './index';
+import {
+  flattenAnthropicThinkingForOpenAI,
+  _convertMessagesToOpenAIParams,
+  _convertMessagesToOpenAIResponsesParams,
+} from './index';
 
 describe('_convertMessagesToOpenAIParams', () => {
   it('includes reasoning_content for assistant messages in tool-call context when requested', () => {
@@ -315,6 +319,203 @@ describe('_convertMessagesToOpenAIParams', () => {
           tool_calls: expect.any(Array),
         })
       );
+    });
+
+    it('defaults to flatten/drop when model is undefined', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: 'reasoning', signature: 'sig' },
+            { type: 'redacted_thinking', data: 'opaque' },
+            { type: 'text', text: 'answer' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages);
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: [
+            { type: 'text', text: '<thinking>reasoning</thinking>' },
+            { type: 'text', text: 'answer' },
+          ],
+        })
+      );
+    });
+
+    it('preserves order across interleaved thinking, text, and redacted_thinking', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: 'first', signature: 'sig1' },
+            { type: 'text', text: 'one' },
+            { type: 'redacted_thinking', data: 'opaque' },
+            { type: 'text', text: 'two' },
+            { type: 'thinking', thinking: '', signature: 'sig2' },
+            { type: 'text', text: 'three' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: [
+            { type: 'text', text: '<thinking>first</thinking>' },
+            { type: 'text', text: 'one' },
+            { type: 'text', text: 'two' },
+            { type: 'text', text: 'three' },
+          ],
+        })
+      );
+    });
+  });
+
+  describe('flattenAnthropicThinkingForOpenAI', () => {
+    it('flattens thinking blocks for non-Claude targets', () => {
+      const out = flattenAnthropicThinkingForOpenAI(
+        [
+          new AIMessage({
+            content: [
+              { type: 'thinking', thinking: 'reason', signature: 'sig' },
+              { type: 'text', text: 'answer' },
+            ] as never,
+          }),
+        ],
+        'gpt-5.4-mini'
+      );
+
+      expect(out[0].content).toEqual([
+        { type: 'text', text: '<thinking>reason</thinking>' },
+        { type: 'text', text: 'answer' },
+      ]);
+    });
+
+    it('passes through unchanged for Claude targets', () => {
+      const original = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: 'reason', signature: 'sig' },
+            { type: 'text', text: 'answer' },
+          ] as never,
+        }),
+      ];
+
+      const out = flattenAnthropicThinkingForOpenAI(
+        original,
+        'anthropic/claude-sonnet-4-5'
+      );
+
+      expect(out).toBe(original);
+    });
+
+    it('returns the same reference when no message has thinking blocks', () => {
+      const original = [
+        new HumanMessage('hi'),
+        new AIMessage({
+          content: [{ type: 'text', text: 'hello' }] as never,
+        }),
+      ];
+
+      const out = flattenAnthropicThinkingForOpenAI(original, 'gpt-5.4-mini');
+
+      expect(out).toBe(original);
+    });
+
+    it('preserves AIMessage tool_calls and additional_kwargs across the rewrite', () => {
+      const original = new AIMessage({
+        content: [
+          { type: 'thinking', thinking: 'thinking', signature: 'sig' },
+          { type: 'text', text: 'will call tool' },
+        ] as never,
+        tool_calls: [
+          { id: 'call_1', name: 'f', args: { x: 1 }, type: 'tool_call' },
+        ],
+        additional_kwargs: { reasoning_content: 'extra' },
+      });
+
+      const out = flattenAnthropicThinkingForOpenAI([original], 'gpt-5.4-mini');
+
+      expect(out[0]).not.toBe(original);
+      expect((out[0] as AIMessage).tool_calls).toEqual(original.tool_calls);
+      expect(out[0].additional_kwargs).toEqual({ reasoning_content: 'extra' });
+      expect(out[0].content).toEqual([
+        { type: 'text', text: '<thinking>thinking</thinking>' },
+        { type: 'text', text: 'will call tool' },
+      ]);
+    });
+
+    it('falls back to empty string content when filtering empties the array', () => {
+      const out = flattenAnthropicThinkingForOpenAI(
+        [
+          new AIMessage({
+            content: [
+              { type: 'thinking', thinking: '', signature: 'sig' },
+              { type: 'redacted_thinking', data: 'opaque' },
+            ] as never,
+          }),
+        ],
+        'gpt-5.4-mini'
+      );
+
+      expect(out[0].content).toBe('');
+    });
+  });
+
+  describe('_convertMessagesToOpenAIResponsesParams cross-provider thinking', () => {
+    it('flattens thinking blocks to <thinking> output_text for non-Claude targets', () => {
+      const messages = [
+        new HumanMessage('hi'),
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: 'consider X', signature: 'sig' },
+            { type: 'text', text: 'answer' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIResponsesParams(messages, 'gpt-5');
+      const assistant = params.find(
+        (p) => 'role' in p && p.role === 'assistant'
+      ) as { content: unknown[] };
+
+      expect(assistant.content).toEqual([
+        {
+          type: 'output_text',
+          text: '<thinking>consider X</thinking>',
+          annotations: [],
+        },
+        {
+          type: 'output_text',
+          text: 'answer',
+          annotations: [],
+        },
+      ]);
+    });
+
+    it('drops empty thinking and redacted_thinking on the Responses path', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: '', signature: 'sig' },
+            { type: 'redacted_thinking', data: 'opaque' },
+            { type: 'text', text: 'visible' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIResponsesParams(messages, 'gpt-5');
+      const assistant = params.find(
+        (p) => 'role' in p && p.role === 'assistant'
+      ) as { content: unknown[] };
+
+      expect(assistant.content).toEqual([
+        { type: 'output_text', text: 'visible', annotations: [] },
+      ]);
     });
   });
 });

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -156,4 +156,141 @@ describe('_convertMessagesToOpenAIParams', () => {
       })
     );
   });
+
+  describe('cross-provider thinking block handling', () => {
+    it('flattens Anthropic thinking block to <thinking> text for OpenAI target', () => {
+      const messages = [
+        new HumanMessage('hi'),
+        new AIMessage({
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'Reviewing whether 17 is prime.',
+              signature: 'sig_abc',
+            },
+            { type: 'text', text: 'Yes, 17 is prime.' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+
+      expect(params[1]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: '<thinking>Reviewing whether 17 is prime.</thinking>',
+            },
+            { type: 'text', text: 'Yes, 17 is prime.' },
+          ],
+        })
+      );
+    });
+
+    it('drops empty thinking block before forwarding to OpenAI', () => {
+      const messages = [
+        new HumanMessage('hi'),
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: '', signature: 'sig_empty' },
+            { type: 'text', text: 'response' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+
+      expect(params[1]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: [{ type: 'text', text: 'response' }],
+        })
+      );
+    });
+
+    it('drops redacted_thinking block for OpenAI target', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            {
+              type: 'redacted_thinking',
+              data: 'opaque-encrypted-blob',
+            },
+            { type: 'text', text: 'visible answer' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          content: [{ type: 'text', text: 'visible answer' }],
+        })
+      );
+    });
+
+    it('preserves thinking block for Claude-via-OpenRouter target', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'Considering options.',
+              signature: 'sig_x',
+            },
+            { type: 'text', text: 'Done.' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(
+        messages,
+        'anthropic/claude-sonnet-4-5'
+      );
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          content: [
+            {
+              type: 'thinking',
+              thinking: 'Considering options.',
+              signature: 'sig_x',
+            },
+            { type: 'text', text: 'Done.' },
+          ],
+        })
+      );
+    });
+
+    it('emits empty content string when thinking-only message is fully dropped alongside tool_calls', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: '', signature: 'sig' },
+          ] as never,
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'noop',
+              args: {},
+              type: 'tool_call',
+            },
+          ],
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: '',
+          tool_calls: expect.any(Array),
+        })
+      );
+    });
+  });
 });

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -426,7 +426,7 @@ describe('_convertMessagesToOpenAIParams', () => {
       expect(out).toBe(original);
     });
 
-    it('preserves AIMessage tool_calls and additional_kwargs across the rewrite', () => {
+    it('preserves all AIMessage fields across the rewrite', () => {
       const original = new AIMessage({
         content: [
           { type: 'thinking', thinking: 'thinking', signature: 'sig' },
@@ -435,18 +435,57 @@ describe('_convertMessagesToOpenAIParams', () => {
         tool_calls: [
           { id: 'call_1', name: 'f', args: { x: 1 }, type: 'tool_call' },
         ],
+        invalid_tool_calls: [
+          { id: 'call_bad', name: 'g', args: 'malformed', error: 'oops' },
+        ],
         additional_kwargs: { reasoning_content: 'extra' },
+        response_metadata: { model_name: 'src-model', finish_reason: 'stop' },
+        name: 'agent-7',
+        id: 'msg_abc',
+        usage_metadata: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
       });
 
       const out = flattenAnthropicThinkingForOpenAI([original], 'gpt-5.4-mini');
 
       expect(out[0]).not.toBe(original);
-      expect((out[0] as AIMessage).tool_calls).toEqual(original.tool_calls);
-      expect(out[0].additional_kwargs).toEqual({ reasoning_content: 'extra' });
-      expect(out[0].content).toEqual([
+      expect(out[0]).toBeInstanceOf(AIMessage);
+      const ai = out[0] as AIMessage;
+      expect(ai.tool_calls).toEqual(original.tool_calls);
+      expect(ai.invalid_tool_calls).toEqual(original.invalid_tool_calls);
+      expect(ai.additional_kwargs).toEqual({ reasoning_content: 'extra' });
+      expect(ai.response_metadata).toEqual({
+        model_name: 'src-model',
+        finish_reason: 'stop',
+      });
+      expect(ai.name).toBe('agent-7');
+      expect(ai.id).toBe('msg_abc');
+      expect(ai.usage_metadata).toEqual({
+        input_tokens: 10,
+        output_tokens: 20,
+        total_tokens: 30,
+      });
+      expect(ai.content).toEqual([
         { type: 'text', text: '<thinking>thinking</thinking>' },
         { type: 'text', text: 'will call tool' },
       ]);
+    });
+
+    it('passes non-AI messages through untouched even if they carry thinking-shaped blocks', () => {
+      const human = new HumanMessage({
+        content: [
+          { type: 'thinking', thinking: 'should be ignored', signature: 'sig' },
+          { type: 'text', text: 'user prompt' },
+        ] as never,
+      });
+
+      const out = flattenAnthropicThinkingForOpenAI([human], 'gpt-5.4-mini');
+
+      expect(out).toHaveLength(1);
+      expect(out[0]).toBe(human);
     });
 
     it('falls back to empty string content when filtering empties the array', () => {
@@ -462,6 +501,7 @@ describe('_convertMessagesToOpenAIParams', () => {
         'gpt-5.4-mini'
       );
 
+      expect(out[0]).toBeInstanceOf(AIMessage);
       expect(out[0].content).toBe('');
     });
   });
@@ -516,6 +556,50 @@ describe('_convertMessagesToOpenAIParams', () => {
       expect(assistant.content).toEqual([
         { type: 'output_text', text: 'visible', annotations: [] },
       ]);
+    });
+
+    it('preserves thinking and redacted_thinking blocks for Claude-via-OpenRouter Responses target', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: 'preserved', signature: 'sig' },
+            { type: 'redacted_thinking', data: 'opaque' },
+            { type: 'text', text: 'answer' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIResponsesParams(
+        messages,
+        'anthropic/claude-sonnet-4-5'
+      );
+      const assistant = params.find(
+        (p) => 'role' in p && p.role === 'assistant'
+      ) as { content: unknown[] };
+
+      expect(assistant.content).toEqual([
+        { type: 'thinking', thinking: 'preserved', signature: 'sig' },
+        { type: 'redacted_thinking', data: 'opaque' },
+        { type: 'output_text', text: 'answer', annotations: [] },
+      ]);
+    });
+
+    it('falls back to empty string when Responses content is fully filtered', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: '', signature: 'sig' },
+            { type: 'redacted_thinking', data: 'opaque' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIResponsesParams(messages, 'gpt-5');
+      const assistant = params.find(
+        (p) => 'role' in p && p.role === 'assistant'
+      ) as { content: unknown };
+
+      expect(assistant.content).toBe('');
     });
   });
 });

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -466,6 +466,30 @@ describe('_convertMessagesToOpenAIParams', () => {
       expect(out).toBe(original);
     });
 
+    it.each([
+      'Anthropic/Claude-Sonnet-4.5',
+      'CLAUDE-3-5-SONNET',
+      'Claude-Opus-4.1',
+      'ANTHROPIC/CLAUDE-HAIKU',
+    ])(
+      'detects Claude targets case-insensitively (%s) and preserves thinking blocks',
+      (model) => {
+        const original = [
+          new AIMessage({
+            content: [
+              { type: 'thinking', thinking: 'reason', signature: 'sig' },
+              { type: 'redacted_thinking', data: 'opaque' },
+              { type: 'text', text: 'answer' },
+            ] as never,
+          }),
+        ];
+
+        const out = flattenAnthropicThinkingForOpenAI(original, model);
+
+        expect(out).toBe(original);
+      }
+    );
+
     it('returns the same reference when no message has thinking blocks', () => {
       const original = [
         new HumanMessage('hi'),

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -293,6 +293,59 @@ describe('_convertMessagesToOpenAIParams', () => {
       expect(params[0]).not.toHaveProperty('tool_calls');
     });
 
+    it('preserves pre-flattened <thinking> text on tool-call assistant messages', () => {
+      // Regression: when the outer wrapper has already flattened thinking
+      // blocks to text, _convertMessagesToOpenAIParams must not clear that
+      // text on tool-call messages just because no raw `thinking` block
+      // was detected. This is the path exercised by ChatMoonshot
+      // (includeReasoningContent=true) after the outer pre-processor runs.
+      const messages = [
+        new AIMessage({
+          content: [
+            { type: 'text', text: '<thinking>reason</thinking>' },
+            { type: 'text', text: 'I will look that up.' },
+          ],
+          tool_calls: [
+            { id: 'call_1', name: 'lookup', args: {}, type: 'tool_call' },
+          ],
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: [
+            { type: 'text', text: '<thinking>reason</thinking>' },
+            { type: 'text', text: 'I will look that up.' },
+          ],
+          tool_calls: expect.any(Array),
+        })
+      );
+    });
+
+    it('clears string content on tool-call assistant messages (OpenAI convention)', () => {
+      const messages = [
+        new AIMessage({
+          content: 'I will look that up.',
+          tool_calls: [
+            { id: 'call_1', name: 'lookup', args: {}, type: 'tool_call' },
+          ],
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: '',
+          tool_calls: expect.any(Array),
+        })
+      );
+    });
+
     it('emits empty content string when thinking-only message is fully dropped alongside tool_calls', () => {
       const messages = [
         new AIMessage({

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -557,6 +557,58 @@ describe('_convertMessagesToOpenAIParams', () => {
       expect(out[0]).toBeInstanceOf(AIMessage);
       expect(out[0].content).toBe('');
     });
+
+    it('preserves block order across interleaved thinking, text, and redacted_thinking', () => {
+      const out = flattenAnthropicThinkingForOpenAI(
+        [
+          new AIMessage({
+            content: [
+              { type: 'thinking', thinking: 'first', signature: 's1' },
+              { type: 'text', text: 'one' },
+              { type: 'redacted_thinking', data: 'opaque' },
+              { type: 'text', text: 'two' },
+              { type: 'thinking', thinking: '', signature: 's2' },
+              { type: 'text', text: 'three' },
+              { type: 'thinking', thinking: 'last', signature: 's3' },
+            ] as never,
+          }),
+        ],
+        'gpt-5.4-mini'
+      );
+
+      expect(out[0].content).toEqual([
+        { type: 'text', text: '<thinking>first</thinking>' },
+        { type: 'text', text: 'one' },
+        { type: 'text', text: 'two' },
+        { type: 'text', text: 'three' },
+        { type: 'text', text: '<thinking>last</thinking>' },
+      ]);
+    });
+
+    it('keeps untouched AI messages reference-equal when other AI messages in the array were rewritten', () => {
+      const unchanged = new AIMessage({
+        content: [
+          { type: 'text', text: 'just text' },
+          { type: 'text', text: 'no thinking here' },
+        ] as never,
+      });
+      const rewriteCandidate = new AIMessage({
+        content: [
+          { type: 'thinking', thinking: 'reason', signature: 'sig' },
+          { type: 'text', text: 'answer' },
+        ] as never,
+      });
+
+      const out = flattenAnthropicThinkingForOpenAI(
+        [unchanged, rewriteCandidate],
+        'gpt-5.4-mini'
+      );
+
+      // Sanity: outer array did mutate
+      expect(out[1]).not.toBe(rewriteCandidate);
+      // Critical: untouched AI message must be the same reference
+      expect(out[0]).toBe(unchanged);
+    });
   });
 
   describe('_convertMessagesToOpenAIResponsesParams cross-provider thinking', () => {

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -490,6 +490,46 @@ describe('_convertMessagesToOpenAIParams', () => {
       }
     );
 
+    it('respects claudeBackend=true for aliased Claude deployments without "claude" in the model name', () => {
+      const original = [
+        new AIMessage({
+          content: [
+            { type: 'thinking', thinking: 'reason', signature: 'sig' },
+            { type: 'redacted_thinking', data: 'opaque' },
+            { type: 'text', text: 'answer' },
+          ] as never,
+        }),
+      ];
+
+      const out = flattenAnthropicThinkingForOpenAI(
+        original,
+        'internal-gateway-llm-v3',
+        { claudeBackend: true }
+      );
+
+      expect(out).toBe(original);
+    });
+
+    it('respects claudeBackend=false even when the model name contains "claude"', () => {
+      const out = flattenAnthropicThinkingForOpenAI(
+        [
+          new AIMessage({
+            content: [
+              { type: 'thinking', thinking: 'reason', signature: 'sig' },
+              { type: 'text', text: 'answer' },
+            ] as never,
+          }),
+        ],
+        'claude-3-passthrough-shim',
+        { claudeBackend: false }
+      );
+
+      expect(out[0].content).toEqual([
+        { type: 'text', text: '<thinking>reason</thinking>' },
+        { type: 'text', text: 'answer' },
+      ]);
+    });
+
     it('returns the same reference when no message has thinking blocks', () => {
       const original = [
         new HumanMessage('hi'),

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -173,7 +173,7 @@ describe('_convertMessagesToOpenAIParams', () => {
         }),
       ];
 
-      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
 
       expect(params[1]).toEqual(
         expect.objectContaining({
@@ -200,7 +200,7 @@ describe('_convertMessagesToOpenAIParams', () => {
         }),
       ];
 
-      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
 
       expect(params[1]).toEqual(
         expect.objectContaining({
@@ -223,7 +223,7 @@ describe('_convertMessagesToOpenAIParams', () => {
         }),
       ];
 
-      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
 
       expect(params[0]).toEqual(
         expect.objectContaining({
@@ -282,7 +282,7 @@ describe('_convertMessagesToOpenAIParams', () => {
         }),
       ];
 
-      const params = _convertMessagesToOpenAIParams(messages, 'gpt-4o-mini');
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
 
       expect(params[0]).toEqual(
         expect.objectContaining({

--- a/src/llm/openai/utils/messages.test.ts
+++ b/src/llm/openai/utils/messages.test.ts
@@ -265,6 +265,30 @@ describe('_convertMessagesToOpenAIParams', () => {
       );
     });
 
+    it('emits empty content string when thinking-only message is fully dropped (no tool_calls)', () => {
+      const messages = [
+        new AIMessage({
+          content: [
+            {
+              type: 'redacted_thinking',
+              data: 'opaque-encrypted-blob',
+            },
+            { type: 'thinking', thinking: '', signature: 'sig' },
+          ] as never,
+        }),
+      ];
+
+      const params = _convertMessagesToOpenAIParams(messages, 'gpt-5.4-mini');
+
+      expect(params[0]).toEqual(
+        expect.objectContaining({
+          role: 'assistant',
+          content: '',
+        })
+      );
+      expect(params[0]).not.toHaveProperty('tool_calls');
+    });
+
     it('emits empty content string when thinking-only message is fully dropped alongside tool_calls', () => {
       const messages = [
         new AIMessage({

--- a/src/scripts/poc-live-x-provider.ts
+++ b/src/scripts/poc-live-x-provider.ts
@@ -196,10 +196,94 @@ async function testOpenAIWithEmptyThinking(): Promise<void> {
   }
 }
 
+// Test 4: collision case — two long IDs that share a 64-char prefix.
+// Without a hash suffix, both would normalize to the same value and Anthropic
+// would reject with "tool_use ids must be unique" (or mis-associate results).
+async function testAnthropicAcceptsCollidingIds(): Promise<void> {
+  header('TEST 4: Two long IDs sharing a 64-char prefix (collision case)');
+
+  const sharedPrefix = 'fc_' + 'a'.repeat(80);
+  const idA = sharedPrefix + '|call_uniqueA';
+  const idB = sharedPrefix + '|call_uniqueB';
+  console.log(`ID A length=${idA.length}, ID B length=${idB.length}`);
+  console.log(`Shared 80-char "a" prefix; differ only past index 90.`);
+
+  const claude = new CustomAnthropic({
+    modelName: 'claude-haiku-4-5',
+    apiKey: ANTHROPIC_KEY,
+    maxTokens: 100,
+  });
+
+  const tools = [
+    {
+      name: 'get_weather',
+      description: 'Get weather',
+      input_schema: {
+        type: 'object',
+        properties: { location: { type: 'string' } },
+        required: ['location'],
+      },
+    },
+  ];
+
+  const history = [
+    new HumanMessage('Weather in Tokyo and Osaka?'),
+    new AIMessage({
+      content: 'Looking up both.',
+      tool_calls: [
+        {
+          id: idA,
+          name: 'get_weather',
+          args: { location: 'Tokyo' },
+          type: 'tool_call',
+        },
+        {
+          id: idB,
+          name: 'get_weather',
+          args: { location: 'Osaka' },
+          type: 'tool_call',
+        },
+      ],
+    }),
+    new ToolMessage({
+      tool_call_id: idA,
+      content: '{"temp": 21, "unit": "C"}',
+    }),
+    new ToolMessage({
+      tool_call_id: idB,
+      content: '{"temp": 18, "unit": "C"}',
+    }),
+    new HumanMessage('Which is warmer?'),
+  ];
+
+  const result = await tryCall(async () => {
+    const stream = await claude.bindTools(tools).stream(history);
+    const chunks = [];
+    for await (const chunk of stream) chunks.push(chunk);
+    return chunks;
+  });
+  if (result.ok) {
+    console.log(
+      'Anthropic ACCEPTED both tool_use blocks — disambiguation works.'
+    );
+    const chunks = result.result as Array<{ content?: unknown }>;
+    const text = chunks
+      .map((c) =>
+        typeof c.content === 'string' ? c.content : JSON.stringify(c.content)
+      )
+      .join('');
+    console.log(`Response sample: ${text.slice(0, 200)}`);
+  } else {
+    console.log('Anthropic rejected:');
+    console.log(`  ${describeError(result.error)}`);
+  }
+}
+
 async function main(): Promise<void> {
   await testAnthropicRejectsResponsesId();
   await testOpenAIWithThinkingBlock();
   await testOpenAIWithEmptyThinking();
+  await testAnthropicAcceptsCollidingIds();
   console.log('\nDone.');
 }
 

--- a/src/scripts/poc-live-x-provider.ts
+++ b/src/scripts/poc-live-x-provider.ts
@@ -40,11 +40,17 @@ async function tryCall<T>(
   }
 }
 
+type SdkLikeError = {
+  status?: number | string;
+  statusCode?: number | string;
+  message?: string;
+};
+
 function describeError(error: unknown): string {
   if (error == null) return 'unknown';
-  const e = error as Record<string, unknown>;
+  const e = error as SdkLikeError;
   const status = e.status ?? e.statusCode ?? '?';
-  const messageRaw = (e.message as string | undefined) ?? String(error);
+  const messageRaw = e.message ?? String(error);
   const message =
     messageRaw.length > 800 ? messageRaw.slice(0, 800) + '…' : messageRaw;
   return `status=${status}\n  message=${message}`;

--- a/src/scripts/poc-live-x-provider.ts
+++ b/src/scripts/poc-live-x-provider.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env bun
+
+/**
+ * Live API confirmation of three suspected bugs:
+ *
+ * 1. OpenAI Responses-style tool-call ID → Anthropic = 400
+ * 2. Anthropic thinking block → OpenAI = ?
+ * 3. Empty thinking block → OpenAI = ?
+ *
+ * Uses cheap models (claude-haiku-4-5, gpt-4o-mini) and minimal token budgets.
+ */
+
+import { config } from 'dotenv';
+config({ override: true });
+
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { CustomAnthropic } from '@/llm/anthropic';
+import { ChatOpenAI } from '@/llm/openai';
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
+const OPENAI_KEY = process.env.OPENAI_API_KEY;
+
+if (!ANTHROPIC_KEY || !OPENAI_KEY) {
+  console.error('Missing ANTHROPIC_API_KEY or OPENAI_API_KEY');
+  process.exit(1);
+}
+
+function header(label: string): void {
+  console.log(`\n${'='.repeat(70)}\n${label}\n${'='.repeat(70)}`);
+}
+
+async function tryCall<T>(
+  fn: () => Promise<T>
+): Promise<{ ok: true; result: T } | { ok: false; error: unknown }> {
+  try {
+    const result = await fn();
+    return { ok: true, result };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}
+
+function describeError(error: unknown): string {
+  if (error == null) return 'unknown';
+  const e = error as Record<string, unknown>;
+  const status = e.status ?? e.statusCode ?? '?';
+  const messageRaw = (e.message as string | undefined) ?? String(error);
+  const message =
+    messageRaw.length > 800 ? messageRaw.slice(0, 800) + '…' : messageRaw;
+  return `status=${status}\n  message=${message}`;
+}
+
+// Test 1: send an OpenAI Responses-style tool-call ID to Anthropic
+async function testAnthropicRejectsResponsesId(): Promise<void> {
+  header('TEST 1: OpenAI Responses-style ID replayed to Anthropic');
+
+  const responsesStyleId =
+    'fc_67abc1234def567|call_abc123def456ghi789jkl0mnopqrs';
+  console.log(`Tool-call id: ${responsesStyleId}`);
+
+  const claude = new CustomAnthropic({
+    modelName: 'claude-haiku-4-5',
+    apiKey: ANTHROPIC_KEY,
+    maxTokens: 100,
+  });
+
+  const tools = [
+    {
+      name: 'get_weather',
+      description: 'Get weather',
+      input_schema: {
+        type: 'object',
+        properties: { location: { type: 'string' } },
+        required: ['location'],
+      },
+    },
+  ];
+
+  const history = [
+    new HumanMessage('What is the weather in Tokyo?'),
+    new AIMessage({
+      content: 'Looking that up.',
+      tool_calls: [
+        {
+          id: responsesStyleId,
+          name: 'get_weather',
+          args: { location: 'Tokyo' },
+          type: 'tool_call',
+        },
+      ],
+    }),
+    new ToolMessage({
+      tool_call_id: responsesStyleId,
+      content: '{"temp": 21, "unit": "C"}',
+    }),
+    new HumanMessage('Now translate that to Fahrenheit.'),
+  ];
+
+  const result = await tryCall(async () => {
+    const stream = await claude.bindTools(tools).stream(history);
+    const chunks = [];
+    for await (const chunk of stream) chunks.push(chunk);
+    return chunks;
+  });
+  if (result.ok) {
+    console.log('Anthropic ACCEPTED the request after normalization.');
+    const chunks = result.result as Array<{ content?: unknown }>;
+    const text = chunks
+      .map((c) =>
+        typeof c.content === 'string' ? c.content : JSON.stringify(c.content)
+      )
+      .join('');
+    console.log(`Response sample: ${text.slice(0, 200)}`);
+  } else {
+    console.log('Anthropic rejected:');
+    console.log(`  ${describeError(result.error)}`);
+  }
+}
+
+// Test 2: send an Anthropic thinking block to OpenAI
+async function testOpenAIWithThinkingBlock(): Promise<void> {
+  header('TEST 2: Anthropic thinking block replayed to OpenAI');
+
+  const openai = new ChatOpenAI({
+    modelName: 'gpt-4o-mini',
+    apiKey: OPENAI_KEY,
+    maxTokens: 100,
+  });
+
+  const history = [
+    new HumanMessage('Is 17 prime?'),
+    new AIMessage({
+      content: [
+        {
+          type: 'thinking',
+          thinking:
+            'Let me check: 17 is not divisible by 2, 3, or 5. So 17 is prime.',
+          signature:
+            'EuYBCkQYAhokAGSEYTYqCfRY8Bz...truncated_signature_blob_for_test...==',
+        },
+        { type: 'text', text: 'Yes, 17 is prime.' },
+      ] as never,
+    }),
+    new HumanMessage('What about 19?'),
+  ];
+
+  const result = await tryCall(() => openai.invoke(history));
+  if (result.ok) {
+    const r = result.result as { content?: unknown };
+    const text =
+      typeof r.content === 'string'
+        ? r.content
+        : JSON.stringify(r.content).slice(0, 200);
+    console.log(`OpenAI accepted. Response: ${text}`);
+    console.log(
+      '  → check whether reasoning text was visible to the model (i.e. did it answer correctly).'
+    );
+  } else {
+    console.log('OpenAI rejected:');
+    console.log(`  ${describeError(result.error)}`);
+  }
+}
+
+// Test 3: send an empty thinking block to OpenAI
+async function testOpenAIWithEmptyThinking(): Promise<void> {
+  header('TEST 3: Empty thinking block replayed to OpenAI');
+
+  const openai = new ChatOpenAI({
+    modelName: 'gpt-4o-mini',
+    apiKey: OPENAI_KEY,
+    maxTokens: 100,
+  });
+
+  const history = [
+    new HumanMessage('What is 2+2?'),
+    new AIMessage({
+      content: [
+        { type: 'thinking', thinking: '', signature: 'sig_empty' },
+        { type: 'text', text: '4' },
+      ] as never,
+    }),
+    new HumanMessage('And 3+3?'),
+  ];
+
+  const result = await tryCall(() => openai.invoke(history));
+  if (result.ok) {
+    const r = result.result as { content?: unknown };
+    const text =
+      typeof r.content === 'string'
+        ? r.content
+        : JSON.stringify(r.content).slice(0, 200);
+    console.log(`OpenAI accepted. Response: ${text}`);
+  } else {
+    console.log('OpenAI rejected:');
+    console.log(`  ${describeError(result.error)}`);
+  }
+}
+
+async function main(): Promise<void> {
+  await testAnthropicRejectsResponsesId();
+  await testOpenAIWithThinkingBlock();
+  await testOpenAIWithEmptyThinking();
+  console.log('\nDone.');
+}
+
+main().catch((e) => {
+  console.error('Fatal:', e);
+  process.exit(1);
+});

--- a/src/scripts/poc-live-x-provider.ts
+++ b/src/scripts/poc-live-x-provider.ts
@@ -7,7 +7,7 @@
  * 2. Anthropic thinking block → OpenAI = ?
  * 3. Empty thinking block → OpenAI = ?
  *
- * Uses cheap models (claude-haiku-4-5, gpt-4o-mini) and minimal token budgets.
+ * Uses cheap models (claude-haiku-4-5, gpt-5.4-mini) and minimal token budgets.
  */
 
 import { config } from 'dotenv';
@@ -122,7 +122,7 @@ async function testOpenAIWithThinkingBlock(): Promise<void> {
   header('TEST 2: Anthropic thinking block replayed to OpenAI');
 
   const openai = new ChatOpenAI({
-    modelName: 'gpt-4o-mini',
+    modelName: 'gpt-5.4-mini',
     apiKey: OPENAI_KEY,
     maxTokens: 100,
   });
@@ -166,7 +166,7 @@ async function testOpenAIWithEmptyThinking(): Promise<void> {
   header('TEST 3: Empty thinking block replayed to OpenAI');
 
   const openai = new ChatOpenAI({
-    modelName: 'gpt-4o-mini',
+    modelName: 'gpt-5.4-mini',
     apiKey: OPENAI_KEY,
     maxTokens: 100,
   });


### PR DESCRIPTION
## Summary

Two narrowly-scoped fixes for cross-provider 400 errors observed when conversation history crosses provider boundaries. Both bugs were confirmed live against real APIs before fixing — see `src/scripts/poc-live-x-provider.ts` for the reproducer.

### Fix 1 — Tool-call IDs survive an OpenAI Responses → Anthropic handoff

OpenAI Responses-style tool-call IDs (e.g. `fc_...|call_...`) routinely contain `|` and exceed 64 chars. Anthropic enforces `^[a-zA-Z0-9_-]+$` and a 64-char cap and rejects with 400 on replay.

Added `normalizeAnthropicToolCallId` (pure, deterministic) and applied at the four wire-bound sites in `src/llm/anthropic/utils/message_inputs.ts`:
- `_convertLangChainToolCallToAnthropic` (assistant tool_use.id)
- the three `tool_result.tool_use_id` constructions in `_ensureMessageContents`

Server tool IDs (`srvtoolu_` prefix) are left untouched. Anthropic-native IDs that already comply pass through unchanged. Determinism means paired `tool_use.id` and `tool_result.tool_use_id` stay matched without any session-scoped Map.

### Fix 2 — Anthropic thinking blocks survive a → OpenAI handoff

`thinking` and `redacted_thinking` content blocks were being forwarded verbatim to OpenAI Chat Completions, which 400s with *Invalid value: 'thinking'*. Even when accepted (server may strip), the reasoning narrative is invisible to the next model.

`_convertMessagesToOpenAIParams` now:
- flattens non-empty `thinking` blocks to `<thinking>...</thinking>` text so the reasoning narrative survives as in-band context
- drops empty `thinking` blocks (empty content is rejected by some providers)
- drops `redacted_thinking` entirely (encrypted, useless to non-Anthropic models)
- continues to pass thinking blocks through verbatim for Claude served via OpenAI-shaped surfaces (e.g. OpenRouter), detected by model name

## Test plan

Unit tests added — all passing:
- [x] `src/llm/anthropic/utils/tool-id-normalization.test.ts` — 9 tests covering helper + round-trip through `_convertMessagesToAnthropicPayload`
- [x] `src/llm/openai/utils/messages.test.ts` — 5 new test cases under "cross-provider thinking block handling"
- [x] Existing test suites still pass (the one pre-existing flake in `src/llm/anthropic/llm.spec.ts` "streaming mode with a signal" reproduces on baseline `9b2081b` — unrelated)

Live verification:
- [x] Anthropic ID fix confirmed end-to-end via `bun ./src/scripts/poc-live-x-provider.ts` — Anthropic accepted the normalized payload and returned a valid response
- [ ] OpenAI thinking-block fixes hit a 429 quota on the test account during verification — covered by unit tests; manual re-verification recommended once quota resets