### PR TITLE
🛡️ feat: Recency-window summarization preserves first-turn user messages

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -20,6 +20,7 @@ import {
   extractToolDiscoveries,
   addBedrockCacheControl,
   formatArtifactPayload,
+  enforceOriginalContentCap,
   formatContentStrings,
   createPruneMessages,
   addCacheControl,
@@ -821,6 +822,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 for (const [idx, content] of originalToolContent) {
                   agentContext.pendingOriginalToolContent.set(idx, content);
                 }
+                /**
+                 * Re-apply the per-store char cap after the union.  The
+                 * pruner enforces ORIGINAL_CONTENT_MAX_CHARS inside its
+                 * own map via the onContentStored callback, but a
+                 * key-wise merge with recency carry-over bypasses that
+                 * accounting and could let the merged map grow without
+                 * bound across long sessions.
+                 */
+                enforceOriginalContentCap(
+                  agentContext.pendingOriginalToolContent
+                );
               }
             }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -804,7 +804,24 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
           if (triggerResult) {
             if (originalToolContent != null && originalToolContent.size > 0) {
-              agentContext.pendingOriginalToolContent = originalToolContent;
+              /**
+               * Merge — never overwrite — the pruner's masking record
+               * into pendingOriginalToolContent.  Carry-over entries
+               * from a prior summarize (preserved by the recency
+               * window for masked tool messages still in the tail) and
+               * the current pruner's new entries are both keyed by
+               * indices in the current `state.messages`, so a key-wise
+               * union is correct.  Overwriting would discard the
+               * carry-over and reduce summary fidelity when those
+               * masked tail messages eventually move into the head.
+               */
+              if (agentContext.pendingOriginalToolContent == null) {
+                agentContext.pendingOriginalToolContent = originalToolContent;
+              } else {
+                for (const [idx, content] of originalToolContent) {
+                  agentContext.pendingOriginalToolContent.set(idx, content);
+                }
+              }
             }
 
             emitAgentLog(

--- a/src/hooks/__tests__/compactHooks.test.ts
+++ b/src/hooks/__tests__/compactHooks.test.ts
@@ -58,7 +58,14 @@ function buildConversation(): t.IState {
 async function createCompactingRun(
   tokenCounter: t.TokenCounter,
   hooks?: HookRegistry,
-  runId = 'compact-run'
+  runId = 'compact-run',
+  /**
+   * Recency-window setting.  Defaults to `{ turns: 0 }` for these tests so
+   * the post-compaction state is the legacy "remove-all only" shape, which
+   * the original assertions were written against.  Tests that want to
+   * exercise the recency-window path should pass an explicit value.
+   */
+  retainRecent: { turns: number } = { turns: 0 }
 ): Promise<Run<t.IState>> {
   const conversation = buildConversation();
   const indexTokenCountMap: Record<string, number> = {};
@@ -79,6 +86,7 @@ async function createCompactingRun(
       summarizationEnabled: true,
       summarizationConfig: {
         provider: Providers.OPENAI,
+        retainRecent,
       },
     },
     returnContent: true,
@@ -138,7 +146,7 @@ describe('Compaction hook integration', () => {
   });
 
   describe('PostCompact', () => {
-    it('fires with summary text after compaction', async () => {
+    it('fires with summary text after compaction (legacy retainRecent.turns=0 shape)', async () => {
       const registry = new HookRegistry();
       let captured: PostCompactHookInput | undefined;
       const hook: HookCallback<'PostCompact'> = async (
@@ -160,6 +168,34 @@ describe('Compaction hook integration', () => {
       expect(captured!.summary).toBe(SUMMARY_RESPONSE);
       expect(captured!.messagesAfterCount).toBe(0);
       expect(captured!.agentId).toBeDefined();
+    });
+
+    it('reports the recency-tail length in messagesAfterCount when retainRecent.turns > 0', async () => {
+      const registry = new HookRegistry();
+      let captured: PostCompactHookInput | undefined;
+      const hook: HookCallback<'PostCompact'> = async (
+        input
+      ): Promise<PostCompactHookOutput> => {
+        captured = input;
+        return {};
+      };
+      registry.register('PostCompact', { hooks: [hook] });
+
+      const run = await createCompactingRun(
+        tokenCounter,
+        registry,
+        'compact-recency-run',
+        { turns: 2 }
+      );
+      run.Graph!.overrideTestModel(['Final answer after compaction.']);
+      const inputs = buildConversation();
+      await run.processStream(inputs, callerConfig);
+
+      expect(captured).toBeDefined();
+      expect(captured!.hook_event_name).toBe('PostCompact');
+      // buildConversation produces 20 user-led turns of [user, ai].  With
+      // retainRecent.turns=2, the tail is the last 2 turns = 4 messages.
+      expect(captured!.messagesAfterCount).toBe(4);
     });
   });
 

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -1,0 +1,199 @@
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
+import { splitAtRecencyBoundary } from '@/messages/recency';
+
+describe('splitAtRecencyBoundary', () => {
+  describe('default behavior (turns: 2)', () => {
+    it('returns empty head and full tail for an empty array', () => {
+      const result = splitAtRecencyBoundary([], { turns: 2 });
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual([]);
+      expect(result.tailTurnCount).toBe(0);
+      expect(result.tailStartIndex).toBe(0);
+    });
+
+    it('always preserves the most recent turn even with one large message', () => {
+      const messages = [new HumanMessage('huge first message'.repeat(1000))];
+      const result = splitAtRecencyBoundary(messages, { turns: 2 });
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual(messages);
+      expect(result.tailTurnCount).toBe(1);
+    });
+
+    it('keeps a complete user-assistant exchange in the tail', () => {
+      const messages = [new HumanMessage('hi'), new AIMessage('hello')];
+      const result = splitAtRecencyBoundary(messages, { turns: 2 });
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual(messages);
+      expect(result.tailTurnCount).toBe(1);
+    });
+
+    it('places older turns in the head when there are more turns than the cap', () => {
+      const messages = [
+        new HumanMessage('turn 1'),
+        new AIMessage('reply 1'),
+        new HumanMessage('turn 2'),
+        new AIMessage('reply 2'),
+        new HumanMessage('turn 3'),
+        new AIMessage('reply 3'),
+      ];
+      const result = splitAtRecencyBoundary(messages, { turns: 2 });
+      expect(result.head).toEqual(messages.slice(0, 2));
+      expect(result.tail).toEqual(messages.slice(2));
+      expect(result.tailTurnCount).toBe(2);
+      expect(result.tailStartIndex).toBe(2);
+    });
+
+    it('preserves tool_use / tool_result pairs across the boundary', () => {
+      const messages = [
+        new HumanMessage('turn 1'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_a', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'result A',
+          tool_call_id: 'call_a',
+          name: 'search',
+        }),
+        new AIMessage('done with turn 1'),
+        new HumanMessage('turn 2'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call_b', name: 'search', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'result B',
+          tool_call_id: 'call_b',
+          name: 'search',
+        }),
+        new AIMessage('done with turn 2'),
+        new HumanMessage('turn 3'),
+        new AIMessage('reply 3'),
+      ];
+      const result = splitAtRecencyBoundary(messages, { turns: 2 });
+      // Head must contain turn 1's complete tool_use → tool_result pair.
+      expect(result.head).toHaveLength(4);
+      expect(result.head[0]).toBe(messages[0]);
+      expect(result.head[3]).toBe(messages[3]);
+      // Tail starts cleanly at turn 2's HumanMessage — never mid-pair.
+      expect(result.tail[0]).toBe(messages[4]);
+      expect(result.tail).toHaveLength(6);
+    });
+  });
+
+  describe('disabled (turns: 0)', () => {
+    it('puts everything in head when turns is 0', () => {
+      const messages = [
+        new HumanMessage('one'),
+        new AIMessage('two'),
+        new HumanMessage('three'),
+      ];
+      const result = splitAtRecencyBoundary(messages, { turns: 0 });
+      expect(result.head).toEqual(messages);
+      expect(result.tail).toEqual([]);
+      expect(result.tailTurnCount).toBe(0);
+    });
+
+    it('treats negative turns as 0', () => {
+      const messages = [new HumanMessage('a'), new AIMessage('b')];
+      const result = splitAtRecencyBoundary(messages, { turns: -5 });
+      expect(result.tail).toEqual([]);
+      expect(result.head).toEqual(messages);
+    });
+  });
+
+  describe('token cap', () => {
+    it('honors the token cap when adding older turns', () => {
+      const messages = [
+        new HumanMessage('turn 1'),
+        new AIMessage('reply 1'),
+        new HumanMessage('turn 2'),
+        new AIMessage('reply 2'),
+        new HumanMessage('turn 3'),
+        new AIMessage('reply 3'),
+      ];
+      const tokenCounter = (): number => 100;
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 5,
+        tokens: 250,
+        tokenCounter,
+      });
+      // Last turn is always preserved (200 tokens for 2 messages).
+      // Adding turn 2 would push to 400, exceeding cap of 250 → stop.
+      expect(result.tailTurnCount).toBe(1);
+      expect(result.tail).toEqual(messages.slice(4));
+    });
+
+    it('always preserves the most recent turn even when it exceeds the cap', () => {
+      const messages = [new HumanMessage('huge'), new AIMessage('also huge')];
+      const tokenCounter = (): number => 1_000_000;
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 2,
+        tokens: 10,
+        tokenCounter,
+      });
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual(messages);
+      expect(result.tailTurnCount).toBe(1);
+    });
+
+    it('ignores the token cap when no tokenCounter is provided', () => {
+      const messages = [
+        new HumanMessage('a'),
+        new AIMessage('b'),
+        new HumanMessage('c'),
+        new AIMessage('d'),
+      ];
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 3,
+        tokens: 1, // would force tail to most-recent-only if applied
+      });
+      // No tokenCounter → fall back to turn-based selection only.
+      expect(result.tailTurnCount).toBe(2);
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual(messages);
+    });
+  });
+
+  describe('degenerate inputs', () => {
+    it('puts everything in the head when there is no HumanMessage', () => {
+      const messages = [
+        new SystemMessage('preamble'),
+        new AIMessage('starter'),
+      ];
+      const result = splitAtRecencyBoundary(messages, { turns: 2 });
+      expect(result.head).toEqual(messages);
+      expect(result.tail).toEqual([]);
+      expect(result.tailTurnCount).toBe(0);
+    });
+
+    it('handles a HumanMessage at index 0 with prior non-human messages absent', () => {
+      const messages = [new HumanMessage('only')];
+      const result = splitAtRecencyBoundary(messages, { turns: 3 });
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual(messages);
+    });
+
+    it('handles tool messages as the very last messages', () => {
+      const messages = [
+        new HumanMessage('q1'),
+        new AIMessage('a1'),
+        new HumanMessage('q2'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'c1', name: 't', args: {} }],
+        }),
+        new ToolMessage({ content: 'r', tool_call_id: 'c1', name: 't' }),
+      ];
+      const result = splitAtRecencyBoundary(messages, { turns: 1 });
+      // Most recent turn includes the trailing tool result.
+      expect(result.tail).toEqual(messages.slice(2));
+      expect(result.head).toEqual(messages.slice(0, 2));
+    });
+  });
+});

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -3,6 +3,7 @@ import {
   HumanMessage,
   ToolMessage,
   SystemMessage,
+  type BaseMessage,
 } from '@langchain/core/messages';
 import { splitAtRecencyBoundary } from '@/messages/recency';
 
@@ -157,6 +158,73 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.tailTurnCount).toBe(2);
       expect(result.head).toEqual([]);
       expect(result.tail).toEqual(messages);
+    });
+  });
+
+  describe('linearity', () => {
+    it('calls tokenCounter once per message in visited turns (no quadratic recount)', () => {
+      // Build a long history: 200 turns × 10 messages = 2,000 messages.
+      // If the boundary search were quadratic in the number of turns,
+      // the call count would explode (e.g., 200 × 2,000 = 400,000).
+      // The disjoint-slice invariant guarantees one call per visited
+      // message, bounded by messages.length even with a generous turn
+      // budget that visits every turn.
+      const messages: BaseMessage[] = [];
+      const turnCount = 200;
+      const messagesPerTurn = 10;
+      for (let t = 0; t < turnCount; t++) {
+        messages.push(new HumanMessage(`turn ${t} query`));
+        for (let m = 1; m < messagesPerTurn; m++) {
+          messages.push(new AIMessage(`turn ${t} reply ${m}`));
+        }
+      }
+
+      let calls = 0;
+      const tokenCounter = (): number => {
+        calls += 1;
+        return 1;
+      };
+
+      // Generous tokens cap so the loop visits every turn.
+      // turnsCap also generous so the limit isn't hit early.
+      splitAtRecencyBoundary(messages, {
+        turns: 1_000_000,
+        tokens: 1_000_000,
+        tokenCounter,
+      });
+
+      // Strictly bounded by messages.length.  No message is counted
+      // twice, regardless of how many turns the splitter walks.
+      expect(calls).toBeLessThanOrEqual(messages.length);
+      expect(calls).toBe(messages.length);
+    });
+
+    it('stops counting once the tokens cap is exceeded (no scan past the boundary)', () => {
+      const messages: BaseMessage[] = [];
+      for (let t = 0; t < 50; t++) {
+        messages.push(new HumanMessage(`turn ${t}`));
+        messages.push(new AIMessage(`reply ${t}`));
+      }
+
+      let calls = 0;
+      const tokenCounter = (): number => {
+        calls += 1;
+        return 1; // 1 token per message → 100 tokens total
+      };
+
+      // Cap of 10 tokens lets us include the last 5 turns (10 messages)
+      // before the next turn's 2 tokens would overflow.
+      const result = splitAtRecencyBoundary(messages, {
+        turns: 1_000,
+        tokens: 10,
+        tokenCounter,
+      });
+
+      // Visited at most: 5 included turns × 2 messages + one over-budget
+      // turn × 2 messages (counted then rejected) = 12 messages.  Far
+      // less than the full 100.
+      expect(calls).toBeLessThanOrEqual(12);
+      expect(result.tailTurnCount).toBe(5);
     });
   });
 

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -8,3 +8,4 @@ export * from './tools';
 export * from './contextPruning';
 export * from './contextPruningSettings';
 export * from './reducer';
+export * from './recency';

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -50,7 +50,33 @@ const PRESSURE_BANDS: [number, number][] = [
 const MASKED_RESULT_MAX_CHARS = 300;
 
 /** Hard cap for the originalToolContent store (~2 MB estimated from char length). */
-const ORIGINAL_CONTENT_MAX_CHARS = 2_000_000;
+export const ORIGINAL_CONTENT_MAX_CHARS = 2_000_000;
+
+/**
+ * Evicts oldest entries from `map` (in Map-iteration / insertion order) until
+ * the cumulative char length of remaining values fits within
+ * `ORIGINAL_CONTENT_MAX_CHARS`.  Used by the recency-window carry-over merge
+ * path in Graph.ts to bound long-running session memory: the pruner enforces
+ * the cap inside its own `originalToolContent` map, but a key-wise union with
+ * recency carry-over bypasses that cap unless re-applied here.
+ */
+export function enforceOriginalContentCap(map: Map<number, string>): void {
+  let total = 0;
+  for (const v of map.values()) {
+    total += v.length;
+  }
+  while (total > ORIGINAL_CONTENT_MAX_CHARS && map.size > 0) {
+    const oldest = map.keys().next();
+    if (oldest.done === true) {
+      break;
+    }
+    const removed = map.get(oldest.value);
+    if (removed != null) {
+      total -= removed.length;
+    }
+    map.delete(oldest.value);
+  }
+}
 
 /** Minimum cumulative calibration ratio — provider can't count fewer tokens
  *  than our raw estimate (within reason). Prevents divide-by-zero edge cases. */

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -1,0 +1,141 @@
+import type { BaseMessage } from '@langchain/core/messages';
+
+/**
+ * Configuration for splitting a message list into a head (to be summarized)
+ * and a tail (to be preserved verbatim).
+ */
+export interface RecencyWindowOptions {
+  /**
+   * Maximum number of recent user-led turns to keep in the tail.  A "turn"
+   * begins at a HumanMessage and includes every following AIMessage and
+   * ToolMessage up to (but not including) the next HumanMessage.  Cutting
+   * at turn boundaries guarantees that tool_use / tool_result pairs are
+   * never split across the head/tail divide.
+   *
+   * The most recent turn is always preserved regardless of this value or
+   * the token cap, so that a single oversized first message is never
+   * destroyed by summarization.
+   *
+   * Defaults to `2`.  A value of `0` disables the recency window (head =
+   * everything, tail = empty), restoring the pre-recency-window behavior.
+   */
+  turns?: number;
+  /**
+   * Optional cap on tail size in tokens.  When set, additional turns
+   * beyond the most recent one are added to the tail only while the
+   * cumulative token count stays at or below this cap.  Turns are added
+   * whole — never partially — so a turn that would exceed the cap is
+   * left in the head.
+   *
+   * The most recent turn is always preserved even if it exceeds the cap.
+   */
+  tokens?: number;
+  /** Token-counter used to evaluate the optional `tokens` cap. */
+  tokenCounter?: (m: BaseMessage) => number;
+}
+
+export interface RecencySplit {
+  /** Older messages eligible for summarization.  Empty when nothing to summarize. */
+  head: BaseMessage[];
+  /** Recent messages preserved verbatim.  Always contains the most recent turn when any HumanMessage exists. */
+  tail: BaseMessage[];
+  /** Number of user-led turns retained in the tail (0 if no HumanMessage exists). */
+  tailTurnCount: number;
+  /** Index in the original `messages` array where the tail begins. */
+  tailStartIndex: number;
+}
+
+/**
+ * Splits `messages` into a head (older, to summarize) and a tail (recent,
+ * to preserve verbatim) at user-message boundaries.  The most recent
+ * user-led turn is always included in the tail; additional older turns
+ * are added subject to `turns` and `tokens` caps.
+ *
+ * Cutting strictly at HumanMessage boundaries ensures that:
+ * - tool_use ↔ tool_result pairs are never split (they always live within
+ *   the same turn);
+ * - the first user message is never replaced by a summary, addressing
+ *   the "first turn destruction" failure mode where a single large
+ *   user-pasted payload would otherwise be replaced by a generic summary.
+ *
+ * When `messages` contains no HumanMessage (degenerate state — e.g. system
+ * + assistant messages from a programmatic preamble), everything is
+ * placed in the head and the tail is empty.  The summarize node treats
+ * an empty tail as "nothing recent to preserve" and falls through to its
+ * existing logic.
+ */
+export function splitAtRecencyBoundary(
+  messages: BaseMessage[],
+  options: RecencyWindowOptions = {}
+): RecencySplit {
+  const turnsCap = options.turns ?? 2;
+
+  if (messages.length === 0 || turnsCap <= 0) {
+    return {
+      head: messages,
+      tail: [],
+      tailTurnCount: 0,
+      tailStartIndex: messages.length,
+    };
+  }
+
+  const turnStarts: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].getType() === 'human') {
+      turnStarts.push(i);
+    }
+  }
+
+  if (turnStarts.length === 0) {
+    return {
+      head: messages,
+      tail: [],
+      tailTurnCount: 0,
+      tailStartIndex: messages.length,
+    };
+  }
+
+  const lastTurnStart = turnStarts[turnStarts.length - 1] as number;
+  let tailStartIndex = lastTurnStart;
+  let tailTurnCount = 1;
+
+  const tokensCap = options.tokens;
+  const tokenCounter = options.tokenCounter;
+  const trackTokens =
+    tokensCap != null && Number.isFinite(tokensCap) && tokenCounter != null;
+
+  let tailTokens = 0;
+  if (trackTokens) {
+    for (let i = tailStartIndex; i < messages.length; i++) {
+      tailTokens += tokenCounter(messages[i] as BaseMessage);
+    }
+  }
+
+  for (let t = turnStarts.length - 2; t >= 0; t--) {
+    if (tailTurnCount >= turnsCap) {
+      break;
+    }
+    const turnStart = turnStarts[t] as number;
+
+    if (trackTokens) {
+      let turnTokens = 0;
+      for (let i = turnStart; i < tailStartIndex; i++) {
+        turnTokens += tokenCounter(messages[i] as BaseMessage);
+      }
+      if (tailTokens + turnTokens > (tokensCap as number)) {
+        break;
+      }
+      tailTokens += turnTokens;
+    }
+
+    tailStartIndex = turnStart;
+    tailTurnCount += 1;
+  }
+
+  return {
+    head: messages.slice(0, tailStartIndex),
+    tail: messages.slice(tailStartIndex),
+    tailTurnCount,
+    tailStartIndex,
+  };
+}

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -104,9 +104,22 @@ export function splitAtRecencyBoundary(
   const trackTokens =
     tokensCap != null && Number.isFinite(tokensCap) && tokenCounter != null;
 
+  /**
+   * Token-counting strategy: each candidate turn `t` spans the half-open
+   * range `[turnStarts[t], turnStarts[t + 1])` (or `[turnStarts[t], messages.length)`
+   * for the most recent turn).  Successive iterations of the outer loop
+   * walk older turns one at a time and never revisit messages from a
+   * later turn — so each message contributes to `tokenCounter` at most
+   * once across the entire selection, making the boundary search
+   * `O(messages_in_visited_turns)` and bounded by `O(messages.length)`
+   * even before the `turnsCap` short-circuit applies.  The inner upper
+   * bound uses `turnStarts[t + 1]` (a value derived from immutable
+   * `turnStarts`) rather than the mutated `tailStartIndex` to make the
+   * disjoint-range invariant self-evident.
+   */
   let tailTokens = 0;
   if (trackTokens) {
-    for (let i = tailStartIndex; i < messages.length; i++) {
+    for (let i = lastTurnStart; i < messages.length; i++) {
       tailTokens += tokenCounter(messages[i] as BaseMessage);
     }
   }
@@ -116,10 +129,11 @@ export function splitAtRecencyBoundary(
       break;
     }
     const turnStart = turnStarts[t] as number;
+    const turnEnd = turnStarts[t + 1] as number;
 
     if (trackTokens) {
       let turnTokens = 0;
-      for (let i = turnStart; i < tailStartIndex; i++) {
+      for (let i = turnStart; i < turnEnd; i++) {
         turnTokens += tokenCounter(messages[i] as BaseMessage);
       }
       if (tailTokens + turnTokens > (tokensCap as number)) {

--- a/src/scripts/summarization-recency.ts
+++ b/src/scripts/summarization-recency.ts
@@ -1,0 +1,462 @@
+/* eslint-disable no-console */
+/**
+ * Live multi-provider validation for the recency-window summarization
+ * change.  Verifies two end-to-end behaviors against real APIs:
+ *
+ *   1. First-turn protection: a single oversized user message does not
+ *      trigger summarization.  Summary events MUST NOT fire.  This
+ *      addresses LibreChat issue #12940.
+ *
+ *   2. Multi-turn compaction: after enough turns accumulate, the
+ *      summarizer fires on older content while the most recent two
+ *      user-led turns are returned in `getRunMessages()` verbatim.
+ *
+ * IMPORTANT: env loading must happen *before* this module's imports
+ * resolve.  The Bedrock AWS SDK in particular captures credentials
+ * during module init.  Run with the dotenv preload + override flag:
+ *
+ *   DOTENV_CONFIG_OVERRIDE=true node -r dotenv/config \
+ *     --loader ./tsconfig-paths-bootstrap.mjs \
+ *     --experimental-specifier-resolution=node \
+ *     ./src/scripts/summarization-recency.ts --provider all
+ */
+import { config as loadEnv } from 'dotenv';
+// Override pre-existing env vars (some shells inject empty placeholders).
+// This is a belt-and-suspenders second pass after the -r dotenv/config
+// preload — covers the case where the script is invoked without preload.
+loadEnv({ override: true });
+
+// The Bedrock llmConfig requires BEDROCK_AWS_REGION specifically; default it
+// to the standard cross-region-inference region when the user has bedrock
+// credentials but the region knob is commented out.
+if (
+  (process.env.BEDROCK_AWS_REGION == null ||
+    process.env.BEDROCK_AWS_REGION === '') &&
+  process.env.BEDROCK_AWS_ACCESS_KEY_ID != null &&
+  process.env.BEDROCK_AWS_ACCESS_KEY_ID !== ''
+) {
+  process.env.BEDROCK_AWS_REGION =
+    process.env.AWS_DEFAULT_REGION ?? 'us-east-1';
+}
+
+import {
+  AIMessage,
+  HumanMessage,
+  type BaseMessage,
+} from '@langchain/core/messages';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+import type * as t from '@/types';
+import { GraphEvents, Providers } from '@/common';
+import { Run } from '@/run';
+import { createTokenCounter } from '@/utils/tokens';
+import { getLLMConfig } from '@/utils/llmConfig';
+
+interface ProviderEntry {
+  name: string;
+  provider: Providers;
+  envCheck: () => boolean;
+  /**
+   * Token budget tight enough that ~30K of dummy content overflows on
+   * turn 1 but the recency window keeps the message verbatim, then
+   * triggers summarization once a 3rd turn arrives.
+   */
+  maxContextTokens: number;
+  /** Optional override for the model field on the agent's llmConfig. */
+  modelOverride?: string;
+}
+
+const PROVIDERS: ProviderEntry[] = [
+  {
+    name: 'anthropic',
+    provider: Providers.ANTHROPIC,
+    envCheck: () =>
+      process.env.ANTHROPIC_API_KEY != null &&
+      process.env.ANTHROPIC_API_KEY !== '',
+    maxContextTokens: 2_000,
+  },
+  {
+    name: Providers.OPENAI, // 'openAI' — must match the llmConfigs key
+    provider: Providers.OPENAI,
+    envCheck: () =>
+      process.env.OPENAI_API_KEY != null && process.env.OPENAI_API_KEY !== '',
+    maxContextTokens: 2_000,
+    modelOverride: 'gpt-5.4-mini',
+  },
+  {
+    name: 'google',
+    provider: Providers.GOOGLE,
+    envCheck: () =>
+      process.env.GOOGLE_API_KEY != null && process.env.GOOGLE_API_KEY !== '',
+    maxContextTokens: 2_000,
+  },
+  {
+    name: 'bedrock',
+    provider: Providers.BEDROCK,
+    envCheck: () =>
+      process.env.BEDROCK_AWS_ACCESS_KEY_ID != null &&
+      process.env.BEDROCK_AWS_ACCESS_KEY_ID !== '' &&
+      process.env.BEDROCK_AWS_SECRET_ACCESS_KEY != null &&
+      process.env.BEDROCK_AWS_SECRET_ACCESS_KEY !== '' &&
+      // The Bedrock llmConfig reads BEDROCK_AWS_REGION specifically; if it's
+      // missing, the SDK throws "Resolved credential object is not valid".
+      process.env.BEDROCK_AWS_REGION != null &&
+      process.env.BEDROCK_AWS_REGION !== '',
+    maxContextTokens: 2_000,
+  },
+  {
+    name: Providers.OPENROUTER,
+    provider: Providers.OPENROUTER,
+    envCheck: () =>
+      process.env.OPENROUTER_API_KEY != null &&
+      process.env.OPENROUTER_API_KEY !== '',
+    maxContextTokens: 2_000,
+    modelOverride: 'moonshotai/kimi-k2.6',
+  },
+  {
+    name: Providers.DEEPSEEK,
+    provider: Providers.DEEPSEEK,
+    envCheck: () =>
+      process.env.DEEPSEEK_API_KEY != null &&
+      process.env.DEEPSEEK_API_KEY !== '',
+    maxContextTokens: 2_000,
+    modelOverride: 'deepseek-v4-flash',
+  },
+];
+
+interface ScenarioSpies {
+  onSummarizeStart: Array<unknown>;
+  onSummarizeComplete: Array<unknown>;
+}
+
+function buildHandlers(spies: ScenarioSpies): Record<string, unknown> {
+  return {
+    [GraphEvents.ON_SUMMARIZE_START]: {
+      handle: (_event: string, data: t.StreamEventData): void => {
+        spies.onSummarizeStart.push(data);
+      },
+    },
+    [GraphEvents.ON_SUMMARIZE_COMPLETE]: {
+      handle: (_event: string, data: t.StreamEventData): void => {
+        spies.onSummarizeComplete.push(data);
+      },
+    },
+  };
+}
+
+function newSpies(): ScenarioSpies {
+  return { onSummarizeStart: [], onSummarizeComplete: [] };
+}
+
+let cachedTokenCounter: t.TokenCounter | undefined;
+async function getTokenCounter(): Promise<t.TokenCounter> {
+  if (cachedTokenCounter == null) {
+    cachedTokenCounter = await createTokenCounter();
+  }
+  return cachedTokenCounter;
+}
+
+async function createRun({
+  entry,
+  threadId,
+  spies,
+  retainTurns,
+}: {
+  entry: ProviderEntry;
+  threadId: string;
+  spies: ScenarioSpies;
+  retainTurns?: number;
+}): Promise<Run<t.IState>> {
+  const baseConfig = getLLMConfig(entry.name);
+  const llmConfig =
+    entry.modelOverride != null
+      ? { ...baseConfig, model: entry.modelOverride }
+      : baseConfig;
+  // tokenCounter is required for pruneMessages to be wired up
+  // (Graph.ts gates createPruneMessages on it).  Without prune, no
+  // messagesToRefine, no summarization trigger.
+  const tokenCounter = await getTokenCounter();
+  return Run.create<t.IState>({
+    runId: `recency-${entry.name}-${Date.now()}`,
+    graphConfig: {
+      type: 'standard',
+      llmConfig,
+      tools: [],
+      instructions:
+        'You are a brief assistant.  Reply in 1-2 short sentences.  Do not echo or restate the user message.',
+      maxContextTokens: entry.maxContextTokens,
+      summarizationEnabled: true,
+      summarizationConfig: {
+        provider: entry.provider,
+        maxSummaryTokens: 400,
+        ...(retainTurns != null
+          ? { retainRecent: { turns: retainTurns } }
+          : {}),
+      },
+    },
+    returnContent: false,
+    tokenCounter,
+    customHandlers: buildHandlers(spies) as never,
+  });
+}
+
+async function runTurn(
+  run: Run<t.IState>,
+  history: BaseMessage[],
+  text: string,
+  threadId: string
+): Promise<BaseMessage[]> {
+  history.push(new HumanMessage(text));
+  await run.processStream({ messages: history }, {
+    configurable: { thread_id: threadId },
+    // Match the recursion limit used by src/specs/summarization.test.ts —
+    // some providers re-cycle through agent ↔ summarize a few times
+    // before settling and the default of 25 trips them.
+    recursionLimit: 80,
+    streamMode: 'values',
+    version: 'v2',
+  } as never);
+  const finalMessages = run.getRunMessages();
+  if (finalMessages != null) {
+    history.push(...finalMessages);
+  }
+  return history;
+}
+
+const PADDING = 'Lorem ipsum dolor sit amet, '.repeat(400);
+
+interface ScenarioResult {
+  name: string;
+  provider: string;
+  passed: boolean;
+  details: string[];
+}
+
+async function scenarioFirstTurnProtection(
+  entry: ProviderEntry
+): Promise<ScenarioResult> {
+  const result: ScenarioResult = {
+    name: 'first-turn protection (large single user message)',
+    provider: entry.name,
+    passed: false,
+    details: [],
+  };
+  const threadId = `recency-1-${entry.name}-${Date.now()}`;
+  const spies = newSpies();
+
+  try {
+    const run = await createRun({ entry, threadId, spies });
+    const history: BaseMessage[] = [];
+    // Sized to overflow the configured 2K budget on a single message.
+    // Old behavior: summarization fires and replaces the user's payload
+    // with a generic summary (LibreChat issue #12940).  New behavior:
+    // recency window skips the LLM summarization call entirely and the
+    // payload is preserved up to the prune step's truncation logic.
+    const oversizedMessage =
+      `Here is a structured payload I need you to keep verbatim:\n\n` +
+      `<payload-MARKER-XYZ123>\n${PADDING}\n</payload-MARKER-XYZ123>\n\n` +
+      `Reply OK so we can continue.`;
+
+    try {
+      await runTurn(run, history, oversizedMessage, threadId);
+    } catch (turnErr) {
+      // A subsequent prune emergency-error ("Message pruning removed all
+      // messages") is acceptable: it means the budget is genuinely too
+      // tight, surfacing as a clear error rather than a silent
+      // summarization that destroys the user's payload.  The signal we
+      // care about is whether ON_SUMMARIZE_START fired beforehand.
+      const msg = turnErr instanceof Error ? turnErr.message : String(turnErr);
+      if (msg.includes('empty_messages')) {
+        result.details.push(
+          'note: prune surfaced empty_messages error (expected when single message > budget)'
+        );
+      } else {
+        throw turnErr;
+      }
+    }
+
+    if (spies.onSummarizeStart.length > 0) {
+      result.details.push(
+        `FAIL: ON_SUMMARIZE_START fired ${spies.onSummarizeStart.length}x — first user message was destroyed by summarization.`
+      );
+    } else {
+      result.details.push('OK: no ON_SUMMARIZE_START on first turn.');
+    }
+    if (spies.onSummarizeComplete.length > 0) {
+      result.details.push(
+        `FAIL: ON_SUMMARIZE_COMPLETE fired ${spies.onSummarizeComplete.length}x.`
+      );
+    }
+
+    result.passed =
+      spies.onSummarizeStart.length === 0 &&
+      spies.onSummarizeComplete.length === 0;
+  } catch (err) {
+    result.details.push(
+      `EXCEPTION: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  return result;
+}
+
+async function scenarioMultiTurnCompaction(
+  entry: ProviderEntry
+): Promise<ScenarioResult> {
+  const result: ScenarioResult = {
+    name: 'multi-turn compaction preserves the recency tail',
+    provider: entry.name,
+    passed: false,
+    details: [],
+  };
+  const threadId = `recency-2-${entry.name}-${Date.now()}`;
+  const spies = newSpies();
+
+  try {
+    const run = await createRun({ entry, threadId, spies, retainTurns: 2 });
+    const history: BaseMessage[] = [];
+
+    // 4 turns; each padded so that older turns will overflow the
+    // configured budget once the conversation has accumulated a few
+    // exchanges (~3K chars per turn ≈ 750 tokens × 4 ≈ 3K tokens).
+    await runTurn(
+      run,
+      history,
+      `Turn 1.  Topic: ALPHA-BEACON.  ${PADDING.slice(0, 3000)}\nReply only "noted alpha".`,
+      threadId
+    );
+    await runTurn(
+      run,
+      history,
+      `Turn 2.  Topic: BETA-LIGHTHOUSE.  ${PADDING.slice(0, 3000)}\nReply only "noted beta".`,
+      threadId
+    );
+    await runTurn(
+      run,
+      history,
+      `Turn 3.  Topic: GAMMA-PARSEC.  ${PADDING.slice(0, 3000)}\nReply only "noted gamma".`,
+      threadId
+    );
+    await runTurn(
+      run,
+      history,
+      `Turn 4.  Final: which topic codenames have I mentioned?  Reply with the comma-separated list of codenames you remember.`,
+      threadId
+    );
+
+    const startedCount = spies.onSummarizeStart.length;
+    const completedCount = spies.onSummarizeComplete.length;
+    result.details.push(
+      `summarize start=${startedCount}, complete=${completedCount}`
+    );
+
+    if (startedCount === 0) {
+      result.details.push(
+        'FAIL: expected at least one summarization to fire across 4 turns at the configured budget.'
+      );
+      return result;
+    }
+
+    // Inspect the final assistant message for codename recall as a soft signal.
+    const lastAi = [...history].reverse().find((m) => m instanceof AIMessage);
+    const lastAiText =
+      lastAi != null
+        ? typeof lastAi.content === 'string'
+          ? lastAi.content
+          : JSON.stringify(lastAi.content)
+        : '';
+    result.details.push(
+      `final-AI-snippet: ${lastAiText.slice(0, 200).replace(/\s+/g, ' ')}`
+    );
+
+    // The recency window keeps the most recent 2 turns verbatim, so the
+    // model must still recall GAMMA and the turn-4 ask.  ALPHA/BETA may
+    // be remembered from the summary or forgotten — that's allowed.
+    const recallsRecent =
+      lastAiText.toLowerCase().includes('gamma') ||
+      lastAiText.toLowerCase().includes('parsec');
+    if (recallsRecent) {
+      result.details.push('OK: recent-tail topic (GAMMA-PARSEC) recalled.');
+    } else {
+      result.details.push(
+        'WARN: recent-tail topic not in final response — could be model wording (not a hard fail).'
+      );
+    }
+
+    result.passed = startedCount > 0 && completedCount > 0;
+  } catch (err) {
+    result.details.push(
+      `EXCEPTION: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  return result;
+}
+
+function summarize(results: ScenarioResult[]): boolean {
+  console.log('\n========== Summary ==========');
+  let allPassed = true;
+  for (const r of results) {
+    const status = r.passed ? 'PASS' : 'FAIL';
+    console.log(`[${status}] ${r.provider}: ${r.name}`);
+    for (const d of r.details) {
+      console.log(`    ${d}`);
+    }
+    if (!r.passed) {
+      allPassed = false;
+    }
+  }
+  console.log('=============================\n');
+  return allPassed;
+}
+
+async function main(): Promise<void> {
+  const argv = await yargs(hideBin(process.argv))
+    .option('provider', {
+      type: 'string',
+      description: 'provider name, or "all" to run every configured provider',
+      default: 'all',
+    })
+    .option('skip-multi', {
+      type: 'boolean',
+      description:
+        'skip the multi-turn compaction scenario (faster smoke test)',
+      default: false,
+    })
+    .help().argv;
+
+  const requested = String(argv.provider).toLowerCase();
+  const targets =
+    requested === 'all'
+      ? PROVIDERS
+      : PROVIDERS.filter((p) => p.name.toLowerCase() === requested);
+
+  if (targets.length === 0) {
+    console.error(
+      `unknown provider "${requested}".  available: ${PROVIDERS.map((p) => p.name).join(', ')}, all`
+    );
+    process.exit(2);
+  }
+
+  const results: ScenarioResult[] = [];
+  for (const entry of targets) {
+    if (!entry.envCheck()) {
+      console.log(`skipping ${entry.name} — credentials not in .env`);
+      continue;
+    }
+    console.log(`\n----- provider: ${entry.name} -----`);
+    results.push(await scenarioFirstTurnProtection(entry));
+    if (!argv['skip-multi']) {
+      results.push(await scenarioMultiTurnCompaction(entry));
+    }
+  }
+
+  const ok = summarize(results);
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -18,6 +18,8 @@ import {
   preFlightTruncateToolCallInputs,
   repairOrphanedToolMessages,
   sanitizeOrphanToolBlocks,
+  enforceOriginalContentCap,
+  ORIGINAL_CONTENT_MAX_CHARS,
   createPruneMessages,
 } from '@/messages/prune';
 import { getLLMConfig } from '@/utils/llmConfig';
@@ -1532,6 +1534,43 @@ describe('Prune Messages Tests', () => {
       const finalMessages = run.getRunMessages();
       expect(finalMessages).toBeDefined();
       expect(finalMessages?.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('enforceOriginalContentCap', () => {
+    it('is a no-op when total chars are below the cap', () => {
+      const map = new Map<number, string>([
+        [0, 'a'.repeat(100)],
+        [1, 'b'.repeat(200)],
+      ]);
+      enforceOriginalContentCap(map);
+      expect(map.size).toBe(2);
+      expect(map.get(0)?.length).toBe(100);
+      expect(map.get(1)?.length).toBe(200);
+    });
+
+    it('evicts oldest entries (by Map insertion order) until under the cap', () => {
+      const map = new Map<number, string>();
+      // Insert 4 entries totaling well over the cap, in insertion order
+      // 0, 1, 2, 3.  Each entry is roughly 700_000 chars (>1/3 of cap).
+      const big = 'x'.repeat(700_000);
+      map.set(0, big);
+      map.set(1, big);
+      map.set(2, big);
+      map.set(3, big);
+
+      // 4 * 700_000 = 2_800_000 > 2_000_000 cap.  Eviction should drop
+      // the oldest entry (key 0) — leaving 3 * 700_000 = 2_100_000 still
+      // > cap, so key 1 is also dropped — 2 * 700_000 = 1_400_000 ≤ cap.
+      enforceOriginalContentCap(map);
+      expect(map.has(0)).toBe(false);
+      expect(map.has(1)).toBe(false);
+      expect(map.has(2)).toBe(true);
+      expect(map.has(3)).toBe(true);
+    });
+
+    it('exposes the cap as a constant for callers', () => {
+      expect(ORIGINAL_CONTENT_MAX_CHARS).toBe(2_000_000);
     });
   });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -886,6 +886,106 @@ describe('recency window — first-turn protection', () => {
     expect((result.messages![2] as AIMessage).content).toBe('turn 2 reply');
   });
 
+  it('keeps the masked tail content (does not re-inject restored tool payloads into state)', async () => {
+    captureEvents();
+
+    let summarizerSawRestored = false;
+    const invokeMock = jest.fn().mockImplementation((messages: unknown) => {
+      const arr = messages as Array<{
+        getType: () => string;
+        content: unknown;
+        tool_call_id?: string;
+      }>;
+      // Confirm the summarizer's input for the restored tool result has
+      // the FULL content, not the masked stub.
+      summarizerSawRestored = arr.some(
+        (m) =>
+          m.getType() === 'tool' &&
+          typeof m.content === 'string' &&
+          (m.content as string).includes('FULL_ORIGINAL_OUTPUT')
+      );
+      return Promise.resolve({ content: 'summary' });
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke: invokeMock };
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      summarizationConfig: { retainRecent: { turns: 1 } },
+      setSummary,
+    } as never);
+    // Restoration map keyed by message index — applies to head (idx 2)
+    // AND to a tool message inside the retained tail (idx 5).  Only the
+    // head's restoration should leak into the summarizer; the tail must
+    // keep the masked content.
+    agentContext.pendingOriginalToolContent = new Map<number, string>([
+      [2, 'FULL_ORIGINAL_OUTPUT for head tool result'],
+      [5, 'FULL_ORIGINAL_OUTPUT for tail tool result — must NOT survive'],
+    ]);
+
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    const headToolCall = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'h', name: 'search', args: {} }],
+    });
+    const headToolResult = new ToolMessage({
+      content: 'masked-head-stub',
+      tool_call_id: 'h',
+      name: 'search',
+    });
+    const tailToolCall = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 't', name: 'search', args: {} }],
+    });
+    const tailToolResult = new ToolMessage({
+      content: 'masked-tail-stub',
+      tool_call_id: 't',
+      name: 'search',
+    });
+    const messages = [
+      new HumanMessage('turn 1 query'),
+      headToolCall,
+      headToolResult, // index 2 — restored for summarizer
+      new HumanMessage('turn 2 query'),
+      tailToolCall,
+      tailToolResult, // index 5 — must stay masked in returned tail
+    ];
+
+    const result = await summarizeNode(
+      {
+        messages,
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    // Summarizer saw the full restored head tool result.
+    expect(summarizerSawRestored).toBe(true);
+
+    // Returned tail must contain the MASKED tool result, not the restored one.
+    expect(result.messages).toBeDefined();
+    const tailToolMsg = result.messages!.find(
+      (m) => m._getType() === 'tool'
+    ) as ToolMessage | undefined;
+    expect(tailToolMsg).toBeDefined();
+    expect(tailToolMsg!.content).toBe('masked-tail-stub');
+    expect(tailToolMsg!.content).not.toContain('FULL_ORIGINAL_OUTPUT');
+  });
+
   it('preserves the legacy "remove all, summary only" shape when retainRecent.turns is 0', async () => {
     captureEvents();
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1,4 +1,4 @@
-import { HumanMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import { GraphEvents, Providers } from '@/common';
@@ -16,7 +16,13 @@ import { AgentContext } from '@/agents/AgentContext';
 // ---------------------------------------------------------------------------
 
 /** Creates a real AgentContext via fromConfig with sensible defaults.
- *  Extra properties are assigned directly for test-specific overrides. */
+ *  Extra properties are assigned directly for test-specific overrides.
+ *
+ *  Defaults `retainRecent.turns` to `0` so that tests which use 1–2 message
+ *  states still exercise the LLM-call summarization path.  The recency-window
+ *  default of `2` turns would otherwise short-circuit summarization for those
+ *  inputs.  Tests that target recency-window behavior should pass an explicit
+ *  `summarizationConfig.retainRecent` value. */
 function createAgentContext(
   overrides: Record<string, unknown> = {}
 ): AgentContext {
@@ -32,12 +38,17 @@ function createAgentContext(
     ...extra
   } = overrides;
 
+  const effectiveSummarizationConfig =
+    summarizationConfig != null
+      ? summarizationConfig
+      : { retainRecent: { turns: 0 } };
+
   const ctx = AgentContext.fromConfig({
     agentId: agentId as string,
     provider: provider as Providers,
     instructions: instructions as string,
     summarizationEnabled: summarizationEnabled as boolean,
-    ...(summarizationConfig != null ? { summarizationConfig } : {}),
+    summarizationConfig: effectiveSummarizationConfig,
     ...(maxContextTokens != null ? { maxContextTokens } : {}),
     ...(tools != null ? { tools } : {}),
   } as import('@/types').AgentInputs);
@@ -703,6 +714,219 @@ describe('budget check — instructions exceed context', () => {
     // Should have summarized — messages returned for state replacement
     expect(result.messages).toBeDefined();
     expect(result.messages!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('recency window — first-turn protection', () => {
+  it('skips the LLM call when only one turn exists (default turns: 2)', async () => {
+    const events = captureEvents();
+
+    const invokeMock = jest
+      .fn()
+      .mockResolvedValue({ content: 'should not be called' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke: invokeMock };
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      summarizationConfig: {} /* defaults to retainRecent.turns = 2 */,
+      setSummary,
+    } as never);
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    const largePayload = 'paste'.repeat(10_000);
+    const result = await summarizeNode(
+      {
+        messages: [new HumanMessage(largePayload)],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    // No LLM call — first user message is preserved verbatim.
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(setSummary).not.toHaveBeenCalled();
+    // No state mutation — original messages stay.
+    expect(result.messages).toBeUndefined();
+    expect(result.summarizationRequest).toBeUndefined();
+    // No ON_SUMMARIZE_START emitted on the skip path.
+    const eventNames = events.map((e) => e.event);
+    expect(eventNames).not.toContain(GraphEvents.ON_SUMMARIZE_START);
+    expect(eventNames).not.toContain(GraphEvents.ON_SUMMARIZE_COMPLETE);
+  });
+
+  it('skips when a single-turn includes assistant + tool messages', async () => {
+    captureEvents();
+
+    const invokeMock = jest.fn().mockResolvedValue({ content: 'unused' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke: invokeMock };
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      summarizationConfig: {},
+      setSummary,
+    } as never);
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    const result = await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('the first user prompt'),
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'c', name: 'search', args: {} }],
+          }),
+          new ToolMessage({
+            content: 'result',
+            tool_call_id: 'c',
+            name: 'search',
+          }),
+          new AIMessage('here is what i found'),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(setSummary).not.toHaveBeenCalled();
+    expect(result.messages).toBeUndefined();
+  });
+
+  it('still summarizes the head when older turns exist beyond the recency window', async () => {
+    captureEvents();
+
+    let capturedMessages: { type: string; content: unknown }[] = [];
+    const invokeMock = jest.fn().mockImplementation((messages: unknown) => {
+      capturedMessages = (
+        messages as Array<{ getType: () => string; content: unknown }>
+      ).map((m) => ({ type: m.getType(), content: m.content }));
+      return Promise.resolve({ content: 'Summary of older turns' });
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke: invokeMock };
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      summarizationConfig: { retainRecent: { turns: 1 } },
+      setSummary,
+    } as never);
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    const messages = [
+      new HumanMessage('turn 1 query'),
+      new AIMessage('turn 1 reply'),
+      new HumanMessage('turn 2 query'),
+      new AIMessage('turn 2 reply'),
+    ];
+    const result = await summarizeNode(
+      {
+        messages,
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    // Head (turn 1) summarized; tail (turn 2) preserved verbatim.
+    expect(setSummary).toHaveBeenCalledWith(
+      expect.stringContaining('Summary of older turns'),
+      expect.any(Number)
+    );
+    // Captured messages are the head + the appended summarization instruction.
+    // Head has 2 messages (turn 1) + 1 instruction = 3 total.
+    expect(capturedMessages).toHaveLength(3);
+    expect(capturedMessages[0]?.content).toBe('turn 1 query');
+    expect(capturedMessages[1]?.content).toBe('turn 1 reply');
+
+    // Returned messages: removeAll marker + tail.
+    expect(result.messages).toBeDefined();
+    expect(result.messages![0]?._getType()).toBe('remove');
+    expect(result.messages!.slice(1)).toHaveLength(2);
+    expect((result.messages![1] as HumanMessage).content).toBe('turn 2 query');
+    expect((result.messages![2] as AIMessage).content).toBe('turn 2 reply');
+  });
+
+  it('preserves the legacy "remove all, summary only" shape when retainRecent.turns is 0', async () => {
+    captureEvents();
+
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel('Legacy summary');
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      summarizationConfig: { retainRecent: { turns: 0 } },
+      setSummary,
+    } as never);
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    const result = await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('only message'),
+          new AIMessage('only reply'),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(setSummary).toHaveBeenCalled();
+    // Legacy: remove-all only, no tail re-injection.
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages![0]?._getType()).toBe('remove');
   });
 });
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -986,6 +986,132 @@ describe('recency window — first-turn protection', () => {
     expect(tailToolMsg!.content).not.toContain('FULL_ORIGINAL_OUTPUT');
   });
 
+  it('preserves tail-relevant pendingOriginalToolContent entries (reindexed) for future summaries', async () => {
+    captureEvents();
+
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel('summary');
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      summarizationConfig: { retainRecent: { turns: 1 } },
+      setSummary,
+    } as never);
+    // Original-content map covers BOTH a head index (1) and tail indices
+    // (3, 5).  Only the tail entries should survive, reindexed to the
+    // post-removeAll state where tail messages start at 0.
+    agentContext.pendingOriginalToolContent = new Map<number, string>([
+      [1, 'fullHead'], // belongs to summarized head — should be dropped
+      [3, 'fullTailA'], // tail position 3 → reindexed to 0
+      [5, 'fullTailB'], // tail position 5 → reindexed to 2
+    ]);
+
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    const messages = [
+      new HumanMessage('turn 1 query'),
+      new AIMessage('turn 1 reply'), // idx 1
+      new HumanMessage('turn 2 query'), // idx 2 — tail starts here
+      new ToolMessage({
+        // idx 3
+        content: 'masked-stub-A',
+        tool_call_id: 'a',
+        name: 'search',
+      }),
+      new AIMessage('turn 2 reply'), // idx 4
+      new ToolMessage({
+        // idx 5
+        content: 'masked-stub-B',
+        tool_call_id: 'b',
+        name: 'search',
+      }),
+    ];
+
+    await summarizeNode(
+      {
+        messages,
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    // Summarize fired (we used a real summary text), so head index 1
+    // is gone.  Tail entries should remain, reindexed by subtracting
+    // tailStartIndex (=2): 3→1, 5→3.
+    const carryOver = agentContext.pendingOriginalToolContent;
+    expect(carryOver).toBeDefined();
+    expect(carryOver!.size).toBe(2);
+    expect(carryOver!.get(1)).toBe('fullTailA');
+    expect(carryOver!.get(3)).toBe('fullTailB');
+    expect(carryOver!.has(0)).toBe(false);
+    expect(carryOver!.has(5)).toBe(false);
+  });
+
+  it('does not clear pendingOriginalToolContent on the skip path (state unchanged)', async () => {
+    captureEvents();
+
+    const invokeMock = jest.fn();
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke: invokeMock };
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext({
+      summarizationConfig: { retainRecent: { turns: 2 } },
+    } as never);
+    const seededMap = new Map<number, string>([[1, 'preserved-original']]);
+    agentContext.pendingOriginalToolContent = seededMap;
+
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('only turn'),
+          new ToolMessage({
+            content: 'masked',
+            tool_call_id: 'x',
+            name: 'search',
+          }),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    // No LLM call (skip path); pendingOriginalToolContent must still be
+    // available so a future summarization can restore the original.
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(agentContext.pendingOriginalToolContent).toBe(seededMap);
+    expect(agentContext.pendingOriginalToolContent!.get(1)).toBe(
+      'preserved-original'
+    );
+  });
+
   it('preserves the legacy "remove all, summary only" shape when retainRecent.turns is 0', async () => {
     captureEvents();
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1060,6 +1060,52 @@ describe('recency window — first-turn protection', () => {
     expect(carryOver!.has(5)).toBe(false);
   });
 
+  it('aligns the dedupe baseline with the surviving tail length after compaction', async () => {
+    captureEvents();
+
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return mockInvokeModel('summary');
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext({
+      summarizationConfig: { retainRecent: { turns: 1 } },
+    } as never);
+    const graph = mockGraph();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph as never,
+      generateStepId,
+    });
+
+    const messages = [
+      new HumanMessage('turn 1 query'),
+      new AIMessage('turn 1 reply'),
+      new HumanMessage('turn 2 query'),
+      new AIMessage('turn 2 reply'),
+    ];
+
+    await summarizeNode(
+      {
+        messages,
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    // Tail = last turn = 2 messages.  Baseline must equal that count
+    // so a follow-up prune call on the unchanged tail short-circuits
+    // via shouldSkipSummarization rather than re-triggering compaction.
+    expect(agentContext.shouldSkipSummarization(2)).toBe(true);
+    expect(agentContext.shouldSkipSummarization(3)).toBe(false);
+  });
+
   it('does not clear pendingOriginalToolContent on the skip path (state unchanged)', async () => {
     captureEvents();
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -14,6 +14,7 @@ import { ContentTypes, GraphEvents, StepTypes, Providers } from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
+import { splitAtRecencyBoundary } from '@/messages/recency';
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { addCacheControl } from '@/messages/cache';
 import { initializeModel } from '@/llm/init';
@@ -21,6 +22,18 @@ import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
 
 const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
+
+/**
+ * Default number of recent user-led turns preserved verbatim during
+ * compaction.  A turn begins at a HumanMessage and includes every
+ * following AIMessage and ToolMessage up to the next HumanMessage.
+ * The most recent turn is always retained regardless of this value;
+ * the default of `2` additionally keeps the prior exchange so the
+ * model has fresh context on what just happened.  Setting
+ * `retainRecent.turns` to `0` reverts to the legacy "summarize every
+ * message" behavior.
+ */
+const DEFAULT_RETAIN_RECENT_TURNS = 2;
 
 /**
  * Token overhead of the XML wrapper + instruction text added around the
@@ -749,18 +762,50 @@ export function createSummarizeNode({
       return { summarizationRequest: undefined };
     }
 
-    const messagesToRefine = restoreOriginalToolContent(
+    const restoredMessages = restoreOriginalToolContent(
       state.messages,
       agentContext.pendingOriginalToolContent
     );
     agentContext.pendingOriginalToolContent = undefined;
 
+    const runnableConfig = config ?? graph.config;
+
+    const retainRecent = agentContext.summarizationConfig?.retainRecent;
+    const { head: messagesToRefine, tail: messagesToRetain } =
+      splitAtRecencyBoundary(restoredMessages, {
+        turns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
+        tokens: retainRecent?.tokens,
+        tokenCounter: agentContext.tokenCounter,
+      });
+
+    if (messagesToRefine.length === 0) {
+      /**
+       * Recency window covers the entire conversation — there is no
+       * older content to summarize.  Skipping prevents the model from
+       * destroying the user's most recent message (e.g. a large pasted
+       * payload on the first turn) by replacing it with a generic
+       * checkpoint summary.  Mark the trigger so the same unchanged
+       * state is not re-evaluated on the next prune cycle.
+       */
+      emitAgentLog(
+        config,
+        'debug',
+        'summarize',
+        'Summarization skipped — recency window retains all messages',
+        {
+          messagesRetained: messagesToRetain.length,
+          retainTurns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
+        },
+        { runId: graph.runId, agentId: request.agentId }
+      );
+      agentContext.markSummarizationTriggered(state.messages.length);
+      return { summarizationRequest: undefined };
+    }
+
     const clientConfig = buildSummarizationClientConfig(
       agentContext,
       agentContext.summarizationConfig
     );
-
-    const runnableConfig = config ?? graph.config;
 
     const stepKey = `summarize-${request.agentId}`;
     const [stepId, stepIndex] = generateStepId(stepKey);
@@ -939,7 +984,10 @@ export function createSummarizeNode({
 
     return {
       summarizationRequest: undefined,
-      messages: [createRemoveAllMessage()],
+      messages:
+        messagesToRetain.length > 0
+          ? [createRemoveAllMessage(), ...messagesToRetain]
+          : [createRemoveAllMessage()],
     };
   };
 }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -779,12 +779,27 @@ export function createSummarizeNode({
     const runnableConfig = config ?? graph.config;
 
     const retainRecent = agentContext.summarizationConfig?.retainRecent;
-    const { head: messagesToRefine, tail: messagesToRetain } =
-      splitAtRecencyBoundary(restoredMessages, {
+    const { head: messagesToRefine, tailStartIndex } = splitAtRecencyBoundary(
+      restoredMessages,
+      {
         turns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
         tokens: retainRecent?.tokens,
         tokenCounter: agentContext.tokenCounter,
-      });
+      }
+    );
+    /**
+     * Use the *masked* messages for the retained tail so that any
+     * truncation prune applied to oversized ToolMessage content stays
+     * truncated in live state.  The summarizer above reads the restored
+     * (full-content) head for summary quality, but reinjecting restored
+     * tool payloads into state would defeat masking and bloat the
+     * checkpoint, forcing more expensive re-pruning on later turns.
+     * `restoreOriginalToolContent` returns an array with identical
+     * length and structure to `state.messages` (replacements only at
+     * specific indices), so the same tailStartIndex slices both arrays
+     * at the same turn boundary.
+     */
+    const messagesToRetain = state.messages.slice(tailStartIndex);
 
     if (messagesToRefine.length === 0) {
       /**

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -770,11 +770,22 @@ export function createSummarizeNode({
       return { summarizationRequest: undefined };
     }
 
+    /**
+     * Capture the original-tool-content map locally before doing the
+     * split.  We need it in three places: to restore the head for
+     * summarizer quality, to leave intact on the skip path (state is
+     * unchanged), and — critically — to carry forward the tail-relevant
+     * entries on the summarize-fired path.  Clearing it eagerly here
+     * would lose the originals for masked tool messages that the
+     * recency window keeps in the tail; a future summarization could
+     * then only summarize the masked stub instead of the full payload.
+     */
+    const originalPending = agentContext.pendingOriginalToolContent;
+
     const restoredMessages = restoreOriginalToolContent(
       state.messages,
-      agentContext.pendingOriginalToolContent
+      originalPending
     );
-    agentContext.pendingOriginalToolContent = undefined;
 
     const runnableConfig = config ?? graph.config;
 
@@ -1005,6 +1016,29 @@ export function createSummarizeNode({
       agentId: request.agentId,
       messagesAfterCount: messagesToRetain.length,
     });
+
+    /**
+     * Carry forward the original-content entries that correspond to the
+     * retained tail, reindexed for the post-removeAll state where tail
+     * messages start at index 0.  Without this, a future summarization
+     * that pulls these tail messages into its head would only see the
+     * masked stubs (since `setSummary` clears `pruneMessages`, and the
+     * fresh pruner at the next turn has no record of prior masks).
+     * Entries for indices < `tailStartIndex` belong to messages we just
+     * summarized — they are no longer reachable so they are dropped.
+     */
+    if (originalPending != null && originalPending.size > 0) {
+      const tailPending = new Map<number, string>();
+      for (const [idx, content] of originalPending) {
+        if (idx >= tailStartIndex) {
+          tailPending.set(idx - tailStartIndex, content);
+        }
+      }
+      agentContext.pendingOriginalToolContent =
+        tailPending.size > 0 ? tailPending : undefined;
+    } else {
+      agentContext.pendingOriginalToolContent = undefined;
+    }
 
     return {
       summarizationRequest: undefined,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -629,6 +629,13 @@ async function dispatchCompletionEvents(params: {
   runStep: t.RunStep;
   summaryUsage?: Partial<UsageMetadata>;
   agentId: string;
+  /**
+   * Number of messages preserved verbatim by the recency window after
+   * compaction.  Reported via the PostCompact hook payload so observers
+   * (metrics, cleanup) see the true post-compaction message count
+   * instead of always-zero.
+   */
+  messagesAfterCount: number;
 }): Promise<void> {
   const {
     graph,
@@ -639,6 +646,7 @@ async function dispatchCompletionEvents(params: {
     runStep,
     summaryUsage,
     agentId,
+    messagesAfterCount,
   } = params;
 
   runStep.summary = summaryBlock;
@@ -691,7 +699,7 @@ async function dispatchCompletionEvents(params: {
         threadId,
         agentId,
         summary: summaryText,
-        messagesAfterCount: 0,
+        messagesAfterCount,
       },
       sessionId,
     }).catch(() => {
@@ -980,6 +988,7 @@ export function createSummarizeNode({
       runStep,
       summaryUsage,
       agentId: request.agentId,
+      messagesAfterCount: messagesToRetain.length,
     });
 
     return {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1018,6 +1018,17 @@ export function createSummarizeNode({
     });
 
     /**
+     * `dispatchCompletionEvents` calls `rebuildTokenMapAfterSummarization({})`
+     * which resets the dedupe baseline to 0 — correct under the legacy
+     * "remove-all only" shape where no messages survived, but stale once
+     * the recency window keeps a tail.  Realign the baseline to the
+     * surviving tail length so a subsequent prune cycle on the unchanged
+     * tail short-circuits via `shouldSkipSummarization` instead of
+     * looping back into another summarize call.
+     */
+    agentContext.markSummarizationTriggered(messagesToRetain.length);
+
+    /**
      * Carry forward the original-content entries that correspond to the
      * retained tail, reindexed for the post-removeAll state where tail
      * messages start at index 0.  Without this, a future summarization

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -10,6 +10,30 @@ export type SummarizationTrigger = {
   value: number;
 };
 
+/**
+ * Controls how many recent messages are preserved verbatim during
+ * compaction.  The most recent user-led turn is always preserved
+ * regardless of these caps, so a single oversized first message is
+ * never destroyed by summarization.
+ */
+export type RetainRecentConfig = {
+  /**
+   * Maximum number of recent user-led turns to keep in the tail.  A turn
+   * begins at a HumanMessage and includes every following AIMessage and
+   * ToolMessage up to (but not including) the next HumanMessage.  Cutting
+   * at turn boundaries guarantees tool_use / tool_result pairs are never
+   * split.  Set to `0` to disable the recency window (legacy behavior:
+   * summarize everything).  Defaults to `2`.
+   */
+  turns?: number;
+  /**
+   * Optional cap on retained-recent tokens beyond the most recent turn.
+   * Older turns are added whole only while cumulative tokens stay below
+   * the cap.  Defaults to undefined (no cap; bounded only by `turns`).
+   */
+  tokens?: number;
+};
+
 export type SummarizationConfig = {
   provider?: Providers;
   model?: string;
@@ -20,6 +44,13 @@ export type SummarizationConfig = {
   maxSummaryTokens?: number;
   /** Fraction of the token budget reserved as headroom (0–1). Defaults to 0.05. */
   reserveRatio?: number;
+  /**
+   * Recent-message preservation policy.  When unset, defaults to
+   * `{ turns: 2 }` so the last two user-led turns are kept verbatim
+   * while older content is summarized.  Setting `{ turns: 0 }` reverts
+   * to the legacy behavior of summarizing every message.
+   */
+  retainRecent?: RetainRecentConfig;
 };
 
 export interface SummarizeResult {


### PR DESCRIPTION
## Summary
- Adds `SummarizationConfig.retainRecent` (`{ turns?, tokens? }`, default `{ turns: 2 }`) so the summarize node now preserves the most recent user-led turns verbatim instead of replacing every message with the LLM-generated checkpoint.
- New `splitAtRecencyBoundary` pure helper cuts strictly at HumanMessage boundaries — tool_use ↔ tool_result pairs are never split, and the most recent turn is *always* preserved (regardless of token cap), so a single oversized first message can no longer be destroyed by summarization.
- When the head is empty (e.g. a fresh conversation with one big paste), the LLM call is skipped entirely and no `ON_SUMMARIZE_*` events fire — the user's payload survives intact.

Addresses [LibreChat #12940](https://github.com/danny-avila/LibreChat/issues/12940) ("Skip Summarization of First Turn") and review item #1 of the prior summarization audit.

## How
1. **`src/messages/recency.ts`** — pure `splitAtRecencyBoundary({ turns, tokens, tokenCounter })`. 13 unit tests cover the default path, the disabled (`turns: 0`) path, the optional token cap, and degenerate inputs.
2. **`src/types/summarize.ts`** — adds `RetainRecentConfig` and the `retainRecent` field on `SummarizationConfig`.
3. **`src/summarization/node.ts`** — splits inside the node before any LLM-call setup; if `head.length === 0`, marks the trigger consumed and returns without changes; otherwise summarizes only the head and returns `[createRemoveAllMessage(), ...messagesToRetain]` for the messages reducer to apply.
4. **Tests** — existing `node.test.ts` cases default to `{ turns: 0 }` to keep exercising the LLM-call path; four new tests cover first-turn skip, single-turn skip with tool messages, multi-turn split, and the legacy shape.

## Verification

### Unit tests
**214 / 214 pass** across 12 impacted suites: `summarization`, `messages`, `multi-agent-summarization`, `summarize-prune`, `summarization-unit`, `prune`, `thinking-prune`, `token-accounting-pipeline`. `tsc --noEmit` clean. `eslint` clean (one pre-existing warning unrelated).

### Live multi-provider runs
Verified end-to-end against real APIs via `src/scripts/summarization-recency.ts`:

| Provider | Model | First-turn protection | Multi-turn compaction |
|---|---|---|---|
| anthropic | claude-sonnet-4-5 | ✅ | ✅ (2 summaries fired) |
| openAI | gpt-5.4-mini | ✅ | ✅ (2 summaries fired) |
| google | gemini-2.5-flash | ✅ | ⚠ free-tier 429 (environmental) |
| bedrock | us.anthropic.claude-sonnet-4-5 | ✅ | ✅ (2 summaries fired) |
| openrouter | moonshotai/kimi-k2.6 | ✅ | ✅ (3 summaries fired) |
| deepseek | deepseek-v4-flash | ✅ | ✅ (3 summaries fired) |

6 / 6 first-turn protection. 5 / 5 multi-turn compaction (Google's free-tier rate limit was the only failure and it's environmental).

## Test plan
- [x] `npx jest src/messages/__tests__ src/summarization src/specs/summarize-prune.test.ts src/specs/multi-agent-summarization.test.ts src/specs/summarization-unit.test.ts src/specs/prune.test.ts src/specs/thinking-prune.test.ts src/specs/token-accounting-pipeline.test.ts` — 214 / 214 pass.
- [x] `npx tsc --noEmit` clean.
- [x] Live verification across anthropic, openAI, google, bedrock, openrouter, deepseek (script invocation in the file header).
- [ ] Reviewer spot-checks the prompt-cache invariant on Anthropic — the cache-friendly compaction call (raw messages + appended instruction) is unchanged; only the head selection and return shape changed.

## Behavior change for users
- Default of `retainRecent.turns: 2` means summarization no longer fires on conversations of ≤ 2 user-led turns. The most recent 2 turns survive every compaction verbatim.
- Single oversized first message: summarization is skipped; if the message still doesn't fit the budget, prune surfaces a clear `empty_messages` error rather than silently destroying the user's payload.
- Existing callers can revert to legacy "summarize everything" behavior with `summarizationConfig: { retainRecent: { turns: 0 } }`.

## Saved for follow-up PRs (intentionally out of scope to keep this change tight)
- `tool_choice: 'none'` on the summarizer model (review #3)
- Pre-emptive (pre-prune) trigger evaluation (review #2)
- Circuit breaker on consecutive compaction failures
- Retry-with-truncated-head when the summarizer's own request overflows
- Tighter `reserveRatio` defaults