### PR TITLE
🧱 refactor: storage_session_id rename + kind discriminator (3.1.80-dev.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.79",
+  "version": "3.1.80-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.79",
+      "version": "3.1.80-dev.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.79",
+  "version": "3.1.80-dev.0",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/scripts/code_exec_multi_session.ts
+++ b/src/scripts/code_exec_multi_session.ts
@@ -46,7 +46,7 @@ function printSessionContext(run: Run<t.IState>, label: string): void {
   console.log(`  Latest session_id: ${session.session_id}`);
   console.log(`  Files tracked: ${session.files?.length ?? 0}`);
   for (const file of session.files ?? []) {
-    console.log(`    - ${file.name} (session: ${file.session_id})`);
+    console.log(`    - ${file.name} (storage: ${file.storage_session_id})`);
   }
 }
 
@@ -200,13 +200,13 @@ Tell me what version it shows.
 
   if (finalSession) {
     const files = finalSession.files ?? [];
-    const uniqueSessionIds = new Set(files.map((f) => f.session_id));
+    const uniqueSessionIds = new Set(files.map((f) => f.storage_session_id));
     console.log(`\nTotal files tracked: ${files.length}`);
-    console.log(`Unique session_ids: ${uniqueSessionIds.size}`);
+    console.log(`Unique storage_session_ids: ${uniqueSessionIds.size}`);
     console.log('\nFiles:');
     for (const file of files) {
       console.log(
-        `  - ${file.name} (session: ${file.session_id?.slice(0, 20)}...)`
+        `  - ${file.name} (storage: ${file.storage_session_id?.slice(0, 20)}...)`
       );
     }
 

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -163,7 +163,10 @@ function createBashExecutionTool(
               const id = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
 
               return {
-                session_id,
+                storage_session_id: session_id,
+                /* `/files` fallback returns code-output files belonging
+                 * to the user; tag them user-private. */
+                kind: 'user' as const,
                 id,
                 name: file.metadata['original-filename'],
               };
@@ -241,11 +244,16 @@ function createBashExecutionTool(
             {
               session_id: result.session_id,
               files: result.files,
-            },
+            } satisfies t.CodeExecutionArtifact,
           ];
         }
 
-        return [formattedOutput.trim(), { session_id: result.session_id }];
+        return [
+          formattedOutput.trim(),
+          {
+            session_id: result.session_id,
+          } satisfies t.CodeExecutionArtifact,
+        ];
       } catch (error) {
         throw new Error(
           `Execution error:\n\n${(error as Error | undefined)?.message}`

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -252,12 +252,12 @@ export function createBashProgrammaticToolCallingTool(
       const params = rawParams as { code: string; timeout?: number };
       const { code, timeout = DEFAULT_TIMEOUT } = params;
 
-      const { toolMap, toolDefs, session_id, _injected_files } =
-        (config.toolCall ?? {}) as ToolCall &
-          Partial<t.ProgrammaticCache> & {
-            session_id?: string;
-            _injected_files?: t.CodeEnvFile[];
-          };
+      const toolCall = (config.toolCall ?? {}) as ToolCall &
+        Partial<t.ProgrammaticCache> & {
+          session_id?: string;
+          _injected_files?: t.CodeEnvFile[];
+        };
+      const { toolMap, toolDefs, session_id, _injected_files } = toolCall;
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -135,8 +135,8 @@ function createCodeExecutionTool(
       };
       /**
        * Extract session context from config.toolCall (injected by ToolNode).
-       * - session_id: For API to associate with previous session
-       * - _injected_files: File refs to pass directly (avoids /files endpoint race condition)
+       * - session_id: associates with the previous run.
+       * - _injected_files: File refs to pass directly (avoids /files endpoint race condition).
        */
       const { session_id, _injected_files } = (config.toolCall ?? {}) as {
         session_id?: string;
@@ -153,7 +153,10 @@ function createCodeExecutionTool(
       /**
        * File injection priority:
        * 1. Use _injected_files from ToolNode (avoids /files endpoint race condition)
-       * 2. Fall back to fetching from /files endpoint if session_id provided but no injected files
+       * 2. Fall back to fetching from /files endpoint if session_id
+       *    provided but no injected files. The /files lookup still uses the
+       *    same id value — codeapi stores output files under the exec id as
+       *    their storage prefix, so the two values coincide here.
        */
       if (_injected_files && _injected_files.length > 0) {
         postData.files = _injected_files;
@@ -186,7 +189,10 @@ function createCodeExecutionTool(
               const id = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
 
               return {
-                session_id,
+                storage_session_id: session_id,
+                /* `/files` fallback returns code-output files belonging
+                 * to the user; tag them user-private. */
+                kind: 'user' as const,
                 id,
                 name: file.metadata['original-filename'],
               };
@@ -259,11 +265,16 @@ function createCodeExecutionTool(
             {
               session_id: result.session_id,
               files: result.files,
-            },
+            } satisfies t.CodeExecutionArtifact,
           ];
         }
 
-        return [formattedOutput.trim(), { session_id: result.session_id }];
+        return [
+          formattedOutput.trim(),
+          {
+            session_id: result.session_id,
+          } satisfies t.CodeExecutionArtifact,
+        ];
       } catch (error) {
         throw new Error(
           `Execution error:\n\n${(error as Error | undefined)?.message}`

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -304,7 +304,10 @@ export async function fetchSessionFiles(
       const id = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
 
       return {
-        session_id: sessionId,
+        storage_session_id: sessionId,
+        /* `/files` fallback returns code-output files belonging to
+         * the user; tag them user-private. */
+        kind: 'user' as const,
         id,
         name: (file.metadata as Record<string, unknown>)[
           'original-filename'
@@ -588,7 +591,7 @@ export function formatCompletedResponse(
     {
       session_id: response.session_id,
       files: response.files,
-    },
+    } satisfies t.ProgrammaticExecutionArtifact,
   ];
 }
 
@@ -629,13 +632,13 @@ export function createProgrammaticToolCallingTool(
       const params = rawParams as { code: string; timeout?: number };
       const { code, timeout = DEFAULT_TIMEOUT } = params;
 
-      // Extra params injected by ToolNode (follows web_search pattern)
-      const { toolMap, toolDefs, session_id, _injected_files } =
-        (config.toolCall ?? {}) as ToolCall &
-          Partial<t.ProgrammaticCache> & {
-            session_id?: string;
-            _injected_files?: t.CodeEnvFile[];
-          };
+      // Extra params injected by ToolNode (follows web_search pattern).
+      const toolCall = (config.toolCall ?? {}) as ToolCall &
+        Partial<t.ProgrammaticCache> & {
+          session_id?: string;
+          _injected_files?: t.CodeEnvFile[];
+        };
+      const { toolMap, toolDefs, session_id, _injected_files } = toolCall;
 
       if (toolMap == null || toolMap.size === 0) {
         throw new Error(
@@ -671,7 +674,8 @@ export function createProgrammaticToolCallingTool(
         /**
          * File injection priority:
          * 1. Use _injected_files from ToolNode (avoids /files endpoint race condition)
-         * 2. Fall back to fetching from /files endpoint if session_id provided but no injected files
+         * 2. Fall back to fetching from /files endpoint if session_id
+         *    provided but no injected files.
          */
         let files: t.CodeEnvFile[] | undefined;
         if (_injected_files && _injected_files.length > 0) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -249,22 +249,23 @@ function normalizeApprovalDecisions(
  *  - `artifact.session_id` (the `sessionId` arg here) is the EXEC session
  *    — the sandbox VM that ran the code. It's transient and torn down
  *    post-execution; subsequent calls cannot reuse it as a sandbox.
- *  - `file.session_id` on each `artifact.files[i]` is the STORAGE
+ *  - `file.storage_session_id` on each `artifact.files[i]` is the STORAGE
  *    session — the file-server bucket prefix where the artifact actually
  *    lives and is served from.
  *
- * Per-file `session_id` is preserved (not overwritten with the exec id)
- * because `_injected_files` are looked up against the file-server's
- * storage path on subsequent tool calls. Stomping the storage id with
- * the exec id silently 404s every follow-up tool call within the same
- * run — `cat /mnt/data/foo.txt` reports "No such file or directory"
- * because the worker can't mount a file at a path the storage doesn't
- * know about. Fall back to `sessionId` only when the per-file id is
- * absent (older worker payloads).
+ * Per-file `storage_session_id` is preserved (not overwritten with the
+ * exec id) because `_injected_files` are looked up against the
+ * file-server's storage path on subsequent tool calls. Stomping the
+ * storage id with the exec id silently 404s every follow-up tool call
+ * within the same run — `cat /mnt/data/foo.txt` reports "No such file
+ * or directory" because the worker can't mount a file at a path the
+ * storage doesn't know about. Fall back to the exec id only when the
+ * per-file id is absent (e.g. inline `content` files have no persistent
+ * storage location).
  */
 function updateCodeSession(
   sessions: t.ToolSessionMap,
-  sessionId: string,
+  execSessionId: string,
   files: t.FileRefs | undefined
 ): void {
   const newFiles = files ?? [];
@@ -276,20 +277,20 @@ function updateCodeSession(
   if (newFiles.length > 0) {
     const filesWithSession: t.FileRefs = newFiles.map((file) => ({
       ...file,
-      session_id: file.session_id ?? sessionId,
+      storage_session_id: file.storage_session_id ?? execSessionId,
     }));
     const newFileNames = new Set(filesWithSession.map((f) => f.name));
     const filteredExisting = existingFiles.filter(
       (f) => !newFileNames.has(f.name)
     );
     sessions.set(Constants.EXECUTE_CODE, {
-      session_id: sessionId,
+      session_id: execSessionId,
       files: [...filteredExisting, ...filesWithSession],
       lastUpdated: Date.now(),
     });
   } else {
     sessions.set(Constants.EXECUTE_CODE, {
-      session_id: sessionId,
+      session_id: execSessionId,
       files: existingFiles,
       lastUpdated: Date.now(),
     });
@@ -400,7 +401,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.loadRuntimeTools = loadRuntimeTools;
     this.errorHandler = errorHandler;
     this.toolUsageCount = new Map<string, number>();
-    this.toolRegistry = resolveLocalToolRegistry({ toolRegistry, toolExecution });
+    this.toolRegistry = resolveLocalToolRegistry({
+      toolRegistry,
+      toolExecution,
+    });
     this.sessions = sessions;
     this.eventDrivenMode = eventDrivenMode ?? false;
     this.agentId = agentId;
@@ -581,8 +585,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       resolveFn = <T>(_runId: string | undefined, args: T): ResolveResult<T> =>
         preBatchSnapshot.resolve(args);
     } else if (registry != null) {
-      resolveFn = <T>(runIdArg: string | undefined, args: T): ResolveResult<T> =>
-        registry.resolve(runIdArg, args);
+      resolveFn = <T>(
+        runIdArg: string | undefined,
+        args: T
+      ): ResolveResult<T> => registry.resolve(runIdArg, args);
     }
     /**
      * Precompute the reference key once per call — captured locally
@@ -717,19 +723,34 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const codeSession = this.sessions?.get(Constants.EXECUTE_CODE) as
           | t.CodeSessionContext
           | undefined;
-        if (codeSession?.session_id != null && codeSession.session_id !== '') {
+        const execSessionId = codeSession?.session_id;
+        if (execSessionId != null && execSessionId !== '') {
           invokeParams = {
             ...invokeParams,
-            session_id: codeSession.session_id,
+            session_id: execSessionId,
           };
 
-          if (codeSession.files != null && codeSession.files.length > 0) {
-            const fileRefs: t.CodeEnvFile[] = codeSession.files.map((file) => ({
-              session_id: file.session_id ?? codeSession.session_id,
-              id: file.id,
-              name: file.name,
-              ...(file.entity_id != null ? { entity_id: file.entity_id } : {}),
-            }));
+          if (codeSession?.files != null && codeSession.files.length > 0) {
+            const fileRefs: t.CodeEnvFile[] = codeSession.files.map((file) => {
+              const ref: t.CodeEnvFile = {
+                id: file.id,
+                name: file.name,
+                /* Inline `content` files have no persistent storage
+                 * location; fall back to the execution session id for
+                 * those entries. */
+                storage_session_id: file.storage_session_id ?? execSessionId,
+                /* `kind` drives codeapi's sessionKey shape (per-skill
+                 * vs per-user vs per-agent). Default to 'user' when
+                 * not explicitly set — most ad-hoc files are user-
+                 * private; shared resources (skills/agents) populate
+                 * their kind upstream. */
+                kind: file.kind ?? 'user',
+              };
+              if (file.version != null) {
+                ref.version = file.version;
+              }
+              return ref;
+            });
             invokeParams._injected_files = fileRefs;
           }
         }
@@ -950,10 +971,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   ): Promise<BaseMessage | Command> {
     const runId = (config.configurable?.run_id as string | undefined) ?? '';
     const hookRegistry = this.hookRegistry;
-    const hasPreHook =
-      hookRegistry?.hasHookFor('PreToolUse', runId) === true;
-    const hasPostHook =
-      hookRegistry?.hasHookFor('PostToolUse', runId) === true;
+    const hasPreHook = hookRegistry?.hasHookFor('PreToolUse', runId) === true;
+    const hasPostHook = hookRegistry?.hasHookFor('PostToolUse', runId) === true;
     const hasFailureHook =
       hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
 
@@ -989,8 +1008,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // assignment.)
     const cachedTurn =
       call.id != null && call.id !== ''
-        ? this.directPathTurns.get(call.id) ??
-          this.toolCallTurns.get(call.id)
+        ? (this.directPathTurns.get(call.id) ?? this.toolCallTurns.get(call.id))
         : undefined;
     if (cachedTurn != null) {
       usageCount = cachedTurn;
@@ -1156,10 +1174,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             return this.blockDirectCall({
               call,
               resolvedArgs,
-              reason:
-                decision.reason ??
-                preResult.reason ??
-                'Rejected by user',
+              reason: decision.reason ?? preResult.reason ?? 'Rejected by user',
               hookRegistry,
               runId,
               threadId,
@@ -1173,7 +1188,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               return this.blockDirectCall({
                 call,
                 resolvedArgs,
-                reason: 'Approval payload `respond` was missing a string `responseText`',
+                reason:
+                  'Approval payload `respond` was missing a string `responseText`',
                 hookRegistry,
                 runId,
                 threadId,
@@ -1464,17 +1480,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return undefined;
     }
 
+    const execSessionId = codeSession.session_id;
     const context: NonNullable<t.ToolCallRequest['codeSessionContext']> = {
-      session_id: codeSession.session_id,
+      session_id: execSessionId,
     };
 
     if (codeSession.files && codeSession.files.length > 0) {
-      context.files = codeSession.files.map((file) => ({
-        session_id: file.session_id ?? codeSession.session_id,
-        id: file.id,
-        name: file.name,
-        ...(file.entity_id != null ? { entity_id: file.entity_id } : {}),
-      }));
+      context.files = codeSession.files.map((file) => {
+        const ref: t.CodeEnvFile = {
+          id: file.id,
+          name: file.name,
+          storage_session_id: file.storage_session_id ?? execSessionId,
+          kind: file.kind ?? 'user',
+        };
+        if (file.version != null) {
+          ref.version = file.version;
+        }
+        return ref;
+      });
     }
 
     return context;
@@ -1509,11 +1532,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const artifact = result.artifact as t.CodeExecutionArtifact | undefined;
-      if (artifact?.session_id == null || artifact.session_id === '') {
+      const execSessionId = artifact?.session_id;
+      if (execSessionId == null || execSessionId === '') {
         continue;
       }
 
-      updateCodeSession(this.sessions, artifact.session_id!, artifact.files);
+      updateCodeSession(this.sessions, execSessionId, artifact?.files);
     }
   }
 
@@ -1558,8 +1582,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const artifact = toolMessage.artifact as
           | t.CodeExecutionArtifact
           | undefined;
-        if (artifact?.session_id != null && artifact.session_id !== '') {
-          updateCodeSession(this.sessions, artifact.session_id, artifact.files);
+        const execSessionId = artifact?.session_id;
+        if (execSessionId != null && execSessionId !== '') {
+          updateCodeSession(this.sessions, execSessionId, artifact?.files);
         }
       }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -263,6 +263,45 @@ function normalizeApprovalDecisions(
  * per-file id is absent (e.g. inline `content` files have no persistent
  * storage location).
  */
+/**
+ * Builds a `CodeEnvFile` ref from an arbitrary `FileRef`-like input,
+ * narrowing onto the discriminated union: `kind: 'skill'` requires
+ * `version`, other kinds forbid it.
+ *
+ * Defaults `kind` to `'user'` when unset — most ad-hoc files are
+ * user-private; shared resources (skills/agents) populate their kind
+ * upstream. A skill ref missing `version` falls back to `'user'` so
+ * the upstream contract bug surfaces as a degraded sessionKey rather
+ * than a runtime crash; primeSkillFiles is the only writer, and it
+ * always sets `version` — see LC packages/api/src/agents/skillFiles.ts.
+ */
+function toInjectedFileRef(
+  file: {
+    id: string;
+    name: string;
+    storage_session_id?: string;
+    kind?: t.CodeEnvKind;
+    version?: number;
+  },
+  execSessionId: string
+): t.CodeEnvFile {
+  const base = {
+    id: file.id,
+    name: file.name,
+    /* Inline `content` files have no persistent storage location;
+     * fall back to the execution session id for those entries. */
+    storage_session_id: file.storage_session_id ?? execSessionId,
+  };
+  const kind = file.kind ?? 'user';
+  if (kind === 'skill' && file.version != null) {
+    return { ...base, kind: 'skill', version: file.version };
+  }
+  if (kind === 'agent') {
+    return { ...base, kind: 'agent' };
+  }
+  return { ...base, kind: 'user' };
+}
+
 function updateCodeSession(
   sessions: t.ToolSessionMap,
   execSessionId: string,
@@ -731,27 +770,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           };
 
           if (codeSession?.files != null && codeSession.files.length > 0) {
-            const fileRefs: t.CodeEnvFile[] = codeSession.files.map((file) => {
-              const ref: t.CodeEnvFile = {
-                id: file.id,
-                name: file.name,
-                /* Inline `content` files have no persistent storage
-                 * location; fall back to the execution session id for
-                 * those entries. */
-                storage_session_id: file.storage_session_id ?? execSessionId,
-                /* `kind` drives codeapi's sessionKey shape (per-skill
-                 * vs per-user vs per-agent). Default to 'user' when
-                 * not explicitly set — most ad-hoc files are user-
-                 * private; shared resources (skills/agents) populate
-                 * their kind upstream. */
-                kind: file.kind ?? 'user',
-              };
-              if (file.version != null) {
-                ref.version = file.version;
-              }
-              return ref;
-            });
-            invokeParams._injected_files = fileRefs;
+            invokeParams._injected_files = codeSession.files.map((file) =>
+              toInjectedFileRef(file, execSessionId)
+            );
           }
         }
       }
@@ -1486,18 +1507,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     };
 
     if (codeSession.files && codeSession.files.length > 0) {
-      context.files = codeSession.files.map((file) => {
-        const ref: t.CodeEnvFile = {
-          id: file.id,
-          name: file.name,
-          storage_session_id: file.storage_session_id ?? execSessionId,
-          kind: file.kind ?? 'user',
-        };
-        if (file.version != null) {
-          ref.version = file.version;
-        }
-        return ref;
-      });
+      context.files = codeSession.files.map((file) =>
+        toInjectedFileRef(file, execSessionId)
+      );
     }
 
     return context;

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1064,8 +1064,11 @@ for member in team:
   });
 
   describe('bash bridge script does not require python3 (Codex P2 #19)', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { _createBashProgramForTests } = require('../local/LocalProgrammaticToolCalling');
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const {
+      _createBashProgramForTests,
+    } = require('../local/LocalProgrammaticToolCalling');
+    /* eslint-enable @typescript-eslint/no-require-imports */
 
     it('uses curl as the primary HTTP helper with python3 only as fallback', () => {
       const script: string = _createBashProgramForTests(
@@ -1129,6 +1132,7 @@ for member in team:
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
         hooks: [
+          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
           async (input) => {
             if (input.toolName === 'write_file') {
               return { decision: 'deny', reason: 'no writes from bridge' };
@@ -1179,6 +1183,7 @@ for member in team:
 
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
+        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
         hooks: [async () => ({ decision: 'allow' })],
       });
 
@@ -1200,6 +1205,7 @@ for member in team:
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
         hooks: [
+          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
           async () => ({
             decision: 'allow',
             updatedInput: { file_path: '/tmp/rewritten' },
@@ -1224,6 +1230,7 @@ for member in team:
 
       const registry = new HookRegistry();
       registry.register('PreToolUse', {
+        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
         hooks: [async () => ({ decision: 'ask' })],
       });
 

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -51,14 +51,22 @@ function createAIMessageWithCodeCall(callId: string): AIMessage {
 
 describe('ToolNode code execution session management', () => {
   describe('session injection via runTool (direct execution)', () => {
-    it('injects session_id and _injected_files when session has files', async () => {
+    it('injects session ids (both names) and _injected_files when session has files', async () => {
       const capturedConfigs: Record<string, unknown>[] = [];
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'prev-session-abc',
         files: [
-          { id: 'file1', name: 'data.csv', session_id: 'prev-session-abc' },
-          { id: 'file2', name: 'chart.png', session_id: 'prev-session-abc' },
+          {
+            id: 'file1',
+            name: 'data.csv',
+            storage_session_id: 'prev-session-abc',
+          },
+          {
+            id: 'file2',
+            name: 'chart.png',
+            storage_session_id: 'prev-session-abc',
+          },
         ],
         lastUpdated: Date.now(),
       } satisfies t.CodeSessionContext);
@@ -70,14 +78,26 @@ describe('ToolNode code execution session management', () => {
       await toolNode.invoke({ messages: [aiMsg] });
 
       expect(capturedConfigs).toHaveLength(1);
+      /* Both names injected so pre- and post-rename consumers see the
+       * field they expect. */
       expect(capturedConfigs[0].session_id).toBe('prev-session-abc');
       expect(capturedConfigs[0]._injected_files).toEqual([
-        { session_id: 'prev-session-abc', id: 'file1', name: 'data.csv' },
-        { session_id: 'prev-session-abc', id: 'file2', name: 'chart.png' },
+        {
+          id: 'file1',
+          name: 'data.csv',
+          storage_session_id: 'prev-session-abc',
+          kind: 'user',
+        },
+        {
+          id: 'file2',
+          name: 'chart.png',
+          storage_session_id: 'prev-session-abc',
+          kind: 'user',
+        },
       ]);
     });
 
-    it('injects session_id even when session has no tracked files', async () => {
+    it('injects session ids even when session has no tracked files', async () => {
       const capturedConfigs: Record<string, unknown>[] = [];
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
@@ -112,14 +132,22 @@ describe('ToolNode code execution session management', () => {
       expect(capturedConfigs[0]._injected_files).toBeUndefined();
     });
 
-    it('preserves per-file session_id for multi-session files', async () => {
+    it('preserves per-file storage_session_id for multi-session files', async () => {
       const capturedConfigs: Record<string, unknown>[] = [];
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'session-B',
         files: [
-          { id: 'f1', name: 'old.csv', session_id: 'session-A' },
-          { id: 'f2', name: 'new.png', session_id: 'session-B' },
+          {
+            id: 'f1',
+            name: 'old.csv',
+            storage_session_id: 'session-A',
+          },
+          {
+            id: 'f2',
+            name: 'new.png',
+            storage_session_id: 'session-B',
+          },
         ],
         lastUpdated: Date.now(),
       } satisfies t.CodeSessionContext);
@@ -131,26 +159,27 @@ describe('ToolNode code execution session management', () => {
       await toolNode.invoke({ messages: [aiMsg] });
 
       const files = capturedConfigs[0]._injected_files as t.CodeEnvFile[];
-      expect(files[0].session_id).toBe('session-A');
-      expect(files[1].session_id).toBe('session-B');
+      expect(files[0].storage_session_id).toBe('session-A');
+      expect(files[1].storage_session_id).toBe('session-B');
     });
 
-    it('forwards per-file entity_id for mixed-entity sessions', async () => {
+    it('forwards per-file kind and version for mixed-kind sessions', async () => {
       const capturedConfigs: Record<string, unknown>[] = [];
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'session-A',
         files: [
           {
-            id: 'skill-file',
+            id: 'skill-123',
             name: 'demo/SKILL.md',
-            session_id: 'session-A',
-            entity_id: 'skill-123',
+            storage_session_id: 'session-A',
+            kind: 'skill',
+            version: 7,
           },
           {
             id: 'user-file',
             name: 'attachment.csv',
-            session_id: 'session-B',
+            storage_session_id: 'session-B',
           },
         ],
         lastUpdated: Date.now(),
@@ -165,15 +194,17 @@ describe('ToolNode code execution session management', () => {
       const files = capturedConfigs[0]._injected_files as t.CodeEnvFile[];
       expect(files).toEqual([
         {
-          session_id: 'session-A',
-          id: 'skill-file',
+          id: 'skill-123',
           name: 'demo/SKILL.md',
-          entity_id: 'skill-123',
+          storage_session_id: 'session-A',
+          kind: 'skill',
+          version: 7,
         },
         {
-          session_id: 'session-B',
           id: 'user-file',
           name: 'attachment.csv',
+          storage_session_id: 'session-B',
+          kind: 'user',
         },
       ]);
     });
@@ -184,7 +215,13 @@ describe('ToolNode code execution session management', () => {
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'evt-session',
-        files: [{ id: 'ef1', name: 'out.parquet', session_id: 'evt-session' }],
+        files: [
+          {
+            id: 'ef1',
+            name: 'out.parquet',
+            storage_session_id: 'evt-session',
+          },
+        ],
         lastUpdated: Date.now(),
       } satisfies t.CodeSessionContext);
 
@@ -201,7 +238,14 @@ describe('ToolNode code execution session management', () => {
 
       expect(context).toEqual({
         session_id: 'evt-session',
-        files: [{ session_id: 'evt-session', id: 'ef1', name: 'out.parquet' }],
+        files: [
+          {
+            id: 'ef1',
+            name: 'out.parquet',
+            storage_session_id: 'evt-session',
+            kind: 'user',
+          },
+        ],
       });
     });
 
@@ -224,7 +268,9 @@ describe('ToolNode code execution session management', () => {
         toolNode as unknown as { getCodeSessionContext: () => unknown }
       ).getCodeSessionContext();
 
-      expect(context).toEqual({ session_id: 'evt-session-empty' });
+      expect(context).toEqual({
+        session_id: 'evt-session-empty',
+      });
     });
 
     it('returns undefined when no session exists', () => {
@@ -244,18 +290,23 @@ describe('ToolNode code execution session management', () => {
       expect(context).toBeUndefined();
     });
 
-    it('forwards per-file entity_id to event-driven request context', () => {
+    it('forwards per-file kind and version to event-driven request context', () => {
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'evt-session',
         files: [
           {
-            id: 'sk1',
+            id: 'skill-abc',
             name: 'demo/SKILL.md',
-            session_id: 'evt-session',
-            entity_id: 'skill-abc',
+            storage_session_id: 'evt-session',
+            kind: 'skill',
+            version: 3,
           },
-          { id: 'usr1', name: 'data.csv', session_id: 'evt-session' },
+          {
+            id: 'usr1',
+            name: 'data.csv',
+            storage_session_id: 'evt-session',
+          },
         ],
         lastUpdated: Date.now(),
       } satisfies t.CodeSessionContext);
@@ -275,12 +326,18 @@ describe('ToolNode code execution session management', () => {
         session_id: 'evt-session',
         files: [
           {
-            session_id: 'evt-session',
-            id: 'sk1',
+            id: 'skill-abc',
             name: 'demo/SKILL.md',
-            entity_id: 'skill-abc',
+            storage_session_id: 'evt-session',
+            kind: 'skill',
+            version: 3,
           },
-          { session_id: 'evt-session', id: 'usr1', name: 'data.csv' },
+          {
+            id: 'usr1',
+            name: 'data.csv',
+            storage_session_id: 'evt-session',
+            kind: 'user',
+          },
         ],
       });
     });
@@ -333,7 +390,7 @@ describe('ToolNode code execution session management', () => {
         expect.objectContaining({
           id: 'f1',
           name: 'result.csv',
-          session_id: 'new-sess',
+          storage_session_id: 'new-sess',
         })
       );
     });
@@ -384,8 +441,8 @@ describe('ToolNode code execution session management', () => {
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'old-sess',
         files: [
-          { id: 'f1', name: 'data.csv', session_id: 'old-sess' },
-          { id: 'f2', name: 'chart.png', session_id: 'old-sess' },
+          { id: 'f1', name: 'data.csv', storage_session_id: 'old-sess' },
+          { id: 'f2', name: 'chart.png', storage_session_id: 'old-sess' },
         ],
         lastUpdated: Date.now(),
       } satisfies t.CodeSessionContext);
@@ -430,18 +487,18 @@ describe('ToolNode code execution session management', () => {
       expect(stored.files).toHaveLength(2);
 
       const csvFile = stored.files!.find((f) => f.name === 'data.csv');
-      expect(csvFile!.session_id).toBe('old-sess');
+      expect(csvFile!.storage_session_id).toBe('old-sess');
 
       const chartFile = stored.files!.find((f) => f.name === 'chart.png');
       expect(chartFile!.id).toBe('f3');
-      expect(chartFile!.session_id).toBe('new-sess');
+      expect(chartFile!.storage_session_id).toBe('new-sess');
     });
 
     it('preserves existing files when new execution has no files', () => {
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'old-sess',
-        files: [{ id: 'f1', name: 'data.csv', session_id: 'old-sess' }],
+        files: [{ id: 'f1', name: 'data.csv', storage_session_id: 'old-sess' }],
         lastUpdated: Date.now(),
       } satisfies t.CodeSessionContext);
 
@@ -507,7 +564,7 @@ describe('ToolNode code execution session management', () => {
           {
             toolCallId: 'tc5',
             content: 'search results',
-            artifact: { session_id: 'should-not-store' },
+            artifact: { storage_session_id: 'should-not-store' },
             status: 'success',
           },
         ],
@@ -597,9 +654,13 @@ describe('ToolNode code execution session management', () => {
                 {
                   id: 'f1',
                   name: 'sentinel.txt',
-                  session_id: 'storage-session-A',
+                  storage_session_id: 'storage-session-A',
                 },
-                { id: 'f2', name: 'data.csv', session_id: 'storage-session-B' },
+                {
+                  id: 'f2',
+                  name: 'data.csv',
+                  storage_session_id: 'storage-session-B',
+                },
               ],
             },
             status: 'success',
@@ -617,18 +678,20 @@ describe('ToolNode code execution session management', () => {
         Constants.EXECUTE_CODE
       ) as t.CodeSessionContext;
       /* The session-level id is the (latest) exec id — fine for tracking
-         "what session ran last" — but per-file storage ids must survive. */
+         "what session ran last" — but per-file storage ids must survive.
+         After the rename, both names appear at the top level (exec) and
+         on each file (storage). */
       expect(stored.session_id).toBe('exec-session-123');
       expect(stored.files).toHaveLength(2);
       expect(stored.files![0]).toEqual({
         id: 'f1',
         name: 'sentinel.txt',
-        session_id: 'storage-session-A',
+        storage_session_id: 'storage-session-A',
       });
       expect(stored.files![1]).toEqual({
         id: 'f2',
         name: 'data.csv',
-        session_id: 'storage-session-B',
+        storage_session_id: 'storage-session-B',
       });
     });
 
@@ -658,7 +721,11 @@ describe('ToolNode code execution session management', () => {
               session_id: 'exec-mixed',
               files: [
                 /* Mix: one file with storage id, one without (older payload). */
-                { id: 'f1', name: 'fresh.csv', session_id: 'storage-fresh' },
+                {
+                  id: 'f1',
+                  name: 'fresh.csv',
+                  storage_session_id: 'storage-fresh',
+                },
                 { id: 'f2', name: 'legacy.csv' },
               ],
             },
@@ -676,9 +743,10 @@ describe('ToolNode code execution session management', () => {
       const stored = sessions.get(
         Constants.EXECUTE_CODE
       ) as t.CodeSessionContext;
-      expect(stored.files![0].session_id).toBe('storage-fresh');
-      /* Fallback only when the per-file id is missing. */
-      expect(stored.files![1].session_id).toBe('exec-mixed');
+      expect(stored.files![0].storage_session_id).toBe('storage-fresh');
+      /* Fallback only when the per-file id is missing — the fallback
+       * value is the exec session id. */
+      expect(stored.files![1].storage_session_id).toBe('exec-mixed');
     });
   });
 
@@ -728,7 +796,13 @@ describe('ToolNode code execution session management', () => {
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {
         session_id: 'rf-session',
-        files: [{ id: 'rf1', name: 'data.csv', session_id: 'rf-session' }],
+        files: [
+          {
+            id: 'rf1',
+            name: 'data.csv',
+            storage_session_id: 'rf-session',
+          },
+        ],
         lastUpdated: Date.now(),
       } satisfies t.CodeSessionContext);
 
@@ -758,7 +832,14 @@ describe('ToolNode code execution session management', () => {
       expect(capturedRequests[0].name).toBe(Constants.READ_FILE);
       expect(capturedRequests[0].codeSessionContext).toEqual({
         session_id: 'rf-session',
-        files: [{ session_id: 'rf-session', id: 'rf1', name: 'data.csv' }],
+        files: [
+          {
+            id: 'rf1',
+            name: 'data.csv',
+            storage_session_id: 'rf-session',
+            kind: 'user',
+          },
+        ],
       });
     });
 

--- a/src/tools/local/LocalExecutionTools.ts
+++ b/src/tools/local/LocalExecutionTools.ts
@@ -115,7 +115,7 @@ export function createLocalCodeExecutionTool(
         {
           session_id: getLocalSessionId(config),
           files: [],
-        },
+        } satisfies t.CodeExecutionArtifact,
       ];
     },
     {
@@ -151,7 +151,7 @@ export function createLocalBashExecutionTool(options?: {
         {
           session_id: getLocalSessionId(config),
           files: [],
-        },
+        } satisfies t.CodeExecutionArtifact,
       ];
     },
     {

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -79,7 +79,9 @@ type LocalProgrammaticParams = {
 
 type ToolFilter = (toolDefs: t.LCTool[], code: string) => t.LCTool[];
 
-function resolveRuntime(params: LocalProgrammaticParams): LocalProgrammaticRuntime {
+function resolveRuntime(
+  params: LocalProgrammaticParams
+): LocalProgrammaticRuntime {
   const rawRuntime = params.lang ?? params.runtime ?? params.language ?? 'bash';
   return rawRuntime === 'py' || rawRuntime === 'python' ? 'python' : 'bash';
 }
@@ -494,13 +496,17 @@ async function runLocalProgrammaticTool(args: {
   localConfig: t.LocalExecutionConfig;
   runtime: LocalProgrammaticRuntime;
 }): Promise<[string, t.ProgrammaticExecutionArtifact]> {
-  const { toolMap, toolDefs, hookContext } = getProgrammaticContext(args.config);
+  const { toolMap, toolDefs, hookContext } = getProgrammaticContext(
+    args.config
+  );
 
   if (toolMap == null || toolMap.size === 0) {
     throw new Error('No toolMap provided for local programmatic execution.');
   }
   if (toolDefs == null || toolDefs.length === 0) {
-    throw new Error('No tool definitions provided for local programmatic execution.');
+    throw new Error(
+      'No tool definitions provided for local programmatic execution.'
+    );
   }
 
   const { effectiveTools, effectiveMap } = createEffectiveToolMap(
@@ -512,17 +518,28 @@ async function runLocalProgrammaticTool(args: {
   const bridge = await createToolBridge(effectiveMap, hookContext);
 
   try {
-    const timeoutMs = args.params.timeout ?? args.localConfig.timeoutMs ?? DEFAULT_TIMEOUT;
+    const timeoutMs =
+      args.params.timeout ?? args.localConfig.timeoutMs ?? DEFAULT_TIMEOUT;
     const result =
       args.runtime === 'bash'
         ? await executeLocalBash(
-          createBashProgram(args.params.code, effectiveTools, bridge.url, bridge.token),
+          createBashProgram(
+            args.params.code,
+            effectiveTools,
+            bridge.url,
+            bridge.token
+          ),
           { ...args.localConfig, timeoutMs }
         )
         : await executeLocalCode(
           {
             lang: 'py',
-            code: createPythonProgram(args.params.code, effectiveTools, bridge.url, bridge.token),
+            code: createPythonProgram(
+              args.params.code,
+              effectiveTools,
+              bridge.url,
+              bridge.token
+            ),
           },
           { ...args.localConfig, timeoutMs }
         );

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -203,6 +203,12 @@ export type CodeExecutionToolParams =
     };
 
 export type FileRef = {
+  /**
+   * Resource identity. Semantics depend on `kind` (when present):
+   *  - `skill` / `agent`: shared resource id (sessionKey-meaningful).
+   *  - `user`: informational only — codeapi derives sessionKey from
+   *    the auth-context user. Do not rely on it for routing.
+   */
   id: string;
   name: string;
   path?: string;
@@ -213,7 +219,8 @@ export type FileRef = {
   storage_session_id?: string;
   /** Resource kind — see `CodeEnvFile.kind`. */
   kind?: CodeEnvKind;
-  /** Resource version — see `CodeEnvFile.version`. */
+  /** Resource version — see `CodeEnvFile.version`. Only meaningful when
+   *  `kind === 'skill'`. */
   version?: number;
   /**
    * `true` when the codeapi sandbox echoed this entry as an unchanged

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -138,24 +138,65 @@ export type ToolEndEvent = {
   type?: 'tool_call';
 };
 
-export type CodeEnvFile = {
+/**
+ * Closed set of resource kinds for sandbox file caching. Defined as a
+ * `as const` tuple so the runtime list and the TypeScript union can't
+ * drift on future additions — adding a new kind to the tuple updates
+ * both at once.
+ *
+ * - `skill`: shared per skill identity. Cross-user-within-tenant
+ *   sharing. Codeapi sessionKey omits the user dimension. `version`
+ *   is required (skill's monotonic counter scopes cache per revision).
+ * - `agent`: shared per agent identity. Same sharing semantic as
+ *   skills.
+ * - `user`: user-private. Codeapi sessionKey is keyed by the
+ *   requesting user from auth context. Used for chat attachments
+ *   and code-output files.
+ */
+export const CODE_ENV_KINDS = ['skill', 'agent', 'user'] as const;
+export type CodeEnvKind = (typeof CODE_ENV_KINDS)[number];
+
+type CodeEnvFileBase = {
+  /**
+   * Resource identity. Semantics depend on `kind`:
+   *  - `skill`: skill `_id` (sessionKey-meaningful, cross-user shared).
+   *  - `agent`: agent id (sessionKey-meaningful, cross-user shared).
+   *  - `user`: informational only — codeapi derives sessionKey from
+   *    the auth-context user. Kept on the type for shape uniformity;
+   *    do not rely on it for routing.
+   */
   id: string;
   name: string;
-  session_id: string;
   /**
-   * Identifier of the entity that owns this file's session (skill id,
-   * agent id, etc). Forwarded to codeapi so it can resolve the
-   * per-file sessionKey instead of falling back to a single
-   * request-level entity. Required when a single execute request
-   * references files uploaded under different entities (e.g. a skill
-   * file plus a user attachment in the same call).
+   * Storage session — the long-lived bucket where this file's bytes
+   * live in object storage. Distinct from the (transient) execution
+   * session id that appears at the top level of an execute response;
+   * the two used to share the field name `session_id` and the
+   * conflation caused real bugs. See codeapi #1455 / agents #148.
    */
-  entity_id?: string;
+  storage_session_id: string;
 };
+
+/**
+ * `CodeEnvFile` is a discriminated union on `kind`. `version` is
+ * statically required for `kind: 'skill'` and statically forbidden
+ * for `agent` / `user` — the constraint holds at compile time on
+ * every consumer, not just on codeapi's runtime validator.
+ *
+ * Codeapi switches on `kind` to derive the sessionKey for cache
+ * scoping (`<tenant>:<kind>:<id>[:v:<version>]`). Cross-user sharing
+ * for `kind: 'skill'` / `'agent'` is a designed property of the
+ * kind switch.
+ */
+export type CodeEnvFile =
+  | (CodeEnvFileBase & { kind: 'skill'; version: number })
+  | (CodeEnvFileBase & { kind: 'agent' })
+  | (CodeEnvFileBase & { kind: 'user' });
 
 export type CodeExecutionToolParams =
   | undefined
   | {
+      /** Execution session — see `CodeSessionContext.session_id`. */
       session_id?: string;
       user_id?: string;
       files?: CodeEnvFile[];
@@ -165,15 +206,15 @@ export type FileRef = {
   id: string;
   name: string;
   path?: string;
-  /** Session ID this file belongs to (for multi-session file tracking) */
-  session_id?: string;
   /**
-   * Entity that owns this file's session (skill id, agent id, etc).
-   * Carried on tracked session files so it can flow through to
-   * `_injected_files` when a subsequent execute references a mix of
-   * files uploaded under different entities.
+   * Storage session this file lives in. See `CodeEnvFile.storage_session_id`
+   * for the full motivation.
    */
-  entity_id?: string;
+  storage_session_id?: string;
+  /** Resource kind — see `CodeEnvFile.kind`. */
+  kind?: CodeEnvKind;
+  /** Resource version — see `CodeEnvFile.version`. */
+  version?: number;
   /**
    * `true` when the codeapi sandbox echoed this entry as an unchanged
    * passthrough of an input the caller already owns (skill files,
@@ -188,6 +229,11 @@ export type FileRef = {
 export type FileRefs = FileRef[];
 
 export type ExecuteResult = {
+  /**
+   * Execution session id — the (transient) sandbox run that produced
+   * this output. Distinct from per-file `storage_session_id` on the
+   * files array.
+   */
   session_id: string;
   stdout: string;
   stderr: string;
@@ -254,6 +300,7 @@ export type ToolCallRequest = {
   turn?: number;
   /** Code execution session context for session continuity in event-driven mode */
   codeSessionContext?: {
+    /** Execution session — see `CodeSessionContext.session_id`. */
     session_id: string;
     files?: CodeEnvFile[];
   };
@@ -775,6 +822,7 @@ export type PTCToolResult = {
  */
 export type ProgrammaticExecutionResponse = {
   status: 'tool_call_required' | 'completed' | 'error' | unknown;
+  /** Execution session — see `CodeSessionContext.session_id`. */
   session_id?: string;
 
   /** Present when status='tool_call_required' */
@@ -794,6 +842,7 @@ export type ProgrammaticExecutionResponse = {
  * Artifact returned by the PTC tool
  */
 export type ProgrammaticExecutionArtifact = {
+  /** Execution session — see `CodeSessionContext.session_id`. */
   session_id?: string;
   files?: FileRefs;
 };
@@ -827,7 +876,12 @@ export type ProgrammaticToolCallingParams = {
  * Stored in Graph.sessions and injected into subsequent tool invocations.
  */
 export type CodeSessionContext = {
-  /** Session ID from the code execution environment */
+  /**
+   * Execution session id — the (transient) sandbox run id. Used by
+   * ToolNode to thread session continuity into the next code-execution
+   * tool call. Distinct from per-file `storage_session_id` carried on
+   * `files`.
+   */
   session_id: string;
   /** Files generated in this session (for context/tracking) */
   files?: FileRefs;
@@ -840,6 +894,7 @@ export type CodeSessionContext = {
  * Used to extract session context after tool completion.
  */
 export type CodeExecutionArtifact = {
+  /** Execution session — see `CodeSessionContext.session_id`. */
   session_id?: string;
   files?: FileRefs;
 };


### PR DESCRIPTION
## Summary

Type-system shape for the lockstep cutover of LibreChat ↔ codeapi sandbox file identity. Two distinct concepts had been sharing the field name `session_id`; this PR also adds the `kind` discriminator so codeapi's sessionKey derives from explicit resource type rather than emergent legacy behavior.

Companions: codeapi [#1455](https://github.com/ClickHouse/ai/pull/1455), LibreChat [#12960](https://github.com/danny-avila/LibreChat/pull/12960). Pre-release lockstep, no legacy aliases.

Bumps to **3.1.80-dev.0**.

## Final shape

```ts
export const CODE_ENV_KINDS = ['skill', 'agent', 'user'] as const;
export type CodeEnvKind = (typeof CODE_ENV_KINDS)[number];

export type CodeEnvFile =
  | (Base & { kind: 'skill'; version: number })
  | (Base & { kind: 'agent' })
  | (Base & { kind: 'user' });

type Base = {
  /** sessionKey-meaningful for `'skill'` / `'agent'`; informational
   *  only for `'user'` (codeapi resolves user from auth context). */
  id: string;
  name: string;
  /** Long-lived storage bucket, distinct from top-level execution session. */
  storage_session_id: string;
};
```

## What's in this PR

1. **Per-file `session_id` → `storage_session_id`** rename. Top-level `session_id` (transient sandbox-run id on `CodeSessionContext`, `ExecuteResult`, `ProgrammaticExecutionResponse`, etc.) keeps its name — only the misnamed side moves. Hard rename, no aliases.
2. **`kind` discriminator** added to `CodeEnvFile` (required) and `FileRef` (optional, since `/files` fallback may not carry it). Drives codeapi's per-resource sessionKey: `<tenant>:<kind>:<id>[:v:<version>]` for shared kinds, `<tenant>:user:<userId>` for user-private.
3. **Discriminated union** on `CodeEnvFile`: `version: number` is statically required for `kind: 'skill'` and statically forbidden for `'agent'` / `'user'`. Constraint holds at compile time on every consumer, not just at codeapi's runtime validator.
4. **`CODE_ENV_KINDS` const-tuple** — adding a new kind to the tuple updates both the runtime list and the TS union at once, so a partial update can't silently widen one side.
5. **Drops `entity_id`** from `CodeEnvFile`, `FileRef`, and ToolNode propagation. Drops `'system'` from the kind union (no emitter ever existed).
6. **`toInjectedFileRef` helper** in `ToolNode`: collapses the two near-identical `CodeEnvFile` constructors (the `runTool` injection path and the event-driven `getCodeSessionContext` path) onto one call site that does the discriminated-union narrowing in one place. Defaults missing-kind to `'user'`; a skill ref missing `version` falls back to `'user'` so an upstream contract bug surfaces as a degraded sessionKey rather than a runtime crash.
7. **JSDoc** on `id` calls out the per-kind asymmetry; on `version` documents the `'skill'`-only requirement.

## Sites updated

- `src/types/tools.ts` — `CodeEnvKind`, `CODE_ENV_KINDS`, discriminated `CodeEnvFile`, JSDoc on `FileRef`.
- `src/tools/ToolNode.ts` — `toInjectedFileRef` helper at `runTool` injection (`_injected_files`) and `getCodeSessionContext`. `updateCodeSession` and `storeCodeSessionFromResults` pass new fields through via spread.
- `CodeExecutor`, `BashExecutor`, `ProgrammaticToolCalling`, `BashProgrammaticToolCalling`, `LocalExecutionTools`, `LocalProgrammaticToolCalling` — per-file refs use `storage_session_id`; top-level `session_id` extraction unchanged.
- Tests: `ToolNode.session.test.ts` repurposed `entity_id`-forwarding cases as `kind` + `version` forwarding cases (the actual Phase C contract).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest src/tools src/types` — 787 / 787 pass (incl. 18 session-management tests with new per-file shape)
- [ ] Manual: bump LibreChat's `@librechat/agents` dep to `3.1.80-dev.0` after this lands and run a multi-turn execute against codeapi to confirm.

## Why no legacy aliases

The deployment matrix is controlled — codeapi service + LC's pinned `@librechat/agents` version + LC itself all ship together. A synchronized cutover is fine; alias plumbing for a deploy ordering that doesn't exist is just code to maintain and clean up.

## Why keep top-level `session_id`

Renaming both sides was symmetric but unnecessary. The bug was that per-file `session_id` was the wrong name (it really meant "storage"). Top-level `session_id` is the right name (it really means "session"). Disambiguating only the misnamed side gives ~half the churn at every call site, and a future engine that uses one session concept lands on `session_id` directly with no rename to undo.

