### PR TITLE
refactor: Preserve per-file entity_id across the codeapi round-trip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.78-dev.0",
+  "version": "3.1.78-dev.1",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -274,10 +274,42 @@ function updateCodeSession(
   const existingFiles = existingSession?.files ?? [];
 
   if (newFiles.length > 0) {
-    const filesWithSession: t.FileRefs = newFiles.map((file) => ({
-      ...file,
-      session_id: file.session_id ?? sessionId,
-    }));
+    /**
+     * Carry forward fields from the prior entry that the worker response
+     * doesn't echo. Right now that's `entity_id` — codeapi echoes
+     * inherited input files in its response without the entity scope
+     * the caller sent in, so a same-name merge would silently drop the
+     * field. Subsequent execute calls would then inject those files
+     * without `entity_id`, codeapi falls back to the request-level
+     * (or userId-only) sessionKey, and the file 403s even though it's
+     * the same file the prior call just ran successfully.
+     *
+     * Index by `(session_id, id)` because that's the stable identity
+     * for a sandbox object (two distinct uploads can share a filename
+     * across sessions). Fall back to `name` only when the per-file id
+     * is absent on the prior entry — older payloads.
+     */
+    const priorByKey = new Map<string, t.FileRef>();
+    for (const f of existingFiles) {
+      const key =
+        f.id != null && f.session_id != null
+          ? `${f.session_id}\0${f.id}`
+          : `name:${f.name}`;
+      priorByKey.set(key, f);
+    }
+
+    const filesWithSession: t.FileRefs = newFiles.map((file) => {
+      const sid = file.session_id ?? sessionId;
+      const key = file.id != null ? `${sid}\0${file.id}` : `name:${file.name}`;
+      const prior = priorByKey.get(key) ?? priorByKey.get(`name:${file.name}`);
+      return {
+        ...file,
+        session_id: sid,
+        ...(file.entity_id == null && prior?.entity_id != null
+          ? { entity_id: prior.entity_id }
+          : {}),
+      };
+    });
     const newFileNames = new Set(filesWithSession.map((f) => f.name));
     const filteredExisting = existingFiles.filter(
       (f) => !newFileNames.has(f.name)

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -632,6 +632,178 @@ describe('ToolNode code execution session management', () => {
       });
     });
 
+    it('preserves per-file entity_id from the prior session when the response strips it', () => {
+      /**
+       * Round-trip regression: codeapi authorizes input files per-file
+       * via `entity_id`, but the worker response echoes `inherited: true`
+       * input files back to the caller without the entity scope they
+       * arrived under. Without this preservation, the same-name merge
+       * silently drops `entity_id` from the stored session, the next
+       * execute injects the file unscoped, and codeapi 403s — even
+       * though the file's bytes are still alive in the same storage
+       * session.
+       *
+       * Concretely: skill bundle uploaded under `entity_id=skill-123`,
+       * first execute runs successfully with all files entity-scoped,
+       * worker echoes them back with no `entity_id`, second execute
+       * loses authorization for every same-name file.
+       */
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'storage-A',
+        files: [
+          {
+            id: 'f1',
+            name: 'pptx/SKILL.md',
+            session_id: 'storage-A',
+            entity_id: 'skill-123',
+          },
+          {
+            id: 'f2',
+            name: 'pptx/pptxgenjs.md',
+            session_id: 'storage-A',
+            entity_id: 'skill-123',
+          },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const mockTool = createMockCodeTool({ capturedConfigs: [] });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions,
+        eventDrivenMode: true,
+      });
+      const storeMethod = (
+        toolNode as unknown as {
+          storeCodeSessionFromResults: (
+            results: t.ToolExecuteResult[],
+            requestMap: Map<string, t.ToolCallRequest>
+          ) => void;
+        }
+      ).storeCodeSessionFromResults.bind(toolNode);
+
+      storeMethod(
+        [
+          {
+            toolCallId: 'tc-roundtrip',
+            content: 'output',
+            artifact: {
+              session_id: 'exec-roundtrip',
+              files: [
+                /* Worker response: same files, no entity_id, marked inherited. */
+                {
+                  id: 'f1',
+                  name: 'pptx/SKILL.md',
+                  session_id: 'storage-A',
+                  inherited: true,
+                },
+                {
+                  id: 'f2',
+                  name: 'pptx/pptxgenjs.md',
+                  session_id: 'storage-A',
+                  inherited: true,
+                },
+              ],
+            },
+            status: 'success',
+          },
+        ],
+        new Map([
+          [
+            'tc-roundtrip',
+            { id: 'tc-roundtrip', name: Constants.EXECUTE_CODE, args: {} },
+          ],
+        ])
+      );
+
+      const stored = sessions.get(
+        Constants.EXECUTE_CODE
+      ) as t.CodeSessionContext;
+      expect(stored.files).toHaveLength(2);
+      expect(stored.files![0]).toEqual({
+        id: 'f1',
+        name: 'pptx/SKILL.md',
+        session_id: 'storage-A',
+        entity_id: 'skill-123',
+        inherited: true,
+      });
+      expect(stored.files![1]).toEqual({
+        id: 'f2',
+        name: 'pptx/pptxgenjs.md',
+        session_id: 'storage-A',
+        entity_id: 'skill-123',
+        inherited: true,
+      });
+    });
+
+    it('does not overwrite an entity_id the worker response explicitly sets', () => {
+      /* If the response ever DOES include entity_id (e.g. a future
+       * codeapi version that echoes it), the response value wins. The
+       * preservation logic only fills in when the response omits the
+       * field. */
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'storage-A',
+        files: [
+          {
+            id: 'f1',
+            name: 'demo/inputs.csv',
+            session_id: 'storage-A',
+            entity_id: 'skill-old',
+          },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const mockTool = createMockCodeTool({ capturedConfigs: [] });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions,
+        eventDrivenMode: true,
+      });
+      const storeMethod = (
+        toolNode as unknown as {
+          storeCodeSessionFromResults: (
+            results: t.ToolExecuteResult[],
+            requestMap: Map<string, t.ToolCallRequest>
+          ) => void;
+        }
+      ).storeCodeSessionFromResults.bind(toolNode);
+
+      storeMethod(
+        [
+          {
+            toolCallId: 'tc-explicit',
+            content: 'output',
+            artifact: {
+              session_id: 'exec-explicit',
+              files: [
+                {
+                  id: 'f1',
+                  name: 'demo/inputs.csv',
+                  session_id: 'storage-A',
+                  entity_id: 'skill-new',
+                },
+              ],
+            },
+            status: 'success',
+          },
+        ],
+        new Map([
+          [
+            'tc-explicit',
+            { id: 'tc-explicit', name: Constants.EXECUTE_CODE, args: {} },
+          ],
+        ])
+      );
+
+      const stored = sessions.get(
+        Constants.EXECUTE_CODE
+      ) as t.CodeSessionContext;
+      expect(stored.files![0].entity_id).toBe('skill-new');
+    });
+
     it('falls back to exec session_id only when per-file session_id is absent (older worker payloads)', () => {
       const sessions: t.ToolSessionMap = new Map();
       const mockTool = createMockCodeTool({ capturedConfigs: [] });


### PR DESCRIPTION
## Summary

Follow-up to #145. After that PR landed, the *first* execute in a run authorized correctly with per-file `entity_id`, but the **second** execute against the same session 403'd on every same-name input file. This PR closes that gap and bumps to `3.1.78-dev.1`.

## Why

`updateCodeSession` ([ToolNode.ts:230](src/tools/ToolNode.ts#L230)) merges the codeapi worker's response files into the stored `CodeSessionContext` by filtering same-name entries out of the existing list and appending the response entries. The worker response echoes `inherited: true` input files back to the caller **without** the `entity_id` they were sent in under, so the merge silently dropped the field on every same-name collision.

Concrete reproduction (skill-bundle workload):

1. Skill priming uploads `pptx/SKILL.md`, `pptx/pptxgenjs.md`, etc. under `entity_id=skill-123`.
2. First execute injects `_injected_files` with `entity_id` on every entry. CodeAPI authorizes per-file. ✓
3. Worker echoes input files back with `inherited: true`, no `entity_id`. Stored session loses the field.
4. Second execute injects from the stored session — no `entity_id` on any file. CodeAPI resolves sessionKey to `userId` (fallback), cached key was `skill-123` (entity scope), 403.

The agent surfaces this as `HTTP error! status: 403 Please fix your mistakes.`, retries with the same broken state, fails the same way.

## Fix

`updateCodeSession` indexes prior entries by `(session_id, id)` (with a `name` fallback for older payloads), and when the response file lacks `entity_id`, fills it in from the prior. Defense-in-depth: if/when codeapi later starts echoing `entity_id`, the response value wins (covered by a dedicated test).

## Tests

- **Round-trip preservation**: prior session has `entity_id`, response strips it, stored session retains it on every same-name file.
- **Response wins on explicit value**: if the response includes a different `entity_id`, that value is stored.
- All existing `storeCodeSessionFromResults` tests still pass — no behavior change for files without `entity_id`.

Locally `npx jest src/tools/__tests__/ToolNode.session.test.ts` (with the `local/` test file pre-existing dep issue ignored) shows all session-management tests green; CI will exercise the full matrix.

## Version

`3.1.78-dev.0` → `3.1.78-dev.1` so LibreChat can pin the exact build that includes this fix.