### PR TITLE
🪪 fix: align thought-signature dispatch by position to fix Vertex tool round-trip

### DIFF
--- a/src/llm/vertexai/fixThoughtSignatures.test.ts
+++ b/src/llm/vertexai/fixThoughtSignatures.test.ts
@@ -1,0 +1,154 @@
+import { expect, test, describe } from '@jest/globals';
+import type { GeminiContent } from '@langchain/google-common';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { fixThoughtSignatures } from './index';
+
+const SIG_A = 'AY89a1/sigA==';
+const SIG_B = 'AY89a1/sigB==';
+
+const buildContents = (
+  blocks: Array<['user' | 'model' | 'function', GeminiContent['parts']]>
+): GeminiContent[] =>
+  blocks.map(([role, parts]) => ({ role, parts }) as GeminiContent);
+
+describe('fixThoughtSignatures', () => {
+  test('attaches signature to functionCall part when prior turn is a plain-text AI message (issue LibreChat#13006-followup)', () => {
+    // Reproduces the live failure from the issue: a Gemini 3 conversation
+    // where turn 1 was plain text ("Hello!") and turn 2 emitted a tool call
+    // with a thought signature. The plain-text AI message has no signatures,
+    // so the old position-by-filter code matched the toolcall AIMessage with
+    // the WRONG model content.
+    const helloAi = new AIMessage('Hello! How can I help you today?');
+    const toolcallAi = new AIMessage({
+      content: '',
+      tool_calls: [
+        { name: 'bash_tool', args: { command: 'echo hi' }, id: 'tc1' },
+      ],
+      additional_kwargs: { signatures: [SIG_A, ''] },
+    });
+    const input = [
+      new HumanMessage('hi there'),
+      helloAi,
+      new HumanMessage('run something'),
+      toolcallAi,
+      new ToolMessage({ content: 'ok', tool_call_id: 'tc1' }),
+    ];
+
+    const contents = buildContents([
+      ['user', [{ text: 'hi there' }]],
+      ['model', [{ text: 'Hello! How can I help you today?' }]],
+      ['user', [{ text: 'run something' }]],
+      [
+        'model',
+        [{ functionCall: { name: 'bash_tool', args: { command: 'echo hi' } } }],
+      ],
+      [
+        'user',
+        [
+          {
+            functionResponse: {
+              name: 'bash_tool',
+              response: { content: 'ok' },
+            },
+          },
+        ],
+      ],
+    ]);
+
+    fixThoughtSignatures(contents, input);
+
+    expect(contents[1].parts[0].thoughtSignature).toBeUndefined();
+    expect(contents[3].parts[0]).toMatchObject({
+      functionCall: { name: 'bash_tool' },
+      thoughtSignature: SIG_A,
+    });
+  });
+
+  test('attaches signatures across multiple tool-call turns by position', () => {
+    const turn1 = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'a', args: {}, id: 't1' }],
+      additional_kwargs: { signatures: [SIG_A, ''] },
+    });
+    const turn2 = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'b', args: {}, id: 't2' }],
+      additional_kwargs: { signatures: [SIG_B, ''] },
+    });
+
+    const input = [
+      new HumanMessage('q1'),
+      turn1,
+      new ToolMessage({ content: '1', tool_call_id: 't1' }),
+      new HumanMessage('q2'),
+      turn2,
+      new ToolMessage({ content: '2', tool_call_id: 't2' }),
+    ];
+    const contents = buildContents([
+      ['user', [{ text: 'q1' }]],
+      ['model', [{ functionCall: { name: 'a', args: {} } }]],
+      ['user', [{ functionResponse: { name: 'a', response: {} } }]],
+      ['user', [{ text: 'q2' }]],
+      ['model', [{ functionCall: { name: 'b', args: {} } }]],
+      ['user', [{ functionResponse: { name: 'b', response: {} } }]],
+    ]);
+
+    fixThoughtSignatures(contents, input);
+
+    expect(contents[1].parts[0].thoughtSignature).toBe(SIG_A);
+    expect(contents[4].parts[0].thoughtSignature).toBe(SIG_B);
+  });
+
+  test('does not overwrite signatures already attached by the library', () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'a', args: {}, id: 't1' }],
+      additional_kwargs: { signatures: [SIG_A] },
+    });
+    const input = [new HumanMessage('q'), ai];
+    const contents = buildContents([
+      ['user', [{ text: 'q' }]],
+      [
+        'model',
+        [{ functionCall: { name: 'a', args: {} }, thoughtSignature: SIG_B }],
+      ],
+    ]);
+
+    fixThoughtSignatures(contents, input);
+
+    expect(contents[1].parts[0].thoughtSignature).toBe(SIG_B);
+  });
+
+  test('no-op when AI message has no signatures', () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'a', args: {}, id: 't1' }],
+    });
+    const input = [new HumanMessage('q'), ai];
+    const contents = buildContents([
+      ['user', [{ text: 'q' }]],
+      ['model', [{ functionCall: { name: 'a', args: {} } }]],
+    ]);
+
+    fixThoughtSignatures(contents, input);
+
+    expect(contents[1].parts[0].thoughtSignature).toBeUndefined();
+  });
+
+  test('skips empty-string signatures', () => {
+    const ai = new AIMessage({
+      content: '',
+      tool_calls: [{ name: 'a', args: {}, id: 't1' }],
+      additional_kwargs: { signatures: ['', '', ''] },
+    });
+    const input = [new HumanMessage('q'), ai];
+    const contents = buildContents([
+      ['user', [{ text: 'q' }]],
+      ['model', [{ functionCall: { name: 'a', args: {} } }]],
+    ]);
+
+    fixThoughtSignatures(contents, input);
+
+    expect(contents[1].parts[0].thoughtSignature).toBeUndefined();
+  });
+});

--- a/src/llm/vertexai/index.ts
+++ b/src/llm/vertexai/index.ts
@@ -65,50 +65,44 @@ type AdditionalKwargs =
  * - The signature for a functionCall part is an empty string
  *
  * This function correlates each "model" content block in the formatted request
- * back to its originating AI message, then re-attaches non-empty signatures
- * that the library failed to apply.
+ * back to its originating AI message by *position*, then re-attaches non-empty
+ * signatures that the library failed to apply. AI messages without signatures
+ * still consume their slot — filtering them out shifted later messages onto
+ * the wrong content block and dropped real signatures on the floor.
  */
-function fixThoughtSignatures(
+export function fixThoughtSignatures(
   contents: GeminiContent[],
   input: BaseMessage[]
 ): void {
-  // Collect AI messages that have signatures, in order
-  const aiMessages = input.filter(
-    (msg) =>
-      isAIMessage(msg) &&
-      Array.isArray((msg.additional_kwargs as AdditionalKwargs)?.signatures) &&
-      (msg.additional_kwargs.signatures as string[]).length > 0
-  );
-
-  // Collect "model" content blocks from the formatted request, in order
+  // All AI messages, in order — non-signature ones still consume positional
+  // slots so later messages line up with their model content blocks.
+  const aiMessages = input.filter(isAIMessage);
   const modelContents = contents.filter((c) => c.role === 'model');
 
-  // They should correspond 1:1 in order (both derived from the same input sequence)
   const count = Math.min(aiMessages.length, modelContents.length);
   for (let i = 0; i < count; i++) {
-    const msg = aiMessages[i];
-    const content = modelContents[i];
-    const signatures = (msg.additional_kwargs as AdditionalKwargs)?.signatures;
+    const signatures = (aiMessages[i].additional_kwargs as AdditionalKwargs)
+      ?.signatures;
+    if (!Array.isArray(signatures) || signatures.length === 0) continue;
 
-    // Collect non-empty signatures that aren't already attached to any part
+    const content = modelContents[i];
     const attachedSignatures = new Set(
       content.parts
         .map((p) => p.thoughtSignature)
         .filter((s): s is string => s != null && s !== '')
     );
-    const availableSignatures = signatures?.filter(
-      (s) => s != null && s !== '' && !attachedSignatures.has(s)
+    const availableSignatures = signatures.filter(
+      (s): s is string => s != null && s !== '' && !attachedSignatures.has(s)
     );
 
-    // Assign available signatures to functionCall parts missing one, in order
     let sigIdx = 0;
     for (const part of content.parts) {
       if (
         'functionCall' in part &&
         (part.thoughtSignature == null || part.thoughtSignature === '') &&
-        sigIdx < (availableSignatures?.length ?? 0)
+        sigIdx < availableSignatures.length
       ) {
-        part.thoughtSignature = availableSignatures?.[sigIdx];
+        part.thoughtSignature = availableSignatures[sigIdx];
         sigIdx++;
       }
     }


### PR DESCRIPTION
## Summary

`fixThoughtSignatures` correlates each AI message with a Gemini "model" content block to re-attach `thoughtSignature` onto functionCall parts. Pre-fix it filtered AI messages to only those with non-empty signatures, then walked the *filtered* array against the *unfiltered* modelContents — as soon as any prior turn's AI message lacked signatures, the indices desynced and the toolcall AI message was matched against the wrong content block. Real signature dropped, Vertex returns 400 on the follow-up call.

Reported in [danny-avila/LibreChat#13006](https://github.com/danny-avila/LibreChat/issues/13006). Triggers reliably on `gemini-3.1-flash-lite-preview` whenever the conversation has ANY plain-text assistant turn before a tool-using turn.

## Live repro

```
turn 1: HumanMessage("hi"), AIMessage("Hello!"),       ← no signatures
turn 2: HumanMessage("run X"), AIMessage(toolcall),    ← has signatures
        ToolMessage(result)
```

Old logic:
- `aiMessages.filter(has signatures)` → [toolcall AI] (1 entry)
- `modelContents` → ["Hello!", functionCall] (2 entries)
- `count = min(1, 2) = 1`
- iteration 0: pairs `toolcall AI` with `"Hello!"` content (NO functionCall part to attach to)
- functionCall content never visited → no signature attached

Vertex 400 confirmed live. With the fix (walk all AI messages by position, skip non-signature ones inline), signature lands on the right functionCall and the round-trip completes.

## Changes

- `src/llm/vertexai/index.ts` — drop the `has signatures` pre-filter, skip inline so positional alignment is preserved.
- `src/llm/vertexai/fixThoughtSignatures.test.ts` — new file, 5 tests covering the failure case + multi-turn dispatch + idempotence + empty-signature handling.
- Function exported so it can be tested directly.

## Verification

- Unit tests: `npx jest fixThoughtSignatures.test.ts` → 5 passed.
- Live integration: `gemini-3.1-flash-lite-preview` Vertex stream + bash-style tool round-trip. Without fix: `Google request failed with status code 400`. With fix: response completes.

## Test plan

- [x] Repro confirmed before fix (400 from Vertex)
- [x] Repro confirmed fixed after the change
- [x] Unit tests pass
- [x] No change to behavior when prior turns also have signatures (existing case path)