### PR TITLE
fix: preserve resource identity on inherited file echoes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.80-dev.1",
+  "version": "3.1.80-dev.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.1.80-dev.1",
+      "version": "3.1.80-dev.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.1.80-dev.1",
+  "version": "3.1.80-dev.2",
   "main": "./dist/cjs/main.cjs",
   "module": "./dist/esm/main.mjs",
   "types": "./dist/types/index.d.ts",

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -313,14 +313,8 @@ function toInjectedFileRef(
   return { ...base, kind: 'user' };
 }
 
-/**
- * Stable identity key for a file ref: `(storage_session_id, id)`. Two
- * files with the same `name` but different storage uuids are distinct
- * (e.g. user re-uploaded `data.csv` after a fresh exec session). Used
- * by the merge below to find the prior entry whose resource identity
- * (`kind`, `resource_id`, `version`) must survive a worker echo that
- * doesn't carry those fields.
- */
+/* Stable file identity = `(storage_session_id, id)`. Same name in
+ * different storage sessions are distinct files. */
 function fileIdentityKey(file: {
   storage_session_id?: string;
   id: string;
@@ -339,58 +333,50 @@ function updateCodeSession(
     | undefined;
   const existingFiles = existingSession?.files ?? [];
 
-  if (newFiles.length > 0) {
-    /**
-     * Worker `inherited: true` echoes carry only `(id, name,
-     * storage_session_id)` — they intentionally don't re-attest to
-     * the ownership identity (`kind`, `resource_id`, `version`)
-     * because the sandbox doesn't know it; that's signed at upload.
-     * Without this preservation, the next `_injected_files` derived
-     * from `CodeSessionContext.files` flips skill / agent files to
-     * `kind: 'user'` (toInjectedFileRef defaults), and codeapi 403s
-     * on `session_key_mismatch` because the cached sessionKey is
-     * `legacy:skill:<id>:v:<v>` but the request resolves
-     * `legacy:user:<authContext.userId>`.
-     *
-     * Merge by `(storage_session_id, id)` so the echo overlays only
-     * the fields it actually owns (the inherited flag, normalized
-     * name, etc.) and prior identity survives.
-     */
-    const existingByIdentity = new Map<string, t.FileRefs[number]>();
-    for (const f of existingFiles) {
-      existingByIdentity.set(fileIdentityKey(f), f);
-    }
-
-    const filesWithSession: t.FileRefs = newFiles.map((file) => {
-      const withSession = {
-        ...file,
-        storage_session_id: file.storage_session_id ?? execSessionId,
-      };
-      const prior = existingByIdentity.get(fileIdentityKey(withSession));
-      if (prior) {
-        /* prior first so its identity fields are defaults; new last
-         * so the echo can override anything it does carry (e.g. an
-         * updated `name` or future-proofed `kind` re-attestation). */
-        return { ...prior, ...withSession };
-      }
-      return withSession;
-    });
-    const newFileNames = new Set(filesWithSession.map((f) => f.name));
-    const filteredExisting = existingFiles.filter(
-      (f) => !newFileNames.has(f.name)
-    );
-    sessions.set(Constants.EXECUTE_CODE, {
-      session_id: execSessionId,
-      files: [...filteredExisting, ...filesWithSession],
-      lastUpdated: Date.now(),
-    });
-  } else {
+  if (newFiles.length === 0) {
     sessions.set(Constants.EXECUTE_CODE, {
       session_id: execSessionId,
       files: existingFiles,
       lastUpdated: Date.now(),
     });
+    return;
   }
+
+  /* Worker echoes lack ownership identity (kind/resource_id/version) —
+   * sandbox doesn't re-attest; that's signed at upload. Merge by
+   * (storage_session_id, id) so prior identity survives the echo. */
+  const filesWithSession: t.FileRefs = [];
+  const newFileNames = new Set<string>();
+  const incomingByIdentity = new Map<string, number>();
+  for (const file of newFiles) {
+    const withSession = {
+      ...file,
+      storage_session_id: file.storage_session_id ?? execSessionId,
+    };
+    incomingByIdentity.set(
+      fileIdentityKey(withSession),
+      filesWithSession.length
+    );
+    newFileNames.add(withSession.name);
+    filesWithSession.push(withSession);
+  }
+
+  const filteredExisting: t.FileRefs = [];
+  for (const e of existingFiles) {
+    const idx = incomingByIdentity.get(fileIdentityKey(e));
+    if (idx !== undefined) {
+      filesWithSession[idx] = { ...e, ...filesWithSession[idx] };
+    }
+    if (!newFileNames.has(e.name)) {
+      filteredExisting.push(e);
+    }
+  }
+
+  sessions.set(Constants.EXECUTE_CODE, {
+    session_id: execSessionId,
+    files: [...filteredExisting, ...filesWithSession],
+    lastUpdated: Date.now(),
+  });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -313,6 +313,21 @@ function toInjectedFileRef(
   return { ...base, kind: 'user' };
 }
 
+/**
+ * Stable identity key for a file ref: `(storage_session_id, id)`. Two
+ * files with the same `name` but different storage uuids are distinct
+ * (e.g. user re-uploaded `data.csv` after a fresh exec session). Used
+ * by the merge below to find the prior entry whose resource identity
+ * (`kind`, `resource_id`, `version`) must survive a worker echo that
+ * doesn't carry those fields.
+ */
+function fileIdentityKey(file: {
+  storage_session_id?: string;
+  id: string;
+}): string {
+  return `${file.storage_session_id ?? ''}\0${file.id}`;
+}
+
 function updateCodeSession(
   sessions: t.ToolSessionMap,
   execSessionId: string,
@@ -325,10 +340,41 @@ function updateCodeSession(
   const existingFiles = existingSession?.files ?? [];
 
   if (newFiles.length > 0) {
-    const filesWithSession: t.FileRefs = newFiles.map((file) => ({
-      ...file,
-      storage_session_id: file.storage_session_id ?? execSessionId,
-    }));
+    /**
+     * Worker `inherited: true` echoes carry only `(id, name,
+     * storage_session_id)` — they intentionally don't re-attest to
+     * the ownership identity (`kind`, `resource_id`, `version`)
+     * because the sandbox doesn't know it; that's signed at upload.
+     * Without this preservation, the next `_injected_files` derived
+     * from `CodeSessionContext.files` flips skill / agent files to
+     * `kind: 'user'` (toInjectedFileRef defaults), and codeapi 403s
+     * on `session_key_mismatch` because the cached sessionKey is
+     * `legacy:skill:<id>:v:<v>` but the request resolves
+     * `legacy:user:<authContext.userId>`.
+     *
+     * Merge by `(storage_session_id, id)` so the echo overlays only
+     * the fields it actually owns (the inherited flag, normalized
+     * name, etc.) and prior identity survives.
+     */
+    const existingByIdentity = new Map<string, t.FileRefs[number]>();
+    for (const f of existingFiles) {
+      existingByIdentity.set(fileIdentityKey(f), f);
+    }
+
+    const filesWithSession: t.FileRefs = newFiles.map((file) => {
+      const withSession = {
+        ...file,
+        storage_session_id: file.storage_session_id ?? execSessionId,
+      };
+      const prior = existingByIdentity.get(fileIdentityKey(withSession));
+      if (prior) {
+        /* prior first so its identity fields are defaults; new last
+         * so the echo can override anything it does carry (e.g. an
+         * updated `name` or future-proofed `kind` re-attestation). */
+        return { ...prior, ...withSession };
+      }
+      return withSession;
+    });
     const newFileNames = new Set(filesWithSession.map((f) => f.name));
     const filteredExisting = existingFiles.filter(
       (f) => !newFileNames.has(f.name)

--- a/src/tools/__tests__/ToolNode.session.test.ts
+++ b/src/tools/__tests__/ToolNode.session.test.ts
@@ -512,6 +512,188 @@ describe('ToolNode code execution session management', () => {
       expect(chartFile!.storage_session_id).toBe('new-sess');
     });
 
+    it('preserves prior kind/resource_id/version when worker echoes inherited file (skill 403 regression)', () => {
+      /**
+       * Regression for the codeapi `session_key_mismatch` 403 that
+       * fires on the second `/exec` after a successful skill prime.
+       *
+       * Worker `inherited: true` echoes carry only
+       * `(id, name, storage_session_id)` — the sandbox doesn't know
+       * the resource identity (`kind`, `resource_id`, `version`),
+       * which was signed at upload time. If `updateCodeSession`
+       * replaces the prior entry verbatim from the echo, the next
+       * `_injected_files` derivation reads `kind: undefined` and
+       * `toInjectedFileRef` falls back to `kind: 'user'` +
+       * `resource_id: file.id`. Codeapi then resolves
+       * `legacy:user:<authContext.userId>`, which doesn't match the
+       * cached `legacy:skill:<skillId>:v:<v>` set at upload, and
+       * authorization 403s.
+       *
+       * The merge must overlay the echo onto the prior entry by
+       * `(storage_session_id, id)` so identity survives.
+       */
+      const SKILL_ID = '69dcf561f37f717858d4d072';
+      const SKILL_VERSION = 59;
+      const STORAGE_SESSION = 'p28pbmz0ejTZ8MMEkObN8';
+      const FILE_ID = 'JqnzC4f6gpirzW0yq_obR';
+
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: STORAGE_SESSION,
+        files: [
+          {
+            id: FILE_ID,
+            resource_id: SKILL_ID,
+            name: 'pptx/editing.md',
+            storage_session_id: STORAGE_SESSION,
+            kind: 'skill',
+            version: SKILL_VERSION,
+          },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const mockTool = createMockCodeTool({ capturedConfigs: [] });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions,
+        eventDrivenMode: true,
+      });
+
+      const storeMethod = (
+        toolNode as unknown as {
+          storeCodeSessionFromResults: (
+            results: t.ToolExecuteResult[],
+            requestMap: Map<string, t.ToolCallRequest>
+          ) => void;
+        }
+      ).storeCodeSessionFromResults.bind(toolNode);
+
+      /* Worker echo shape — exactly what codeapi sends on
+       * `inherited: true` files. No kind, no resource_id, no version. */
+      storeMethod(
+        [
+          {
+            toolCallId: 'tc-skill-rerun',
+            content: 'output',
+            artifact: {
+              session_id: 'exec-sess-2',
+              files: [
+                {
+                  id: FILE_ID,
+                  name: 'pptx/editing.md',
+                  storage_session_id: STORAGE_SESSION,
+                  inherited: true,
+                } as unknown as t.FileRefs[number],
+              ],
+            },
+            status: 'success',
+          },
+        ],
+        new Map([
+          [
+            'tc-skill-rerun',
+            { id: 'tc-skill-rerun', name: Constants.EXECUTE_CODE, args: {} },
+          ],
+        ])
+      );
+
+      const stored = sessions.get(
+        Constants.EXECUTE_CODE
+      ) as t.CodeSessionContext;
+      const merged = stored.files!.find((f) => f.id === FILE_ID);
+      expect(merged).toBeDefined();
+      /* Identity preserved from prior entry: */
+      expect(merged!.kind).toBe('skill');
+      expect(merged!.resource_id).toBe(SKILL_ID);
+      expect((merged as { version?: number }).version).toBe(SKILL_VERSION);
+      /* Echo-owned fields propagated: */
+      expect((merged as { inherited?: boolean }).inherited).toBe(true);
+    });
+
+    it('uses fresh kind defaults for genuinely new files (no prior entry to merge from)', () => {
+      /**
+       * The merge keys on `(storage_session_id, id)`, not `name`.
+       * A file the worker emits for the first time (typical
+       * code-output / generated artifact) has no prior to inherit
+       * identity from — it lands as `kind: 'user'` via the standard
+       * fallback in `toInjectedFileRef`. Locks the contract that
+       * the merge doesn't accidentally re-tag user output as skill.
+       */
+      const sessions: t.ToolSessionMap = new Map();
+      sessions.set(Constants.EXECUTE_CODE, {
+        session_id: 'old-sess',
+        files: [
+          {
+            id: 'skill-f1',
+            resource_id: 'skill-id-1',
+            name: 'pptx/editing.md',
+            storage_session_id: 'skill-storage',
+            kind: 'skill',
+            version: 7,
+          },
+        ],
+        lastUpdated: Date.now(),
+      } satisfies t.CodeSessionContext);
+
+      const mockTool = createMockCodeTool({ capturedConfigs: [] });
+      const toolNode = new ToolNode({
+        tools: [mockTool],
+        sessions,
+        eventDrivenMode: true,
+      });
+
+      const storeMethod = (
+        toolNode as unknown as {
+          storeCodeSessionFromResults: (
+            results: t.ToolExecuteResult[],
+            requestMap: Map<string, t.ToolCallRequest>
+          ) => void;
+        }
+      ).storeCodeSessionFromResults.bind(toolNode);
+
+      storeMethod(
+        [
+          {
+            toolCallId: 'tc-output',
+            content: 'output',
+            artifact: {
+              session_id: 'output-sess',
+              files: [
+                {
+                  id: 'fresh-output-id',
+                  name: 'generated-chart.png',
+                  storage_session_id: 'output-sess',
+                } as unknown as t.FileRefs[number],
+              ],
+            },
+            status: 'success',
+          },
+        ],
+        new Map([
+          [
+            'tc-output',
+            { id: 'tc-output', name: Constants.EXECUTE_CODE, args: {} },
+          ],
+        ])
+      );
+
+      const stored = sessions.get(
+        Constants.EXECUTE_CODE
+      ) as t.CodeSessionContext;
+      const fresh = stored.files!.find((f) => f.id === 'fresh-output-id');
+      expect(fresh).toBeDefined();
+      /* No prior to inherit from — kind/resource_id/version absent
+       * on the entry; toInjectedFileRef will default kind to 'user'
+       * downstream. */
+      expect(fresh!.kind).toBeUndefined();
+      expect(fresh!.resource_id).toBeUndefined();
+      expect((fresh as { version?: number }).version).toBeUndefined();
+      /* Skill file untouched. */
+      const skillFile = stored.files!.find((f) => f.id === 'skill-f1');
+      expect(skillFile!.kind).toBe('skill');
+    });
+
     it('preserves existing files when new execution has no files', () => {
       const sessions: t.ToolSessionMap = new Map();
       sessions.set(Constants.EXECUTE_CODE, {


### PR DESCRIPTION
## Summary

Companion fix to PR #154. After a successful skill prime + first `/exec`, the second `/exec` was failing codeapi authorization with `session_key_mismatch` 403:

```
cached:    legacy:skill:69dcf561...:v:59
resolved:  legacy:user:local-test-user
file:      kind=user, resource_id=<storage_id>, name=pptx/editing.md
```

The skill file was correctly stored under the skill's session key on upload. But on the follow-up `/exec`, LC was sending it with `kind: 'user'` and `resource_id` collapsed onto the storage uuid — the resource identity had been **stripped** between turns.

## Root cause

The codeapi worker's `inherited: true` echoes carry only `(id, name, storage_session_id)`. The sandbox doesn't re-attest to ownership identity (`kind`, `resource_id`, `version`) — that's signed at upload time, not known to the executor.

`updateCodeSession` was matching prior entries by `name` alone and overwriting them verbatim from the echo, so the identity fields fell off the in-memory `CodeSessionContext`. On the next turn, `toInjectedFileRef` saw `kind: undefined` and fell back to `'user'`, then `resource_id: undefined` and fell back to `file.id` (the storage uuid). codeapi resolved `legacy:user:<authContext.userId>`, didn't match the cached skill sessionKey, 403'd.

## Fix

Merge worker echoes onto the prior entry by `(storage_session_id, id)` (the stable identity key — two files with the same name in different sessions are distinct). Echo overlays only the fields it actually owns (`inherited` flag, normalized name); identity persists.

```ts
const prior = existingByIdentity.get(fileIdentityKey(withSession));
if (prior) {
  return { ...prior, ...withSession };  // prior identity + echo overlay
}
return withSession;
```

## Test plan

Two regression tests added to `storeCodeSessionFromResults`:

- [x] `worker echo of a kind: 'skill' file preserves kind/resource_id/version` — locks the regression
- [x] `genuinely new files (no prior) land without identity fields` — confirms code-output files still default to `kind: 'user'` via `toInjectedFileRef`

22/22 ToolNode session tests pass; tsc clean.