### PR TITLE
🛰️ fix: Handle Anthropic Web Search Persistence

### DIFF
--- a/src/llm/anthropic/llm.spec.ts
+++ b/src/llm/anthropic/llm.spec.ts
@@ -31,7 +31,13 @@ import type {
   MessageContentComplex,
 } from '@langchain/core/messages';
 import { toLangChainContent } from '@/messages/langchain';
+import { formatAgentMessages } from '@/messages/format';
+import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import { _documentsInParams, CustomAnthropic as ChatAnthropic } from './index';
+import { partitionAndMarkAnthropicToolCache } from '@/messages/anthropicToolCache';
+import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
+import { ModelEndHandler, ToolEndHandler } from '@/events';
+import { Run } from '@/run';
 import type { CustomAnthropicCallOptions } from './index';
 import type {
   AnthropicContextManagementConfigParam,
@@ -44,6 +50,20 @@ import type {
   AnthropicThinkingConfigParam,
   ChatAnthropicContentBlock,
 } from './types';
+import type {
+  AnthropicClientOptions,
+  IState,
+  MessageContentComplex as LibreChatContentBlock,
+  MessageDeltaEvent,
+  ReasoningDeltaEvent,
+  RunConfig,
+  RunStep,
+  RunStepDeltaEvent,
+  SharedLLMConfig,
+  StreamEventData,
+  ToolEndEvent,
+  TPayload,
+} from '@/types';
 import { _convertMessagesToAnthropicPayload } from './utils/message_inputs';
 import {
   _makeMessageChunkFromAnthropicEvent,
@@ -89,6 +109,8 @@ const remoteImageUrl =
 
 // Use this model for all other tests
 const modelName = 'claude-haiku-4-5-20251001';
+const webSearchModelName =
+  process.env.ANTHROPIC_WEB_SEARCH_MODEL ?? 'claude-opus-4-7';
 
 type AnthropicThinkingResponseBlock = Anthropic.Messages.ThinkingBlock & {
   index?: number;
@@ -120,6 +142,12 @@ type CitationContentBlock = ContentBlock & {
 type CompactionContentBlock = ContentBlock & {
   type: 'compaction';
   content: string;
+};
+
+type AnthropicContentBlockWithId = ContentBlock & {
+  id?: unknown;
+  input?: unknown;
+  name?: unknown;
 };
 
 function getLangChainErrorCode(error: unknown): string | undefined {
@@ -201,6 +229,184 @@ function isCompactionBlock(
 
   const { content } = block as { content?: unknown };
   return typeof content === 'string';
+}
+
+function isServerToolUseBlock(
+  block: ContentBlock
+): block is AnthropicContentBlockWithId {
+  return (
+    block.type === 'server_tool_use' &&
+    typeof (block as AnthropicContentBlockWithId).id === 'string' &&
+    ((block as AnthropicContentBlockWithId).id as string).startsWith(
+      Constants.ANTHROPIC_SERVER_TOOL_PREFIX
+    )
+  );
+}
+
+function expectAnthropicPayloadContentIsNonEmpty(
+  payload: AnthropicMessageCreateParams
+): void {
+  for (const message of payload.messages) {
+    if (typeof message.content === 'string') {
+      expect(message.content.trim().length).toBeGreaterThan(0);
+      continue;
+    }
+
+    expect(message.content.length).toBeGreaterThan(0);
+    for (const block of message.content) {
+      if (block.type !== 'text') {
+        continue;
+      }
+      expect(block.text.trim().length).toBeGreaterThan(0);
+    }
+  }
+}
+
+function expectNoDanglingServerToolUses(
+  payload: AnthropicMessageCreateParams
+): void {
+  for (const message of payload.messages) {
+    if (typeof message.content === 'string') {
+      continue;
+    }
+
+    const serverToolResultIds = new Set(
+      message.content
+        .map((block) =>
+          'tool_use_id' in block &&
+          typeof block.tool_use_id === 'string' &&
+          block.tool_use_id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+            ? block.tool_use_id
+            : undefined
+        )
+        .filter((id): id is string => id != null)
+    );
+
+    for (const block of message.content) {
+      if (block.type !== 'server_tool_use') {
+        continue;
+      }
+      expect(serverToolResultIds.has(block.id)).toBe(true);
+    }
+  }
+}
+
+function getPromptCachedWebSearchTools(): Parameters<
+  ChatAnthropic['bindTools']
+>[0] {
+  const tools = partitionAndMarkAnthropicToolCache(
+    [
+      {
+        type: 'web_search_20250305',
+        name: 'web_search',
+        max_uses: 3,
+      },
+    ] as never,
+    () => false
+  );
+  return tools as Parameters<ChatAnthropic['bindTools']>[0];
+}
+
+function getWebSearchTool(): {
+  type: 'web_search_20250305';
+  name: 'web_search';
+  max_uses: number;
+} {
+  return {
+    type: 'web_search_20250305',
+    name: 'web_search',
+    max_uses: 3,
+  };
+}
+
+function getWebSearchLLMConfig(): AnthropicClientOptions & SharedLLMConfig {
+  return {
+    provider: Providers.ANTHROPIC,
+    model: webSearchModelName,
+    maxTokens: 1024,
+    promptCache: true,
+    streaming: true,
+    streamUsage: true,
+    thinking: { type: 'adaptive' },
+  } as AnthropicClientOptions & SharedLLMConfig;
+}
+
+async function createWebSearchRun({
+  runId,
+  customHandlers,
+}: {
+  runId: string;
+  customHandlers?: RunConfig['customHandlers'];
+}): Promise<Run<IState>> {
+  return await Run.create<IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: getWebSearchLLMConfig(),
+      tools: [getWebSearchTool()],
+      instructions:
+        'You are a concise assistant. Use web search when current facts are needed.',
+    },
+    returnContent: true,
+    skipCleanup: true,
+    customHandlers,
+  });
+}
+
+function createLibreChatContentHandlers(): {
+  aggregateContent: ReturnType<
+    typeof createContentAggregator
+  >['aggregateContent'];
+  contentParts: Array<LibreChatContentBlock | undefined>;
+  customHandlers: NonNullable<RunConfig['customHandlers']>;
+} {
+  const { contentParts, aggregateContent } = createContentAggregator();
+  const customHandlers = {
+    [GraphEvents.TOOL_END]: new ToolEndHandler(),
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP_COMPLETED,
+        data: StreamEventData
+      ): void => {
+        aggregateContent({
+          event,
+          data: data as unknown as { result: ToolEndEvent },
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event: GraphEvents.ON_RUN_STEP, data: StreamEventData): void => {
+        aggregateContent({ event, data: data as RunStep });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP_DELTA,
+        data: StreamEventData
+      ): void => {
+        aggregateContent({ event, data: data as RunStepDeltaEvent });
+      },
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_MESSAGE_DELTA,
+        data: StreamEventData
+      ): void => {
+        aggregateContent({ event, data: data as MessageDeltaEvent });
+      },
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: StreamEventData
+      ): void => {
+        aggregateContent({ event, data: data as ReasoningDeltaEvent });
+      },
+    },
+  };
+  return { aggregateContent, contentParts, customHandlers };
 }
 
 test('Test ChatAnthropic', async () => {
@@ -1448,6 +1654,101 @@ test('human message caching', async () => {
   expect(agg!.usage_metadata?.input_tokens).toBeGreaterThan(
     agg!.usage_metadata?.input_token_details?.cache_read ?? 0
   );
+});
+
+describe('Anthropic web search live regressions', () => {
+  test('accepts prompt-cache markers on built-in web search tools', async () => {
+    const model = new ChatAnthropic({
+      model: webSearchModelName,
+      maxTokens: 1024,
+      thinking: { type: 'adaptive' },
+    });
+    const tools = getPromptCachedWebSearchTools();
+    const formattedTools = model.formatStructuredToolToAnthropic(tools);
+
+    expect(formattedTools?.[0]).toMatchObject({
+      type: 'web_search_20250305',
+      name: 'web_search',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(formattedTools?.[0]).not.toHaveProperty('extras');
+
+    const response = await model
+      .bindTools(tools)
+      .invoke([
+        new HumanMessage(
+          'Use web search once and answer with only the word: ok'
+        ),
+      ]);
+
+    expect(response.content.length).toBeGreaterThan(0);
+  });
+
+  test('replays LibreChat-persisted web search content across runs', async () => {
+    const threadId = `web-search-e2e-${Date.now()}`;
+    const firstPrompt =
+      'Use web search. Who is the lowest seed survived in 2026 NBA playoffs? Answer with only the team name.';
+    const followUpPrompt = "Who are 76ers' opponents in current series?";
+    const { contentParts: firstContentParts, customHandlers: firstHandlers } =
+      createLibreChatContentHandlers();
+    const firstRun = await createWebSearchRun({
+      runId: `${threadId}-turn-1`,
+      customHandlers: firstHandlers,
+    });
+    const runConfig = {
+      configurable: { provider: Providers.ANTHROPIC, thread_id: threadId },
+      streamMode: 'values',
+      version: 'v2' as const,
+    };
+
+    const firstRunContent = await firstRun.processStream(
+      { messages: [new HumanMessage(firstPrompt)] },
+      runConfig
+    );
+    const persistedAssistantContent = firstContentParts.filter(
+      (part): part is LibreChatContentBlock => part != null
+    );
+    const hasPersistedServerToolCall = persistedAssistantContent.some(
+      (part) =>
+        part.type === ContentTypes.TOOL_CALL &&
+        typeof part.tool_call?.id === 'string' &&
+        part.tool_call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+    );
+    const hasPersistedAnswerText = persistedAssistantContent.some(
+      (part) =>
+        part.type === ContentTypes.TEXT &&
+        typeof part.text === 'string' &&
+        part.text.trim().length > 0
+    );
+
+    expect(firstRunContent).toBeDefined();
+    expect(persistedAssistantContent.length).toBeGreaterThan(0);
+    expect(hasPersistedServerToolCall).toBe(true);
+    expect(hasPersistedAnswerText).toBe(true);
+
+    const persistedPayload: TPayload = [
+      { role: 'user', content: firstPrompt },
+      { role: 'assistant', content: persistedAssistantContent },
+      { role: 'user', content: followUpPrompt },
+    ];
+    const { messages } = formatAgentMessages(
+      persistedPayload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const secondRun = await createWebSearchRun({
+      runId: `${threadId}-turn-2`,
+    });
+
+    expectAnthropicPayloadContentIsNonEmpty(anthropicPayload);
+    expectNoDanglingServerToolUses(anthropicPayload);
+    await expect(
+      secondRun.processStream({ messages }, runConfig)
+    ).resolves.toBeDefined();
+  });
 });
 
 test('Can accept PDF documents', async () => {

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -47,6 +47,8 @@ type GoogleFunctionCallBlock = MessageContentComplex & {
   };
 };
 
+const ANTHROPIC_EMPTY_TEXT_PLACEHOLDER = '_';
+
 function _formatImage(imageUrl: string) {
   const parsed = parseBase64DataUrl({ dataUrl: imageUrl });
   if (parsed) {
@@ -126,13 +128,15 @@ function _ensureMessageContents(
           );
         }
       } else {
+        const toolMessageContent = (
+          message as { content?: BaseMessage['content'] | null }
+        ).content;
         updatedMsgs.push(
           new HumanMessage({
             content: [
               {
                 type: 'tool_result',
-                // rare case: message.content could be undefined
-                ...(message.content != null
+                ...(toolMessageContent != null
                   ? { content: _formatContent(message) }
                   : {}),
                 tool_use_id: (message as ToolMessage).tool_call_id,
@@ -486,7 +490,7 @@ function _formatContent(message: BaseMessage) {
         return {
           type: 'image' as const, // Explicitly setting the type as "image"
           source,
-          ...(cacheControl ? { cache_control: cacheControl } : {}),
+          ...(cacheControl != null ? { cache_control: cacheControl } : {}),
         };
       } else if (isAnthropicImageBlockParam(contentPart)) {
         return contentPart;
@@ -494,7 +498,7 @@ function _formatContent(message: BaseMessage) {
         // PDF
         return {
           ...contentPart,
-          ...(cacheControl ? { cache_control: cacheControl } : {}),
+          ...(cacheControl != null ? { cache_control: cacheControl } : {}),
         };
       } else if (contentPart.type === 'thinking') {
         const thinkingPart = contentPart as AnthropicThinkingBlockParam;
@@ -502,7 +506,7 @@ function _formatContent(message: BaseMessage) {
           type: 'thinking' as const, // Explicitly setting the type as "thinking"
           thinking: thinkingPart.thinking,
           signature: thinkingPart.signature,
-          ...(cacheControl ? { cache_control: cacheControl } : {}),
+          ...(cacheControl != null ? { cache_control: cacheControl } : {}),
         };
         return block;
       } else if (contentPart.type === 'redacted_thinking') {
@@ -510,7 +514,7 @@ function _formatContent(message: BaseMessage) {
         const block: AnthropicRedactedThinkingBlockParam = {
           type: 'redacted_thinking' as const, // Explicitly setting the type as "redacted_thinking"
           data: redactedPart.data,
-          ...(cacheControl ? { cache_control: cacheControl } : {}),
+          ...(cacheControl != null ? { cache_control: cacheControl } : {}),
         };
         return block;
       } else if (contentPart.type === 'search_result') {
@@ -519,10 +523,11 @@ function _formatContent(message: BaseMessage) {
           type: 'search_result' as const,
           title: searchResultPart.title,
           source: searchResultPart.source,
-          ...('cache_control' in contentPart && contentPart.cache_control
+          ...('cache_control' in contentPart &&
+          contentPart.cache_control != null
             ? { cache_control: contentPart.cache_control }
             : {}),
-          ...('citations' in contentPart && contentPart.citations
+          ...('citations' in contentPart && contentPart.citations != null
             ? { citations: contentPart.citations }
             : {}),
           content: searchResultPart.content,
@@ -533,23 +538,23 @@ function _formatContent(message: BaseMessage) {
         const block: AnthropicCompactionBlockParam = {
           type: 'compaction' as const,
           content: compactionPart.content,
-          ...(cacheControl ? { cache_control: cacheControl } : {}),
+          ...(cacheControl != null ? { cache_control: cacheControl } : {}),
         };
         return block;
       } else if (
-        textTypes.find((t) => t === contentPart.type) &&
+        textTypes.some((t) => t === contentPart.type) &&
         'text' in contentPart
       ) {
         // Assuming contentPart is of type MessageContentText here
         return {
           type: 'text' as const, // Explicitly setting the type as "text"
           text: contentPart.text,
-          ...(cacheControl ? { cache_control: cacheControl } : {}),
-          ...('citations' in contentPart && contentPart.citations
+          ...(cacheControl != null ? { cache_control: cacheControl } : {}),
+          ...('citations' in contentPart && contentPart.citations != null
             ? { citations: contentPart.citations }
             : {}),
         };
-      } else if (toolTypes.find((t) => t === contentPart.type)) {
+      } else if (toolTypes.some((t) => t === contentPart.type)) {
         const contentPartCopy = { ...contentPart };
         if ('index' in contentPartCopy) {
           // Anthropic does not support passing the index field here, so we remove it.
@@ -593,12 +598,12 @@ function _formatContent(message: BaseMessage) {
         // TODO: Fix when SDK types are fixed
         return {
           ...contentPartCopy,
-          ...(cacheControl ? { cache_control: cacheControl } : {}),
+          ...(cacheControl != null ? { cache_control: cacheControl } : {}),
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any;
       } else if (
         'functionCall' in contentPart &&
-        contentPart.functionCall &&
+        contentPart.functionCall != null &&
         typeof contentPart.functionCall === 'object' &&
         isAIMessage(message)
       ) {
@@ -626,7 +631,7 @@ function _formatContent(message: BaseMessage) {
         throw new Error('Unsupported message content format');
       }
     });
-    return contentBlocks.filter(
+    const filteredContentBlocks = contentBlocks.filter(
       (block) =>
         block !== null &&
         !(
@@ -636,6 +641,9 @@ function _formatContent(message: BaseMessage) {
           block.text.trim() === ''
         )
     );
+    return filteredContentBlocks.length > 0
+      ? filteredContentBlocks
+      : [{ type: 'text' as const, text: ANTHROPIC_EMPTY_TEXT_PLACEHOLDER }];
   }
 }
 
@@ -670,9 +678,11 @@ export function _convertMessagesToAnthropicPayload(
     } else {
       throw new Error(`Message type "${message._getType()}" is not supported.`);
     }
-    if (isAIMessage(message) && !!message.tool_calls?.length) {
+    const isAI = isAIMessage(message);
+    const toolCalls = isAI ? (message.tool_calls ?? []) : [];
+    if (isAI && toolCalls.length > 0) {
       if (typeof message.content === 'string') {
-        const clientToolCalls = message.tool_calls.filter(
+        const clientToolCalls = toolCalls.filter(
           (tc) =>
             !(
               tc.id?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) ?? false
@@ -684,7 +694,12 @@ export function _convertMessagesToAnthropicPayload(
             content:
               clientToolCalls.length > 0
                 ? clientToolCalls.map(_convertLangChainToolCallToAnthropic)
-                : [{ type: 'text' as const, text: ' ' }],
+                : [
+                  {
+                    type: 'text' as const,
+                    text: ANTHROPIC_EMPTY_TEXT_PLACEHOLDER,
+                  },
+                ],
           };
         } else {
           return {
@@ -697,7 +712,7 @@ export function _convertMessagesToAnthropicPayload(
         }
       } else {
         const { content } = message;
-        const hasMismatchedToolCalls = !message.tool_calls.every(
+        const hasMismatchedToolCalls = !toolCalls.every(
           (toolCall) =>
             !!content.find(
               (contentPart) =>
@@ -731,7 +746,7 @@ export function _convertMessagesToAnthropicPayload(
 }
 
 function mergeMessages(messages: AnthropicMessageCreateParams['messages']) {
-  if (!messages || messages.length <= 1) {
+  if (messages.length <= 1) {
     return messages;
   }
 

--- a/src/llm/anthropic/utils/server-tool-inputs.test.ts
+++ b/src/llm/anthropic/utils/server-tool-inputs.test.ts
@@ -3,6 +3,14 @@ import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import { _convertMessagesToAnthropicPayload } from './message_inputs';
 
+type AnthropicTestBlock = {
+  id?: unknown;
+  type?: unknown;
+};
+
+const isServerToolId = (id: unknown): id is string =>
+  typeof id === 'string' && id.startsWith('srvtoolu_');
+
 describe('_convertMessagesToAnthropicPayload — server tool use (web search) multi-turn', () => {
   it('corrects tool_use blocks with srvtoolu_ IDs to server_tool_use', () => {
     const messageHistory: BaseMessage[] = [
@@ -78,9 +86,10 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     const searchResultBlocks = assistantContent.filter(
       (b: any) => b.type === 'web_search_tool_result'
     );
-    const regularToolUseBlocks = assistantContent.filter(
-      (b: any) => b.type === 'tool_use' && b.id?.startsWith('srvtoolu_')
-    );
+    const regularToolUseBlocks = assistantContent.filter((block: unknown) => {
+      const b = block as AnthropicTestBlock;
+      return b.type === 'tool_use' && isServerToolId(b.id);
+    });
 
     expect(serverToolBlocks).toHaveLength(2);
     expect(searchResultBlocks).toHaveLength(2);
@@ -190,9 +199,10 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     expect(toolUseBlocks).toHaveLength(1);
     expect(toolUseBlocks[0].id).toBe('toolu_regular');
 
-    const serverToolBlocks = assistantContent.filter((b: any) =>
-      b.id?.startsWith('srvtoolu_')
-    );
+    const serverToolBlocks = assistantContent.filter((block: unknown) => {
+      const b = block as AnthropicTestBlock;
+      return isServerToolId(b.id);
+    });
     expect(serverToolBlocks).toHaveLength(0);
   });
 
@@ -217,7 +227,80 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     const assistantContent = messages[1].content as any[];
     expect(assistantContent).toHaveLength(1);
     expect(assistantContent[0].type).toBe('text');
-    expect(assistantContent[0].text).toBe(' ');
+    expect(assistantContent[0].text).toBe('_');
+    expect(assistantContent[0].text.trim()).toBe('_');
+  });
+
+  it('uses non-whitespace fallback content after filtering empty array text', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage({
+        content: [
+          { type: 'text', text: ' ' },
+          { type: 'text', text: '\n' },
+        ],
+      }),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    expect(messages[0].content).toEqual([{ type: 'text', text: '_' }]);
+  });
+
+  it('uses non-whitespace fallback content for empty server tool result artifacts', () => {
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('search for X'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'X' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: '',
+        tool_call_id: 'srvtoolu_1',
+      }),
+      new HumanMessage('follow up'),
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+
+    expect(messages[1].content).toEqual([{ type: 'text', text: '_' }]);
+    expect(messages[2].content).toEqual([{ type: 'text', text: '_' }]);
+  });
+
+  it('does not throw when a non-string ToolMessage has undefined content', () => {
+    const undefinedContentToolMessage = {
+      _getType: (): 'tool' => 'tool',
+      content: undefined,
+      tool_call_id: 'toolu_calc',
+    } as unknown as ToolMessage;
+    const messageHistory: BaseMessage[] = [
+      new HumanMessage('call the calculator'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'toolu_calc',
+            name: 'calculator',
+            args: { expr: '2+2' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      undefinedContentToolMessage,
+    ];
+
+    const { messages } = _convertMessagesToAnthropicPayload(messageHistory);
+    expect(messages[2].content).toEqual([
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_calc',
+      },
+    ]);
   });
 
   it('preserves regular tool_use blocks alongside corrected server tool blocks', () => {
@@ -283,9 +366,10 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
     const webSearchResult = assistantContent.filter(
       (b: any) => b.type === 'web_search_tool_result'
     );
-    const regularToolUse = assistantContent.filter(
-      (b: any) => b.type === 'tool_use' && !b.id?.startsWith('srvtoolu_')
-    );
+    const regularToolUse = assistantContent.filter((block: unknown) => {
+      const b = block as AnthropicTestBlock;
+      return b.type === 'tool_use' && !isServerToolId(b.id);
+    });
 
     expect(serverToolUse).toHaveLength(1);
     expect(serverToolUse[0].id).toBe('srvtoolu_1');
@@ -416,9 +500,7 @@ describe('_convertMessagesToAnthropicPayload — server tool use (web search) mu
       );
       expect(whitespaceTextBlocks).toHaveLength(0);
 
-      const textBlocks = assistantContent.filter(
-        (b: any) => b.type === 'text'
-      );
+      const textBlocks = assistantContent.filter((b: any) => b.type === 'text');
       expect(textBlocks).toHaveLength(1);
       expect(textBlocks[0].text).toBe('Here are the results.');
     }

--- a/src/messages/__tests__/anthropicToolCache.test.ts
+++ b/src/messages/__tests__/anthropicToolCache.test.ts
@@ -5,6 +5,7 @@ import {
   makeIsDeferred,
   partitionAndMarkAnthropicToolCache,
 } from '../anthropicToolCache';
+import { CustomAnthropic } from '@/llm/anthropic';
 
 function fakeTool(name: string): unknown {
   return tool(async () => 'ok', {
@@ -84,6 +85,51 @@ describe('partitionAndMarkAnthropicToolCache', () => {
     ) as Array<{ extras?: Record<string, unknown> }>;
     expect(out[0].extras?.providerToolDefinition).toEqual({ foo: 'bar' });
     expect(out[0].extras?.cache_control).toEqual({ type: 'ephemeral' });
+  });
+
+  it('stamps Anthropic built-in tools with direct cache_control', () => {
+    const webSearch = {
+      type: 'web_search_20250305',
+      name: 'web_search',
+      max_uses: 3,
+    };
+    const out = partitionAndMarkAnthropicToolCache(
+      [webSearch] as never,
+      () => false
+    ) as Array<{
+      cache_control?: { type: string };
+      extras?: { cache_control?: { type: string } };
+    }>;
+
+    expect(out[0]).not.toBe(webSearch);
+    expect(out[0].cache_control).toEqual({ type: 'ephemeral' });
+    expect(out[0].extras).toBeUndefined();
+  });
+
+  it('does not serialize extras on Anthropic built-in tools', () => {
+    const model = new CustomAnthropic({
+      model: 'claude-haiku-4-5',
+      apiKey: 'testing',
+    });
+    const webSearch = {
+      type: 'web_search_20250305',
+      name: 'web_search',
+      max_uses: 3,
+    };
+    const tools = partitionAndMarkAnthropicToolCache(
+      [webSearch] as never,
+      () => false
+    );
+    const formattedTools = model.formatStructuredToolToAnthropic(tools);
+    const formatted = formattedTools?.[0];
+
+    expect(formatted).toEqual({
+      type: 'web_search_20250305',
+      name: 'web_search',
+      max_uses: 3,
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(formatted).not.toHaveProperty('extras');
   });
 
   it('is idempotent when re-marking a tool that already has the marker', () => {

--- a/src/messages/anthropicToolCache.ts
+++ b/src/messages/anthropicToolCache.ts
@@ -19,13 +19,73 @@
  * the breakpoint.
  *
  * LangChain's Anthropic adapter passes the marker through via
- * `tool.extras.cache_control` (`AnthropicToolExtrasSchema`), so we set
- * it as an `extras` field on a fresh wrapper around the tool — never
- * mutating the original tool instance, since callers may share them
+ * `tool.extras.cache_control` for custom tools, while Anthropic built-ins
+ * require direct `cache_control`. Either way, we stamp a fresh wrapper —
+ * never mutating the original tool instance, since callers may share them
  * across runs.
  */
 
 import type { GraphTools } from '@/types';
+
+const ANTHROPIC_BUILT_IN_TOOL_PREFIXES = [
+  'text_editor_',
+  'computer_',
+  'bash_',
+  'web_search_',
+  'web_fetch_',
+  'str_replace_editor_',
+  'str_replace_based_edit_tool_',
+  'code_execution_',
+  'memory_',
+  'tool_search_',
+  'mcp_toolset',
+] as const;
+
+const CACHE_CONTROL = { type: 'ephemeral' as const };
+
+type AnthropicToolCacheCandidate = {
+  name?: unknown;
+  type?: unknown;
+  extras?: Record<string, unknown>;
+  cache_control?: unknown;
+};
+
+function isAnthropicBuiltInTool(
+  tool: AnthropicToolCacheCandidate
+): tool is AnthropicToolCacheCandidate & { type: string } {
+  const { type } = tool;
+  return (
+    typeof type === 'string' &&
+    ANTHROPIC_BUILT_IN_TOOL_PREFIXES.some((prefix) => type.startsWith(prefix))
+  );
+}
+
+function hasCacheControl(tool: AnthropicToolCacheCandidate): boolean {
+  if (isAnthropicBuiltInTool(tool)) {
+    return tool.cache_control != null;
+  }
+  return tool.extras?.cache_control != null;
+}
+
+function markCacheControl(
+  tool: AnthropicToolCacheCandidate
+): AnthropicToolCacheCandidate {
+  const prototype = Object.getPrototypeOf(tool) ?? Object.prototype;
+  if (isAnthropicBuiltInTool(tool)) {
+    const wrapped = { ...tool };
+    delete wrapped.extras;
+    return Object.assign(Object.create(prototype), wrapped, {
+      cache_control: CACHE_CONTROL,
+    });
+  }
+
+  return Object.assign(Object.create(prototype), tool, {
+    extras: {
+      ...(tool.extras ?? {}),
+      cache_control: CACHE_CONTROL,
+    },
+  });
+}
 
 /**
  * Returns a callable that reports whether a given tool *name* is deferred
@@ -59,8 +119,8 @@ export function makeIsDeferred(
  *
  * The original tool instances are never mutated. The marked entry is a
  * shallow wrapper that preserves the prototype chain so downstream
- * `instanceof` checks still pass. `extras` is merged so any existing
- * `providerToolDefinition` / other extras the host attached are kept.
+ * `instanceof` checks still pass. For custom tools, `extras` is merged
+ * so any existing `providerToolDefinition` / other extras are kept.
  */
 export function partitionAndMarkAnthropicToolCache(
   tools: GraphTools | undefined,
@@ -87,30 +147,15 @@ export function partitionAndMarkAnthropicToolCache(
     return tools;
   }
 
-  const last = staticTools[staticTools.length - 1] as {
-    extras?: Record<string, unknown>;
-  };
+  const last = staticTools[
+    staticTools.length - 1
+  ] as AnthropicToolCacheCandidate;
   // Already marked? Don't double-clone.
-  if (
-    last.extras != null &&
-    'cache_control' in last.extras &&
-    (last.extras as { cache_control?: unknown }).cache_control != null
-  ) {
+  if (hasCacheControl(last)) {
     if (deferredTools.length === 0) return tools;
     return [...staticTools, ...deferredTools] as GraphTools;
   }
 
-  const wrapped = Object.assign(
-    Object.create(Object.getPrototypeOf(last) ?? Object.prototype),
-    last,
-    {
-      extras: {
-        ...((last.extras as Record<string, unknown> | undefined) ?? {}),
-        cache_control: { type: 'ephemeral' as const },
-      },
-    }
-  );
-
-  staticTools[staticTools.length - 1] = wrapped;
+  staticTools[staticTools.length - 1] = markCacheControl(last);
   return [...staticTools, ...deferredTools] as GraphTools;
 }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -285,6 +285,7 @@ export const formatFromLangChain = (
 
 interface FormatAssistantMessageOptions {
   preserveReasoningContent?: boolean;
+  provider?: Providers;
 }
 
 interface FormatAgentMessagesOptions {
@@ -316,6 +317,60 @@ function extractReasoningContent(
   return '';
 }
 
+type ServerToolInput = Exclude<NonNullable<ToolCallPart['args']>, string>;
+
+function parseServerToolInput(args: ToolCallPart['args']): ServerToolInput {
+  if (typeof args === 'string') {
+    try {
+      const parsed = JSON.parse(args) as unknown;
+      return parsed != null &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed)
+        ? (parsed as ServerToolInput)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+  return args != null && typeof args === 'object' ? args : {};
+}
+
+function getTextContent(part: MessageContentComplex): string {
+  const { text } = part as { text?: unknown };
+  return typeof text === 'string' ? text : '';
+}
+
+function hasMeaningfulAssistantContent(part: MessageContentComplex): boolean {
+  if (part.type === ContentTypes.TEXT) {
+    return getTextContent(part).trim().length > 0;
+  }
+  if (
+    part.type === ContentTypes.TOOL_CALL ||
+    part.type === ContentTypes.ERROR ||
+    part.type === ContentTypes.AGENT_UPDATE ||
+    part.type === ContentTypes.SUMMARY
+  ) {
+    return false;
+  }
+  if (
+    part.type === ContentTypes.THINK ||
+    part.type === ContentTypes.THINKING ||
+    part.type === ContentTypes.REASONING ||
+    part.type === ContentTypes.REASONING_CONTENT ||
+    part.type === 'redacted_thinking'
+  ) {
+    return extractReasoningContent(part).trim().length > 0;
+  }
+  return part.type != null && part.type !== '';
+}
+
+function getToolUseId(part: MessageContentComplex): string | undefined {
+  if (!('tool_use_id' in part) || typeof part.tool_use_id !== 'string') {
+    return undefined;
+  }
+  return part.tool_use_id;
+}
+
 /**
  * Helper function to format an assistant message
  * @param message The message to format
@@ -331,6 +386,8 @@ function formatAssistantMessage(
   let lastAIMessage: AIMessage | null = null;
   let hasReasoning = false;
   let pendingReasoningContent = '';
+  const emittedServerToolUseIds = new Set<string>();
+  const pendingServerToolUses = new Map<string, MessageContentComplex>();
   const shouldPreserveReasoningContent =
     options?.preserveReasoningContent === true;
 
@@ -364,12 +421,31 @@ function formatAssistantMessage(
         : reasoningContent;
   };
 
+  const flushPendingServerToolUse = (toolUseId: string): void => {
+    for (const [id, content] of pendingServerToolUses) {
+      pendingServerToolUses.delete(id);
+      if (id === toolUseId) {
+        currentContent.push(content);
+        emittedServerToolUseIds.add(id);
+        return;
+      }
+    }
+  };
+
   if (Array.isArray(message.content)) {
-    for (const part of message.content as Array<
+    const contentParts = message.content as Array<
       MessageContentComplex | undefined | null
-    >) {
+    >;
+
+    for (const part of contentParts) {
       if (part == null) {
         continue;
+      }
+      const toolUseId = getToolUseId(part);
+      if (toolUseId != null) {
+        flushPendingServerToolUse(toolUseId);
+      } else if (hasMeaningfulAssistantContent(part)) {
+        pendingServerToolUses.clear();
       }
       if (part.type === ContentTypes.TEXT && part.tool_call_ids) {
         /*
@@ -379,19 +455,18 @@ function formatAssistantMessage(
         if (currentContent.length > 0) {
           let content = currentContent.reduce((acc, curr) => {
             if (curr.type === ContentTypes.TEXT) {
-              return `${acc}${String(curr[ContentTypes.TEXT] ?? '')}\n`;
+              return `${acc}${getTextContent(curr)}\n`;
             }
             return acc;
           }, '');
-          content =
-            `${content}\n${part[ContentTypes.TEXT] ?? part.text ?? ''}`.trim();
+          content = `${content}\n${getTextContent(part)}`.trim();
           lastAIMessage = createAIMessage(content);
           formattedMessages.push(lastAIMessage);
           currentContent = [];
           continue;
         }
         // Create a new AIMessage with this text and prepare for tool calls
-        lastAIMessage = createAIMessage(part.text != null ? part.text : '');
+        lastAIMessage = createAIMessage(getTextContent(part));
         formattedMessages.push(lastAIMessage);
       } else if (part.type === ContentTypes.TOOL_CALL) {
         // Skip malformed tool call entries without tool_call property
@@ -411,6 +486,26 @@ function formatAssistantMessage(
           _tool_call.name == null ||
           (_tool_call.name === '' && (output == null || output === ''))
         ) {
+          continue;
+        }
+
+        if (
+          options?.provider === Providers.ANTHROPIC &&
+          typeof _tool_call.id === 'string' &&
+          _tool_call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+        ) {
+          if (
+            emittedServerToolUseIds.has(_tool_call.id) ||
+            pendingServerToolUses.has(_tool_call.id)
+          ) {
+            continue;
+          }
+          pendingServerToolUses.set(_tool_call.id, {
+            type: 'server_tool_use',
+            id: _tool_call.id,
+            name: _tool_call.name,
+            input: parseServerToolInput(_args),
+          } as MessageContentComplex);
           continue;
         }
 
@@ -465,26 +560,29 @@ function formatAssistantMessage(
       ) {
         continue;
       } else {
-        if (
-          part.type === ContentTypes.TEXT &&
-          !String(part.text ?? '').trim()
-        ) {
+        if (part.type === ContentTypes.TEXT && !getTextContent(part).trim()) {
           continue;
         }
         currentContent.push(part);
       }
     }
+    for (const content of pendingServerToolUses.values()) {
+      currentContent.push(content);
+    }
   }
 
   if (hasReasoning && currentContent.length > 0) {
-    const content = currentContent
-      .reduce((acc, curr) => {
-        if (curr.type === ContentTypes.TEXT) {
-          return `${acc}${String(curr[ContentTypes.TEXT] ?? '')}\n`;
-        }
-        return acc;
-      }, '')
-      .trim();
+    let content = '';
+    for (const part of currentContent) {
+      if (part.type !== ContentTypes.TEXT) {
+        formattedMessages.push(
+          createAIMessage(toLangChainContent(currentContent))
+        );
+        return formattedMessages;
+      }
+      content += `${getTextContent(part)}\n`;
+    }
+    content = content.trim();
 
     if (content) {
       formattedMessages.push(createAIMessage(content));
@@ -1157,6 +1255,7 @@ export const formatAgentMessages = (
 
     const formattedMessages = formatAssistantMessage(processedMessage, {
       preserveReasoningContent: options?.provider === Providers.DEEPSEEK,
+      provider: options?.provider,
     });
     if (sourceMessageId != null && sourceMessageId !== '') {
       for (const formattedMessage of formattedMessages) {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -6,7 +6,8 @@ import {
 } from '@langchain/core/messages';
 import type { MessageContentComplex, TPayload } from '@/types';
 import { formatAgentMessages } from './format';
-import { ContentTypes, Providers } from '@/common';
+import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
+import { Constants, ContentTypes, Providers } from '@/common';
 
 describe('formatAgentMessages', () => {
   it('should format simple user and AI messages', () => {
@@ -181,6 +182,206 @@ describe('formatAgentMessages', () => {
     expect(result.messages[1]).toBeInstanceOf(ToolMessage);
     expect((result.messages[0] as AIMessage).tool_calls).toHaveLength(1);
     expect((result.messages[1] as ToolMessage).tool_call_id).toBe('123');
+  });
+
+  it('skips persisted Anthropic server tool calls from web search turns', () => {
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content:
+          'who is the lowest seed survived in 2026 nba playoffs, only the team name, nothing else',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}web_search`,
+              name: 'web_search',
+              args: '{"query":"2026 NBA playoffs lowest seed survived"}',
+            },
+          },
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'Philadelphia 76ers',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'who are 76ers\' opponents in current series?',
+      },
+    ];
+
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[1]).toBeInstanceOf(AIMessage);
+    expect(
+      result.messages.some((message) => message instanceof ToolMessage)
+    ).toBe(false);
+    expect((result.messages[1] as AIMessage).tool_calls).toHaveLength(0);
+    expect(result.messages[1].content).toEqual([
+      {
+        type: ContentTypes.TEXT,
+        [ContentTypes.TEXT]: 'Philadelphia 76ers',
+      },
+    ]);
+  });
+
+  it('preserves paused Anthropic server tool calls without creating ToolMessages', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}paused`,
+              name: 'web_search',
+              args: '{"query":"latest Anthropic server tools"}',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(
+      result.messages
+    );
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toBeInstanceOf(AIMessage);
+    expect(result.messages.some((message) => message instanceof ToolMessage))
+      .toBe(false);
+    expect((result.messages[0] as AIMessage).tool_calls).toHaveLength(0);
+    expect(result.messages[0].content).toEqual([
+      {
+        type: 'server_tool_use',
+        id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}paused`,
+        name: 'web_search',
+        input: { query: 'latest Anthropic server tools' },
+      },
+    ]);
+    expect(anthropicPayload.messages[0].content).toEqual([
+      {
+        type: 'server_tool_use',
+        id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}paused`,
+        name: 'web_search',
+        input: { query: 'latest Anthropic server tools' },
+      },
+    ]);
+  });
+
+  it('keeps srvtoolu tool calls portable for non-Anthropic providers', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}paused`,
+              name: 'web_search',
+              args: '{"query":"latest Anthropic server tools"}',
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.OPENAI }
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toBeInstanceOf(AIMessage);
+    expect(result.messages[1]).toBeInstanceOf(ToolMessage);
+    expect(result.messages[0].content).toBe('');
+    expect((result.messages[0] as AIMessage).tool_calls).toEqual([
+      {
+        id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}paused`,
+        name: 'web_search',
+        args: { query: 'latest Anthropic server tools' },
+      },
+    ]);
+    expect((result.messages[1] as ToolMessage).tool_call_id).toBe(
+      `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}paused`
+    );
+  });
+
+  it('does not emit empty Anthropic payload content for persisted web search turns', () => {
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content:
+          'who is the lowest seed survived in 2026 nba playoffs, only the team name, nothing else',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}web_search`,
+              name: 'web_search',
+              args: '{"query":"2026 NBA playoffs lowest seed survived"}',
+            },
+          },
+          {
+            type: ContentTypes.TEXT,
+            text: 'Philadelphia 76ers',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'who are 76ers\' opponents in current series?',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+
+    expect(anthropicPayload.messages).toHaveLength(3);
+    for (const message of anthropicPayload.messages) {
+      expect(Array.isArray(message.content)).toBe(true);
+      const content = message.content as Array<{
+        text?: unknown;
+        type: string;
+      }>;
+      expect(content.length).toBeGreaterThan(0);
+      for (const block of content) {
+        if (block.type === ContentTypes.TEXT) {
+          expect(typeof block.text).toBe('string');
+          expect((block.text as string).trim().length).toBeGreaterThan(0);
+        }
+      }
+    }
   });
 
   it('should handle malformed tool call entries with missing tool_call property', () => {


### PR DESCRIPTION
## Summary

I fixed Anthropic web search persistence and prompt-cache handling so server-side web search turns can be replayed safely after being stored and reloaded. Related to #144.

- Fixed Anthropic built-in tool prompt-cache serialization by applying direct `cache_control` to `web_search_20250305` and preserving `extras.cache_control` for custom LangChain tools.
- Preserved paused Anthropic `srvtoolu_` server tool uses during history reconstruction, while still dropping completed persisted server-tool artifacts that have no matching `web_search_tool_result` once answer content follows.
- Added a non-whitespace fallback for Anthropic payload content when filtering empty text blocks would otherwise produce invalid empty content.
- Added regression coverage for built-in web search cache serialization, paused and completed persisted web search `contentParts`, Anthropic payload validation, and always-on live web-search API checks in `llm.spec.ts`.
- Added a live E2E flow that starts a `Run`, aggregates streamed `contentParts` with the same `createContentAggregator` path LibreChat uses, rebuilds the next request with `formatAgentMessages`, and starts a second `Run` from that reconstructed history.
- Reproduced the reporter path with the real Anthropic API using `claude-opus-4-7`, `promptCache: true`, and `web_search_20250305`; confirmed the fixed persisted-history follow-up succeeds.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran focused regression tests, typechecking, linting, and real Anthropic API repros against the main worktree `.env`.

### **Test Configuration**:

- Base branch: `dev`
- Model: `claude-opus-4-7`
- Provider: Anthropic
- Tool: `web_search_20250305`
- Prompt cache: enabled
- Repro path: first web-search turn persisted as LibreChat-style `contentParts`, reconstructed with `formatAgentMessages`, converted with `_convertMessagesToAnthropicPayload`, then sent through a second `Run.processStream` call

```sh
npx jest src/messages/__tests__/anthropicToolCache.test.ts src/messages/formatAgentMessages.test.ts src/llm/anthropic/utils/server-tool-inputs.test.ts --runInBand --testPathIgnorePatterns=.claude/worktrees
npx tsc --noEmit --pretty false
npx eslint src/messages/anthropicToolCache.ts src/messages/__tests__/anthropicToolCache.test.ts src/messages/format.ts src/messages/formatAgentMessages.test.ts src/llm/anthropic/utils/message_inputs.ts src/llm/anthropic/utils/server-tool-inputs.test.ts
npx jest src/llm/anthropic/llm.spec.ts -t "Anthropic web search live regressions" --runInBand
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
