### PR TITLE
refactor: forward per-file entity_id through _injected_files

### DIFF
--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -558,6 +558,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               session_id: file.session_id ?? codeSession.session_id,
               id: file.id,
               name: file.name,
+              ...(file.entity_id != null ? { entity_id: file.entity_id } : {}),
             }));
             invokeParams._injected_files = fileRefs;
           }
@@ -797,6 +798,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         session_id: file.session_id ?? codeSession.session_id,
         id: file.id,
         name: file.name,
+        ...(file.entity_id != null ? { entity_id: file.entity_id } : {}),
       }));
     }
 

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -134,6 +134,49 @@ describe('ToolNode code execution session management', () => {
       expect(files[0].session_id).toBe('session-A');
       expect(files[1].session_id).toBe('session-B');
     });
+
+    it('forwards per-file entity_id for mixed-entity sessions', async () => {
+      const capturedConfigs: Record<string, unknown>[] = [];
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'session-A',
+        files: [
+          {
+            id: 'skill-file',
+            name: 'demo/SKILL.md',
+            session_id: 'session-A',
+            entity_id: 'skill-123',
+          },
+          {
+            id: 'user-file',
+            name: 'attachment.csv',
+            session_id: 'session-B',
+          },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const mockTool = createMockCodeTool({ capturedConfigs });
+      const toolNode = new ToolNode({ tools: [mockTool], sessions });
+
+      const aiMsg = createAIMessageWithCodeCall('call_5');
+      await toolNode.invoke({ messages: [aiMsg] });
+
+      const files = capturedConfigs[0]._injected_files as t.CodeEnvFile[];
+      expect(files).toEqual([
+        {
+          session_id: 'session-A',
+          id: 'skill-file',
+          name: 'demo/SKILL.md',
+          entity_id: 'skill-123',
+        },
+        {
+          session_id: 'session-B',
+          id: 'user-file',
+          name: 'attachment.csv',
+        },
+      ]);
+    });
   });
 
   describe('getCodeSessionContext (via dispatchToolEvents request building)', () => {
@@ -199,6 +242,47 @@ describe('ToolNode code execution session management', () => {
       ).getCodeSessionContext();
 
       expect(context).toBeUndefined();
+    });
+
+    it('forwards per-file entity_id to event-driven request context', () => {
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'evt-session',
+        files: [
+          {
+            id: 'sk1',
+            name: 'demo/SKILL.md',
+            session_id: 'evt-session',
+            entity_id: 'skill-abc',
+          },
+          { id: 'usr1', name: 'data.csv', session_id: 'evt-session' },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const mockTool = createMockCodeTool({ capturedConfigs: [] });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions,
+        eventDrivenMode: true,
+      });
+
+      const context = (
+        toolNode as unknown as { getCodeSessionContext: () => unknown }
+      ).getCodeSessionContext();
+
+      expect(context).toEqual({
+        session_id: 'evt-session',
+        files: [
+          {
+            session_id: 'evt-session',
+            id: 'sk1',
+            name: 'demo/SKILL.md',
+            entity_id: 'skill-abc',
+          },
+          { session_id: 'evt-session', id: 'usr1', name: 'data.csv' },
+        ],
+      });
     });
   });
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -116,6 +116,15 @@ export type CodeEnvFile = {
   id: string;
   name: string;
   session_id: string;
+  /**
+   * Identifier of the entity that owns this file's session (skill id,
+   * agent id, etc). Forwarded to codeapi so it can resolve the
+   * per-file sessionKey instead of falling back to a single
+   * request-level entity. Required when a single execute request
+   * references files uploaded under different entities (e.g. a skill
+   * file plus a user attachment in the same call).
+   */
+  entity_id?: string;
 };
 
 export type CodeExecutionToolParams =
@@ -132,6 +141,13 @@ export type FileRef = {
   path?: string;
   /** Session ID this file belongs to (for multi-session file tracking) */
   session_id?: string;
+  /**
+   * Entity that owns this file's session (skill id, agent id, etc).
+   * Carried on tracked session files so it can flow through to
+   * `_injected_files` when a subsequent execute references a mix of
+   * files uploaded under different entities.
+   */
+  entity_id?: string;
   /**
    * `true` when the codeapi sandbox echoed this entry as an unchanged
    * passthrough of an input the caller already owns (skill files,


### PR DESCRIPTION
## Summary

`CodeEnvFile` and `FileRef` gain an optional `entity_id`, and `ToolNode` forwards it through both injection paths (`runTool` direct execution and `getCodeSessionContext` event-driven request building) so codeapi can resolve sessionKey per file instead of per request.

This is the agents-side plumbing for a cross-repo fix. Without it, an execute call that mixes files uploaded under different entities (e.g. a skill bundle plus a user attachment) has to collapse to a single request-level `entity_id` — and whichever entity loses, those files 403 during authorization.

## Why

Today `ToolNode` strips file metadata down to `{ id, name, session_id }` ([ToolNode.ts:557-561](https://github.com/danny-avila/agents/blob/main/src/tools/ToolNode.ts#L557-L561), [:795-801](https://github.com/danny-avila/agents/blob/main/src/tools/ToolNode.ts#L795-L801)) when projecting `codeSession.files` onto the wire. CodeAPI is being changed in parallel to accept per-file `entity_id` and resolve sessionKey from `(tenant, user, file.entity_id ?? request.entity_id)`. For that fix to actually reach the server, this layer has to stop dropping the field.

The change is additive: every existing call site that builds `CodeSessionContext` without `entity_id` continues to behave exactly as before. The forwarder uses a conditional spread so absent values don't produce stray `entity_id: undefined` keys on the wire.

## Changes

- `CodeEnvFile` (`src/types/tools.ts`) — optional `entity_id`
- `FileRef` (`src/types/tools.ts`) — optional `entity_id`, so tracked session files can carry it through to `_injected_files`
- `ToolNode.runTool` direct-execution path — forward `entity_id` onto each `_injected_files` entry
- `ToolNode.getCodeSessionContext` event-driven path — same forward
- Tests in `ToolNode.session.test.ts` covering both paths with mixed-entity sessions (skill file with `entity_id` + user file without)

## Test plan

- [ ] CI: existing tests still pass
- [ ] CI: two new mixed-entity propagation tests pass
- [ ] CI: build (rollup + tsc) clean

Locally `npx jest src/tools/__tests__/ToolNode.session.test.ts` passes 110/110, and `npx rollup -c && npx tsc -p tsconfig.build.json` builds clean. Letting CI confirm on its full matrix.

## Coordination

Companion changes are in flight on the codeapi side (accept per-file `entity_id`, resolve sessionKey per file, mixed-entity authorization test) and the LibreChat side (parse `entity_id` off persisted `codeEnvIdentifier` at the executor build site, stop sending request-level `entity_id` on execute). Wire-format is fully back-compat in both directions: this PR can land independently of either.