### PR TITLE
🛰️ fix: Preserve OpenRouter Responses Verbosity

### DIFF
--- a/src/llm/openrouter/index.ts
+++ b/src/llm/openrouter/index.ts
@@ -16,6 +16,8 @@ export type OpenRouterReasoningEffort =
   | 'minimal'
   | 'none';
 
+export type OpenRouterVerbosity = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
 export interface OpenRouterReasoning {
   effort?: OpenRouterReasoningEffort;
   max_tokens?: number;
@@ -24,28 +26,49 @@ export interface OpenRouterReasoning {
 }
 
 export interface ChatOpenRouterCallOptions
-  extends Omit<ChatOpenAICallOptions, 'reasoning'> {
+  extends Omit<ChatOpenAICallOptions, 'reasoning' | 'verbosity'> {
   /** @deprecated Use `reasoning` object instead */
   include_reasoning?: boolean;
   reasoning?: OpenRouterReasoning;
+  verbosity?: OpenRouterVerbosity | null;
+  useResponsesApi?: boolean;
   modelKwargs?: OpenAIChatInput['modelKwargs'];
   promptCache?: boolean;
 }
 
 export type ChatOpenRouterInput = Partial<
-  ChatOpenRouterCallOptions & OpenAIChatInput
+  ChatOpenRouterCallOptions & Omit<OpenAIChatInput, 'verbosity'>
 >;
 
 /** invocationParams return type extended with OpenRouter reasoning */
 export type OpenRouterInvocationParams = Omit<
   OpenAIClient.Chat.ChatCompletionCreateParams,
-  'messages'
+  'messages' | 'verbosity'
 > & {
   reasoning?: OpenRouterReasoning;
+  text?: OpenRouterResponsesTextConfig;
+  verbosity?: OpenRouterVerbosity | null;
 };
 
 type InvocationParamsExtra = {
   streaming?: boolean;
+};
+
+type OpenRouterResponsesTextConfig = Omit<
+  NonNullable<OpenAIClient.Responses.ResponseCreateParams['text']>,
+  'verbosity'
+> & {
+  verbosity?: OpenRouterVerbosity | null;
+};
+
+type MutableParams = Omit<
+  OpenAIClient.Chat.ChatCompletionCreateParams,
+  'messages' | 'verbosity'
+> & {
+  reasoning_effort?: string;
+  reasoning?: OpenRouterReasoning;
+  verbosity?: OpenRouterVerbosity | null;
+  text?: OpenRouterResponsesTextConfig;
 };
 
 interface OpenRouterReasoningTextDetail {
@@ -99,8 +122,19 @@ function getReasoningDetails(value: unknown): OpenRouterReasoningDetail[] {
   );
 }
 
+function isOpenRouterVerbosity(value: unknown): value is OpenRouterVerbosity {
+  return (
+    value === 'low' ||
+    value === 'medium' ||
+    value === 'high' ||
+    value === 'xhigh' ||
+    value === 'max'
+  );
+}
+
 export class ChatOpenRouter extends ChatOpenAI {
   private openRouterReasoning?: OpenRouterReasoning;
+  private openRouterVerbosity?: OpenRouterVerbosity | null;
   /** @deprecated Use `reasoning` object instead */
   private includeReasoning?: boolean;
 
@@ -111,6 +145,7 @@ export class ChatOpenRouter extends ChatOpenAI {
     const {
       include_reasoning,
       reasoning: openRouterReasoning,
+      verbosity: openRouterVerbosity,
       modelKwargs = {},
       ...fields
     } = fieldsWithoutPromptCache;
@@ -145,6 +180,12 @@ export class ChatOpenRouter extends ChatOpenAI {
     if (mergedReasoning != null) {
       this.openRouterReasoning = mergedReasoning;
     }
+    if (
+      openRouterVerbosity === null ||
+      isOpenRouterVerbosity(openRouterVerbosity)
+    ) {
+      this.openRouterVerbosity = openRouterVerbosity;
+    }
 
     this.includeReasoning = include_reasoning;
   }
@@ -156,17 +197,14 @@ export class ChatOpenRouter extends ChatOpenAI {
   // effort levels ('xhigh' | 'none' | 'minimal') not in ReasoningEffort.
   // The parent's generic conditional return type cannot be widened in an override.
   override invocationParams(
-    options?: this['ParsedCallOptions'],
+    options?: this['ParsedCallOptions'] | ChatOpenRouterCallOptions,
     extra?: InvocationParamsExtra
   ): OpenRouterInvocationParams {
-    type MutableParams = Omit<
-      OpenAIClient.Chat.ChatCompletionCreateParams,
-      'messages'
-    > & { reasoning_effort?: string; reasoning?: OpenRouterReasoning };
-
-    const optionsWithDefaults = this._combineCallOptions(options);
+    const parsedOptions = options as this['ParsedCallOptions'] | undefined;
+    const optionsWithDefaults = this._combineCallOptions(parsedOptions);
+    const useResponsesApi = this._useResponsesApi(parsedOptions);
     const params = (
-      this._useResponsesApi(options)
+      useResponsesApi
         ? this.responses.invocationParams(optionsWithDefaults)
         : this.completions.invocationParams(optionsWithDefaults, extra)
     ) as MutableParams;
@@ -183,7 +221,44 @@ export class ChatOpenRouter extends ChatOpenAI {
       delete params.reasoning;
     }
 
+    this.applyOpenRouterVerbosity(params, optionsWithDefaults, useResponsesApi);
+
     return params;
+  }
+
+  private applyOpenRouterVerbosity(
+    params: MutableParams,
+    options: this['ParsedCallOptions'] | undefined,
+    useResponsesApi: boolean
+  ): void {
+    const verbosity = this.getOpenRouterVerbosity(options);
+    if (verbosity == null) {
+      return;
+    }
+    if (!useResponsesApi) {
+      params.verbosity = verbosity;
+      return;
+    }
+    params.text = {
+      ...params.text,
+      verbosity,
+    };
+  }
+
+  private getOpenRouterVerbosity(
+    options?: this['ParsedCallOptions']
+  ): OpenRouterVerbosity | undefined {
+    const callOptions = options as ChatOpenRouterCallOptions | undefined;
+    if (isOpenRouterVerbosity(callOptions?.verbosity)) {
+      return callOptions.verbosity;
+    }
+    if (isOpenRouterVerbosity(this.openRouterVerbosity)) {
+      return this.openRouterVerbosity;
+    }
+    if (isOpenRouterVerbosity(this.verbosity)) {
+      return this.verbosity;
+    }
+    return undefined;
   }
 
   private buildOpenRouterReasoning(

--- a/src/llm/openrouter/reasoning.test.ts
+++ b/src/llm/openrouter/reasoning.test.ts
@@ -1,5 +1,9 @@
 import { ChatOpenRouter } from './index';
-import type { OpenRouterReasoning, ChatOpenRouterCallOptions } from './index';
+import type {
+  ChatOpenRouterCallOptions,
+  OpenRouterInvocationParams,
+  OpenRouterReasoning,
+} from './index';
 import type { OpenAIChatInput } from '@langchain/openai';
 
 type CreateRouterOptions = Partial<
@@ -10,6 +14,7 @@ type CreateRouterOptions = Partial<
 type RuntimeInvocationParams = {
   reasoning?: OpenRouterReasoning;
   reasoning_effort?: string;
+  text?: OpenRouterInvocationParams['text'];
 };
 
 class RuntimeInspectableChatOpenRouter extends ChatOpenRouter {
@@ -135,6 +140,51 @@ describe('ChatOpenRouter reasoning handling', () => {
       const router = createRouter({ streamUsage: true });
       const params = router.invocationParams(undefined, { streaming: true });
       expect(params.stream_options).toEqual({ include_usage: true });
+    });
+
+    it('passes OpenRouter verbosity through Responses text config', () => {
+      const router = createRouter({
+        useResponsesApi: true,
+        verbosity: 'xhigh',
+      });
+      const params = router.invocationParams();
+      expect(params.text).toEqual(
+        expect.objectContaining({
+          verbosity: 'xhigh',
+        })
+      );
+    });
+
+    it('merges OpenRouter verbosity with existing Responses text config', () => {
+      const router = createRouter({
+        useResponsesApi: true,
+        verbosity: 'high',
+        modelKwargs: {
+          text: {
+            format: { type: 'text' },
+          },
+        },
+      });
+      const params = router.invocationParams();
+      expect(params.text).toEqual({
+        format: { type: 'text' },
+        verbosity: 'high',
+      });
+    });
+
+    it('lets call-level verbosity override constructor verbosity for Responses', () => {
+      const router = createRouter({
+        useResponsesApi: true,
+        verbosity: 'xhigh',
+      });
+      const params = router.invocationParams({
+        verbosity: 'low',
+      });
+      expect(params.text).toEqual(
+        expect.objectContaining({
+          verbosity: 'low',
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

I preserved OpenRouter verbosity when `ChatOpenRouter` uses the Responses API, so LibreChat's OpenRouter Claude 4.7 settings survive the SDK request builder.

- Added OpenRouter-specific verbosity typing for `xhigh` and `max` without widening the generic OpenAI path.
- Stored constructor-level OpenRouter verbosity separately so values outside OpenAI's native `low|medium|high` set are not dropped before request construction.
- Merged OpenRouter verbosity into Responses `text` config while keeping chat-completions as top-level `verbosity`.
- Added regression coverage for Responses verbosity, existing `text` config merging, and call-level verbosity overrides.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm ci` in `/Users/danny/.codex/worktrees/or-responses-verbosity/agents`.
- Ran `npx jest src/llm/openrouter/reasoning.test.ts --runInBand`.
- Ran `npx tsc --noEmit`.
- Ran `npx eslint src/llm/openrouter/index.ts src/llm/openrouter/reasoning.test.ts`.
- Ran `npm run build`.
- Live-tested `ChatOpenRouter` with OpenRouter Responses API using `anthropic/claude-opus-4.7`, `reasoning: { enabled: true }`, `verbosity: "xhigh"`, and `maxTokens: 4096`; `invocationParams()` produced `text: { verbosity: "xhigh" }`, and OpenRouter returned `output_token_details.reasoning: 183` on a logic prompt.

### **Test Configuration**:

- Node.js: local workspace default
- Provider: OpenRouter Responses API
- Model: `anthropic/claude-opus-4.7`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes