### PR TITLE
🩹 fix: Vertex/Gemini tool-call crash via @langchain/core uuid CJS bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "@langchain/aws": "^1.3.5",
         "@langchain/core": "1.1.44",
         "@langchain/deepseek": "^1.0.25",
-        "@langchain/google-common": "2.1.30",
-        "@langchain/google-gauth": "2.1.30",
-        "@langchain/google-genai": "2.1.30",
-        "@langchain/google-vertexai": "2.1.30",
+        "@langchain/google-common": "2.1.28",
+        "@langchain/google-gauth": "2.1.28",
+        "@langchain/google-genai": "2.1.28",
+        "@langchain/google-vertexai": "2.1.28",
         "@langchain/langgraph": "^1.2.9",
         "@langchain/mistralai": "^1.0.8",
         "@langchain/openai": "1.4.5",
@@ -220,21 +220,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/vertex-sdk/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3073,24 +3058,27 @@
       }
     },
     "node_modules/@langchain/google-common": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/@langchain/google-common/-/google-common-2.1.30.tgz",
-      "integrity": "sha512-IYxGeJbhzBi7+fW9sbkWGqpSSDDf05Kd1DvCM0RoDeYJx4zQk2aPbmB/PI6uUWl9NHISkEZ4dxbZmBSrVelckw==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/@langchain/google-common/-/google-common-2.1.28.tgz",
+      "integrity": "sha512-iSQ3IKYDWW56F0FMrk4ztm1vABox4S3EfY2ZFhEHRD/ckC3pvcAa6n5ZEH0cuMUY63OBKxPiLS0+lJG3TgLJ2A==",
       "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.43"
+        "@langchain/core": "^1.1.41"
       }
     },
     "node_modules/@langchain/google-gauth": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/@langchain/google-gauth/-/google-gauth-2.1.30.tgz",
-      "integrity": "sha512-NtLPBlpWnYu2hJUOM9G72rsalpuQu3S9F0mL5qeCy51bgSnFHx4lmBrIpWHpMFcmPejFJGt6AyJ0WSmEJur0Mg==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/@langchain/google-gauth/-/google-gauth-2.1.28.tgz",
+      "integrity": "sha512-aMxBwv0OrAa+oNQ/5kUuBo1MLXi6xtjOLtRN5XF6qpbCmqx21Z0PsMfZ4+dD0128H3O8jY8M4whgr3cdyhbVpQ==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/google-common": "2.1.30",
+        "@langchain/google-common": "2.1.28",
         "google-auth-library": "^10.6.2"
       },
       "engines": {
@@ -3098,27 +3086,28 @@
       }
     },
     "node_modules/@langchain/google-genai": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-2.1.30.tgz",
-      "integrity": "sha512-0wKgy1NvV89fw5MwYiOOhh18SnUEH20z6MZrPV6Tj2hMAA3jAHVSLlIcCQ2mDRJo2r1aHLV8MDXhzkvD1tEHoQ==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-2.1.28.tgz",
+      "integrity": "sha512-iTzNYWST8hTRqOXZdme18tq5GnCUwtrrJECE51ZCjg6Vg0mPsV44amdC+/bc+UK0+uphKWESGWs277aAyM2MlA==",
       "license": "MIT",
       "dependencies": {
-        "@google/generative-ai": "^0.24.0"
+        "@google/generative-ai": "^0.24.0",
+        "uuid": "^11.1.0"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.1.43"
+        "@langchain/core": "^1.1.41"
       }
     },
     "node_modules/@langchain/google-vertexai": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/@langchain/google-vertexai/-/google-vertexai-2.1.30.tgz",
-      "integrity": "sha512-67Mf2f6ILTsof5b/t8JXN1/xbcD1LaNcq80ytmmR/rgIDPrOmql2JWaxfgV1l6903quS/CD+wOWt2AF+E+6ewQ==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/@langchain/google-vertexai/-/google-vertexai-2.1.28.tgz",
+      "integrity": "sha512-NuZAvM3xlkQWZa2CCFhPAaeYwGI+raY+piwwF0f5sZTjWgYEwAQC2/GMoOK4/uaC23visNdhKGW2GeY31AQoNw==",
       "license": "MIT",
       "dependencies": {
-        "@langchain/google-gauth": "2.1.30"
+        "@langchain/google-gauth": "2.1.28"
       },
       "engines": {
         "node": ">=20"
@@ -3162,20 +3151,6 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.0.1"
-      }
-    },
-    "node_modules/@langchain/langgraph-checkpoint/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
@@ -3253,20 +3228,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@langchain/langgraph/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@langchain/mistralai": {

--- a/package.json
+++ b/package.json
@@ -184,6 +184,11 @@
     "@browserbasehq/stagehand": {
       "openai": "$openai"
     },
+    "@langchain/google-common": "$@langchain/google-common",
+    "@langchain/google-gauth": "$@langchain/google-gauth",
+    "@langchain/google-genai": "$@langchain/google-genai",
+    "@langchain/google-vertexai": "$@langchain/google-vertexai",
+    "uuid": "$uuid",
     "fast-xml-parser": "5.7.2",
     "ajv": "6.14.0",
     "minimatch": "3.1.4"
@@ -195,10 +200,10 @@
     "@langchain/aws": "^1.3.5",
     "@langchain/core": "1.1.44",
     "@langchain/deepseek": "^1.0.25",
-    "@langchain/google-common": "2.1.30",
-    "@langchain/google-gauth": "2.1.30",
-    "@langchain/google-genai": "2.1.30",
-    "@langchain/google-vertexai": "2.1.30",
+    "@langchain/google-common": "2.1.28",
+    "@langchain/google-gauth": "2.1.28",
+    "@langchain/google-genai": "2.1.28",
+    "@langchain/google-vertexai": "2.1.28",
     "@langchain/langgraph": "^1.2.9",
     "@langchain/mistralai": "^1.0.8",
     "@langchain/openai": "1.4.5",


### PR DESCRIPTION
## Summary

Pin `@langchain/google-{common,gauth,genai,vertexai}` to `2.1.28` to work around the broken Rolldown CJS emit in `@langchain/core@1.1.42+` that makes `require("@langchain/core/utils/uuid").v4` a namespace object instead of a function — currently crashes any Vertex/Gemini tool/function call.

Reported downstream in [danny-avila/LibreChat#13003](https://github.com/danny-avila/LibreChat/issues/13003).

## Root cause

1. `@langchain/google-common@2.1.29` ([PR #10776](https://github.com/langchain-ai/langchainjs/pull/10776) — "remediate uuid@10 vulnerability") swapped two import sites in `gemini.ts` and `experimental/utils/media_core.ts` from `require("uuid")` to `require("@langchain/core/utils/uuid")`.
2. `@langchain/core@1.1.42+` is built with Rolldown ([rolldown/rolldown#9299](https://github.com/rolldown/rolldown/issues/9299)). With `preserveModules: true`, it miscompiles `export { default as v4 } from "./v4.js"` as:
   ```js
   exports.v4 = require_v4;          // ← namespace { default: [Function] }
   // should be: exports.v4 = require_v4.default;
   ```
3. Result: `(0, _langchain_core_utils_uuid.v4)()` throws `TypeError: v4 is not a function` from `partsToToolsRaw → functionCallPartToToolRaw` whenever Gemini emits a function call.

## Reproduction

```js
const u = require("@langchain/core/utils/uuid");
u.v4();
// TypeError: u.v4 is not a function
// (u.v4 is { default: [Function: v4] })
```

## Why 2.1.28?

Last `@langchain/google-common` release that imports from `"uuid"` directly. The functional delta vs `2.1.30` is two lines:

```diff
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
```

`2.1.30` had **no google-common code changes** — peer-dep version bump only ([PR #10814](https://github.com/langchain-ai/langchainjs/pull/10814) only touched `@langchain/core` parsers). All Gemini features (multimodal blocks, MINIMAL thinking level, structured-output reasoning fix, empty-text fix) come from `@langchain/core@1.1.44`, which we keep.

## Changes

- Pin `@langchain/google-{common,gauth,genai,vertexai}` from `2.1.30` → `2.1.28` in `dependencies`.
- Add `$@langchain/google-*` overrides so transitive consumers can't pull 2.1.29+ back in.
- Add `"uuid": "$uuid"` override forcing the entire tree to this package's `uuid@^11.1.1` — closes the same `uuid@10` deprecation concern that motivated 2.1.29 upstream, without the broken code path. Also clears the `npm warn deprecated uuid@9.0.1 / uuid@10.0.0` install warnings.

## Verification

- Original repro before patch:
  ```
  typeof u.v4: object
  v4() FAIL: u.v4 is not a function
  ```
- After patch:
  ```
  google-common gemini.cjs import line: let uuid = require("uuid");
  typeof uuid.v4: function
  uuid.v4() → 51bb8044-d67e-48c5-837f-6c9d5b5d0d99
  REPRO PATH (id assignment): 46dd6e6a86804453b44a4a0a5e50227f ✓ FIXED
  ```
- Full `npm test` (excluding `title.memory-leak`): 1781 passing. The 30 failures are all missing-credential integration tests (Anthropic key, GCP Project Id, AWS region, OpenAI key, Jina endpoint) — same set fails on clean `dev`.

## Upstream

Both upstream issues are still open as of this PR:
- [rolldown/rolldown#9299](https://github.com/rolldown/rolldown/issues/9299) — the CJS emit bug
- [langchain-ai/langchainjs#10827](https://github.com/langchain-ai/langchainjs/issues/10827) — the symptom
- [langchain-ai/langchainjs#10832](https://github.com/langchain-ai/langchainjs/pull/10832) — proposed `@langchain/core` fix (open, CI green, awaiting merge)

Once `@langchain/core@1.1.46` ships with PR #10832 merged, these pins/overrides can be reverted — the existing `^1.1.43` semver range in `google-common` will pick the fix up automatically.

## Test plan

- [x] Bug reproduces on installed `2.1.30`
- [x] Bug does not reproduce after pin to `2.1.28`
- [x] `npm install` clean, no `uuid@9/10` deprecation warnings
- [x] `npm run build` green
- [x] Test suite delta vs baseline = 0 (all failures are pre-existing credential-gated)