### PR TITLE
🧬 feat: Forward Code API Auth Headers

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -389,7 +389,7 @@ export class AgentContext {
   /**
    * Builds instructions text for tools that are ONLY callable via programmatic code execution.
    * These tools cannot be called directly by the LLM but are available through the
-   * run_tools_with_code tool.
+   * run_tools_with_bash tool.
    *
    * Includes:
    * - Code_execution-only tools that are NOT deferred
@@ -431,8 +431,8 @@ export class AgentContext {
 
     return (
       '\n\n## Programmatic-Only Tools\n\n' +
-      'The following tools are available exclusively through the `run_tools_with_code` tool. ' +
-      'You cannot call these tools directly; instead, use `run_tools_with_code` with Python code that invokes them.\n\n' +
+      'The following tools are available exclusively through the `run_tools_with_bash` tool. ' +
+      'You cannot call these tools directly; instead, use `run_tools_with_bash` with bash code that invokes them.\n\n' +
       toolDescriptions
     );
   }

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -13,6 +13,7 @@ import {
   ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
   ContentTypes,
+  Constants,
   Providers,
 } from '@/common';
 import { createSchemaOnlyTools } from '@/tools/schema';
@@ -389,7 +390,7 @@ export class AgentContext {
   /**
    * Builds instructions text for tools that are ONLY callable via programmatic code execution.
    * These tools cannot be called directly by the LLM but are available through the
-   * run_tools_with_bash tool.
+   * configured programmatic tool.
    *
    * Includes:
    * - Code_execution-only tools that are NOT deferred
@@ -416,6 +417,7 @@ export class AgentContext {
 
     if (programmaticOnlyTools.length === 0) return '';
 
+    const programmaticTool = this.getProgrammaticToolInstructionTarget();
     const toolDescriptions = programmaticOnlyTools
       .map((tool) => {
         let desc = `- **${tool.name}**`;
@@ -431,10 +433,37 @@ export class AgentContext {
 
     return (
       '\n\n## Programmatic-Only Tools\n\n' +
-      'The following tools are available exclusively through the `run_tools_with_bash` tool. ' +
-      'You cannot call these tools directly; instead, use `run_tools_with_bash` with bash code that invokes them.\n\n' +
+      `The following tools are available exclusively through the \`${programmaticTool.name}\` tool. ` +
+      `You cannot call these tools directly; instead, use \`${programmaticTool.name}\` with ${programmaticTool.language} code that invokes them.\n\n` +
       toolDescriptions
     );
+  }
+
+  private getProgrammaticToolInstructionTarget(): {
+    name: string;
+    language: 'bash' | 'Python';
+    } {
+    if (this.hasAvailableTool(Constants.BASH_PROGRAMMATIC_TOOL_CALLING)) {
+      return {
+        name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+        language: 'bash',
+      };
+    }
+
+    if (this.hasAvailableTool(Constants.PROGRAMMATIC_TOOL_CALLING)) {
+      return { name: Constants.PROGRAMMATIC_TOOL_CALLING, language: 'Python' };
+    }
+
+    return { name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING, language: 'bash' };
+  }
+
+  private hasAvailableTool(name: string): boolean {
+    if (this.toolDefinitions?.some((tool) => tool.name === name)) return true;
+    if (this.tools?.some((tool) => 'name' in tool && tool.name === name)) {
+      return true;
+    }
+    if (this.toolMap?.has(name)) return true;
+    return this.toolRegistry?.has(name) === true;
   }
 
   /**

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -593,7 +593,7 @@ describe('AgentContext', () => {
   });
 
   describe('buildProgrammaticOnlyToolsInstructions', () => {
-    it('includes code_execution-only tools in system message', () => {
+    it('includes code_execution-only tools in system message', async () => {
       const toolRegistry: t.LCToolRegistry = new Map([
         [
           'programmatic_tool',
@@ -611,6 +611,9 @@ describe('AgentContext', () => {
 
       const runnable = ctx.systemRunnable;
       expect(runnable).toBeDefined();
+      const result = await runnable!.invoke([]);
+      expect(result[0].content).toContain('run_tools_with_bash');
+      expect(result[0].content).not.toContain('run_tools_with_code');
     });
 
     it('excludes direct-callable tools from programmatic section', () => {

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1,7 +1,7 @@
 // src/agents/__tests__/AgentContext.test.ts
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import { AgentContext } from '../AgentContext';
-import { Providers } from '@/common';
+import { Constants, Providers } from '@/common';
 import { addBedrockCacheControl } from '@/messages/cache';
 import type * as t from '@/types';
 
@@ -606,7 +606,11 @@ describe('AgentContext', () => {
       ]);
 
       const ctx = createBasicContext({
-        agentConfig: { instructions: 'Base', toolRegistry },
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry,
+        },
       });
 
       const runnable = ctx.systemRunnable;
@@ -614,6 +618,32 @@ describe('AgentContext', () => {
       const result = await runnable!.invoke([]);
       expect(result[0].content).toContain('run_tools_with_bash');
       expect(result[0].content).not.toContain('run_tools_with_code');
+    });
+
+    it('uses Python PTC guidance when only run_tools_with_code is available', async () => {
+      const toolRegistry: t.LCToolRegistry = new Map([
+        [
+          'programmatic_tool',
+          {
+            name: 'programmatic_tool',
+            description: 'Only callable via code execution',
+            allowed_callers: ['code_execution'],
+          },
+        ],
+      ]);
+
+      const ctx = createBasicContext({
+        agentConfig: {
+          instructions: 'Base',
+          toolDefinitions: [{ name: Constants.PROGRAMMATIC_TOOL_CALLING }],
+          toolRegistry,
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([]);
+      expect(result[0].content).toContain('run_tools_with_code');
+      expect(result[0].content).toContain('Python code');
+      expect(result[0].content).not.toContain('run_tools_with_bash');
     });
 
     it('excludes direct-callable tools from programmatic section', () => {

--- a/src/events.ts
+++ b/src/events.ts
@@ -90,7 +90,10 @@ export class ToolEndHandler implements t.EventHandler {
         return;
       }
 
-      if (metadata[Constants.PROGRAMMATIC_TOOL_CALLING] === true) {
+      if (
+        metadata[Constants.PROGRAMMATIC_TOOL_CALLING] === true ||
+        metadata[Constants.BASH_PROGRAMMATIC_TOOL_CALLING] === true
+      ) {
         return;
       }
 

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -3,7 +3,11 @@ import fetch, { RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
-import { emptyOutputMessage, getCodeBaseURL } from './CodeExecutor';
+import {
+  emptyOutputMessage,
+  getCodeBaseURL,
+  resolveCodeApiAuthHeaders,
+} from './CodeExecutor';
 import { Constants } from '@/common';
 
 config();
@@ -137,11 +141,15 @@ function createBashExecutionTool(
       }
 
       try {
+        const authHeaders = await resolveCodeApiAuthHeaders(
+          params.authHeaders
+        );
         const fetchOptions: RequestInit = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
+            ...authHeaders,
           },
           body: JSON.stringify(postData),
         };

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -108,6 +108,7 @@ function createBashExecutionTool(
 ): DynamicStructuredTool {
   return tool(
     async (rawInput, config) => {
+      const { authHeaders, ...executionParams } = params ?? {};
       const { command, ...rest } = rawInput as {
         command: string;
         args?: string[];
@@ -121,7 +122,7 @@ function createBashExecutionTool(
         lang: 'bash',
         code: command,
         ...rest,
-        ...params,
+        ...executionParams,
       };
 
       /* See `CodeExecutor.ts` for the rationale — `/files/<session_id>`
@@ -141,15 +142,14 @@ function createBashExecutionTool(
       }
 
       try {
-        const authHeaders = await resolveCodeApiAuthHeaders(
-          params.authHeaders
-        );
+        const resolvedAuthHeaders =
+          await resolveCodeApiAuthHeaders(authHeaders);
         const fetchOptions: RequestInit = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
-            ...authHeaders,
+            ...resolvedAuthHeaders,
           },
           body: JSON.stringify(postData),
         };

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -5,6 +5,7 @@ import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
 import {
   emptyOutputMessage,
+  buildCodeApiHttpErrorMessage,
   getCodeBaseURL,
   resolveCodeApiAuthHeaders,
 } from './CodeExecutor';
@@ -159,7 +160,9 @@ function createBashExecutionTool(
         }
         const response = await fetch(EXEC_ENDPOINT, fetchOptions);
         if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+          throw new Error(
+            await buildCodeApiHttpErrorMessage('POST', EXEC_ENDPOINT, response)
+          );
         }
 
         const result: t.ExecuteResult = await response.json();

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -312,7 +312,8 @@ export function createBashProgrammaticToolCallingTool(
             timeout,
             ...(files && files.length > 0 ? { files } : {}),
           },
-          proxy
+          proxy,
+          initParams.authHeaders
         );
 
         // ====================================================================
@@ -348,7 +349,8 @@ export function createBashProgrammaticToolCallingTool(
               continuation_token: response.continuation_token,
               tool_results: toolResults,
             },
-            proxy
+            proxy,
+            initParams.authHeaders
           );
         }
 

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -340,7 +340,8 @@ export function createBashProgrammaticToolCallingTool(
 
           const toolResults = await executeTools(
             response.tool_calls ?? [],
-            toolMap
+            toolMap,
+            Constants.BASH_PROGRAMMATIC_TOOL_CALLING
           );
 
           response = await makeRequest(

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -82,6 +82,22 @@ export async function resolveCodeApiAuthHeaders(
   return authHeaders;
 }
 
+export async function buildCodeApiHttpErrorMessage(
+  method: string,
+  endpoint: string,
+  response: { status: number; text: () => Promise<string> }
+): Promise<string> {
+  let responseBody = '';
+  try {
+    responseBody = await response.text();
+  } catch {
+    responseBody = '';
+  }
+  const body = responseBody.trim();
+  const bodySuffix = body === '' ? '' : `, body: ${body.slice(0, 1000)}`;
+  return `CodeAPI request failed: ${method} ${endpoint} returned ${response.status}${bodySuffix}`;
+}
+
 export const CodeExecutionToolDescription = `
 Runs code and returns stdout/stderr output from a stateless execution environment, similar to running scripts in a command-line interface. Each execution is isolated and independent.
 
@@ -165,7 +181,9 @@ function createCodeExecutionTool(
         }
         const response = await fetch(EXEC_ENDPOINT, fetchOptions);
         if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
+          throw new Error(
+            await buildCodeApiHttpErrorMessage('POST', EXEC_ENDPOINT, response)
+          );
         }
 
         const result: t.ExecuteResult = await response.json();

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -104,6 +104,7 @@ function createCodeExecutionTool(
 ): DynamicStructuredTool {
   return tool(
     async (rawInput, config) => {
+      const { authHeaders, ...executionParams } = params ?? {};
       const { lang, code, ...rest } = rawInput as {
         lang: SupportedLanguage;
         code: string;
@@ -123,7 +124,7 @@ function createCodeExecutionTool(
         lang,
         code,
         ...rest,
-        ...params,
+        ...executionParams,
       };
 
       /* File injection: `_injected_files` from ToolNode (set when host
@@ -147,15 +148,14 @@ function createCodeExecutionTool(
       }
 
       try {
-        const authHeaders = await resolveCodeApiAuthHeaders(
-          params.authHeaders
-        );
+        const resolvedAuthHeaders =
+          await resolveCodeApiAuthHeaders(authHeaders);
         const fetchOptions: RequestInit = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
-            ...authHeaders,
+            ...resolvedAuthHeaders,
           },
           body: JSON.stringify(postData),
         };

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -70,6 +70,18 @@ const EXEC_ENDPOINT = `${baseEndpoint}/exec`;
 
 type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
+export async function resolveCodeApiAuthHeaders(
+  authHeaders?: t.CodeApiAuthHeaders
+): Promise<t.CodeApiAuthHeaderMap> {
+  if (authHeaders == null) {
+    return {};
+  }
+  if (typeof authHeaders === 'function') {
+    return authHeaders();
+  }
+  return authHeaders;
+}
+
 export const CodeExecutionToolDescription = `
 Runs code and returns stdout/stderr output from a stateless execution environment, similar to running scripts in a command-line interface. Each execution is isolated and independent.
 
@@ -135,11 +147,15 @@ function createCodeExecutionTool(
       }
 
       try {
+        const authHeaders = await resolveCodeApiAuthHeaders(
+          params.authHeaders
+        );
         const fetchOptions: RequestInit = {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'User-Agent': 'LibreChat/1.0',
+            ...authHeaders,
           },
           body: JSON.stringify(postData),
         };

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -628,7 +628,8 @@ export function unwrapToolResponse(
  */
 export async function executeTools(
   toolCalls: t.PTCToolCall[],
-  toolMap: t.ToolMap
+  toolMap: t.ToolMap,
+  programmaticToolName = Constants.PROGRAMMATIC_TOOL_CALLING
 ): Promise<t.PTCToolResult[]> {
   const executions = toolCalls.map(async (call): Promise<t.PTCToolResult> => {
     const tool = toolMap.get(call.name);
@@ -644,7 +645,7 @@ export async function executeTools(
 
     try {
       const result = await tool.invoke(call.input, {
-        metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
+        metadata: { [programmaticToolName]: true },
       });
 
       const isMCPTool = tool.mcp === true;

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -5,7 +5,11 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
-import { emptyOutputMessage, getCodeBaseURL } from './CodeExecutor';
+import {
+  emptyOutputMessage,
+  getCodeBaseURL,
+  resolveCodeApiAuthHeaders,
+} from './CodeExecutor';
 import { Constants } from '@/common';
 
 config();
@@ -256,14 +260,17 @@ export function filterToolsByUsage(
 export async function fetchSessionFiles(
   baseUrl: string,
   sessionId: string,
-  proxy?: string
+  proxy?: string,
+  authHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.CodeEnvFile[]> {
   try {
     const filesEndpoint = `${baseUrl}/files/${sessionId}?detail=full`;
+    const resolvedAuthHeaders = await resolveCodeApiAuthHeaders(authHeaders);
     const fetchOptions: RequestInit = {
       method: 'GET',
       headers: {
         'User-Agent': 'LibreChat/1.0',
+        ...resolvedAuthHeaders,
       },
     };
 
@@ -319,13 +326,16 @@ export async function fetchSessionFiles(
 export async function makeRequest(
   endpoint: string,
   body: Record<string, unknown>,
-  proxy?: string
+  proxy?: string,
+  authHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.ProgrammaticExecutionResponse> {
+  const resolvedAuthHeaders = await resolveCodeApiAuthHeaders(authHeaders);
   const fetchOptions: RequestInit = {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'User-Agent': 'LibreChat/1.0',
+      ...resolvedAuthHeaders,
     },
     body: JSON.stringify(body),
   };
@@ -661,7 +671,8 @@ export function createProgrammaticToolCallingTool(
             timeout,
             ...(files && files.length > 0 ? { files } : {}),
           },
-          proxy
+          proxy,
+          initParams.authHeaders
         );
 
         // ====================================================================
@@ -697,7 +708,8 @@ export function createProgrammaticToolCallingTool(
               continuation_token: response.continuation_token,
               tool_results: toolResults,
             },
-            proxy
+            proxy,
+            initParams.authHeaders
           );
         }
 

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -292,7 +292,7 @@ export async function fetchSessionFiles(
   baseUrl: string,
   sessionId: string,
   scope: FetchSessionFilesScope,
-  proxy?: string,
+  proxyOrAuthHeaders?: string | t.CodeApiAuthHeaders,
   authHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.CodeEnvFile[]>;
 export async function fetchSessionFiles(
@@ -306,18 +306,17 @@ export async function fetchSessionFiles(
     const scope = isFetchSessionFilesScope(scopeOrProxy)
       ? scopeOrProxy
       : undefined;
-    const proxy =
-      scope == null
-        ? typeof scopeOrProxy === 'string'
-          ? scopeOrProxy
-          : undefined
-        : typeof proxyOrAuthHeaders === 'string'
-          ? proxyOrAuthHeaders
-          : undefined;
-    const authHeaders =
-      scope == null
-        ? (proxyOrAuthHeaders as t.CodeApiAuthHeaders | undefined)
-        : scopedAuthHeaders;
+    let proxy: string | undefined;
+    let authHeaders: t.CodeApiAuthHeaders | undefined;
+    if (scope == null) {
+      proxy = typeof scopeOrProxy === 'string' ? scopeOrProxy : undefined;
+      authHeaders = proxyOrAuthHeaders as t.CodeApiAuthHeaders | undefined;
+    } else if (typeof proxyOrAuthHeaders === 'string') {
+      proxy = proxyOrAuthHeaders;
+      authHeaders = scopedAuthHeaders;
+    } else {
+      authHeaders = proxyOrAuthHeaders ?? scopedAuthHeaders;
+    }
     const query = new URLSearchParams({ detail: 'full' });
     if (scope != null) {
       query.set('kind', scope.kind);

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -155,6 +155,26 @@ export type FetchSessionFilesScope =
   | { kind: 'skill'; id: string; version: number }
   | { kind: 'agent' | 'user'; id: string; version?: never };
 
+function isFetchSessionFilesScope(
+  value: unknown
+): value is FetchSessionFilesScope {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const scope = value as { kind?: unknown; id?: unknown; version?: unknown };
+  if (
+    (scope.kind === 'agent' || scope.kind === 'user') &&
+    typeof scope.id === 'string'
+  ) {
+    return true;
+  }
+  return (
+    scope.kind === 'skill' &&
+    typeof scope.id === 'string' &&
+    typeof scope.version === 'number'
+  );
+}
+
 /**
  * Normalizes a tool name to Python identifier format.
  * Must match the Code API's `normalizePythonFunctionName` exactly:
@@ -265,18 +285,46 @@ export function filterToolsByUsage(
 export async function fetchSessionFiles(
   baseUrl: string,
   sessionId: string,
+  proxy?: string,
+  authHeaders?: t.CodeApiAuthHeaders
+): Promise<t.CodeEnvFile[]>;
+export async function fetchSessionFiles(
+  baseUrl: string,
+  sessionId: string,
   scope: FetchSessionFilesScope,
   proxy?: string,
   authHeaders?: t.CodeApiAuthHeaders
+): Promise<t.CodeEnvFile[]>;
+export async function fetchSessionFiles(
+  baseUrl: string,
+  sessionId: string,
+  scopeOrProxy?: FetchSessionFilesScope | string,
+  proxyOrAuthHeaders?: string | t.CodeApiAuthHeaders,
+  scopedAuthHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.CodeEnvFile[]> {
   try {
-    const query = new URLSearchParams({
-      detail: 'full',
-      kind: scope.kind,
-      id: scope.id,
-    });
-    if (scope.kind === 'skill') {
-      query.set('version', String(scope.version));
+    const scope = isFetchSessionFilesScope(scopeOrProxy)
+      ? scopeOrProxy
+      : undefined;
+    const proxy =
+      scope == null
+        ? typeof scopeOrProxy === 'string'
+          ? scopeOrProxy
+          : undefined
+        : typeof proxyOrAuthHeaders === 'string'
+          ? proxyOrAuthHeaders
+          : undefined;
+    const authHeaders =
+      scope == null
+        ? (proxyOrAuthHeaders as t.CodeApiAuthHeaders | undefined)
+        : scopedAuthHeaders;
+    const query = new URLSearchParams({ detail: 'full' });
+    if (scope != null) {
+      query.set('kind', scope.kind);
+      query.set('id', scope.id);
+      if (scope.kind === 'skill') {
+        query.set('version', String(scope.version));
+      }
     }
     const filesEndpoint = `${baseUrl}/files/${encodeURIComponent(sessionId)}?${query.toString()}`;
     const resolvedAuthHeaders = await resolveCodeApiAuthHeaders(authHeaders);
@@ -320,9 +368,9 @@ export async function fetchSessionFiles(
       const resource_id =
         typeof file.resource_id === 'string' && file.resource_id !== ''
           ? file.resource_id
-          : scope.id;
+          : (scope?.id ?? id);
 
-      if (scope.kind === 'skill') {
+      if (scope?.kind === 'skill') {
         return {
           storage_session_id,
           kind: 'skill' as const,
@@ -332,11 +380,20 @@ export async function fetchSessionFiles(
           version: scope.version,
         };
       }
+      if (scope != null) {
+        return {
+          storage_session_id,
+          kind: scope.kind,
+          id,
+          resource_id,
+          name,
+        };
+      }
       return {
         storage_session_id,
-        kind: scope.kind,
+        kind: 'user' as const,
         id,
-        resource_id,
+        resource_id: id,
         name,
       };
     });

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -151,6 +151,10 @@ const PYTHON_KEYWORDS = new Set([
   'yield',
 ]);
 
+export type FetchSessionFilesScope =
+  | { kind: 'skill'; id: string; version: number }
+  | { kind: 'agent' | 'user'; id: string; version?: never };
+
 /**
  * Normalizes a tool name to Python identifier format.
  * Must match the Code API's `normalizePythonFunctionName` exactly:
@@ -254,17 +258,27 @@ export function filterToolsByUsage(
  * Files are returned as CodeEnvFile references to be included in the request.
  * @param baseUrl - The base URL for the Code API
  * @param sessionId - The session ID to fetch files from
+ * @param scope - Resource scope used by CodeAPI to authorize the session
  * @param proxy - Optional HTTP proxy URL
  * @returns Array of CodeEnvFile references, or empty array if fetch fails
  */
 export async function fetchSessionFiles(
   baseUrl: string,
   sessionId: string,
+  scope: FetchSessionFilesScope,
   proxy?: string,
   authHeaders?: t.CodeApiAuthHeaders
 ): Promise<t.CodeEnvFile[]> {
   try {
-    const filesEndpoint = `${baseUrl}/files/${sessionId}?detail=full`;
+    const query = new URLSearchParams({
+      detail: 'full',
+      kind: scope.kind,
+      id: scope.id,
+    });
+    if (scope.kind === 'skill') {
+      query.set('version', String(scope.version));
+    }
+    const filesEndpoint = `${baseUrl}/files/${encodeURIComponent(sessionId)}?${query.toString()}`;
     const resolvedAuthHeaders = await resolveCodeApiAuthHeaders(authHeaders);
     const fetchOptions: RequestInit = {
       method: 'GET',
@@ -289,22 +303,41 @@ export async function fetchSessionFiles(
     }
 
     return files.map((file: Record<string, unknown>) => {
-      // Extract the ID from the file name (part after session ID prefix and before extension)
-      const nameParts = (file.name as string).split('/');
-      const id = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
+      const metadata = (file.metadata ?? {}) as Record<string, unknown>;
+      const rawName = typeof file.name === 'string' ? file.name : '';
+      const nameParts = rawName.split('/');
+      const fallbackId = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
+      const id =
+        typeof file.id === 'string' && file.id !== '' ? file.id : fallbackId;
+      const name =
+        typeof metadata['original-filename'] === 'string'
+          ? metadata['original-filename']
+          : rawName;
+      const storage_session_id =
+        typeof file.storage_session_id === 'string'
+          ? file.storage_session_id
+          : sessionId;
+      const resource_id =
+        typeof file.resource_id === 'string' && file.resource_id !== ''
+          ? file.resource_id
+          : scope.id;
 
+      if (scope.kind === 'skill') {
+        return {
+          storage_session_id,
+          kind: 'skill' as const,
+          id,
+          resource_id,
+          name,
+          version: scope.version,
+        };
+      }
       return {
-        storage_session_id: sessionId,
-        /* `/files` fallback returns code-output files belonging to
-         * the user; tag them user-private. */
-        kind: 'user' as const,
+        storage_session_id,
+        kind: scope.kind,
         id,
-        /* `resource_id` informational for `kind: 'user'` —
-         * codeapi derives sessionKey from auth context. */
-        resource_id: id,
-        name: (file.metadata as Record<string, unknown>)[
-          'original-filename'
-        ] as string,
+        resource_id,
+        name,
       };
     });
   } catch (error) {

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -6,6 +6,7 @@ import { tool, DynamicStructuredTool } from '@langchain/core/tools';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
+  buildCodeApiHttpErrorMessage,
   emptyOutputMessage,
   getCodeBaseURL,
   resolveCodeApiAuthHeaders,
@@ -426,7 +427,9 @@ export async function fetchSessionFiles(
 
     const response = await fetch(filesEndpoint, fetchOptions);
     if (!response.ok) {
-      throw new Error(`Failed to fetch files for session: ${response.status}`);
+      throw new Error(
+        await buildCodeApiHttpErrorMessage('GET', filesEndpoint, response)
+      );
     }
 
     const files = await response.json();
@@ -477,9 +480,8 @@ export async function makeRequest(
   const response = await fetch(endpoint, fetchOptions);
 
   if (!response.ok) {
-    const errorText = await response.text();
     throw new Error(
-      `HTTP error! status: ${response.status}, body: ${errorText}`
+      await buildCodeApiHttpErrorMessage('POST', endpoint, response)
     );
   }
 

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -155,6 +155,18 @@ export type FetchSessionFilesScope =
   | { kind: 'skill'; id: string; version: number }
   | { kind: 'agent' | 'user'; id: string; version?: never };
 
+type CodeApiSessionFileWire = {
+  id?: unknown;
+  name?: unknown;
+  metadata?: unknown;
+  resource_id?: unknown;
+  storage_session_id?: unknown;
+};
+
+type CodeApiSessionFileMetadata = {
+  'original-filename'?: unknown;
+};
+
 function isFetchSessionFilesScope(
   value: unknown
 ): value is FetchSessionFilesScope {
@@ -173,6 +185,77 @@ function isFetchSessionFilesScope(
     typeof scope.id === 'string' &&
     typeof scope.version === 'number'
   );
+}
+
+function isCodeApiAuthHeaders(
+  value: string | t.CodeApiAuthHeaders | undefined
+): value is t.CodeApiAuthHeaders {
+  return value != null && typeof value !== 'string';
+}
+
+function isCodeApiSessionFileWire(
+  value: unknown
+): value is CodeApiSessionFileWire {
+  return value != null && typeof value === 'object';
+}
+
+function isCodeApiSessionFileMetadata(
+  value: unknown
+): value is CodeApiSessionFileMetadata {
+  return value != null && typeof value === 'object';
+}
+
+function normalizeSessionFile(
+  file: CodeApiSessionFileWire,
+  sessionId: string,
+  scope?: FetchSessionFilesScope
+): t.CodeEnvFile {
+  const metadata = isCodeApiSessionFileMetadata(file.metadata)
+    ? file.metadata
+    : undefined;
+  const rawName = typeof file.name === 'string' ? file.name : '';
+  const nameParts = rawName.split('/');
+  const fallbackId = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
+  const id =
+    typeof file.id === 'string' && file.id !== '' ? file.id : fallbackId;
+  const originalFilename = metadata?.['original-filename'];
+  const name =
+    typeof originalFilename === 'string' ? originalFilename : rawName;
+  const storage_session_id =
+    typeof file.storage_session_id === 'string'
+      ? file.storage_session_id
+      : sessionId;
+  const resource_id =
+    typeof file.resource_id === 'string' && file.resource_id !== ''
+      ? file.resource_id
+      : (scope?.id ?? id);
+
+  if (scope?.kind === 'skill') {
+    return {
+      storage_session_id,
+      kind: 'skill',
+      id,
+      resource_id,
+      name,
+      version: scope.version,
+    };
+  }
+  if (scope != null) {
+    return {
+      storage_session_id,
+      kind: scope.kind,
+      id,
+      resource_id,
+      name,
+    };
+  }
+  return {
+    storage_session_id,
+    kind: 'user',
+    id,
+    resource_id: id,
+    name,
+  };
 }
 
 /**
@@ -310,7 +393,9 @@ export async function fetchSessionFiles(
     let authHeaders: t.CodeApiAuthHeaders | undefined;
     if (scope == null) {
       proxy = typeof scopeOrProxy === 'string' ? scopeOrProxy : undefined;
-      authHeaders = proxyOrAuthHeaders as t.CodeApiAuthHeaders | undefined;
+      authHeaders = isCodeApiAuthHeaders(proxyOrAuthHeaders)
+        ? proxyOrAuthHeaders
+        : undefined;
     } else if (typeof proxyOrAuthHeaders === 'string') {
       proxy = proxyOrAuthHeaders;
       authHeaders = scopedAuthHeaders;
@@ -349,53 +434,9 @@ export async function fetchSessionFiles(
       return [];
     }
 
-    return files.map((file: Record<string, unknown>) => {
-      const metadata = (file.metadata ?? {}) as Record<string, unknown>;
-      const rawName = typeof file.name === 'string' ? file.name : '';
-      const nameParts = rawName.split('/');
-      const fallbackId = nameParts.length > 1 ? nameParts[1].split('.')[0] : '';
-      const id =
-        typeof file.id === 'string' && file.id !== '' ? file.id : fallbackId;
-      const name =
-        typeof metadata['original-filename'] === 'string'
-          ? metadata['original-filename']
-          : rawName;
-      const storage_session_id =
-        typeof file.storage_session_id === 'string'
-          ? file.storage_session_id
-          : sessionId;
-      const resource_id =
-        typeof file.resource_id === 'string' && file.resource_id !== ''
-          ? file.resource_id
-          : (scope?.id ?? id);
-
-      if (scope?.kind === 'skill') {
-        return {
-          storage_session_id,
-          kind: 'skill' as const,
-          id,
-          resource_id,
-          name,
-          version: scope.version,
-        };
-      }
-      if (scope != null) {
-        return {
-          storage_session_id,
-          kind: scope.kind,
-          id,
-          resource_id,
-          name,
-        };
-      }
-      return {
-        storage_session_id,
-        kind: 'user' as const,
-        id,
-        resource_id: id,
-        name,
-      };
-    });
+    return files
+      .filter(isCodeApiSessionFileWire)
+      .map((file) => normalizeSessionFile(file, sessionId, scope));
   } catch (error) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -844,10 +844,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           // Plumb the hook context into the programmatic-tool path so
           // inner tool calls made via the in-process bridge can run
           // through `PreToolUse` (deny / updatedInput) before reaching
-          // the underlying tool. Without this, `run_tools_with_code`
-          // bypassed every PreToolUse hook the host registered for
-          // the tools it dispatches — including HITL gates on
-          // `write_file` / `edit_file` (manual review finding A).
+          // the underlying tool. Without this, programmatic tool calls
+          // bypass every PreToolUse hook the host registered for the tools
+          // they dispatch — including HITL gates on `write_file` / `edit_file`.
           hookContext: {
             registry: this.hookRegistry,
             runId: (config.configurable?.run_id as string | undefined) ?? '',

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -1,0 +1,207 @@
+import fetch from 'node-fetch';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type * as t from '@/types';
+import {
+  createCodeExecutionTool,
+  resolveCodeApiAuthHeaders,
+} from '../CodeExecutor';
+import { createBashExecutionTool } from '../BashExecutor';
+import {
+  createProgrammaticToolCallingTool,
+  makeRequest,
+} from '../ProgrammaticToolCalling';
+import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
+
+jest.mock('node-fetch', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+type FetchMock = jest.MockedFunction<
+  (url: unknown, init?: unknown) => Promise<unknown>
+>;
+
+const fetchMock = fetch as unknown as FetchMock;
+
+function jsonResponse(body: unknown): unknown {
+  return {
+    ok: true,
+    json: jest.fn(async () => body),
+    text: jest.fn(async () => JSON.stringify(body)),
+  };
+}
+
+function completedResponse(stdout = 'ok'): unknown {
+  return jsonResponse({
+    status: 'completed',
+    session_id: 'session_123',
+    stdout,
+  });
+}
+
+const toolDefs = [
+  {
+    name: 'lookup_user',
+    description: 'Lookup a user',
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+  },
+] as unknown as t.LCTool[];
+
+function toolMap(): t.ToolMap {
+  return new Map([
+    [
+      'lookup_user',
+      {
+        name: 'lookup_user',
+        invoke: jest.fn(async () => ({ id: 'user_123' })),
+      },
+    ],
+  ]) as unknown as t.ToolMap;
+}
+
+describe('CodeAPI auth header injection', () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(completedResponse());
+  });
+
+  it('resolves static and dynamic auth header params', async () => {
+    await expect(
+      resolveCodeApiAuthHeaders({ Authorization: 'Bearer static' })
+    ).resolves.toEqual({
+      Authorization: 'Bearer static',
+    });
+    await expect(
+      resolveCodeApiAuthHeaders(async () => ({
+        Authorization: 'Bearer dynamic',
+      }))
+    ).resolves.toEqual({
+      Authorization: 'Bearer dynamic',
+    });
+    await expect(resolveCodeApiAuthHeaders()).resolves.toEqual({});
+  });
+
+  it('keeps the no-auth request path unchanged', async () => {
+    await makeRequest('https://code.example.com/exec/programmatic', {
+      code: 'print(1)',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://code.example.com/exec/programmatic',
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          Authorization: expect.any(String),
+        }),
+      })
+    );
+  });
+
+  it('forwards Authorization for direct code execution', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ session_id: 'session_123', stdout: '1\n' })
+    );
+    const tool = createCodeExecutionTool({
+      authHeaders: async () => ({ Authorization: 'Bearer code-token' }),
+    });
+
+    await tool.invoke({ lang: 'py', code: 'print(1)' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer code-token',
+        }),
+      })
+    );
+  });
+
+  it('forwards Authorization for bash execution', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ session_id: 'session_123', stdout: '1\n' })
+    );
+    const tool = createBashExecutionTool({
+      authHeaders: { Authorization: 'Bearer bash-token' },
+    });
+
+    await tool.invoke({ command: 'echo 1' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer bash-token',
+        }),
+      })
+    );
+  });
+
+  it('forwards Authorization on programmatic initial and continuation requests', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          status: 'tool_call_required',
+          continuation_token: 'continue_123',
+          tool_calls: [{ id: 'call_1', name: 'lookup_user', input: {} }],
+        })
+      )
+      .mockResolvedValueOnce(completedResponse('done'));
+
+    const tool = createProgrammaticToolCallingTool({
+      authHeaders: () => ({ Authorization: 'Bearer ptc-token' }),
+    });
+
+    await tool.invoke(
+      { code: 'result = await lookup_user()\nprint(result)' },
+      {
+        toolCall: {
+          name: 'programmatic_code_execution',
+          args: {},
+          toolMap: toolMap(),
+          toolDefs,
+        },
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer ptc-token',
+          }),
+        })
+      );
+    }
+  });
+
+  it('forwards Authorization for bash programmatic requests', async () => {
+    const tool = createBashProgrammaticToolCallingTool({
+      authHeaders: { Authorization: 'Bearer bash-ptc-token' },
+    });
+
+    await tool.invoke(
+      { code: 'lookup_user "{}"' },
+      {
+        toolCall: {
+          name: 'bash_programmatic_code_execution',
+          args: {},
+          toolMap: toolMap(),
+          toolDefs,
+        },
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer bash-ptc-token',
+        }),
+      })
+    );
+  });
+});

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -41,6 +41,14 @@ function completedResponse(stdout = 'ok'): unknown {
   });
 }
 
+function errorResponse(status: number, body: string): unknown {
+  return {
+    ok: false,
+    status,
+    text: jest.fn(async () => body),
+  };
+}
+
 const toolDefs = [
   {
     name: 'lookup_user',
@@ -145,6 +153,15 @@ describe('CodeAPI auth header injection', () => {
     expect(
       JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string)
     ).not.toHaveProperty('authHeaders');
+  });
+
+  it('includes the CodeAPI endpoint and response body on direct execution failures', async () => {
+    fetchMock.mockResolvedValueOnce(errorResponse(404, 'Cannot POST /exec'));
+    const tool = createBashExecutionTool();
+
+    await expect(tool.invoke({ command: 'echo 1' })).rejects.toThrow(
+      /CodeAPI request failed: POST .*\/exec returned 404, body: Cannot POST \/exec/
+    );
   });
 
   it('forwards Authorization on programmatic initial and continuation requests', async () => {

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -246,6 +246,26 @@ describe('CodeAPI auth header injection', () => {
     );
   });
 
+  it('fetches scoped session files with auth headers and no proxy placeholder', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    await fetchSessionFiles(
+      'https://code.example.com',
+      'session_123',
+      { kind: 'skill', id: 'skill-1', version: 7 },
+      { Authorization: 'Bearer scoped-files-token' }
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://code.example.com/files/session_123?detail=full&kind=skill&id=skill-1&version=7',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer scoped-files-token',
+        }),
+      })
+    );
+  });
+
   it('preserves the legacy fetchSessionFiles proxy/auth argument order', async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse([

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { RequestInit } from 'node-fetch';
 import type * as t from '@/types';
 import {
   createCodeExecutionTool,
@@ -117,6 +118,9 @@ describe('CodeAPI auth header injection', () => {
         }),
       })
     );
+    expect(
+      JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string)
+    ).not.toHaveProperty('authHeaders');
   });
 
   it('forwards Authorization for bash execution', async () => {
@@ -137,6 +141,9 @@ describe('CodeAPI auth header injection', () => {
         }),
       })
     );
+    expect(
+      JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string)
+    ).not.toHaveProperty('authHeaders');
   });
 
   it('forwards Authorization on programmatic initial and continuation requests', async () => {

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -9,6 +9,7 @@ import {
 import { createBashExecutionTool } from '../BashExecutor';
 import {
   createProgrammaticToolCallingTool,
+  fetchSessionFiles,
   makeRequest,
 } from '../ProgrammaticToolCalling';
 import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
@@ -207,6 +208,39 @@ describe('CodeAPI auth header injection', () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: 'Bearer bash-ptc-token',
+        }),
+      })
+    );
+  });
+
+  it('fetches session files with the CodeAPI resource scope and auth headers', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 'file-1',
+          resource_id: 'skill-1',
+          storage_session_id: 'session_123',
+          name: 'skill/file.txt',
+          kind: 'skill',
+          version: 7,
+        },
+      ])
+    );
+
+    const files = await fetchSessionFiles(
+      'https://code.example.com',
+      'session_123',
+      { kind: 'skill', id: 'skill-1', version: 7 },
+      undefined,
+      { Authorization: 'Bearer files-token' }
+    );
+
+    expect(files).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://code.example.com/files/session_123?detail=full&kind=skill&id=skill-1&version=7',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer files-token',
         }),
       })
     );

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -245,4 +245,40 @@ describe('CodeAPI auth header injection', () => {
       })
     );
   });
+
+  it('preserves the legacy fetchSessionFiles proxy/auth argument order', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          name: 'session_123/file-1.txt',
+          metadata: { 'original-filename': 'file.txt' },
+        },
+      ])
+    );
+
+    const files = await fetchSessionFiles(
+      'https://code.example.com',
+      'session_123',
+      '',
+      { Authorization: 'Bearer legacy-files-token' }
+    );
+
+    expect(files).toEqual([
+      {
+        storage_session_id: 'session_123',
+        kind: 'user',
+        id: 'file-1',
+        resource_id: 'file-1',
+        name: 'file.txt',
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://code.example.com/files/session_123?detail=full',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer legacy-files-token',
+        }),
+      })
+    );
+  });
 });

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -3,8 +3,9 @@
  * Unit tests for Programmatic Tool Calling.
  * Tests manual invocation with mock tools and Code API responses.
  */
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import type * as t from '@/types';
+import { Constants } from '@/common';
 import {
   createProgrammaticToolCallingTool,
   formatCompletedResponse,
@@ -54,6 +55,35 @@ describe('ProgrammaticToolCalling', () => {
         temperature: 65,
         condition: 'Foggy',
       });
+    });
+
+    it('marks bash PTC inner tool invocations with bash metadata', async () => {
+      const invoke = jest.fn<
+        (_input: unknown, _config: unknown) => Promise<{ ok: boolean }>
+          >(async () => ({ ok: true }));
+      const customTool = {
+        name: 'custom_tool',
+        invoke,
+      } as unknown as t.GenericTool;
+      const customToolMap: t.ToolMap = new Map([['custom_tool', customTool]]);
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'custom_tool',
+          input: { value: 1 },
+        },
+      ];
+
+      await executeTools(
+        toolCalls,
+        customToolMap,
+        Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+      );
+
+      expect(invoke).toHaveBeenCalledWith(
+        { value: 1 },
+        { metadata: { [Constants.BASH_PROGRAMMATIC_TOOL_CALLING]: true } }
+      );
     });
 
     it('executes multiple tools in parallel', async () => {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -219,7 +219,15 @@ export type CodeExecutionToolParams =
       session_id?: string;
       user_id?: string;
       files?: CodeEnvFile[];
+      /** Optional host-supplied Code API auth headers. */
+      authHeaders?: CodeApiAuthHeaders;
     };
+
+export type CodeApiAuthHeaderMap = Record<string, string>;
+
+export type CodeApiAuthHeaders =
+  | CodeApiAuthHeaderMap
+  | (() => CodeApiAuthHeaderMap | Promise<CodeApiAuthHeaderMap>);
 
 export type FileRef = {
   /**
@@ -896,6 +904,8 @@ export type ProgrammaticToolCallingParams = {
   proxy?: string;
   /** Enable debug logging (or set PTC_DEBUG=true env var) */
   debug?: boolean;
+  /** Optional host-supplied Code API auth headers. */
+  authHeaders?: CodeApiAuthHeaders;
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary

I added a generic CodeAPI auth-header injector for AI-905 so callers can pass LibreChat-minted authorization without coupling agents to LibreChat internals.

- Added an `authHeaders` tool parameter that accepts static headers or an async resolver.
- Merged injected headers into every CodeAPI fetch across direct execution, programmatic tool calling, and bash programmatic tool calling.
- Preserved the no-auth/default request path for OSS and direct CodeAPI users.
- Avoided LibreChat-specific imports and API-key-specific behavior in the generic agents layer.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `npm run build`.
- Ran `npm test -- src/tools/__tests__/CodeApiAuthHeaders.test.ts --runInBand`.
- Ran repository pre-commit formatting and lint hooks during commit.

### **Test Configuration**:

- macOS local worktree
- Node/npm workspace tooling from the repository

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
