### PR TITLE
🧭 fix: Handle Mistyped Handoff Tools Locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "start:dev": "node --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/main.ts",
     "supervised": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/supervised.ts --provider anthropic --name Jo --location \"New York, NY\"",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "test:live:handoffs": "RUN_HANDOFF_LIVE_TESTS=1 NODE_OPTIONS='--experimental-vm-modules' jest src/specs/agent-handoffs.live.test.ts --runInBand",
     "test:memory": "NODE_OPTIONS='--expose-gc' npx jest src/specs/title.memory-leak.test.ts",
     "test:all": "npm test -- --testPathIgnorePatterns=title.memory-leak.test.ts && npm run test:memory",
     "reinstall": "npm run clean && npm ci && rm -rf ./dist && npm run build",

--- a/src/specs/agent-handoffs.live.test.ts
+++ b/src/specs/agent-handoffs.live.test.ts
@@ -1,0 +1,140 @@
+// src/specs/agent-handoffs.live.test.ts
+/**
+ * Live handoff integration verification.
+ *
+ * Run with:
+ * RUN_HANDOFF_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- agent-handoffs.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import { HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { BaseMessage, ToolMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { Constants, Providers } from '@/common';
+import { Run } from '@/run';
+
+const shouldRunLive =
+  process.env.RUN_HANDOFF_LIVE_TESTS === '1' &&
+  process.env.ANTHROPIC_API_KEY != null &&
+  process.env.ANTHROPIC_API_KEY !== '';
+
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+const modelName =
+  process.env.ANTHROPIC_HANDOFF_LIVE_MODEL ?? 'claude-sonnet-4-6';
+
+function createAnthropicAgent(
+  agentId: string,
+  instructions: string
+): t.AgentInputs {
+  return {
+    agentId,
+    provider: Providers.ANTHROPIC,
+    clientOptions: {
+      modelName,
+      apiKey: process.env.ANTHROPIC_API_KEY,
+      temperature: 0,
+      maxTokens: 256,
+      streaming: true,
+    },
+    instructions,
+    maxContextTokens: 8000,
+  };
+}
+
+function createStreamConfig(threadId: string): Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+} {
+  return {
+    configurable: { thread_id: threadId },
+    streamMode: 'values',
+    version: 'v2',
+  };
+}
+
+function contentToText(message: BaseMessage): string {
+  if (typeof message.content === 'string') {
+    return message.content;
+  }
+  if (!Array.isArray(message.content)) {
+    return '';
+  }
+  return message.content
+    .map((part) => {
+      if (typeof part === 'string') {
+        return part;
+      }
+      if ('text' in part && typeof part.text === 'string') {
+        return part.text;
+      }
+      return '';
+    })
+    .join('');
+}
+
+describeIfLive('Agent handoffs live integration', () => {
+  jest.setTimeout(120_000);
+
+  it('routes through a real Anthropic handoff and preserves instructions', async () => {
+    const nonce = `live-handoff-${Date.now()}`;
+    const expectedReply = `${nonce}-specialist-confirmed`;
+    const handoffToolName = `${Constants.LC_TRANSFER_TO_}specialist`;
+    const agents: t.AgentInputs[] = [
+      createAnthropicAgent(
+        'router',
+        `You are a routing agent. For every user request, your only valid action is to call the handoff tool named ${handoffToolName}. Do not answer directly.
+
+When you call the handoff tool, include instructions telling the specialist to reply exactly with this marker and no extra words: ${expectedReply}`
+      ),
+      createAnthropicAgent(
+        'specialist',
+        'You are the specialist. When you receive handoff instructions with a marker, reply exactly with that marker and no extra words.'
+      ),
+    ];
+    const edges: t.GraphEdge[] = [
+      {
+        from: 'router',
+        to: 'specialist',
+        edgeType: 'handoff',
+        description: 'Transfer to the specialist for the final response',
+        prompt:
+          'Instructions for the specialist. Include any exact marker that must be returned.',
+        promptKey: 'instructions',
+      },
+    ];
+    const run = await Run.create({
+      runId: `${nonce}-run`,
+      graphConfig: { type: 'multi-agent', agents, edges },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    await run.processStream(
+      {
+        messages: [
+          new HumanMessage(
+            `Please delegate this to the specialist. The final answer must be exactly: ${expectedReply}`
+          ),
+        ],
+      },
+      createStreamConfig(`${nonce}-thread`)
+    );
+
+    const messages = run.getRunMessages() ?? [];
+    const handoffMessage = messages.find(
+      (message): message is ToolMessage =>
+        message.getType() === 'tool' &&
+        (message as ToolMessage).name === handoffToolName
+    );
+    const finalText = messages
+      .filter((message) => message.getType() === 'ai')
+      .map(contentToText)
+      .join('\n');
+
+    expect(handoffMessage).toBeDefined();
+    expect(finalText).toContain(expectedReply);
+  });
+});

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -4,7 +4,7 @@ import { HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
-import { Providers, Constants } from '@/common';
+import { Providers, GraphEvents, Constants } from '@/common';
 import { StandardGraph } from '@/graphs/Graph';
 import { Run } from '@/run';
 
@@ -987,6 +987,165 @@ describe('Agent Handoffs Tests', () => {
       expect(handoffTool).toBeDefined();
       expect(getToolName(handoffTool!)).toBe(
         `${Constants.LC_TRANSFER_TO_}AgentWithCamelCase`
+      );
+    });
+
+    it('should return exact-name guidance for handoff names with extra suffixes', async () => {
+      const agents: t.AgentInputs[] = [
+        createBasicAgent('router', 'You are a router'),
+        createBasicAgent('data_analyst', 'You are a data analyst'),
+      ];
+
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: 'data_analyst',
+          edgeType: 'handoff',
+        },
+      ];
+
+      const run = await Run.create(createTestConfig(agents, edges));
+      const correctName = `${Constants.LC_TRANSFER_TO_}data_analyst`;
+      const wrongName = `${correctName}_analyst`;
+
+      run.Graph?.overrideTestModel(
+        ['Trying to transfer', 'Stopping after invalid tool name'],
+        10,
+        [
+          {
+            id: 'tool_call_wrong_handoff',
+            name: wrongName,
+            args: { instructions: 'Analyze the uploaded data' },
+          } as ToolCall,
+        ]
+      );
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: {
+          thread_id: 'test-wrong-handoff-name-thread',
+        },
+        streamMode: 'values',
+        version: 'v2' as const,
+      };
+
+      await run.processStream(
+        { messages: [new HumanMessage('Please analyze my data')] },
+        config
+      );
+
+      const toolMessages = run
+        .getRunMessages()!
+        .filter((msg) => msg.getType() === 'tool') as ToolMessage[];
+      const wrongNameMessage = toolMessages.find(
+        (msg) => msg.name === wrongName
+      );
+
+      expect(wrongNameMessage).toBeDefined();
+      expect(wrongNameMessage?.status).toBe('error');
+      expect(wrongNameMessage?.content).toContain(
+        `Did you mean "${correctName}"`
+      );
+    });
+
+    it('should not dispatch mistyped graph handoffs to event-driven tool hosts', async () => {
+      const executedToolNames: string[] = [];
+      const agents: t.AgentInputs[] = [
+        {
+          ...createBasicAgent('router', 'You are a router'),
+          toolDefinitions: [
+            {
+              name: 'lookup_sessions',
+              description: 'List upload sessions',
+              parameters: {
+                type: 'object',
+                properties: {},
+                required: [],
+              },
+            },
+          ],
+        },
+        createBasicAgent('data_analyst', 'You are a data analyst'),
+      ];
+
+      const edges: t.GraphEdge[] = [
+        {
+          from: 'router',
+          to: 'data_analyst',
+          edgeType: 'handoff',
+        },
+      ];
+
+      const run = await Run.create({
+        ...createTestConfig(agents, edges),
+        customHandlers: {
+          [GraphEvents.ON_TOOL_EXECUTE]: {
+            handle: (_event: string, data: t.StreamEventData): void => {
+              const batch = data as t.ToolExecuteBatchRequest;
+              executedToolNames.push(
+                ...batch.toolCalls.map((toolCall) => toolCall.name)
+              );
+              batch.resolve(
+                batch.toolCalls.map((toolCall) => ({
+                  toolCallId: toolCall.id,
+                  status: 'success' as const,
+                  content: `host result for ${toolCall.name}`,
+                }))
+              );
+            },
+          },
+        },
+      });
+      const correctName = `${Constants.LC_TRANSFER_TO_}data_analyst`;
+      const wrongName = `${correctName}_analyst`;
+
+      run.Graph?.overrideTestModel(
+        ['Checking sessions and transferring', 'Handled invalid transfer'],
+        10,
+        [
+          {
+            id: 'tool_call_lookup',
+            name: 'lookup_sessions',
+            args: {},
+          } as ToolCall,
+          {
+            id: 'tool_call_wrong_handoff',
+            name: wrongName,
+            args: { instructions: 'Analyze the upload session data' },
+          } as ToolCall,
+        ]
+      );
+
+      const config: Partial<RunnableConfig> & {
+        version: 'v1' | 'v2';
+        streamMode: string;
+      } = {
+        configurable: {
+          thread_id: 'test-event-wrong-handoff-name-thread',
+        },
+        streamMode: 'values',
+        version: 'v2' as const,
+      };
+
+      await run.processStream(
+        { messages: [new HumanMessage('Check my sessions and analyze them')] },
+        config
+      );
+
+      const toolMessages = run
+        .getRunMessages()!
+        .filter((msg) => msg.getType() === 'tool') as ToolMessage[];
+      const wrongNameMessage = toolMessages.find(
+        (msg) => msg.name === wrongName
+      );
+
+      expect(executedToolNames).toEqual(['lookup_sessions']);
+      expect(wrongNameMessage).toBeDefined();
+      expect(wrongNameMessage?.status).toBe('error');
+      expect(wrongNameMessage?.content).toContain(
+        `Did you mean "${correctName}"`
       );
     });
   });

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -1,11 +1,12 @@
 // src/specs/agent-handoffs.test.ts
 import { DynamicStructuredTool } from '@langchain/core/tools';
-import { HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import { Providers, GraphEvents, Constants } from '@/common';
 import { StandardGraph } from '@/graphs/Graph';
+import { ToolNode } from '@/tools/ToolNode';
 import { Run } from '@/run';
 
 /**
@@ -1041,6 +1042,38 @@ describe('Agent Handoffs Tests', () => {
         .filter((msg) => msg.getType() === 'tool') as ToolMessage[];
       const wrongNameMessage = toolMessages.find(
         (msg) => msg.name === wrongName
+      );
+
+      expect(wrongNameMessage).toBeDefined();
+      expect(wrongNameMessage?.status).toBe('error');
+      expect(wrongNameMessage?.content).toContain(
+        `Did you mean "${correctName}"`
+      );
+    });
+
+    it('should include toolMap handoffs when direct tool names are present', async () => {
+      const correctName = `${Constants.LC_TRANSFER_TO_}data_analyst`;
+      const wrongName = `${correctName}_analyst`;
+      const handoffTool = new DynamicStructuredTool({
+        name: correctName,
+        description: 'Transfer to data analyst',
+        schema: { type: 'object', properties: {}, required: [] },
+        func: async (): Promise<string> => 'transferred',
+      }) as t.GenericTool;
+      const node = new ToolNode({
+        tools: [handoffTool],
+        directToolNames: new Set(['execute_code']),
+      });
+      const result = (await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'wrong_handoff', name: wrongName, args: {} }],
+          }),
+        ],
+      })) as { messages: ToolMessage[] };
+      const wrongNameMessage = result.messages.find(
+        (msg) => msg.tool_call_id === 'wrong_handoff'
       );
 
       expect(wrongNameMessage).toBeDefined();

--- a/src/specs/agent-handoffs.test.ts
+++ b/src/specs/agent-handoffs.test.ts
@@ -7,6 +7,7 @@ import type * as t from '@/types';
 import { Providers, GraphEvents, Constants } from '@/common';
 import { StandardGraph } from '@/graphs/Graph';
 import { ToolNode } from '@/tools/ToolNode';
+import * as events from '@/utils/events';
 import { Run } from '@/run';
 
 /**
@@ -1081,6 +1082,77 @@ describe('Agent Handoffs Tests', () => {
       expect(wrongNameMessage?.content).toContain(
         `Did you mean "${correctName}"`
       );
+    });
+
+    it('should keep event-driven unknown handoffs local without direct tool names', async () => {
+      const executedToolNames: string[] = [];
+      const correctName = `${Constants.LC_TRANSFER_TO_}data_analyst`;
+      const wrongName = `${correctName}_analyst`;
+      const lookupName = 'lookup_sessions';
+      const handoffTool = new DynamicStructuredTool({
+        name: correctName,
+        description: 'Transfer to data analyst',
+        schema: { type: 'object', properties: {}, required: [] },
+        func: async (): Promise<string> => 'transferred',
+      }) as t.GenericTool;
+      const lookupTool = new DynamicStructuredTool({
+        name: lookupName,
+        description: 'List upload sessions',
+        schema: { type: 'object', properties: {}, required: [] },
+        func: async (): Promise<string> => 'sessions',
+      }) as t.GenericTool;
+      const dispatchSpy = jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data): Promise<void> => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+            return;
+          }
+          const batch = data as t.ToolExecuteBatchRequest;
+          executedToolNames.push(
+            ...batch.toolCalls.map((toolCall) => toolCall.name)
+          );
+          batch.resolve(
+            batch.toolCalls.map((toolCall) => ({
+              toolCallId: toolCall.id,
+              status: 'success' as const,
+              content: `host result for ${toolCall.name}`,
+            }))
+          );
+        });
+      const node = new ToolNode({
+        tools: [handoffTool, lookupTool],
+        eventDrivenMode: true,
+        toolCallStepIds: new Map([
+          ['lookup_call', 'step_lookup'],
+          ['wrong_handoff', 'step_wrong_handoff'],
+        ]),
+      });
+
+      try {
+        const result = (await node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                { id: 'lookup_call', name: lookupName, args: {} },
+                { id: 'wrong_handoff', name: wrongName, args: {} },
+              ],
+            }),
+          ],
+        })) as { messages: ToolMessage[] };
+        const wrongNameMessage = result.messages.find(
+          (msg) => msg.tool_call_id === 'wrong_handoff'
+        );
+
+        expect(executedToolNames).toEqual([lookupName]);
+        expect(wrongNameMessage).toBeDefined();
+        expect(wrongNameMessage?.status).toBe('error');
+        expect(wrongNameMessage?.content).toContain(
+          `Did you mean "${correctName}"`
+        );
+      } finally {
+        dispatchSpy.mockRestore();
+      }
     });
 
     it('should not dispatch mistyped graph handoffs to event-driven tool hosts', async () => {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -131,6 +131,10 @@ function isSend(value: unknown): value is Send {
   return value instanceof Send;
 }
 
+function isHandoffToolName(name: string): boolean {
+  return name.startsWith(Constants.LC_TRANSFER_TO_);
+}
+
 /**
  * Format a fail-closed diagnostic for malformed approval-decision
  * fields. Hosts deserialize resume payloads from untyped JSON, so
@@ -581,6 +585,61 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     return this.fileCheckpointer;
   }
 
+  private getRegisteredHandoffNames(): Iterable<string> {
+    return this.directToolNames != null && this.directToolNames.size > 0
+      ? this.directToolNames
+      : this.toolMap.keys();
+  }
+
+  private hasRegisteredHandoffTool(): boolean {
+    for (const toolName of this.getRegisteredHandoffNames()) {
+      if (isHandoffToolName(toolName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private getHandoffToolNameSuggestion(callName: string): string | undefined {
+    if (!isHandoffToolName(callName)) {
+      return undefined;
+    }
+
+    let suggestion: string | undefined;
+    for (const toolName of this.getRegisteredHandoffNames()) {
+      if (
+        !isHandoffToolName(toolName) ||
+        toolName.length >= callName.length ||
+        !callName.startsWith(toolName)
+      ) {
+        continue;
+      }
+      if (suggestion == null || toolName.length > suggestion.length) {
+        suggestion = toolName;
+      }
+    }
+    return suggestion;
+  }
+
+  private shouldHandleUnknownHandoffLocally(callName: string): boolean {
+    return (
+      isHandoffToolName(callName) &&
+      !this.toolMap.has(callName) &&
+      this.hasRegisteredHandoffTool()
+    );
+  }
+
+  private getUnknownToolErrorMessage(callName: string): string {
+    const suggestion = this.getHandoffToolNameSuggestion(callName);
+    if (suggestion == null) {
+      return `Tool "${callName}" not found.`;
+    }
+    return (
+      `Tool "${callName}" not found. Did you mean "${suggestion}"? ` +
+      'Handoff tool names must match exactly.'
+    );
+  }
+
   /**
    * Flush the per-Run direct-path turn cache. Called by the Graph at
    * end-of-Run via `clearHeavyState`. The map intentionally survives
@@ -699,7 +758,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       batchScopeId ?? (config.configurable?.run_id as string | undefined);
     try {
       if (tool === undefined) {
-        throw new Error(`Tool "${call.name}" not found.`);
+        throw new Error(this.getUnknownToolErrorMessage(call.name));
       }
       /**
        * `usageCount` is the per-tool-name invocation index that
@@ -2742,8 +2801,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     let outputs: (BaseMessage | Command)[];
 
     if (this.isSendInput(input)) {
-      const isDirectTool = this.directToolNames?.has(input.lg_tool_call.name);
-      if (this.eventDrivenMode && isDirectTool !== true) {
+      const isLocalTool =
+        this.directToolNames?.has(input.lg_tool_call.name) === true ||
+        this.shouldHandleUnknownHandoffLocally(input.lg_tool_call.name);
+      if (this.eventDrivenMode && !isLocalTool) {
         return this.executeViaEvent([input.lg_tool_call], config, input, {
           batchIndices: [0],
           turn,
@@ -2849,8 +2910,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
       if (this.eventDrivenMode && filteredCalls.length > 0) {
         const filteredIndices = filteredCalls.map((_, idx) => idx);
+        const directToolNames = this.directToolNames;
 
-        if (!this.directToolNames || this.directToolNames.size === 0) {
+        if (directToolNames == null || directToolNames.size === 0) {
           return this.executeViaEvent(filteredCalls, config, input, {
             batchIndices: filteredIndices,
             turn,
@@ -2863,7 +2925,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         for (let i = 0; i < filteredCalls.length; i++) {
           const call = filteredCalls[i];
           const entry = { call, batchIndex: i };
-          if (this.directToolNames!.has(call.name)) {
+          if (
+            directToolNames.has(call.name) ||
+            this.shouldHandleUnknownHandoffLocally(call.name)
+          ) {
             directEntries.push(entry);
           } else {
             eventEntries.push(entry);

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -585,10 +585,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     return this.fileCheckpointer;
   }
 
-  private getRegisteredHandoffNames(): Iterable<string> {
-    return this.directToolNames != null && this.directToolNames.size > 0
-      ? this.directToolNames
-      : this.toolMap.keys();
+  private *getRegisteredHandoffNames(): IterableIterator<string> {
+    if (this.directToolNames != null) {
+      for (const toolName of this.directToolNames) {
+        yield toolName;
+      }
+    }
+
+    for (const toolName of this.toolMap.keys()) {
+      if (this.directToolNames?.has(toolName) === true) {
+        continue;
+      }
+      yield toolName;
+    }
   }
 
   private hasRegisteredHandoffTool(): boolean {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -630,12 +630,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     return suggestion;
   }
 
-  private shouldHandleUnknownHandoffLocally(callName: string): boolean {
-    return (
-      isHandoffToolName(callName) &&
-      !this.toolMap.has(callName) &&
-      this.hasRegisteredHandoffTool()
-    );
+  private shouldHandleUnknownHandoffLocally(
+    callName: string,
+    hasRegisteredHandoffTool?: boolean
+  ): boolean {
+    if (!isHandoffToolName(callName) || this.toolMap.has(callName)) {
+      return false;
+    }
+    return hasRegisteredHandoffTool ?? this.hasRegisteredHandoffTool();
   }
 
   private getUnknownToolErrorMessage(callName: string): string {
@@ -2918,16 +2920,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }) ?? [];
 
       if (this.eventDrivenMode && filteredCalls.length > 0) {
-        const filteredIndices = filteredCalls.map((_, idx) => idx);
         const directToolNames = this.directToolNames;
-
-        if (directToolNames == null || directToolNames.size === 0) {
-          return this.executeViaEvent(filteredCalls, config, input, {
-            batchIndices: filteredIndices,
-            turn,
-            batchScopeId,
-          });
-        }
+        const hasRegisteredHandoffTool = this.hasRegisteredHandoffTool();
 
         const directEntries: Array<{ call: ToolCall; batchIndex: number }> = [];
         const eventEntries: Array<{ call: ToolCall; batchIndex: number }> = [];
@@ -2935,13 +2929,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           const call = filteredCalls[i];
           const entry = { call, batchIndex: i };
           if (
-            directToolNames.has(call.name) ||
-            this.shouldHandleUnknownHandoffLocally(call.name)
+            directToolNames?.has(call.name) === true ||
+            this.shouldHandleUnknownHandoffLocally(
+              call.name,
+              hasRegisteredHandoffTool
+            )
           ) {
             directEntries.push(entry);
           } else {
             eventEntries.push(entry);
           }
+        }
+
+        if (directEntries.length === 0) {
+          return this.executeViaEvent(filteredCalls, config, input, {
+            batchIndices: eventEntries.map((entry) => entry.batchIndex),
+            turn,
+            batchScopeId,
+          });
         }
 
         const directCalls = directEntries.map((e) => e.call);


### PR DESCRIPTION
## Summary

I fixed mistyped graph-managed handoff tool calls so they fail closed inside `ToolNode` with exact-name guidance instead of being silently executed as a guessed handoff or dispatched to the host tool executor.

Fixes #60.

- Added exact handoff-name detection helpers that only suggest a registered handoff when the model emitted a strict longer prefix match.
- Routed unknown handoff-shaped calls through the local/direct `runTool` error path so the model receives a normal `ToolMessage` error tied to its original tool call id.
- Preserved host event dispatch for real event-driven tools, while preventing typo-shaped handoffs from reaching `ON_TOOL_EXECUTE`.
- Added regression coverage for plain graph handoffs, mixed event-driven host tools, local-execution direct-tool overlays, and event-driven ToolNodes without direct tool names.
- Added an opt-in live Anthropic handoff integration test using real `Run.processStream` execution and a reusable `test:live:handoffs` script.

This is empirically better than the contributor patch because the tests now measure the behavioral contract directly: a mistyped handoff is not executed, does not reach the host executor, and still returns actionable exact-name feedback. The live integration test also proves a real Anthropic handoff routes through the graph-managed transfer tool and preserves instructions into the receiving agent. The prior approach added synthetic correction output after resolving the typo, but it introduced several extra passes over the same call list and did not prove the host-dispatch leakage case. This patch keeps the error in the same existing unknown-tool path and verifies the real edge cases with executable assertions.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `NODE_OPTIONS='--experimental-vm-modules' npx jest src/specs/agent-handoffs.test.ts --runInBand`.
- Ran `NODE_OPTIONS='--experimental-vm-modules' npx jest src/specs/agent-handoffs.live.test.ts --runInBand` to verify the live test is skipped by default.
- Ran `NODE_OPTIONS='--experimental-vm-modules' npx jest src/specs/agent-handoffs.live.test.ts src/specs/agent-handoffs.test.ts --runInBand`.
- Ran `npm run test:live:handoffs` with `.env` credentials; the live Anthropic handoff passed with `claude-sonnet-4-6`.
- Ran `npx tsc --noEmit`.
- Ran `npx eslint src/tools/ToolNode.ts src/specs/agent-handoffs.test.ts`.
- Ran `npx eslint src/specs/agent-handoffs.live.test.ts`.
- Ran `git diff --check`.
- Ran live OpenAI handoff steering script successfully across three real handoff scenarios.
- Ran a compact live Anthropic handoff smoke with `claude-sonnet-4-6`; it returned `handoff: true`, `toolNames: ["lc_transfer_to_specialist"]`, and `specialistReplied: true`.

### **Test Configuration**:

- Base branch: `origin/dev` at `da06b06ada4b6fe3c12757fa2084b445e84b7197`
- Node: `v20.19.5`
- npm: `10.8.2`
- Anthropic model used for live smoke and live Jest handoff: `claude-sonnet-4-6`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
