### PR TITLE
🧊 fix: Preserve Prompt Cache Across Dynamic Context

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -16,7 +16,10 @@ import {
   Providers,
 } from '@/common';
 import { createSchemaOnlyTools } from '@/tools/schema';
-import { addCacheControl } from '@/messages/cache';
+import {
+  addCacheControl,
+  addCacheControlToStablePrefixMessages,
+} from '@/messages/cache';
 import { DEFAULT_RESERVE_RATIO } from '@/messages';
 import { toJsonSchema } from '@/utils/schema';
 
@@ -584,24 +587,24 @@ export class AgentContext {
     }
 
     const promptCacheProvider = this.getPromptCacheProvider();
-    const shouldMoveOpenRouterDynamicInstructions =
-      promptCacheProvider === Providers.OPENROUTER &&
+    const shouldMoveDynamicInstructions =
+      promptCacheProvider != null &&
       stableInstructions !== '' &&
       dynamicInstructions !== '';
     const systemMessage = this.buildSystemMessage({
       stableInstructions,
       dynamicInstructions,
       promptCacheProvider,
+      shouldMoveDynamicInstructions,
     });
 
     if (this.tokenCounter) {
       this.systemMessageTokens = systemMessage
         ? this.tokenCounter(systemMessage)
         : 0;
-      this.dynamicInstructionTokens =
-        shouldMoveOpenRouterDynamicInstructions
-          ? this.tokenCounter(new HumanMessage(dynamicInstructions))
-          : 0;
+      this.dynamicInstructionTokens = shouldMoveDynamicInstructions
+        ? this.tokenCounter(new HumanMessage(dynamicInstructions))
+        : 0;
     }
 
     return RunnableLambda.from((messages: BaseMessage[]) => {
@@ -616,16 +619,20 @@ export class AgentContext {
         this.summaryText !== '';
 
       const bodyWithSummary =
-        hasSummaryBody && promptCacheProvider !== Providers.OPENROUTER
+        hasSummaryBody && promptCacheProvider == null
           ? [this.buildSummaryHumanMessage(promptCacheProvider), ...messages]
           : messages;
-      const dynamicTail = this.buildOpenRouterDynamicTail({
+      const dynamicTail = this.buildPromptCacheDynamicTail({
         dynamicInstructions,
         hasSummaryBody,
         promptCacheProvider,
-        shouldMoveOpenRouterDynamicInstructions,
+        shouldMoveDynamicInstructions,
       });
-      let body = this.insertAfterFirstMessage(bodyWithSummary, dynamicTail);
+      let body = this.buildBodyWithPromptCacheDynamicTail(
+        bodyWithSummary,
+        dynamicTail,
+        promptCacheProvider
+      );
 
       if (
         promptCacheProvider != null &&
@@ -662,22 +669,22 @@ export class AgentContext {
     });
   }
 
-  private buildOpenRouterDynamicTail({
+  private buildPromptCacheDynamicTail({
     dynamicInstructions,
     hasSummaryBody,
     promptCacheProvider,
-    shouldMoveOpenRouterDynamicInstructions,
+    shouldMoveDynamicInstructions,
   }: {
     dynamicInstructions: string;
     hasSummaryBody: boolean;
     promptCacheProvider: PromptCacheProvider | undefined;
-    shouldMoveOpenRouterDynamicInstructions: boolean;
+    shouldMoveDynamicInstructions: boolean;
   }): BaseMessage[] {
-    if (promptCacheProvider !== Providers.OPENROUTER) {
+    if (promptCacheProvider == null) {
       return [];
     }
 
-    const dynamicTail = shouldMoveOpenRouterDynamicInstructions
+    const dynamicTail = shouldMoveDynamicInstructions
       ? [new HumanMessage(dynamicInstructions)]
       : [];
 
@@ -685,22 +692,59 @@ export class AgentContext {
       return dynamicTail;
     }
 
-    return [...dynamicTail, this.buildSummaryHumanMessage(promptCacheProvider)];
+    return [...dynamicTail, this.buildSummaryHumanMessage(undefined)];
   }
 
-  private insertAfterFirstMessage(
+  private buildBodyWithPromptCacheDynamicTail(
     messages: BaseMessage[],
-    tail: BaseMessage[]
+    tail: BaseMessage[],
+    promptCacheProvider: PromptCacheProvider | undefined
   ): BaseMessage[] {
     if (tail.length === 0) {
       return messages;
     }
 
-    if (messages.length === 0) {
-      return tail;
+    const tailIndex = this.getPromptCacheDynamicTailIndex(
+      messages,
+      promptCacheProvider
+    );
+    const stablePrefix = messages.slice(0, tailIndex);
+    const trailingMessages = messages.slice(tailIndex);
+    const cacheablePrefix = this.addStablePromptCacheMarkers(stablePrefix);
+
+    return [...cacheablePrefix, ...tail, ...trailingMessages];
+  }
+
+  private getPromptCacheDynamicTailIndex(
+    messages: BaseMessage[],
+    promptCacheProvider: PromptCacheProvider | undefined
+  ): number {
+    const lastIndex = messages.length - 1;
+
+    if (lastIndex < 0) {
+      return 0;
     }
 
-    return [messages[0], ...tail, ...messages.slice(1)];
+    if (promptCacheProvider === Providers.OPENROUTER && messages.length === 1) {
+      return messages.length;
+    }
+
+    if (messages[lastIndex].getType() === 'human') {
+      return lastIndex;
+    }
+
+    return messages.length;
+  }
+
+  private addStablePromptCacheMarkers(messages: BaseMessage[]): BaseMessage[] {
+    if (messages.length <= 1) {
+      return messages;
+    }
+
+    return [
+      messages[0],
+      ...addCacheControlToStablePrefixMessages(messages.slice(1), 2),
+    ];
   }
 
   private getPromptCacheProvider(): PromptCacheProvider | undefined {
@@ -739,10 +783,12 @@ export class AgentContext {
     stableInstructions,
     dynamicInstructions,
     promptCacheProvider,
+    shouldMoveDynamicInstructions,
   }: {
     stableInstructions: string;
     dynamicInstructions: string;
     promptCacheProvider: PromptCacheProvider | undefined;
+    shouldMoveDynamicInstructions: boolean;
   }): SystemMessage | undefined {
     if (!stableInstructions && !dynamicInstructions) {
       return undefined;
@@ -757,16 +803,13 @@ export class AgentContext {
           cache_control: { type: 'ephemeral' },
         });
       }
-      if (dynamicInstructions) {
+      if (dynamicInstructions && !shouldMoveDynamicInstructions) {
         content.push({ type: 'text', text: dynamicInstructions });
       }
       return new SystemMessage({ content } as BaseMessageFields);
     }
 
-    if (
-      promptCacheProvider === Providers.OPENROUTER &&
-      !stableInstructions
-    ) {
+    if (promptCacheProvider === Providers.OPENROUTER && !stableInstructions) {
       return new SystemMessage(dynamicInstructions);
     }
 

--- a/src/agents/__tests__/AgentContext.openrouter.live.test.ts
+++ b/src/agents/__tests__/AgentContext.openrouter.live.test.ts
@@ -1,15 +1,15 @@
-// src/agents/__tests__/AgentContext.anthropic.live.test.ts
+// src/agents/__tests__/AgentContext.openrouter.live.test.ts
 /**
- * Live Anthropic prompt-cache verification.
+ * Live OpenRouter prompt-cache verification.
  *
  * Run with:
- * RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- AgentContext.anthropic.live.test.ts --runInBand
+ * RUN_OPENROUTER_PROMPT_CACHE_LIVE_TESTS=1 OPENROUTER_API_KEY=... npm test -- AgentContext.openrouter.live.test.ts --runInBand
  */
 import { config as dotenvConfig } from 'dotenv';
-dotenvConfig();
+dotenvConfig({ path: process.env.DOTENV_CONFIG_PATH ?? '.env' });
 
 import { describe, expect, it } from '@jest/globals';
-import type * as t from '@/types';
+import type { ClientOptions } from '@langchain/openai';
 import {
   runLiveTurn,
   assertSystemPayloadShape,
@@ -17,38 +17,56 @@ import {
   buildStableInstructions,
   waitForCachePropagation,
 } from './promptCacheLiveHelpers';
+import type { ChatOpenRouterInput } from '@/llm/openrouter';
 import { Providers } from '@/common';
 
+const apiKey = process.env.OPENROUTER_API_KEY ?? process.env.OPENROUTER_KEY;
 const shouldRunLive =
-  process.env.RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS === '1' &&
-  process.env.ANTHROPIC_API_KEY != null &&
-  process.env.ANTHROPIC_API_KEY !== '';
+  process.env.RUN_OPENROUTER_PROMPT_CACHE_LIVE_TESTS === '1' &&
+  apiKey != null &&
+  apiKey !== '';
 
 const describeIfLive = shouldRunLive ? describe : describe.skip;
 
-const modelName =
-  process.env.ANTHROPIC_PROMPT_CACHE_MODEL ?? 'claude-sonnet-4-5';
-const providerLabel = 'Anthropic';
+const model =
+  process.env.OPENROUTER_PROMPT_CACHE_MODEL ?? 'anthropic/claude-sonnet-4.6';
+const providerLabel = 'OpenRouter';
+type OpenRouterLiveClientOptions = ChatOpenRouterInput & {
+  configuration?: ClientOptions;
+};
 
-function createClientOptions(): t.AnthropicClientOptions {
+function createClientOptions(): OpenRouterLiveClientOptions {
+  if (apiKey == null || apiKey === '') {
+    throw new Error('OPENROUTER_API_KEY is required');
+  }
+
+  const reasoning = model.startsWith('google/gemini-3')
+    ? { max_tokens: 16 }
+    : undefined;
+
   return {
-    modelName,
+    model,
+    apiKey,
     temperature: 0,
-    maxTokens: 8,
+    maxTokens: 256,
     streaming: true,
     streamUsage: true,
     promptCache: true,
-    clientOptions: {
+    configuration: {
+      baseURL:
+        process.env.OPENROUTER_BASE_URL ?? 'https://openrouter.ai/api/v1',
       defaultHeaders: {
-        'anthropic-beta': 'prompt-caching-2024-07-31',
+        'HTTP-Referer': 'https://librechat.ai',
+        'X-Title': 'LibreChat OpenRouter Prompt Cache Live Test',
       },
     },
+    ...(reasoning != null ? { reasoning } : {}),
   };
 }
 
-describeIfLive('AgentContext Anthropic prompt cache live API', () => {
-  it('caches only the stable system prefix while dynamic tail changes', async () => {
-    const nonce = `agent-cache-live-${Date.now()}`;
+describeIfLive('AgentContext OpenRouter prompt cache live API', () => {
+  it('keeps dynamic instructions outside the cached system prefix', async () => {
+    const nonce = `agent-openrouter-cache-live-${Date.now()}`;
     const clientOptions = createClientOptions();
     const stableInstructions = buildStableInstructions({
       nonce,
@@ -66,8 +84,8 @@ describeIfLive('AgentContext Anthropic prompt cache live API', () => {
     });
 
     await assertSystemPayloadShape({
-      agentId: 'live-cache-shape-check',
-      provider: Providers.ANTHROPIC,
+      agentId: 'live-openrouter-cache-shape-check',
+      provider: Providers.OPENROUTER,
       clientOptions,
       stableInstructions,
       dynamicInstructions: firstDynamicInstructions,
@@ -81,7 +99,7 @@ describeIfLive('AgentContext Anthropic prompt cache live API', () => {
     });
 
     const first = await runLiveTurn({
-      provider: Providers.ANTHROPIC,
+      provider: Providers.OPENROUTER,
       providerLabel,
       clientOptions,
       runId: `${nonce}-first`,
@@ -91,13 +109,11 @@ describeIfLive('AgentContext Anthropic prompt cache live API', () => {
     });
 
     expect(first.text.toLowerCase()).toContain('alpha');
-    expect(first.usage.input_token_details?.cache_creation).toBeGreaterThan(0);
-    expect(first.usage.input_token_details?.cache_read ?? 0).toBe(0);
 
     await waitForCachePropagation();
 
     const second = await runLiveTurn({
-      provider: Providers.ANTHROPIC,
+      provider: Providers.OPENROUTER,
       providerLabel,
       clientOptions,
       runId: `${nonce}-second`,

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1,5 +1,5 @@
 // src/agents/__tests__/AgentContext.test.ts
-import { HumanMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import { AgentContext } from '../AgentContext';
 import { Providers } from '@/common';
 import { addBedrockCacheControl } from '@/messages/cache';
@@ -79,7 +79,7 @@ describe('AgentContext', () => {
       );
     });
 
-    it('marks only stable system text for Anthropic prompt caching', async () => {
+    it('moves Anthropic dynamic instructions behind stable history', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           provider: Providers.ANTHROPIC,
@@ -89,18 +89,39 @@ describe('AgentContext', () => {
         },
       });
 
-      const result = await ctx.systemRunnable!.invoke([]);
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Hello'),
+        new HumanMessage('Second'),
+      ]);
       const content = result[0].content as TestSystemContentBlock[];
-      expect(content).toHaveLength(2);
-      expect(content[0]).toMatchObject({
-        type: 'text',
-        text: 'Stable instructions',
-        cache_control: { type: 'ephemeral' },
+      expect(content).toEqual([
+        {
+          type: 'text',
+          text: 'Stable instructions',
+          cache_control: { type: 'ephemeral' },
+        },
+      ]);
+      expect(result[1].content).toBe('Hello');
+      expect(result[2].content).toBe('Dynamic instructions');
+      expect(result[3].content).toBe('Second');
+    });
+
+    it('places Anthropic dynamic instructions before a single latest user prompt', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: { model: 'claude-3-5-sonnet', promptCache: true },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
       });
-      expect(content[1]).toEqual({
-        type: 'text',
-        text: 'Dynamic instructions',
-      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Latest'),
+      ]);
+
+      expect(result[1].content).toBe('Dynamic instructions');
+      expect(result[2].content).toBe('Latest');
     });
 
     it('omits Anthropic cache control when only dynamic system text exists', async () => {
@@ -119,7 +140,7 @@ describe('AgentContext', () => {
       expect(content[0]).not.toHaveProperty('cache_control');
     });
 
-    it('keeps cross-run summaries in the dynamic Anthropic system tail', async () => {
+    it('keeps cross-run summaries in the dynamic Anthropic tail', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           provider: Providers.ANTHROPIC,
@@ -131,12 +152,11 @@ describe('AgentContext', () => {
 
       const result = await ctx.systemRunnable!.invoke([]);
       const content = result[0].content as TestSystemContentBlock[];
-      expect(content).toHaveLength(2);
+      expect(content).toHaveLength(1);
       expect(content[0]).toHaveProperty('cache_control');
-      expect(content[1]).toEqual({
-        type: 'text',
-        text: '## Conversation Summary\n\nPrior summary',
-      });
+      expect(result[1].content).toBe(
+        '## Conversation Summary\n\nPrior summary'
+      );
     });
 
     it('places the Bedrock cache point before dynamic system text', async () => {
@@ -198,7 +218,7 @@ describe('AgentContext', () => {
       );
     });
 
-    it('marks stable OpenRouter system text and keeps first user message stable', async () => {
+    it('moves OpenRouter dynamic instructions behind stable history', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           provider: Providers.OPENROUTER,
@@ -223,7 +243,6 @@ describe('AgentContext', () => {
           cache_control: { type: 'ephemeral' },
         },
       ]);
-      expect(result[1]).toBeInstanceOf(HumanMessage);
       expect(result[1].content).toBe('Hello');
       expect(result[2].content).toBe('Dynamic instructions');
       expect(result[3].content).toBe('Second');
@@ -298,12 +317,132 @@ describe('AgentContext', () => {
       expect(result[3].content).toBe('Second');
     });
 
-    it('adds OpenRouter body cache points when there is no dynamic tail', async () => {
+    it('keeps the first OpenRouter user message before single-turn dynamic instructions', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           provider: Providers.OPENROUTER,
           clientOptions: {
             model: 'anthropic/claude-haiku-4.5',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Latest'),
+      ]);
+
+      expect(result[1].content).toBe('Latest');
+      expect(result[2].content).toBe('Dynamic instructions');
+    });
+
+    it('caches stable Anthropic history before dynamic instructions', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: {
+            model: 'claude-3-5-sonnet',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('First'),
+        new AIMessage('Stable assistant history'),
+        new HumanMessage('Latest'),
+      ]);
+      const stableHistory = result[2].content as TestSystemContentBlock[];
+
+      expect(result[1].content).toBe('First');
+      expect(stableHistory[0]).toMatchObject({
+        type: 'text',
+        text: 'Stable assistant history',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[3].content).toBe('Dynamic instructions');
+      expect(result[4].content).toBe('Latest');
+    });
+
+    it('does not place Anthropic dynamic instructions between tool calls and results', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: {
+            model: 'claude-3-5-sonnet',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Use the tool'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '2+2' },
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: '4',
+          name: 'calculator',
+          tool_call_id: 'call_1',
+        }),
+      ]);
+
+      expect(result[1].content).toBe('Use the tool');
+      expect((result[2] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+      expect(result[3].getType()).toBe('tool');
+      expect(result[4].content).toBe('Dynamic instructions');
+    });
+
+    it('caches stable OpenRouter history before dynamic instructions', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.OPENROUTER,
+          clientOptions: {
+            model: 'anthropic/claude-haiku-4.5',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('First'),
+        new AIMessage('Stable assistant history'),
+        new HumanMessage('Latest'),
+      ]);
+      const stableHistory = result[2].content as TestSystemContentBlock[];
+
+      expect(result[1].content).toBe('First');
+      expect(stableHistory[0]).toMatchObject({
+        type: 'text',
+        text: 'Stable assistant history',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[3].content).toBe('Dynamic instructions');
+      expect(result[4].content).toBe('Latest');
+    });
+
+    it('adds OpenRouter body cache points when there is no dynamic tail', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.OPENROUTER,
+          clientOptions: {
+            model: 'google/gemini-3.1-pro-preview',
             promptCache: true,
           },
           instructions: 'Stable instructions',
@@ -325,7 +464,7 @@ describe('AgentContext', () => {
         agentConfig: {
           provider: Providers.OPENROUTER,
           clientOptions: {
-            model: 'anthropic/claude-haiku-4.5',
+            model: 'google/gemini-3.1-pro-preview',
             promptCache: true,
           },
           instructions: 'Stable instructions',
@@ -707,7 +846,7 @@ describe('AgentContext', () => {
         agentConfig: {
           provider: Providers.OPENROUTER,
           clientOptions: {
-            model: 'anthropic/claude-haiku-4.5',
+            model: 'google/gemini-3.1-pro-preview',
             promptCache: true,
           },
           instructions: 'Stable',
@@ -733,7 +872,7 @@ describe('AgentContext', () => {
         agentConfig: {
           provider: Providers.OPENROUTER,
           clientOptions: {
-            model: 'anthropic/claude-haiku-4.5',
+            model: 'google/gemini-3.1-pro-preview',
             promptCache: true,
           },
           instructions: 'Stable instructions',

--- a/src/agents/__tests__/promptCacheLiveHelpers.ts
+++ b/src/agents/__tests__/promptCacheLiveHelpers.ts
@@ -1,13 +1,18 @@
 import { expect } from '@jest/globals';
 import { HumanMessage } from '@langchain/core/messages';
 import type { UsageMetadata } from '@langchain/core/messages';
+import type { ClientOptions } from '@langchain/openai';
 import type * as t from '@/types';
 import { GraphEvents, Providers } from '@/common';
 import { AgentContext } from '../AgentContext';
 import { ModelEndHandler } from '@/events';
 import { Run } from '@/run';
+import type { ChatOpenRouterInput } from '@/llm/openrouter';
 
-type LivePromptCacheProvider = Providers.ANTHROPIC | Providers.BEDROCK;
+type LivePromptCacheProvider =
+  | Providers.ANTHROPIC
+  | Providers.BEDROCK
+  | Providers.OPENROUTER;
 
 type PromptCacheExpectedSystemBlock =
   | { type: 'text'; text: string; cache_control?: { type: 'ephemeral' } }
@@ -15,7 +20,8 @@ type PromptCacheExpectedSystemBlock =
 
 type LivePromptCacheClientOptions =
   | t.ClientOptions
-  | t.BedrockAnthropicClientOptions;
+  | t.BedrockAnthropicClientOptions
+  | (ChatOpenRouterInput & { configuration?: ClientOptions });
 
 export function buildStableInstructions({
   nonce,

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -240,6 +240,149 @@ function isCachePoint(block: MessageContentComplex): boolean {
   return 'cachePoint' in block && !('type' in block);
 }
 
+function getMessageRole(message: MessageWithContent): string | undefined {
+  if (message instanceof BaseMessage) {
+    return message.getType();
+  }
+  if ('role' in message && typeof message.role === 'string') {
+    return message.role;
+  }
+  return undefined;
+}
+
+function isCacheableConversationMessage(message: MessageWithContent): boolean {
+  const role = getMessageRole(message);
+  return (
+    role === 'human' || role === 'user' || role === 'ai' || role === 'assistant'
+  );
+}
+
+function isAssistantConversationMessage(message: MessageWithContent): boolean {
+  const role = getMessageRole(message);
+  return role === 'ai' || role === 'assistant';
+}
+
+function hasCacheMarker(message: MessageWithContent): boolean {
+  return (
+    Array.isArray(message.content) &&
+    message.content.some((block) => 'cache_control' in block)
+  );
+}
+
+function addCacheControlToRecentMessages<
+  T extends AnthropicMessage | BaseMessage,
+>(
+  messages: T[],
+  maxCachePoints: number,
+  canUseMessage: (message: MessageWithContent) => boolean
+): T[] {
+  if (
+    !Array.isArray(messages) ||
+    messages.length === 0 ||
+    maxCachePoints <= 0
+  ) {
+    return messages;
+  }
+
+  const updatedMessages: T[] = [...messages];
+  let cachePointsAdded = 0;
+
+  for (let i = updatedMessages.length - 1; i >= 0; i--) {
+    const originalMessage = updatedMessages[i];
+    const content = originalMessage.content;
+    const hasArrayContent = Array.isArray(content);
+    const canAddCache =
+      cachePointsAdded < maxCachePoints && canUseMessage(originalMessage);
+
+    if (!canAddCache && !hasArrayContent) {
+      continue;
+    }
+
+    let workingContent: MessageContentComplex[];
+    let modified = false;
+
+    if (hasArrayContent) {
+      const src = content as MessageContentComplex[];
+      workingContent = [];
+      let lastNonEmptyTextIndex = -1;
+
+      for (let j = 0; j < src.length; j++) {
+        const block = src[j];
+        if (isCachePoint(block)) {
+          modified = true;
+          continue;
+        }
+
+        const cloned = { ...block };
+        if ('cache_control' in cloned) {
+          delete (cloned as Record<string, unknown>).cache_control;
+          modified = true;
+        }
+
+        if ('type' in cloned && cloned.type === 'text') {
+          const text = (cloned as { text?: string }).text;
+          if (text != null && text.trim() !== '') {
+            lastNonEmptyTextIndex = workingContent.length;
+          }
+        }
+        workingContent.push(cloned as MessageContentComplex);
+      }
+
+      if (canAddCache && lastNonEmptyTextIndex >= 0) {
+        (
+          workingContent[lastNonEmptyTextIndex] as Anthropic.TextBlockParam
+        ).cache_control = {
+          type: 'ephemeral',
+        };
+        cachePointsAdded++;
+        modified = true;
+      }
+
+      if (!modified) {
+        continue;
+      }
+    } else if (
+      typeof content === 'string' &&
+      content.trim() !== '' &&
+      canAddCache
+    ) {
+      workingContent = [
+        { type: 'text', text: content, cache_control: { type: 'ephemeral' } },
+      ] as unknown as MessageContentComplex[];
+      cachePointsAdded++;
+    } else {
+      continue;
+    }
+
+    updatedMessages[i] = cloneMessage(
+      originalMessage as MessageWithContent,
+      workingContent
+    ) as T;
+  }
+
+  return updatedMessages;
+}
+
+export function addCacheControlToStablePrefixMessages<
+  T extends AnthropicMessage | BaseMessage,
+>(messages: T[], maxCachePoints: number): T[] {
+  const assistantMarked = addCacheControlToRecentMessages(
+    messages,
+    maxCachePoints,
+    isAssistantConversationMessage
+  );
+
+  if (assistantMarked.some(hasCacheMarker)) {
+    return assistantMarked;
+  }
+
+  return addCacheControlToRecentMessages(
+    messages,
+    maxCachePoints,
+    isCacheableConversationMessage
+  );
+}
+
 /**
  * Checks if a message's content has Anthropic cache_control fields.
  */


### PR DESCRIPTION
## Summary

I preserved prompt-cache reuse when runtime context changes by keeping dynamic instructions out of cacheable prefixes and using provider-specific message boundaries for Anthropic and OpenRouter.

- Move prompt-cache dynamic instructions into a runtime tail instead of appending them to cached system text.
- Keep Anthropic dynamic instructions before the latest user message, while preserving OpenRouter's first user message on single-turn prompts so provider sticky routing can stay stable.
- Mark stable conversation history before the dynamic tail, preferring recent assistant/history messages and falling back to recent cacheable chat messages.
- Avoid inserting dynamic runtime context between Anthropic/OpenRouter tool-use messages and their required tool-result replies.
- Keep dynamic-only prompt-cache requests as plain system text, since there is no stable prefix to cache.
- Add OpenRouter live prompt-cache coverage alongside the existing Anthropic/Bedrock live helpers.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/agents/__tests__/AgentContext.test.ts --runInBand`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/agents/AgentContext.ts src/messages/cache.ts src/agents/__tests__/AgentContext.test.ts src/agents/__tests__/AgentContext.openrouter.live.test.ts src/agents/__tests__/promptCacheLiveHelpers.ts`
- `AWS_DEFAULT_REGION=us-west-2 DOTENV_CONFIG_PATH=/Users/danny/Projects/LibreChat/.env NODE_OPTIONS="--experimental-vm-modules -r dotenv/config" npx jest src/specs/cache.simple.test.ts --runInBand`
- `RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS=1 ANTHROPIC_PROMPT_CACHE_MODEL=claude-sonnet-4-5 npx jest src/agents/__tests__/AgentContext.anthropic.live.test.ts --runInBand`
- `RUN_OPENROUTER_PROMPT_CACHE_LIVE_TESTS=1 OPENROUTER_PROMPT_CACHE_MODEL=anthropic/claude-sonnet-4.6 npx jest src/agents/__tests__/AgentContext.openrouter.live.test.ts --runInBand`
- `RUN_OPENROUTER_PROMPT_CACHE_LIVE_TESTS=1 OPENROUTER_PROMPT_CACHE_MODEL=google/gemini-3.1-pro-preview npx jest src/agents/__tests__/AgentContext.openrouter.live.test.ts --runInBand`
- `OPENROUTER_PROMPT_CACHE_MODELS='anthropic/claude-sonnet-4.6,google/gemini-3.1-pro-preview,qwen/qwen3-coder-flash' OPENROUTER_PROMPT_CACHE_ATTEMPTS=3 node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/openrouter_prompt_cache_live.ts`
- Live direct Anthropic regular chat, 4 turns with changing `additional_instructions`: turn 1 wrote cache, turns 2-4 read cache while returning the current dynamic marker.
- Live OpenRouter Claude regular chat, 4 turns with changing `additional_instructions`: every turn read the stable prefix after preserving the first user message boundary.
- Live OpenRouter Claude minimal tool-call turn with calculator: first LLM call wrote `8944` cache tokens; post-tool LLM call read `8944` cache tokens and preserved `ai -> tool -> ai` message order.
- `npm run build`

### **Test Configuration**:

- OpenRouter endpoint: `https://openrouter.ai/api/v1`
- OpenRouter Claude model: `anthropic/claude-sonnet-4.6`
- OpenRouter Gemini model: `google/gemini-3.1-pro-preview`
- OpenRouter Qwen model: `qwen/qwen3-coder-flash`
- OpenRouter static-tool model: `anthropic/claude-haiku-4.5`
- Direct Anthropic model: `claude-sonnet-4-5`
- Prompt cache: enabled
- API keys loaded from the main LibreChat `.env`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
