### PR TITLE
🤖 feat: Add Programmatic Agent Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,66 @@ const content = await run.processStream(
 );
 ```
 
+## Programmatic Sessions
+
+For scripts, CI, and programmatic integrations, use the session facade. It
+keeps a JSONL session tree by default, so runs can be resumed, cloned, forked,
+branched in place, compacted, and inspected later.
+
+```typescript
+import { Providers, createAgentSession } from '@librechat/agents';
+
+const session = await createAgentSession({
+  graphConfig: {
+    type: 'standard',
+    instructions: 'You are a concise coding assistant.',
+    llmConfig: {
+      provider: Providers.OPENAI,
+      model: 'gpt-4o-mini',
+      apiKey: process.env.OPENAI_API_KEY,
+    },
+  },
+});
+
+const result = await session.run('Summarize this repository.');
+console.log(result.text);
+console.log(session.sessionPath); // durable .jsonl session file
+```
+
+Sessions expose tree operations inspired by Pi-style workflows:
+
+```typescript
+const store = session.getSessionStore();
+const forkPoint = store?.getForkPoints()[0];
+
+if (forkPoint) {
+  const forked = await session.fork(forkPoint.id, { position: 'before' });
+  await forked.run('Try a different approach from here.');
+}
+
+const cloned = await session.clone();
+await cloned.compact({ instructions: 'Keep only implementation decisions.' });
+```
+
+`session.stream()` projects the SDK's existing graph events, and
+`session.compact()` uses the same summarization node, hooks, and provider
+logic as normal runs. JSONL is the durable journal; the graph remains the
+execution engine.
+
+OpenAI-compatible streaming helpers are available as experimental subpaths:
+
+```typescript
+import { composeEventHandlers } from '@librechat/agents';
+import { createOpenAIHandlers } from '@librechat/agents/openai';
+import { createResponsesEventHandlers } from '@librechat/agents/responses';
+
+const customHandlers = composeEventHandlers(
+  createOpenAIHandlers(openAIConfig),
+  createResponsesEventHandlers(responsesConfig),
+  hostHandlers
+);
+```
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ branched in place, compacted, and inspected later.
 import { Providers, createAgentSession } from '@librechat/agents';
 
 const session = await createAgentSession({
+  checkpointing: true,
   graphConfig: {
     type: 'standard',
     instructions: 'You are a concise coding assistant.',
@@ -71,6 +72,14 @@ const result = await session.run('Summarize this repository.');
 console.log(result.text);
 console.log(session.sessionPath); // durable .jsonl session file
 ```
+
+When `checkpointing` is enabled, the session injects a shared LangGraph
+checkpointer into `compileOptions`, records checkpoint IDs in JSONL, and uses
+checkpoint state for later turns on the same `thread_id`. When HITL is enabled
+(`humanInTheLoop: { enabled: true }`), sessions also get a `MemorySaver` by
+default so `resumeInterrupt()` can reuse the same saver instead of relying on a
+per-run fallback. JSONL still owns portable replay, clone, fork, and audit
+records.
 
 Sessions expose tree operations inspired by Pi-style workflows:
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,16 @@
       "require": "./dist/cjs/main.cjs",
       "types": "./dist/types/index.d.ts"
     },
+    "./openai": {
+      "import": "./dist/esm/openai/index.mjs",
+      "require": "./dist/cjs/openai/index.cjs",
+      "types": "./dist/types/openai/index.d.ts"
+    },
+    "./responses": {
+      "import": "./dist/esm/responses/index.mjs",
+      "require": "./dist/cjs/responses/index.cjs",
+      "types": "./dist/types/responses/index.d.ts"
+    },
     "./langchain": {
       "import": "./dist/esm/langchain/index.mjs",
       "require": "./dist/cjs/langchain/index.cjs",
@@ -68,6 +78,12 @@
       ],
       "langchain/*": [
         "dist/types/langchain/*"
+      ],
+      "openai": [
+        "dist/types/openai/index.d.ts"
+      ],
+      "responses": [
+        "dist/types/responses/index.d.ts"
       ]
     }
   },
@@ -133,6 +149,7 @@
     "local:image": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/local_engine_image.ts --provider 'anthropic' --name 'Jo' --location 'New York, NY'",
     "local:compile": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/local_engine_compile.ts --provider 'anthropic' --name 'Jo' --location 'New York, NY'",
     "compare:pi": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/compare_pi_vs_ours.ts",
+    "session:live": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/session_live.ts",
     "local:workspace": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/local_engine_workspace.ts --provider 'anthropic' --name 'Jo' --location 'New York, NY'",
     "programmatic_exec_agent": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/programmatic_exec_agent.ts --provider 'openAI' --name 'Jo' --location 'New York, NY'",
     "ant_web_search": "node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/ant_web_search.ts --name 'Jo' --location 'New York, NY'",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,8 +31,8 @@ function filterProdFiles(id) {
 export default {
   input: {
     main: './src/index.ts',
-    openai: './src/openai/index.ts',
-    responses: './src/responses/index.ts',
+    'openai/index': './src/openai/index.ts',
+    'responses/index': './src/responses/index.ts',
     'langchain/index': './src/langchain/index.ts',
     'langchain/google-common': './src/langchain/google-common.ts',
     'langchain/language_models/chat_models':

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,8 @@ function filterProdFiles(id) {
 export default {
   input: {
     main: './src/index.ts',
+    openai: './src/openai/index.ts',
+    responses: './src/responses/index.ts',
     'langchain/index': './src/langchain/index.ts',
     'langchain/google-common': './src/langchain/google-common.ts',
     'langchain/language_models/chat_models':

--- a/src/events.ts
+++ b/src/events.ts
@@ -21,6 +21,35 @@ export class HandlerRegistry {
   }
 }
 
+export function composeEventHandlers(
+  ...handlerSets: Array<Record<string, t.EventHandler> | undefined>
+): Record<string, t.EventHandler> {
+  const composed: Partial<Record<string, t.EventHandler>> = {};
+
+  for (const handlerSet of handlerSets) {
+    if (!handlerSet) {
+      continue;
+    }
+    for (const [eventType, handler] of Object.entries(handlerSet)) {
+      const previous = composed[eventType];
+      if (previous === undefined) {
+        composed[eventType] = handler;
+        continue;
+      }
+      composed[eventType] = {
+        handle: async (
+          ...args: Parameters<t.EventHandler['handle']>
+        ): Promise<void> => {
+          await previous.handle(...args);
+          await handler.handle(...args);
+        },
+      };
+    }
+  }
+
+  return composed as Record<string, t.EventHandler>;
+}
+
 export class ModelEndHandler implements t.EventHandler {
   collectedUsage?: UsageMetadata[];
   constructor(collectedUsage?: UsageMetadata[]) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -279,9 +279,7 @@ export abstract class Graph<
   private _compiledToolNodes: Set<{
     clearDirectPathTurns(): void;
   }> = new Set();
-  public getOrCreateFileCheckpointer():
-    | t.LocalFileCheckpointer
-    | undefined {
+  public getOrCreateFileCheckpointer(): t.LocalFileCheckpointer | undefined {
     // Return the cached instance unconditionally if one exists. The
     // toolExecution check below decides whether to *create* a new
     // one — `clearHeavyState` nulls `this.toolExecution` at end-of-
@@ -301,9 +299,7 @@ export abstract class Graph<
     // cleanup hooks fire). The bundle factory itself accepts a pre-
     // supplied checkpointer when present, so re-injecting this one
     // into every ToolNode is idempotent.
-    const bundle = createLocalCodingToolBundle(
-      this.toolExecution.local ?? {}
-    );
+    const bundle = createLocalCodingToolBundle(this.toolExecution.local ?? {});
     this._fileCheckpointer = bundle.checkpointer;
     return this._fileCheckpointer;
   }
@@ -1663,7 +1659,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({
         reducer: (a, b) => {
-          if (!a.length) {
+          if (!this.messages.length) {
             this.startIndex = a.length + b.length;
           }
           const result = messagesStateReducer(a, b);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -70,6 +70,13 @@ const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 /** Minimum relative variance before calibrated toolSchemaTokens overrides current value. */
 const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
 
+function getHandlerDispatchedEventKey(
+  eventName: string,
+  stepId: string
+): string {
+  return `${eventName}:${stepId}`;
+}
+
 export abstract class Graph<
   T extends t.BaseGraphState = t.BaseGraphState,
   _TNodeName extends string = string,
@@ -99,15 +106,18 @@ export abstract class Graph<
   ): Promise<string>;
   abstract dispatchRunStepDelta(
     id: string,
-    delta: t.ToolCallDelta
+    delta: t.ToolCallDelta,
+    metadata?: Record<string, unknown>
   ): Promise<void>;
   abstract dispatchMessageDelta(
     id: string,
-    delta: t.MessageDelta
+    delta: t.MessageDelta,
+    metadata?: Record<string, unknown>
   ): Promise<void>;
   abstract dispatchReasoningDelta(
     stepId: string,
-    delta: t.ReasoningDelta
+    delta: t.ReasoningDelta,
+    metadata?: Record<string, unknown>
   ): Promise<void>;
   abstract createCallModel(
     agentId?: string,
@@ -125,11 +135,12 @@ export abstract class Graph<
   contentIndexMap: Map<string, number> = new Map();
   toolCallStepIds: Map<string, string> = new Map();
   /**
-   * Step IDs that have been dispatched via handler registry directly
-   * (in dispatchRunStep).  Used by the custom event callback to skip
-   * duplicate dispatch through the LangGraph callback chain.
+   * Step IDs dispatched through the handler registry during this run.
+   * Event echo suppression is tracked separately so repeated deltas for
+   * the same step are scoped to the active custom event dispatch.
    */
   handlerDispatchedStepIds: Set<string> = new Set();
+  protected handlerDispatchedEventCounts: Map<string, number> = new Map();
   signal?: AbortSignal;
   /** Set of invoked tool call IDs from non-message run steps completed mid-run, if any */
   invokedToolIds?: Set<string>;
@@ -188,6 +199,7 @@ export abstract class Graph<
     this.humanInTheLoop = undefined;
     this.toolOutputReferences = undefined;
     this.toolExecution = undefined;
+    this.handlerDispatchedEventCounts.clear();
     /**
      * ToolNodes compiled from this graph captured the registry
      * instance at construction time, so simply dropping the Graph's
@@ -216,6 +228,27 @@ export abstract class Graph<
     }
     this._compiledToolNodes.clear();
     this.sessions.clear();
+  }
+
+  markHandlerDispatchedEvent(eventName: string, stepId: string): () => void {
+    const key = getHandlerDispatchedEventKey(eventName, stepId);
+    this.handlerDispatchedEventCounts.set(
+      key,
+      (this.handlerDispatchedEventCounts.get(key) ?? 0) + 1
+    );
+    return () => {
+      const count = this.handlerDispatchedEventCounts.get(key) ?? 0;
+      if (count <= 1) {
+        this.handlerDispatchedEventCounts.delete(key);
+        return;
+      }
+      this.handlerDispatchedEventCounts.set(key, count - 1);
+    };
+  }
+
+  hasHandlerDispatchedEvent(eventName: string, stepId: string): boolean {
+    const key = getHandlerDispatchedEventKey(eventName, stepId);
+    return (this.handlerDispatchedEventCounts.get(key) ?? 0) > 0;
   }
 
   /**
@@ -380,6 +413,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()
+    );
+    this.handlerDispatchedEventCounts = resetIfNotEmpty(
+      this.handlerDispatchedEventCounts,
+      new Map()
     );
     this.messageIdsByStepKey = resetIfNotEmpty(
       this.messageIdsByStepKey,
@@ -1303,9 +1340,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             );
             const stepId = this.getStepIdByKey(stepKey);
             if (typeof content === 'string') {
-              await this.dispatchMessageDelta(stepId, {
-                content: [{ type: ContentTypes.TEXT, text: content }],
-              });
+              await this.dispatchMessageDelta(
+                stepId,
+                {
+                  content: [{ type: ContentTypes.TEXT, text: content }],
+                },
+                metadata
+              );
             } else if (
               Array.isArray(content) &&
               content.every(
@@ -1316,9 +1357,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   c.type.startsWith('text')
               )
             ) {
-              await this.dispatchMessageDelta(stepId, {
-                content: content as t.MessageDelta['content'],
-              });
+              await this.dispatchMessageDelta(
+                stepId,
+                {
+                  content: content as t.MessageDelta['content'],
+                },
+                metadata
+              );
             }
           }
         }
@@ -1356,9 +1401,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const stepId = this.getStepIdByKey(stepKey);
           const content = responseMessage.content;
           if (typeof content === 'string') {
-            await this.dispatchMessageDelta(stepId, {
-              content: [{ type: ContentTypes.TEXT, text: content }],
-            });
+            await this.dispatchMessageDelta(
+              stepId,
+              {
+                content: [{ type: ContentTypes.TEXT, text: content }],
+              },
+              metadata
+            );
           } else if (
             Array.isArray(content) &&
             content.every(
@@ -1369,9 +1418,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 c.type.startsWith('text')
             )
           ) {
-            await this.dispatchMessageDelta(stepId, {
-              content: content as t.MessageDelta['content'],
-            });
+            await this.dispatchMessageDelta(
+              stepId,
+              {
+                content: content as t.MessageDelta['content'],
+              },
+              metadata
+            );
           }
         }
       }
@@ -1609,12 +1662,22 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 this.handlerDispatchedStepIds.add(runStep.id);
               }
 
-              if (resolvedConfig) {
-                await safeDispatchCustomEvent(
+              const unmarkHandlerDispatchedEvent = handler
+                ? this.markHandlerDispatchedEvent(
                   GraphEvents.ON_RUN_STEP,
-                  runStep,
-                  resolvedConfig
-                );
+                  runStep.id
+                )
+                : undefined;
+              try {
+                if (resolvedConfig) {
+                  await safeDispatchCustomEvent(
+                    GraphEvents.ON_RUN_STEP,
+                    runStep,
+                    resolvedConfig
+                  );
+                }
+              } finally {
+                unmarkHandlerDispatchedEvent?.();
               }
             },
             dispatchRunStepCompleted: async (
@@ -1778,11 +1841,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     // but the primary dispatch above guarantees the event reaches the handler.
     // The customEventCallback in run.ts skips events already dispatched above
     // to prevent double handling.
-    await safeDispatchCustomEvent(
-      GraphEvents.ON_RUN_STEP,
-      runStep,
-      this.config
-    );
+    const unmarkHandlerDispatchedEvent = handler
+      ? this.markHandlerDispatchedEvent(GraphEvents.ON_RUN_STEP, stepId)
+      : undefined;
+    try {
+      await safeDispatchCustomEvent(
+        GraphEvents.ON_RUN_STEP,
+        runStep,
+        this.config
+      );
+    } finally {
+      unmarkHandlerDispatchedEvent?.();
+    }
     return stepId;
   }
 
@@ -1854,7 +1924,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   async dispatchRunStepDelta(
     id: string,
-    delta: t.ToolCallDelta
+    delta: t.ToolCallDelta,
+    metadata?: Record<string, unknown>
   ): Promise<void> {
     if (!this.config) {
       throw new Error('No config provided');
@@ -1865,14 +1936,37 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       id,
       delta,
     };
-    await safeDispatchCustomEvent(
-      GraphEvents.ON_RUN_STEP_DELTA,
-      runStepDelta,
-      this.config
+    const handler = this.handlerRegistry?.getHandler(
+      GraphEvents.ON_RUN_STEP_DELTA
     );
+    if (handler) {
+      await handler.handle(
+        GraphEvents.ON_RUN_STEP_DELTA,
+        runStepDelta,
+        metadata,
+        this
+      );
+      this.handlerDispatchedStepIds.add(id);
+    }
+    const unmarkHandlerDispatchedEvent = handler
+      ? this.markHandlerDispatchedEvent(GraphEvents.ON_RUN_STEP_DELTA, id)
+      : undefined;
+    try {
+      await safeDispatchCustomEvent(
+        GraphEvents.ON_RUN_STEP_DELTA,
+        runStepDelta,
+        this.config
+      );
+    } finally {
+      unmarkHandlerDispatchedEvent?.();
+    }
   }
 
-  async dispatchMessageDelta(id: string, delta: t.MessageDelta): Promise<void> {
+  async dispatchMessageDelta(
+    id: string,
+    delta: t.MessageDelta,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
     if (!this.config) {
       throw new Error('No config provided');
     }
@@ -1880,16 +1974,36 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       id,
       delta,
     };
-    await safeDispatchCustomEvent(
-      GraphEvents.ON_MESSAGE_DELTA,
-      messageDelta,
-      this.config
+    const handler = this.handlerRegistry?.getHandler(
+      GraphEvents.ON_MESSAGE_DELTA
     );
+    if (handler) {
+      await handler.handle(
+        GraphEvents.ON_MESSAGE_DELTA,
+        messageDelta,
+        metadata,
+        this
+      );
+      this.handlerDispatchedStepIds.add(id);
+    }
+    const unmarkHandlerDispatchedEvent = handler
+      ? this.markHandlerDispatchedEvent(GraphEvents.ON_MESSAGE_DELTA, id)
+      : undefined;
+    try {
+      await safeDispatchCustomEvent(
+        GraphEvents.ON_MESSAGE_DELTA,
+        messageDelta,
+        this.config
+      );
+    } finally {
+      unmarkHandlerDispatchedEvent?.();
+    }
   }
 
   dispatchReasoningDelta = async (
     stepId: string,
-    delta: t.ReasoningDelta
+    delta: t.ReasoningDelta,
+    metadata?: Record<string, unknown>
   ): Promise<void> => {
     if (!this.config) {
       throw new Error('No config provided');
@@ -1898,10 +2012,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       id: stepId,
       delta,
     };
-    await safeDispatchCustomEvent(
-      GraphEvents.ON_REASONING_DELTA,
-      reasoningDelta,
-      this.config
+    const handler = this.handlerRegistry?.getHandler(
+      GraphEvents.ON_REASONING_DELTA
     );
+    if (handler) {
+      await handler.handle(
+        GraphEvents.ON_REASONING_DELTA,
+        reasoningDelta,
+        metadata,
+        this
+      );
+      this.handlerDispatchedStepIds.add(stepId);
+    }
+    const unmarkHandlerDispatchedEvent = handler
+      ? this.markHandlerDispatchedEvent(GraphEvents.ON_REASONING_DELTA, stepId)
+      : undefined;
+    try {
+      await safeDispatchCustomEvent(
+        GraphEvents.ON_REASONING_DELTA,
+        reasoningDelta,
+        this.config
+      );
+    } finally {
+      unmarkHandlerDispatchedEvent?.();
+    }
   };
 }

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -723,7 +723,7 @@ export class MultiAgentGraph extends StandardGraph {
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({
         reducer: (a, b) => {
-          if (!a.length) {
+          if (!this.messages.length) {
             this.startIndex = a.length + b.length;
           }
           const result = messagesStateReducer(a, b);

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,9 @@ export * from './utils';
 /* Hooks */
 export * from './hooks';
 
+/* Programmatic sessions */
+export * from './session';
+
 /* HITL helpers */
 export * from './hitl';
 

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -1,0 +1,60 @@
+import { GraphEvents } from '@/common';
+import {
+  createChatCompletionChunk,
+  createOpenAIHandlers,
+  createOpenAIStreamTracker,
+  sendOpenAIFinalChunk,
+} from '@/openai';
+import type * as t from '@/types';
+
+describe('OpenAI-compatible adapters', () => {
+  it('creates chunks and streams message deltas as SSE data', async () => {
+    const writes: string[] = [];
+    const handlers = createOpenAIHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { requestId: 'chatcmpl_1', model: 'agent', created: 1 },
+      tracker: createOpenAIStreamTracker(),
+    });
+
+    await handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'msg',
+        delta: { content: [{ type: 'text', text: 'hello' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+
+    expect(writes.join('')).toContain('"content":"hello"');
+  });
+
+  it('sends a final usage chunk and done marker', async () => {
+    const writes: string[] = [];
+    const tracker = createOpenAIStreamTracker();
+    tracker.usage.promptTokens = 3;
+    tracker.usage.completionTokens = 5;
+
+    await sendOpenAIFinalChunk({
+      writer: { write: (data) => void writes.push(data) },
+      context: { requestId: 'chatcmpl_2', model: 'agent', created: 1 },
+      tracker,
+    });
+
+    expect(writes.join('')).toContain('"total_tokens":8');
+    expect(writes.at(-1)).toBe('data: [DONE]\n\n');
+  });
+
+  it('builds a chat completion chunk without transport dependencies', () => {
+    expect(
+      createChatCompletionChunk(
+        { requestId: 'chatcmpl_3', model: 'agent', created: 1 },
+        { content: 'x' }
+      )
+    ).toEqual({
+      id: 'chatcmpl_3',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'agent',
+      choices: [{ index: 0, delta: { content: 'x' }, finish_reason: null }],
+    });
+  });
+});

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -24,7 +24,9 @@ describe('OpenAI-compatible adapters', () => {
       } satisfies t.MessageDeltaEvent
     );
 
-    expect(writes.join('')).toContain('"content":"hello"');
+    expect(writes).toHaveLength(2);
+    expect(writes[0]).toContain('"role":"assistant"');
+    expect(writes[1]).toContain('"content":"hello"');
   });
 
   it('sends a final usage chunk and done marker', async () => {
@@ -39,8 +41,13 @@ describe('OpenAI-compatible adapters', () => {
       tracker,
     });
 
-    expect(writes.join('')).toContain('"total_tokens":8');
-    expect(writes.at(-1)).toBe('data: [DONE]\n\n');
+    expect(writes).toHaveLength(4);
+    expect(writes[0]).toContain('"role":"assistant"');
+    expect(writes[1]).toContain('"finish_reason":"stop"');
+    expect(writes[1]).not.toContain('"usage"');
+    expect(writes[2]).toContain('"choices":[]');
+    expect(writes[2]).toContain('"total_tokens":8');
+    expect(writes[3]).toBe('data: [DONE]\n\n');
   });
 
   it('uses tool_calls finish reason after streaming tool deltas', async () => {
@@ -75,7 +82,10 @@ describe('OpenAI-compatible adapters', () => {
       tracker,
     });
 
-    expect(writes.at(-2)).toContain('"finish_reason":"tool_calls"');
+    expect(writes[0]).toContain('"role":"assistant"');
+    expect(writes[1]).toContain('"tool_calls"');
+    expect(writes.at(-3)).toContain('"finish_reason":"tool_calls"');
+    expect(writes.at(-2)).toContain('"choices":[]');
   });
 
   it('uses stop finish reason when assistant text follows tool calls', async () => {
@@ -120,7 +130,8 @@ describe('OpenAI-compatible adapters', () => {
       tracker,
     });
 
-    expect(writes.at(-2)).toContain('"finish_reason":"stop"');
+    expect(writes.at(-3)).toContain('"finish_reason":"stop"');
+    expect(writes.at(-2)).toContain('"choices":[]');
   });
 
   it('scopes tool-call argument state by run step', async () => {
@@ -234,11 +245,13 @@ describe('OpenAI-compatible adapters', () => {
       tracker,
     });
 
-    expect(writes[0]).toContain('"tool_calls"');
-    expect(writes[0]).toContain('"id":"call_complete"');
-    expect(writes[0]).toContain('"name":"search"');
-    expect(writes[0]).toContain('"{\\"query\\":\\"sessions\\"}"');
-    expect(writes.at(-2)).toContain('"finish_reason":"tool_calls"');
+    expect(writes[0]).toContain('"role":"assistant"');
+    expect(writes[1]).toContain('"tool_calls"');
+    expect(writes[1]).toContain('"id":"call_complete"');
+    expect(writes[1]).toContain('"name":"search"');
+    expect(writes[1]).toContain('"{\\"query\\":\\"sessions\\"}"');
+    expect(writes.at(-3)).toContain('"finish_reason":"tool_calls"');
+    expect(writes.at(-2)).toContain('"choices":[]');
   });
 
   it('tracks partial usage metadata without NaN totals', async () => {
@@ -301,6 +314,7 @@ describe('OpenAI-compatible adapters', () => {
       tracker,
     });
 
+    expect(writes.at(-2)).toContain('"choices":[]');
     expect(writes.at(-2)).toContain(
       '"completion_tokens_details":{"reasoning_tokens":2}'
     );

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -43,6 +43,41 @@ describe('OpenAI-compatible adapters', () => {
     expect(writes.at(-1)).toBe('data: [DONE]\n\n');
   });
 
+  it('uses tool_calls finish reason after streaming tool deltas', async () => {
+    const writes: string[] = [];
+    const tracker = createOpenAIStreamTracker();
+    const handlers = createOpenAIHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { requestId: 'chatcmpl_tools', model: 'agent', created: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              name: 'search',
+              args: '{"query":"sessions"}',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await sendOpenAIFinalChunk({
+      writer: { write: (data) => void writes.push(data) },
+      context: { requestId: 'chatcmpl_tools', model: 'agent', created: 1 },
+      tracker,
+    });
+
+    expect(writes.at(-2)).toContain('"finish_reason":"tool_calls"');
+  });
+
   it('tracks partial usage metadata without NaN totals', async () => {
     const tracker = createOpenAIStreamTracker();
     const handlers = createOpenAIHandlers({

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -78,6 +78,54 @@ describe('OpenAI-compatible adapters', () => {
     expect(writes.at(-2)).toContain('"finish_reason":"tool_calls"');
   });
 
+  it('streams completed tool-call run steps without deltas', async () => {
+    const writes: string[] = [];
+    const tracker = createOpenAIStreamTracker();
+    const handlers = createOpenAIHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        requestId: 'chatcmpl_complete_tools',
+        model: 'agent',
+        created: 1,
+      },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP].handle(GraphEvents.ON_RUN_STEP, {
+      id: 'step_complete',
+      index: 2,
+      type: 'tool_calls',
+      stepDetails: {
+        type: 'tool_calls',
+        tool_calls: [
+          {
+            id: 'call_complete',
+            type: 'function',
+            function: {
+              name: 'search',
+              arguments: { query: 'sessions' },
+            },
+          },
+        ],
+      },
+    } as t.RunStep);
+    await sendOpenAIFinalChunk({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        requestId: 'chatcmpl_complete_tools',
+        model: 'agent',
+        created: 1,
+      },
+      tracker,
+    });
+
+    expect(writes[0]).toContain('"tool_calls"');
+    expect(writes[0]).toContain('"id":"call_complete"');
+    expect(writes[0]).toContain('"name":"search"');
+    expect(writes[0]).toContain('"{\\"query\\":\\"sessions\\"}"');
+    expect(writes.at(-2)).toContain('"finish_reason":"tool_calls"');
+  });
+
   it('tracks partial usage metadata without NaN totals', async () => {
     const tracker = createOpenAIStreamTracker();
     const handlers = createOpenAIHandlers({

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -78,6 +78,41 @@ describe('OpenAI-compatible adapters', () => {
     expect(writes.at(-2)).toContain('"finish_reason":"tool_calls"');
   });
 
+  it('uses stop finish reason when assistant text follows tool calls', async () => {
+    const writes: string[] = [];
+    const tracker = createOpenAIStreamTracker();
+    const handlers = createOpenAIHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { requestId: 'chatcmpl_tools_done', model: 'agent', created: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [{ index: 0, id: 'call_1', name: 'search' }],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'msg',
+        delta: { content: [{ type: 'text', text: 'done' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+    await sendOpenAIFinalChunk({
+      writer: { write: (data) => void writes.push(data) },
+      context: { requestId: 'chatcmpl_tools_done', model: 'agent', created: 1 },
+      tracker,
+    });
+
+    expect(writes.at(-2)).toContain('"finish_reason":"stop"');
+  });
+
   it('streams completed tool-call run steps without deltas', async () => {
     const writes: string[] = [];
     const tracker = createOpenAIStreamTracker();

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -151,6 +151,46 @@ describe('OpenAI-compatible adapters', () => {
     expect(tracker.usage.completionTokens).toBe(5);
   });
 
+  it('includes reasoning token usage in the final chunk', async () => {
+    const writes: string[] = [];
+    const tracker = createOpenAIStreamTracker();
+    const handlers = createOpenAIHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        requestId: 'chatcmpl_reasoning_usage',
+        model: 'agent',
+        created: 1,
+      },
+      tracker,
+    });
+
+    await handlers[GraphEvents.CHAT_MODEL_END].handle(
+      GraphEvents.CHAT_MODEL_END,
+      {
+        output: {
+          usage_metadata: {
+            input_tokens: 3,
+            output_tokens: 5,
+            output_token_details: { reasoning: 2 },
+          },
+        },
+      } as t.ModelEndData
+    );
+    await sendOpenAIFinalChunk({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        requestId: 'chatcmpl_reasoning_usage',
+        model: 'agent',
+        created: 1,
+      },
+      tracker,
+    });
+
+    expect(writes.at(-2)).toContain(
+      '"completion_tokens_details":{"reasoning_tokens":2}'
+    );
+  });
+
   it('builds a chat completion chunk without transport dependencies', () => {
     expect(
       createChatCompletionChunk(

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -104,6 +104,16 @@ describe('OpenAI-compatible adapters', () => {
         delta: { content: [{ type: 'text', text: 'done' }] },
       } satisfies t.MessageDeltaEvent
     );
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [{ index: 0, id: 'call_1', name: 'search' }],
+        },
+      } as t.RunStepDeltaEvent
+    );
     await sendOpenAIFinalChunk({
       writer: { write: (data) => void writes.push(data) },
       context: { requestId: 'chatcmpl_tools_done', model: 'agent', created: 1 },

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -43,6 +43,31 @@ describe('OpenAI-compatible adapters', () => {
     expect(writes.at(-1)).toBe('data: [DONE]\n\n');
   });
 
+  it('tracks partial usage metadata without NaN totals', async () => {
+    const tracker = createOpenAIStreamTracker();
+    const handlers = createOpenAIHandlers({
+      writer: { write: jest.fn() },
+      context: { requestId: 'chatcmpl_usage', model: 'agent', created: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.CHAT_MODEL_END].handle(
+      GraphEvents.CHAT_MODEL_END,
+      {
+        output: { usage_metadata: { input_tokens: 3 } },
+      } as t.ModelEndData
+    );
+    await handlers[GraphEvents.CHAT_MODEL_END].handle(
+      GraphEvents.CHAT_MODEL_END,
+      {
+        output: { usage_metadata: { output_tokens: 5 } },
+      } as t.ModelEndData
+    );
+
+    expect(tracker.usage.promptTokens).toBe(3);
+    expect(tracker.usage.completionTokens).toBe(5);
+  });
+
   it('builds a chat completion chunk without transport dependencies', () => {
     expect(
       createChatCompletionChunk(

--- a/src/openai/__tests__/openai.test.ts
+++ b/src/openai/__tests__/openai.test.ts
@@ -123,6 +123,76 @@ describe('OpenAI-compatible adapters', () => {
     expect(writes.at(-2)).toContain('"finish_reason":"stop"');
   });
 
+  it('scopes tool-call argument state by run step', async () => {
+    const writes: string[] = [];
+    const tracker = createOpenAIStreamTracker();
+    const handlers = createOpenAIHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { requestId: 'chatcmpl_step_tools', model: 'agent', created: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              name: 'search',
+              args: '{"query":"first"}',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_2',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_2',
+              name: 'search',
+              args: '{"query":"second"}',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+
+    const toolCallDeltas = writes
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            choices: Array<{
+              delta: {
+                tool_calls?: Array<{
+                  id?: string;
+                  function?: { name?: string; arguments?: string };
+                }>;
+              };
+            }>;
+          }
+      )
+      .flatMap((chunk) => chunk.choices[0].delta.tool_calls ?? []);
+
+    expect(toolCallDeltas).toHaveLength(2);
+    expect(toolCallDeltas[1]).toMatchObject({
+      id: 'call_2',
+      function: { name: 'search', arguments: '{"query":"second"}' },
+    });
+    expect(tracker.toolCalls.get(0)?.function.arguments).toBe(
+      '{"query":"second"}'
+    );
+  });
+
   it('streams completed tool-call run steps without deltas', async () => {
     const writes: string[] = [];
     const tracker = createOpenAIStreamTracker();

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -103,6 +103,10 @@ function getTokenCount(value: number | null | undefined): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
+function getReasoningTokenCount(usage: Partial<UsageMetadata>): number {
+  return getTokenCount(usage.output_token_details?.reasoning);
+}
+
 function getToolCallIndex(
   toolCall: OpenAIToolCallFragment,
   fallbackIndex: number
@@ -304,6 +308,7 @@ export function createOpenAIHandlers(
         config.tracker.usage.completionTokens += getTokenCount(
           usage.output_tokens
         );
+        config.tracker.usage.reasoningTokens += getReasoningTokenCount(usage);
       },
     },
   };

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -167,12 +167,28 @@ export function createOpenAIHandlers(
           return;
         }
         for (const toolCall of delta.tool_calls ?? []) {
+          const index = toolCall.index ?? 0;
+          const current = config.tracker.toolCalls.get(index) ?? {
+            id: toolCall.id ?? '',
+            type: 'function' as const,
+            function: { name: '', arguments: '' },
+          };
+          if (toolCall.id != null && toolCall.id !== '') {
+            current.id = toolCall.id;
+          }
+          if (toolCall.name != null && toolCall.name !== '') {
+            current.function.name = toolCall.name;
+          }
+          if (toolCall.args != null && toolCall.args !== '') {
+            current.function.arguments += toolCall.args;
+          }
+          config.tracker.toolCalls.set(index, current);
           await writeOpenAISSE(
             config.writer,
             createChatCompletionChunk(config.context, {
               tool_calls: [
                 {
-                  index: toolCall.index ?? 0,
+                  index,
                   ...(toolCall.id != null && toolCall.id !== ''
                     ? { id: toolCall.id }
                     : {}),
@@ -211,8 +227,10 @@ export function createOpenAIHandlers(
 
 export async function sendOpenAIFinalChunk(
   config: OpenAIHandlerConfig,
-  finishReason: OpenAIChatCompletionChunkChoice['finish_reason'] = 'stop'
+  finishReason?: OpenAIChatCompletionChunkChoice['finish_reason']
 ): Promise<void> {
+  const resolvedFinishReason =
+    finishReason ?? (config.tracker.toolCalls.size > 0 ? 'tool_calls' : 'stop');
   const usage: OpenAICompletionUsage = {
     prompt_tokens: config.tracker.usage.promptTokens,
     completion_tokens: config.tracker.usage.completionTokens,
@@ -226,7 +244,7 @@ export async function sendOpenAIFinalChunk(
   }
   await writeOpenAISSE(
     config.writer,
-    createChatCompletionChunk(config.context, {}, finishReason, usage)
+    createChatCompletionChunk(config.context, {}, resolvedFinishReason, usage)
   );
   await writeOpenAISSE(config.writer, '[DONE]');
 }

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -209,11 +209,11 @@ async function emitToolCallChunk(params: {
   if (name !== '') {
     current.function.name = name;
   }
-  config.tracker.lastChunkKind = 'tool_call';
   config.tracker.toolCalls.set(index, current);
   if (!idChanged && !nameChanged && argumentDelta === '' && existing) {
     return;
   }
+  config.tracker.lastChunkKind = 'tool_call';
   const functionDelta: { name?: string; arguments?: string } = {};
   if (nameChanged || (!existing && current.function.name !== '')) {
     functionDelta.name = current.function.name;

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -59,6 +59,7 @@ export interface OpenAIChatCompletionChunk {
 }
 
 export interface OpenAIStreamTracker {
+  hasRole: boolean;
   hasText: boolean;
   hasReasoning: boolean;
   lastChunkKind?: 'text' | 'reasoning' | 'tool_call';
@@ -90,6 +91,7 @@ interface OpenAIToolCallFragment {
 
 export function createOpenAIStreamTracker(): OpenAIStreamTracker {
   return {
+    hasRole: false,
     hasText: false,
     hasReasoning: false,
     toolCalls: new Map(),
@@ -163,6 +165,20 @@ export function createChatCompletionChunk(
   };
 }
 
+export function createChatCompletionUsageChunk(
+  context: OpenAIResponseContext,
+  usage: OpenAICompletionUsage
+): OpenAIChatCompletionChunk {
+  return {
+    id: context.requestId,
+    object: 'chat.completion.chunk',
+    created: context.created,
+    model: context.model,
+    choices: [],
+    usage,
+  };
+}
+
 export async function writeOpenAISSE(
   writer: OpenAICompatibleWriter,
   data: OpenAIChatCompletionChunk | '[DONE]'
@@ -187,6 +203,19 @@ function getTextParts(
     }
   }
   return text;
+}
+
+async function emitAssistantRoleChunk(
+  config: OpenAIHandlerConfig
+): Promise<void> {
+  if (config.tracker.hasRole) {
+    return;
+  }
+  config.tracker.hasRole = true;
+  await writeOpenAISSE(
+    config.writer,
+    createChatCompletionChunk(config.context, { role: 'assistant' })
+  );
 }
 
 async function emitToolCallChunk(params: {
@@ -241,6 +270,7 @@ async function emitToolCallChunk(params: {
   if (argumentDelta !== '') {
     functionDelta.arguments = argumentDelta;
   }
+  await emitAssistantRoleChunk(config);
   await writeOpenAISSE(
     config.writer,
     createChatCompletionChunk(config.context, {
@@ -267,6 +297,7 @@ export function createOpenAIHandlers(
         for (const text of getTextParts(data as t.MessageDeltaEvent)) {
           config.tracker.hasText = true;
           config.tracker.lastChunkKind = 'text';
+          await emitAssistantRoleChunk(config);
           await writeOpenAISSE(
             config.writer,
             createChatCompletionChunk(config.context, { content: text })
@@ -279,6 +310,7 @@ export function createOpenAIHandlers(
         for (const text of getTextParts(data as t.ReasoningDeltaEvent)) {
           config.tracker.hasReasoning = true;
           config.tracker.lastChunkKind = 'reasoning';
+          await emitAssistantRoleChunk(config);
           await writeOpenAISSE(
             config.writer,
             createChatCompletionChunk(config.context, { reasoning: text })
@@ -359,9 +391,14 @@ export async function sendOpenAIFinalChunk(
       reasoning_tokens: config.tracker.usage.reasoningTokens,
     };
   }
+  await emitAssistantRoleChunk(config);
   await writeOpenAISSE(
     config.writer,
-    createChatCompletionChunk(config.context, {}, resolvedFinishReason, usage)
+    createChatCompletionChunk(config.context, {}, resolvedFinishReason)
+  );
+  await writeOpenAISSE(
+    config.writer,
+    createChatCompletionUsageChunk(config.context, usage)
   );
   await writeOpenAISSE(config.writer, '[DONE]');
 }

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -63,6 +63,7 @@ export interface OpenAIStreamTracker {
   hasReasoning: boolean;
   lastChunkKind?: 'text' | 'reasoning' | 'tool_call';
   toolCalls: Map<number, OpenAIToolCall>;
+  toolCallsByStep?: Map<string, Map<number, OpenAIToolCall>>;
   usage: {
     promptTokens: number;
     completionTokens: number;
@@ -92,6 +93,7 @@ export function createOpenAIStreamTracker(): OpenAIStreamTracker {
     hasText: false,
     hasReasoning: false,
     toolCalls: new Map(),
+    toolCallsByStep: new Map(),
     usage: {
       promptTokens: 0,
       completionTokens: 0,
@@ -128,6 +130,21 @@ function getToolCallArguments(toolCall: OpenAIToolCallFragment): string {
     return args;
   }
   return JSON.stringify(args);
+}
+
+function getStepToolCalls(
+  tracker: OpenAIStreamTracker,
+  stepId: string
+): Map<number, OpenAIToolCall> {
+  const toolCallsByStep = tracker.toolCallsByStep ?? new Map();
+  tracker.toolCallsByStep = toolCallsByStep;
+  const existing = toolCallsByStep.get(stepId);
+  if (existing != null) {
+    return existing;
+  }
+  const stepToolCalls = new Map<number, OpenAIToolCall>();
+  toolCallsByStep.set(stepId, stepToolCalls);
+  return stepToolCalls;
 }
 
 export function createChatCompletionChunk(
@@ -174,13 +191,15 @@ function getTextParts(
 
 async function emitToolCallChunk(params: {
   config: OpenAIHandlerConfig;
+  stepId: string;
   toolCall: OpenAIToolCallFragment;
   fallbackIndex: number;
   completed: boolean;
 }): Promise<void> {
-  const { config, toolCall, fallbackIndex, completed } = params;
+  const { config, stepId, toolCall, fallbackIndex, completed } = params;
   const index = getToolCallIndex(toolCall, fallbackIndex);
-  const existing = config.tracker.toolCalls.get(index);
+  const stepToolCalls = getStepToolCalls(config.tracker, stepId);
+  const existing = stepToolCalls.get(index);
   const current = existing ?? {
     id: toolCall.id ?? '',
     type: 'function' as const,
@@ -209,6 +228,7 @@ async function emitToolCallChunk(params: {
   if (name !== '') {
     current.function.name = name;
   }
+  stepToolCalls.set(index, current);
   config.tracker.toolCalls.set(index, current);
   if (!idChanged && !nameChanged && argumentDelta === '' && existing) {
     return;
@@ -268,7 +288,8 @@ export function createOpenAIHandlers(
     },
     [GraphEvents.ON_RUN_STEP_DELTA]: {
       handle: async (_event, data): Promise<void> => {
-        const delta = (data as t.RunStepDeltaEvent).delta;
+        const runStepDelta = data as t.RunStepDeltaEvent;
+        const delta = runStepDelta.delta;
         if (delta.type !== 'tool_calls') {
           return;
         }
@@ -276,6 +297,7 @@ export function createOpenAIHandlers(
         for (let index = 0; index < toolCalls.length; index++) {
           await emitToolCallChunk({
             config,
+            stepId: runStepDelta.id,
             toolCall: toolCalls[index],
             fallbackIndex: index,
             completed: false,
@@ -293,6 +315,7 @@ export function createOpenAIHandlers(
         for (let index = 0; index < toolCalls.length; index++) {
           await emitToolCallChunk({
             config,
+            stepId: runStep.id,
             toolCall: toolCalls[index],
             fallbackIndex: index,
             completed: true,

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -1,0 +1,223 @@
+import { GraphEvents } from '@/common';
+import type * as t from '@/types';
+
+export interface OpenAICompatibleWriter {
+  write(data: string): void | Promise<void>;
+}
+
+export interface OpenAIResponseContext {
+  requestId: string;
+  model: string;
+  created: number;
+}
+
+export interface OpenAICompletionUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  completion_tokens_details?: {
+    reasoning_tokens?: number;
+  };
+}
+
+export interface OpenAIToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export interface OpenAIChatCompletionChunkChoice {
+  index: number;
+  delta: {
+    role?: 'assistant';
+    content?: string | null;
+    reasoning?: string | null;
+    tool_calls?: Array<{
+      index: number;
+      id?: string;
+      type?: 'function';
+      function?: {
+        name?: string;
+        arguments?: string;
+      };
+    }>;
+  };
+  finish_reason: 'stop' | 'length' | 'tool_calls' | 'content_filter' | null;
+}
+
+export interface OpenAIChatCompletionChunk {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: OpenAIChatCompletionChunkChoice[];
+  usage?: OpenAICompletionUsage;
+}
+
+export interface OpenAIStreamTracker {
+  hasText: boolean;
+  hasReasoning: boolean;
+  toolCalls: Map<number, OpenAIToolCall>;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    reasoningTokens: number;
+  };
+}
+
+export interface OpenAIHandlerConfig {
+  writer: OpenAICompatibleWriter;
+  context: OpenAIResponseContext;
+  tracker: OpenAIStreamTracker;
+}
+
+export function createOpenAIStreamTracker(): OpenAIStreamTracker {
+  return {
+    hasText: false,
+    hasReasoning: false,
+    toolCalls: new Map(),
+    usage: {
+      promptTokens: 0,
+      completionTokens: 0,
+      reasoningTokens: 0,
+    },
+  };
+}
+
+export function createChatCompletionChunk(
+  context: OpenAIResponseContext,
+  delta: OpenAIChatCompletionChunkChoice['delta'],
+  finishReason: OpenAIChatCompletionChunkChoice['finish_reason'] = null,
+  usage?: OpenAICompletionUsage
+): OpenAIChatCompletionChunk {
+  return {
+    id: context.requestId,
+    object: 'chat.completion.chunk',
+    created: context.created,
+    model: context.model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+export async function writeOpenAISSE(
+  writer: OpenAICompatibleWriter,
+  data: OpenAIChatCompletionChunk | '[DONE]'
+): Promise<void> {
+  await writer.write(
+    `data: ${data === '[DONE]' ? data : JSON.stringify(data)}\n\n`
+  );
+}
+
+function getTextParts(
+  data: t.MessageDeltaEvent | t.ReasoningDeltaEvent
+): string[] {
+  const parts = data.delta.content ?? [];
+  const text: string[] = [];
+  for (const part of parts) {
+    if ('text' in part && typeof part.text === 'string') {
+      text.push(part.text);
+      continue;
+    }
+    if ('think' in part && typeof part.think === 'string') {
+      text.push(part.think);
+    }
+  }
+  return text;
+}
+
+export function createOpenAIHandlers(
+  config: OpenAIHandlerConfig
+): Record<string, t.EventHandler> {
+  return {
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: async (_event, data): Promise<void> => {
+        for (const text of getTextParts(data as t.MessageDeltaEvent)) {
+          config.tracker.hasText = true;
+          await writeOpenAISSE(
+            config.writer,
+            createChatCompletionChunk(config.context, { content: text })
+          );
+        }
+      },
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: async (_event, data): Promise<void> => {
+        for (const text of getTextParts(data as t.ReasoningDeltaEvent)) {
+          config.tracker.hasReasoning = true;
+          await writeOpenAISSE(
+            config.writer,
+            createChatCompletionChunk(config.context, { reasoning: text })
+          );
+        }
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: async (_event, data): Promise<void> => {
+        const delta = (data as t.RunStepDeltaEvent).delta;
+        if (delta.type !== 'tool_calls') {
+          return;
+        }
+        for (const toolCall of delta.tool_calls ?? []) {
+          await writeOpenAISSE(
+            config.writer,
+            createChatCompletionChunk(config.context, {
+              tool_calls: [
+                {
+                  index: toolCall.index ?? 0,
+                  ...(toolCall.id != null && toolCall.id !== ''
+                    ? { id: toolCall.id }
+                    : {}),
+                  type: 'function',
+                  function: {
+                    ...(toolCall.name != null && toolCall.name !== ''
+                      ? { name: toolCall.name }
+                      : {}),
+                    ...(toolCall.args != null && toolCall.args !== ''
+                      ? { arguments: toolCall.args }
+                      : {}),
+                  },
+                },
+              ],
+            })
+          );
+        }
+      },
+    },
+    [GraphEvents.CHAT_MODEL_END]: {
+      handle: (_event, data): void => {
+        const usage = (data as t.ModelEndData)?.output?.usage_metadata;
+        if (!usage) {
+          return;
+        }
+        config.tracker.usage.promptTokens += usage.input_tokens;
+        config.tracker.usage.completionTokens += usage.output_tokens;
+      },
+    },
+  };
+}
+
+export async function sendOpenAIFinalChunk(
+  config: OpenAIHandlerConfig,
+  finishReason: OpenAIChatCompletionChunkChoice['finish_reason'] = 'stop'
+): Promise<void> {
+  const usage: OpenAICompletionUsage = {
+    prompt_tokens: config.tracker.usage.promptTokens,
+    completion_tokens: config.tracker.usage.completionTokens,
+    total_tokens:
+      config.tracker.usage.promptTokens + config.tracker.usage.completionTokens,
+  };
+  if (config.tracker.usage.reasoningTokens > 0) {
+    usage.completion_tokens_details = {
+      reasoning_tokens: config.tracker.usage.reasoningTokens,
+    };
+  }
+  await writeOpenAISSE(
+    config.writer,
+    createChatCompletionChunk(config.context, {}, finishReason, usage)
+  );
+  await writeOpenAISSE(config.writer, '[DONE]');
+}

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -1,4 +1,5 @@
 import { GraphEvents } from '@/common';
+import type { UsageMetadata } from '@langchain/core/messages';
 import type * as t from '@/types';
 
 export interface OpenAICompatibleWriter {
@@ -85,6 +86,10 @@ export function createOpenAIStreamTracker(): OpenAIStreamTracker {
       reasoningTokens: 0,
     },
   };
+}
+
+function getTokenCount(value: number | null | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 export function createChatCompletionChunk(
@@ -189,12 +194,16 @@ export function createOpenAIHandlers(
     },
     [GraphEvents.CHAT_MODEL_END]: {
       handle: (_event, data): void => {
-        const usage = (data as t.ModelEndData)?.output?.usage_metadata;
+        const usage = (data as t.ModelEndData)?.output?.usage_metadata as
+          | Partial<UsageMetadata>
+          | undefined;
         if (!usage) {
           return;
         }
-        config.tracker.usage.promptTokens += usage.input_tokens;
-        config.tracker.usage.completionTokens += usage.output_tokens;
+        config.tracker.usage.promptTokens += getTokenCount(usage.input_tokens);
+        config.tracker.usage.completionTokens += getTokenCount(
+          usage.output_tokens
+        );
       },
     },
   };

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -61,6 +61,7 @@ export interface OpenAIChatCompletionChunk {
 export interface OpenAIStreamTracker {
   hasText: boolean;
   hasReasoning: boolean;
+  lastChunkKind?: 'text' | 'reasoning' | 'tool_call';
   toolCalls: Map<number, OpenAIToolCall>;
   usage: {
     promptTokens: number;
@@ -208,6 +209,7 @@ async function emitToolCallChunk(params: {
   if (name !== '') {
     current.function.name = name;
   }
+  config.tracker.lastChunkKind = 'tool_call';
   config.tracker.toolCalls.set(index, current);
   if (!idChanged && !nameChanged && argumentDelta === '' && existing) {
     return;
@@ -244,6 +246,7 @@ export function createOpenAIHandlers(
       handle: async (_event, data): Promise<void> => {
         for (const text of getTextParts(data as t.MessageDeltaEvent)) {
           config.tracker.hasText = true;
+          config.tracker.lastChunkKind = 'text';
           await writeOpenAISSE(
             config.writer,
             createChatCompletionChunk(config.context, { content: text })
@@ -255,6 +258,7 @@ export function createOpenAIHandlers(
       handle: async (_event, data): Promise<void> => {
         for (const text of getTextParts(data as t.ReasoningDeltaEvent)) {
           config.tracker.hasReasoning = true;
+          config.tracker.lastChunkKind = 'reasoning';
           await writeOpenAISSE(
             config.writer,
             createChatCompletionChunk(config.context, { reasoning: text })
@@ -319,7 +323,8 @@ export async function sendOpenAIFinalChunk(
   finishReason?: OpenAIChatCompletionChunkChoice['finish_reason']
 ): Promise<void> {
   const resolvedFinishReason =
-    finishReason ?? (config.tracker.toolCalls.size > 0 ? 'tool_calls' : 'stop');
+    finishReason ??
+    (config.tracker.lastChunkKind === 'tool_call' ? 'tool_calls' : 'stop');
   const usage: OpenAICompletionUsage = {
     prompt_tokens: config.tracker.usage.promptTokens,
     completion_tokens: config.tracker.usage.completionTokens,

--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -75,6 +75,17 @@ export interface OpenAIHandlerConfig {
   tracker: OpenAIStreamTracker;
 }
 
+interface OpenAIToolCallFragment {
+  index?: number;
+  id?: string;
+  name?: string;
+  args?: string | object;
+  function?: {
+    name?: string;
+    arguments?: string | object;
+  };
+}
+
 export function createOpenAIStreamTracker(): OpenAIStreamTracker {
   return {
     hasText: false,
@@ -90,6 +101,28 @@ export function createOpenAIStreamTracker(): OpenAIStreamTracker {
 
 function getTokenCount(value: number | null | undefined): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function getToolCallIndex(
+  toolCall: OpenAIToolCallFragment,
+  fallbackIndex: number
+): number {
+  return typeof toolCall.index === 'number' ? toolCall.index : fallbackIndex;
+}
+
+function getToolCallName(toolCall: OpenAIToolCallFragment): string {
+  return toolCall.name ?? toolCall.function?.name ?? '';
+}
+
+function getToolCallArguments(toolCall: OpenAIToolCallFragment): string {
+  const args = toolCall.args ?? toolCall.function?.arguments;
+  if (args == null) {
+    return '';
+  }
+  if (typeof args === 'string') {
+    return args;
+  }
+  return JSON.stringify(args);
 }
 
 export function createChatCompletionChunk(
@@ -134,6 +167,71 @@ function getTextParts(
   return text;
 }
 
+async function emitToolCallChunk(params: {
+  config: OpenAIHandlerConfig;
+  toolCall: OpenAIToolCallFragment;
+  fallbackIndex: number;
+  completed: boolean;
+}): Promise<void> {
+  const { config, toolCall, fallbackIndex, completed } = params;
+  const index = getToolCallIndex(toolCall, fallbackIndex);
+  const existing = config.tracker.toolCalls.get(index);
+  const current = existing ?? {
+    id: toolCall.id ?? '',
+    type: 'function' as const,
+    function: { name: '', arguments: '' },
+  };
+  const name = getToolCallName(toolCall);
+  const args = getToolCallArguments(toolCall);
+  const idChanged =
+    toolCall.id != null && toolCall.id !== '' && current.id !== toolCall.id;
+  const nameChanged = name !== '' && current.function.name !== name;
+  let argumentDelta = '';
+  if (completed) {
+    if (args !== '' && args !== current.function.arguments) {
+      argumentDelta = args.startsWith(current.function.arguments)
+        ? args.slice(current.function.arguments.length)
+        : args;
+      current.function.arguments = args;
+    }
+  } else if (args !== '') {
+    argumentDelta = args;
+    current.function.arguments += args;
+  }
+  if (toolCall.id != null && toolCall.id !== '') {
+    current.id = toolCall.id;
+  }
+  if (name !== '') {
+    current.function.name = name;
+  }
+  config.tracker.toolCalls.set(index, current);
+  if (!idChanged && !nameChanged && argumentDelta === '' && existing) {
+    return;
+  }
+  const functionDelta: { name?: string; arguments?: string } = {};
+  if (nameChanged || (!existing && current.function.name !== '')) {
+    functionDelta.name = current.function.name;
+  }
+  if (argumentDelta !== '') {
+    functionDelta.arguments = argumentDelta;
+  }
+  await writeOpenAISSE(
+    config.writer,
+    createChatCompletionChunk(config.context, {
+      tool_calls: [
+        {
+          index,
+          ...(current.id !== '' ? { id: current.id } : {}),
+          type: 'function',
+          ...(functionDelta.name != null || functionDelta.arguments != null
+            ? { function: functionDelta }
+            : {}),
+        },
+      ],
+    })
+  );
+}
+
 export function createOpenAIHandlers(
   config: OpenAIHandlerConfig
 ): Record<string, t.EventHandler> {
@@ -166,45 +264,31 @@ export function createOpenAIHandlers(
         if (delta.type !== 'tool_calls') {
           return;
         }
-        for (const toolCall of delta.tool_calls ?? []) {
-          const index = toolCall.index ?? 0;
-          const current = config.tracker.toolCalls.get(index) ?? {
-            id: toolCall.id ?? '',
-            type: 'function' as const,
-            function: { name: '', arguments: '' },
-          };
-          if (toolCall.id != null && toolCall.id !== '') {
-            current.id = toolCall.id;
-          }
-          if (toolCall.name != null && toolCall.name !== '') {
-            current.function.name = toolCall.name;
-          }
-          if (toolCall.args != null && toolCall.args !== '') {
-            current.function.arguments += toolCall.args;
-          }
-          config.tracker.toolCalls.set(index, current);
-          await writeOpenAISSE(
-            config.writer,
-            createChatCompletionChunk(config.context, {
-              tool_calls: [
-                {
-                  index,
-                  ...(toolCall.id != null && toolCall.id !== ''
-                    ? { id: toolCall.id }
-                    : {}),
-                  type: 'function',
-                  function: {
-                    ...(toolCall.name != null && toolCall.name !== ''
-                      ? { name: toolCall.name }
-                      : {}),
-                    ...(toolCall.args != null && toolCall.args !== ''
-                      ? { arguments: toolCall.args }
-                      : {}),
-                  },
-                },
-              ],
-            })
-          );
+        const toolCalls = delta.tool_calls ?? [];
+        for (let index = 0; index < toolCalls.length; index++) {
+          await emitToolCallChunk({
+            config,
+            toolCall: toolCalls[index],
+            fallbackIndex: index,
+            completed: false,
+          });
+        }
+      },
+    },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: async (_event, data): Promise<void> => {
+        const runStep = data as t.RunStep;
+        if (runStep.stepDetails.type !== 'tool_calls') {
+          return;
+        }
+        const toolCalls = runStep.stepDetails.tool_calls ?? [];
+        for (let index = 0; index < toolCalls.length; index++) {
+          await emitToolCallChunk({
+            config,
+            toolCall: toolCalls[index],
+            fallbackIndex: index,
+            completed: true,
+          });
         }
       },
     },

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -52,4 +52,38 @@ describe('Responses-compatible adapters', () => {
       total_tokens: 9,
     });
   });
+
+  it('tracks partial usage metadata without NaN totals', async () => {
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: jest.fn() },
+      context: { responseId: 'resp_usage', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.CHAT_MODEL_END].handle(
+      GraphEvents.CHAT_MODEL_END,
+      {
+        output: { usage_metadata: { input_tokens: 2 } },
+      } as t.ModelEndData
+    );
+    await handlers[GraphEvents.CHAT_MODEL_END].handle(
+      GraphEvents.CHAT_MODEL_END,
+      {
+        output: { usage_metadata: { output_tokens: 4 } },
+      } as t.ModelEndData
+    );
+
+    expect(
+      buildResponse(
+        { responseId: 'resp_usage', model: 'agent', createdAt: 1 },
+        tracker,
+        'completed'
+      ).usage
+    ).toEqual({
+      input_tokens: 2,
+      output_tokens: 4,
+      total_tokens: 6,
+    });
+  });
 });

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -53,6 +53,41 @@ describe('Responses-compatible adapters', () => {
     });
   });
 
+  it('streams reasoning text with official Responses event names', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { responseId: 'resp_reasoning', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_REASONING_DELTA].handle(
+      GraphEvents.ON_REASONING_DELTA,
+      {
+        id: 'reasoning',
+        delta: { content: [{ type: 'text', text: 'thinking' }] },
+      } as t.ReasoningDeltaEvent
+    );
+
+    const events = writes
+      .filter((data) => data.startsWith('data: '))
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            type: string;
+            delta?: string;
+          }
+      );
+    expect(events.map((event) => event.type)).toEqual([
+      'response.output_item.added',
+      'response.reasoning_text.delta',
+    ]);
+    expect(events[1]).toMatchObject({
+      delta: 'thinking',
+    });
+  });
+
   it('tracks partial usage metadata without NaN totals', async () => {
     const tracker = createResponseTracker();
     const handlers = createResponsesEventHandlers({
@@ -134,7 +169,7 @@ describe('Responses-compatible adapters', () => {
       {
         result: {
           id: 'step_1',
-          index: 0,
+          index: 7,
           type: 'tool_call',
           tool_call: {
             id: 'call_1',
@@ -183,7 +218,7 @@ describe('Responses-compatible adapters', () => {
     });
   });
 
-  it('keeps tool-call items stable when ids arrive after argument deltas', async () => {
+  it('keeps tool-call items stable when ids arrive and indexes differ', async () => {
     const writes: string[] = [];
     const tracker = createResponseTracker();
     const handlers = createResponsesEventHandlers({

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -500,4 +500,80 @@ describe('Responses-compatible adapters', () => {
       status: 'completed',
     });
   });
+
+  it('keeps id-less single-chunk tool calls distinct by explicit index', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        responseId: 'resp_tools_indexed',
+        model: 'agent',
+        createdAt: 1,
+      },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [{ index: 0, name: 'search', args: '{"query":"first"}' }],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            { index: 1, name: 'search', args: '{"query":"second"}' },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_COMPLETED].handle(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: 'step_1',
+          type: 'tool_call',
+          tool_call: {
+            index: 1,
+            name: 'search',
+            args: '{"query":"second"}',
+            output: 'ok',
+            progress: 1,
+          },
+        },
+      }
+    );
+
+    const events = writes
+      .filter((data) => data.startsWith('data: '))
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            type: string;
+          }
+      );
+    expect(
+      events.filter((event) => event.type === 'response.output_item.added')
+    ).toHaveLength(2);
+    expect(tracker.items).toHaveLength(2);
+    expect(tracker.items[0]).toMatchObject({
+      call_id: 'step_1:0',
+      arguments: '{"query":"first"}',
+      status: 'in_progress',
+    });
+    expect(tracker.items[1]).toMatchObject({
+      call_id: 'step_1:1',
+      arguments: '{"query":"second"}',
+      status: 'completed',
+    });
+  });
 });

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -149,7 +149,15 @@ describe('Responses-compatible adapters', () => {
 
     const events = writes
       .filter((data) => data.startsWith('data: '))
-      .map((data) => JSON.parse(data.slice(6)) as { type: string });
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            type: string;
+            call_id?: string;
+            name?: string;
+            arguments?: string;
+          }
+      );
     expect(events.map((event) => event.type)).toEqual([
       'response.output_item.added',
       'response.function_call_arguments.delta',
@@ -157,6 +165,106 @@ describe('Responses-compatible adapters', () => {
       'response.function_call_arguments.done',
       'response.output_item.done',
     ]);
+    expect(
+      events.find(
+        (event) => event.type === 'response.function_call_arguments.done'
+      )
+    ).toMatchObject({
+      call_id: 'call_1',
+      name: 'search',
+      arguments: '{"query":"sessions"}',
+    });
+    expect(tracker.items[0]).toMatchObject({
+      type: 'function_call',
+      call_id: 'call_1',
+      name: 'search',
+      arguments: '{"query":"sessions"}',
+      status: 'completed',
+    });
+  });
+
+  it('keeps tool-call items stable when ids arrive after argument deltas', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        responseId: 'resp_tools_late_id',
+        model: 'agent',
+        createdAt: 1,
+      },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [{ index: 0, args: '{"query"' }],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              name: 'search',
+              args: ':"sessions"}',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_COMPLETED].handle(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: 'step_1',
+          index: 0,
+          type: 'tool_call',
+          tool_call: {
+            id: 'call_1',
+            name: 'search',
+            args: '{"query":"sessions"}',
+            output: 'ok',
+            progress: 1,
+          },
+        },
+      }
+    );
+
+    const events = writes
+      .filter((data) => data.startsWith('data: '))
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            type: string;
+            call_id?: string;
+            name?: string;
+            arguments?: string;
+          }
+      );
+    expect(
+      events.filter((event) => event.type === 'response.output_item.added')
+    ).toHaveLength(1);
+    expect(
+      events.find(
+        (event) => event.type === 'response.function_call_arguments.done'
+      )
+    ).toMatchObject({
+      call_id: 'call_1',
+      name: 'search',
+      arguments: '{"query":"sessions"}',
+    });
+    expect(tracker.items).toHaveLength(1);
     expect(tracker.items[0]).toMatchObject({
       type: 'function_call',
       call_id: 'call_1',

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -30,9 +30,48 @@ describe('Responses-compatible adapters', () => {
       tracker,
     });
 
+    expect(writes.join('')).toContain('response.created');
     expect(writes.join('')).toContain('response.output_text.delta');
     expect(writes.join('')).toContain('response.completed');
     expect(writes.at(-1)).toBe('data: [DONE]\n\n');
+  });
+
+  it('emits response.created before output item events once', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { responseId: 'resp_created', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'msg',
+        delta: { content: [{ type: 'text', text: 'hello' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+    await handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'msg',
+        delta: { content: [{ type: 'text', text: ' again' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+
+    const events = writes
+      .filter((data) => data.startsWith('data: '))
+      .map((data) => JSON.parse(data.slice(6)) as { type: string });
+    expect(events[0].type).toBe('response.created');
+    expect(
+      events.filter((event) => event.type === 'response.created')
+    ).toHaveLength(1);
+    expect(
+      events.findIndex((event) => event.type === 'response.created')
+    ).toBeLessThan(
+      events.findIndex((event) => event.type === 'response.output_item.added')
+    );
   });
 
   it('emits output item completion events before response completion', async () => {
@@ -146,10 +185,11 @@ describe('Responses-compatible adapters', () => {
           }
       );
     expect(events.map((event) => event.type)).toEqual([
+      'response.created',
       'response.output_item.added',
       'response.reasoning_text.delta',
     ]);
-    expect(events[1]).toMatchObject({
+    expect(events[2]).toMatchObject({
       delta: 'thinking',
     });
   });
@@ -260,6 +300,7 @@ describe('Responses-compatible adapters', () => {
           }
       );
     expect(events.map((event) => event.type)).toEqual([
+      'response.created',
       'response.output_item.added',
       'response.function_call_arguments.delta',
       'response.function_call_arguments.delta',

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -35,6 +35,72 @@ describe('Responses-compatible adapters', () => {
     expect(writes.at(-1)).toBe('data: [DONE]\n\n');
   });
 
+  it('emits output item completion events before response completion', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { responseId: 'resp_done', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'msg',
+        delta: { content: [{ type: 'text', text: 'hello' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+    await handlers[GraphEvents.ON_REASONING_DELTA].handle(
+      GraphEvents.ON_REASONING_DELTA,
+      {
+        id: 'reasoning',
+        delta: { content: [{ type: 'text', text: 'thinking' }] },
+      } as t.ReasoningDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [{ index: 0, id: 'call_1', name: 'search' }],
+        },
+      } as t.RunStepDeltaEvent
+    );
+
+    await emitResponseCompleted({
+      writer: { write: (data) => void writes.push(data) },
+      context: { responseId: 'resp_done', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    const events = writes
+      .filter(
+        (data) => data.startsWith('data: ') && data !== 'data: [DONE]\n\n'
+      )
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            type: string;
+            output_index?: number;
+          }
+      );
+    const completedIndex = events.findIndex(
+      (event) => event.type === 'response.completed'
+    );
+    const doneEvents = events.filter(
+      (event) => event.type === 'response.output_item.done'
+    );
+    expect(doneEvents.map((event) => event.output_index)).toEqual([0, 1, 2]);
+    expect(
+      doneEvents.every(
+        (event) =>
+          events.indexOf(event) >= 0 && events.indexOf(event) < completedIndex
+      )
+    ).toBe(true);
+  });
+
   it('builds completed response usage from tracker state', () => {
     const tracker = createResponseTracker();
     tracker.usage.inputTokens = 2;

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -86,4 +86,83 @@ describe('Responses-compatible adapters', () => {
       total_tokens: 6,
     });
   });
+
+  it('streams function call items and argument events', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { responseId: 'resp_tools', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              name: 'search',
+              args: '{"query"',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              args: ':"sessions"}',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_COMPLETED].handle(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: 'step_1',
+          index: 0,
+          type: 'tool_call',
+          tool_call: {
+            id: 'call_1',
+            name: 'search',
+            args: '{"query":"sessions"}',
+            output: 'ok',
+            progress: 1,
+          },
+        },
+      }
+    );
+
+    const events = writes
+      .filter((data) => data.startsWith('data: '))
+      .map((data) => JSON.parse(data.slice(6)) as { type: string });
+    expect(events.map((event) => event.type)).toEqual([
+      'response.output_item.added',
+      'response.function_call_arguments.delta',
+      'response.function_call_arguments.delta',
+      'response.function_call_arguments.done',
+      'response.output_item.done',
+    ]);
+    expect(tracker.items[0]).toMatchObject({
+      type: 'function_call',
+      call_id: 'call_1',
+      name: 'search',
+      arguments: '{"query":"sessions"}',
+      status: 'completed',
+    });
+  });
 });

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -149,6 +149,7 @@ describe('Responses-compatible adapters', () => {
       'response.output_item.done',
       'response.reasoning_text.done',
       'response.output_item.done',
+      'response.function_call_arguments.done',
       'response.output_item.done',
       'response.completed',
     ]);
@@ -335,6 +336,78 @@ describe('Responses-compatible adapters', () => {
       call_id: 'call_1',
       name: 'search',
       arguments: '{"query":"sessions"}',
+      status: 'completed',
+    });
+  });
+
+  it('emits function call arguments done before closing unfinished tool items', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        responseId: 'resp_unfinished_tool',
+        model: 'agent',
+        createdAt: 1,
+      },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [
+            {
+              index: 0,
+              id: 'call_1',
+              name: 'search',
+              args: '{"query":"sessions"}',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent
+    );
+
+    await emitResponseCompleted({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        responseId: 'resp_unfinished_tool',
+        model: 'agent',
+        createdAt: 1,
+      },
+      tracker,
+    });
+
+    const events = writes
+      .filter(
+        (data) => data.startsWith('data: ') && data !== 'data: [DONE]\n\n'
+      )
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            type: string;
+            call_id?: string;
+            arguments?: string;
+          }
+      );
+    const argumentsDoneIndex = events.findIndex(
+      (event) => event.type === 'response.function_call_arguments.done'
+    );
+    const itemDoneIndex = events.findIndex(
+      (event) => event.type === 'response.output_item.done'
+    );
+
+    expect(argumentsDoneIndex).toBeGreaterThan(-1);
+    expect(itemDoneIndex).toBeGreaterThan(argumentsDoneIndex);
+    expect(events[argumentsDoneIndex]).toMatchObject({
+      call_id: 'call_1',
+      arguments: '{"query":"sessions"}',
+    });
+    expect(tracker.items[0]).toMatchObject({
+      type: 'function_call',
       status: 'completed',
     });
   });

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -138,6 +138,20 @@ describe('Responses-compatible adapters', () => {
           events.indexOf(event) >= 0 && events.indexOf(event) < completedIndex
       )
     ).toBe(true);
+    expect(events.map((event) => event.type)).toEqual([
+      'response.created',
+      'response.output_item.added',
+      'response.output_text.delta',
+      'response.output_item.added',
+      'response.reasoning_text.delta',
+      'response.output_item.added',
+      'response.output_text.done',
+      'response.output_item.done',
+      'response.reasoning_text.done',
+      'response.output_item.done',
+      'response.output_item.done',
+      'response.completed',
+    ]);
   });
 
   it('builds completed response usage from tracker state', () => {
@@ -410,6 +424,77 @@ describe('Responses-compatible adapters', () => {
     expect(tracker.items[0]).toMatchObject({
       type: 'function_call',
       call_id: 'call_1',
+      name: 'search',
+      arguments: '{"query":"sessions"}',
+      status: 'completed',
+    });
+  });
+
+  it('completes id-less tool calls using the tool-call position', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: {
+        responseId: 'resp_tools_no_id',
+        model: 'agent',
+        createdAt: 1,
+      },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_RUN_STEP_DELTA].handle(
+      GraphEvents.ON_RUN_STEP_DELTA,
+      {
+        id: 'step_1',
+        delta: {
+          type: 'tool_calls',
+          tool_calls: [{ index: 0, name: 'search', args: '{"query"' }],
+        },
+      } as t.RunStepDeltaEvent
+    );
+    await handlers[GraphEvents.ON_RUN_STEP_COMPLETED].handle(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: 'step_1',
+          index: 7,
+          type: 'tool_call',
+          tool_call: {
+            name: 'search',
+            args: '{"query":"sessions"}',
+            output: 'ok',
+            progress: 1,
+          },
+        },
+      }
+    );
+
+    const events = writes
+      .filter((data) => data.startsWith('data: '))
+      .map(
+        (data) =>
+          JSON.parse(data.slice(6)) as {
+            type: string;
+            call_id?: string;
+            arguments?: string;
+          }
+      );
+    expect(
+      events.filter((event) => event.type === 'response.output_item.added')
+    ).toHaveLength(1);
+    expect(
+      events.find(
+        (event) => event.type === 'response.function_call_arguments.done'
+      )
+    ).toMatchObject({
+      call_id: 'step_1:0',
+      arguments: '{"query":"sessions"}',
+    });
+    expect(tracker.items).toHaveLength(1);
+    expect(tracker.items[0]).toMatchObject({
+      type: 'function_call',
+      call_id: 'step_1:0',
       name: 'search',
       arguments: '{"query":"sessions"}',
       status: 'completed',

--- a/src/responses/__tests__/responses.test.ts
+++ b/src/responses/__tests__/responses.test.ts
@@ -1,0 +1,55 @@
+import { GraphEvents } from '@/common';
+import {
+  buildResponse,
+  createResponseTracker,
+  createResponsesEventHandlers,
+  emitResponseCompleted,
+} from '@/responses';
+import type * as t from '@/types';
+
+describe('Responses-compatible adapters', () => {
+  it('streams semantic response events through a generic writer', async () => {
+    const writes: string[] = [];
+    const tracker = createResponseTracker();
+    const handlers = createResponsesEventHandlers({
+      writer: { write: (data) => void writes.push(data) },
+      context: { responseId: 'resp_1', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    await handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'msg',
+        delta: { content: [{ type: 'text', text: 'hello' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+    await emitResponseCompleted({
+      writer: { write: (data) => void writes.push(data) },
+      context: { responseId: 'resp_1', model: 'agent', createdAt: 1 },
+      tracker,
+    });
+
+    expect(writes.join('')).toContain('response.output_text.delta');
+    expect(writes.join('')).toContain('response.completed');
+    expect(writes.at(-1)).toBe('data: [DONE]\n\n');
+  });
+
+  it('builds completed response usage from tracker state', () => {
+    const tracker = createResponseTracker();
+    tracker.usage.inputTokens = 2;
+    tracker.usage.outputTokens = 7;
+
+    expect(
+      buildResponse(
+        { responseId: 'resp_2', model: 'agent', createdAt: 1 },
+        tracker,
+        'completed'
+      ).usage
+    ).toEqual({
+      input_tokens: 2,
+      output_tokens: 7,
+      total_tokens: 9,
+    });
+  });
+});

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -1,0 +1,289 @@
+import { GraphEvents } from '@/common';
+import type * as t from '@/types';
+
+export interface ResponsesCompatibleWriter {
+  write(data: string): void | Promise<void>;
+}
+
+export type ResponseStatus =
+  | 'in_progress'
+  | 'completed'
+  | 'failed'
+  | 'incomplete';
+export type ItemStatus = 'in_progress' | 'incomplete' | 'completed';
+
+export interface ResponseContext {
+  responseId: string;
+  model: string;
+  createdAt: number;
+  previousResponseId?: string;
+  instructions?: string;
+}
+
+export interface ResponseOutputTextContent {
+  type: 'output_text';
+  text: string;
+  annotations: [];
+  logprobs: [];
+}
+
+export interface ResponseMessageItem {
+  type: 'message';
+  id: string;
+  role: 'assistant';
+  status: ItemStatus;
+  content: ResponseOutputTextContent[];
+}
+
+export interface ResponseFunctionCallItem {
+  type: 'function_call';
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+  status: ItemStatus;
+}
+
+export interface ResponseReasoningItem {
+  type: 'reasoning';
+  id: string;
+  status: ItemStatus;
+  content: Array<{ type: 'reasoning_text'; text: string }>;
+  summary: [];
+}
+
+export type ResponseOutputItem =
+  | ResponseMessageItem
+  | ResponseFunctionCallItem
+  | ResponseReasoningItem;
+
+export interface ResponseObject {
+  id: string;
+  object: 'response';
+  created_at: number;
+  completed_at: number | null;
+  status: ResponseStatus;
+  model: string;
+  previous_response_id: string | null;
+  instructions: string | null;
+  output: ResponseOutputItem[];
+  error: { type: string; message: string; code?: string } | null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+  } | null;
+}
+
+export interface ResponseEvent {
+  type: string;
+  sequence_number: number;
+  [key: string]: unknown;
+}
+
+export interface ResponseTracker {
+  sequenceNumber: number;
+  items: ResponseOutputItem[];
+  message: ResponseMessageItem | undefined;
+  reasoning: ResponseReasoningItem | undefined;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+  nextSequence(): number;
+}
+
+export interface ResponsesHandlerConfig {
+  writer: ResponsesCompatibleWriter;
+  context: ResponseContext;
+  tracker: ResponseTracker;
+}
+
+let responseItemId = 0;
+
+function createItemId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}${(responseItemId++).toString(36)}`;
+}
+
+export function createResponseTracker(): ResponseTracker {
+  const tracker: ResponseTracker = {
+    sequenceNumber: 0,
+    items: [],
+    message: undefined,
+    reasoning: undefined,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+    },
+    nextSequence: () => tracker.sequenceNumber++,
+  };
+  return tracker;
+}
+
+export function buildResponse(
+  context: ResponseContext,
+  tracker: ResponseTracker,
+  status: ResponseStatus = 'in_progress'
+): ResponseObject {
+  const completed = status === 'completed';
+  return {
+    id: context.responseId,
+    object: 'response',
+    created_at: context.createdAt,
+    completed_at: completed ? Math.floor(Date.now() / 1000) : null,
+    status,
+    model: context.model,
+    previous_response_id: context.previousResponseId ?? null,
+    instructions: context.instructions ?? null,
+    output: tracker.items,
+    error: null,
+    usage: completed
+      ? {
+        input_tokens: tracker.usage.inputTokens,
+        output_tokens: tracker.usage.outputTokens,
+        total_tokens: tracker.usage.inputTokens + tracker.usage.outputTokens,
+      }
+      : null,
+  };
+}
+
+export async function writeResponseEvent(
+  writer: ResponsesCompatibleWriter,
+  event: ResponseEvent
+): Promise<void> {
+  await writer.write(`event: ${event.type}\n`);
+  await writer.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+export async function writeResponsesDone(
+  writer: ResponsesCompatibleWriter
+): Promise<void> {
+  await writer.write('data: [DONE]\n\n');
+}
+
+async function ensureMessage(
+  config: ResponsesHandlerConfig
+): Promise<ResponseMessageItem> {
+  if (config.tracker.message) {
+    return config.tracker.message;
+  }
+  const item: ResponseMessageItem = {
+    type: 'message',
+    id: createItemId('msg'),
+    role: 'assistant',
+    status: 'in_progress',
+    content: [{ type: 'output_text', text: '', annotations: [], logprobs: [] }],
+  };
+  config.tracker.message = item;
+  config.tracker.items.push(item);
+  await writeResponseEvent(config.writer, {
+    type: 'response.output_item.added',
+    sequence_number: config.tracker.nextSequence(),
+    output_index: config.tracker.items.length - 1,
+    item,
+  });
+  return item;
+}
+
+async function ensureReasoning(
+  config: ResponsesHandlerConfig
+): Promise<ResponseReasoningItem> {
+  if (config.tracker.reasoning) {
+    return config.tracker.reasoning;
+  }
+  const item: ResponseReasoningItem = {
+    type: 'reasoning',
+    id: createItemId('reason'),
+    status: 'in_progress',
+    content: [{ type: 'reasoning_text', text: '' }],
+    summary: [],
+  };
+  config.tracker.reasoning = item;
+  config.tracker.items.push(item);
+  await writeResponseEvent(config.writer, {
+    type: 'response.output_item.added',
+    sequence_number: config.tracker.nextSequence(),
+    output_index: config.tracker.items.length - 1,
+    item,
+  });
+  return item;
+}
+
+export function createResponsesEventHandlers(
+  config: ResponsesHandlerConfig
+): Record<string, t.EventHandler> {
+  return {
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: async (_event, data): Promise<void> => {
+        const item = await ensureMessage(config);
+        for (const part of (data as t.MessageDeltaEvent).delta.content ?? []) {
+          if (!('text' in part) || typeof part.text !== 'string') {
+            continue;
+          }
+          item.content[0].text += part.text;
+          await writeResponseEvent(config.writer, {
+            type: 'response.output_text.delta',
+            sequence_number: config.tracker.nextSequence(),
+            item_id: item.id,
+            output_index: config.tracker.items.indexOf(item),
+            content_index: 0,
+            delta: part.text,
+          });
+        }
+      },
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: async (_event, data): Promise<void> => {
+        const item = await ensureReasoning(config);
+        for (const part of (data as t.ReasoningDeltaEvent).delta.content ??
+          []) {
+          let text: string | undefined;
+          if ('think' in part && typeof part.think === 'string') {
+            text = part.think;
+          } else if ('text' in part && typeof part.text === 'string') {
+            text = part.text;
+          }
+          if (typeof text !== 'string') {
+            continue;
+          }
+          item.content[0].text += text;
+          await writeResponseEvent(config.writer, {
+            type: 'response.reasoning.delta',
+            sequence_number: config.tracker.nextSequence(),
+            item_id: item.id,
+            output_index: config.tracker.items.indexOf(item),
+            content_index: 0,
+            delta: text,
+          });
+        }
+      },
+    },
+    [GraphEvents.CHAT_MODEL_END]: {
+      handle: (_event, data): void => {
+        const usage = (data as t.ModelEndData)?.output?.usage_metadata;
+        if (!usage) {
+          return;
+        }
+        config.tracker.usage.inputTokens += usage.input_tokens;
+        config.tracker.usage.outputTokens += usage.output_tokens;
+      },
+    },
+  };
+}
+
+export async function emitResponseCompleted(
+  config: ResponsesHandlerConfig
+): Promise<void> {
+  if (config.tracker.message) {
+    config.tracker.message.status = 'completed';
+  }
+  if (config.tracker.reasoning) {
+    config.tracker.reasoning.status = 'completed';
+  }
+  await writeResponseEvent(config.writer, {
+    type: 'response.completed',
+    sequence_number: config.tracker.nextSequence(),
+    response: buildResponse(config.context, config.tracker, 'completed'),
+  });
+  await writeResponsesDone(config.writer);
+}

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -336,6 +336,21 @@ async function emitFunctionCallArgumentsDelta(params: {
   });
 }
 
+async function emitFunctionCallArgumentsDone(
+  config: ResponsesHandlerConfig,
+  item: ResponseFunctionCallItem
+): Promise<void> {
+  await writeResponseEvent(config.writer, {
+    type: 'response.function_call_arguments.done',
+    sequence_number: config.tracker.nextSequence(),
+    item_id: item.id,
+    output_index: config.tracker.items.indexOf(item),
+    call_id: item.call_id,
+    name: item.name,
+    arguments: item.arguments,
+  });
+}
+
 async function completeFunctionCall(
   config: ResponsesHandlerConfig,
   stepId: string,
@@ -373,15 +388,7 @@ async function completeFunctionCall(
   } else if (finalArguments !== '') {
     item.arguments = finalArguments;
   }
-  await writeResponseEvent(config.writer, {
-    type: 'response.function_call_arguments.done',
-    sequence_number: config.tracker.nextSequence(),
-    item_id: item.id,
-    output_index: config.tracker.items.indexOf(item),
-    call_id: item.call_id,
-    name: item.name,
-    arguments: item.arguments,
-  });
+  await emitFunctionCallArgumentsDone(config, item);
   item.status = 'completed';
   await writeResponseEvent(config.writer, {
     type: 'response.output_item.done',
@@ -650,6 +657,8 @@ export async function emitResponseCompleted(
     }
     if (item.type === 'message' || item.type === 'reasoning') {
       await emitOutputContentDone(config, item);
+    } else {
+      await emitFunctionCallArgumentsDone(config, item);
     }
     item.status = 'completed';
     await writeResponseEvent(config.writer, {

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -207,7 +207,7 @@ function findFunctionCallByStep(
     return undefined;
   }
   const index = typeof toolCall.index === 'number' ? toolCall.index : undefined;
-  if (index != null && items[index] != null) {
+  if (index != null) {
     return items[index];
   }
   const name = getToolCallName(toolCall);
@@ -284,10 +284,11 @@ async function ensureFunctionCall(
     stepId,
     toolCall
   );
+  const toolCallIndex = getToolCallIndex(toolCall, fallbackIndex);
   const name = getToolCallName(toolCall);
   if (existing) {
     trackFunctionCallKeys(config, existing, idKey, positionKey);
-    trackFunctionCallStep(config, stepId, existing, fallbackIndex);
+    trackFunctionCallStep(config, stepId, existing, toolCallIndex);
     if (idKey != null) {
       existing.call_id = idKey;
     }
@@ -305,7 +306,7 @@ async function ensureFunctionCall(
     status: 'in_progress',
   };
   trackFunctionCallKeys(config, item, idKey, positionKey);
-  trackFunctionCallStep(config, stepId, item, fallbackIndex);
+  trackFunctionCallStep(config, stepId, item, toolCallIndex);
   config.tracker.items.push(item);
   await writeResponseEvent(config.writer, {
     type: 'response.output_item.added',

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -88,6 +88,7 @@ export interface ResponseTracker {
   message: ResponseMessageItem | undefined;
   reasoning: ResponseReasoningItem | undefined;
   functionCalls: Map<string, ResponseFunctionCallItem>;
+  responseCreated: boolean;
   usage: {
     inputTokens: number;
     outputTokens: number;
@@ -114,6 +115,7 @@ export function createResponseTracker(): ResponseTracker {
     message: undefined,
     reasoning: undefined,
     functionCalls: new Map(),
+    responseCreated: false,
     usage: {
       inputTokens: 0,
       outputTokens: 0,
@@ -207,6 +209,7 @@ async function ensureFunctionCall(
   toolCall: ResponseToolCallFragment,
   fallbackIndex: number
 ): Promise<ResponseFunctionCallItem> {
+  await ensureResponseCreated(config);
   const positionKey = getToolCallPositionKey(stepId, toolCall, fallbackIndex);
   const idKey = getToolCallIdKey(toolCall);
   const existing = getExistingFunctionCall(config, idKey, positionKey);
@@ -347,9 +350,24 @@ export async function writeResponsesDone(
   await writer.write('data: [DONE]\n\n');
 }
 
+export async function ensureResponseCreated(
+  config: ResponsesHandlerConfig
+): Promise<void> {
+  if (config.tracker.responseCreated) {
+    return;
+  }
+  config.tracker.responseCreated = true;
+  await writeResponseEvent(config.writer, {
+    type: 'response.created',
+    sequence_number: config.tracker.nextSequence(),
+    response: buildResponse(config.context, config.tracker),
+  });
+}
+
 async function ensureMessage(
   config: ResponsesHandlerConfig
 ): Promise<ResponseMessageItem> {
+  await ensureResponseCreated(config);
   if (config.tracker.message) {
     return config.tracker.message;
   }
@@ -374,6 +392,7 @@ async function ensureMessage(
 async function ensureReasoning(
   config: ResponsesHandlerConfig
 ): Promise<ResponseReasoningItem> {
+  await ensureResponseCreated(config);
   if (config.tracker.reasoning) {
     return config.tracker.reasoning;
   }
@@ -517,6 +536,7 @@ export function createResponsesEventHandlers(
 export async function emitResponseCompleted(
   config: ResponsesHandlerConfig
 ): Promise<void> {
+  await ensureResponseCreated(config);
   for (const item of config.tracker.items) {
     if (item.status === 'completed') {
       continue;

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -145,7 +145,7 @@ function getToolCallIndex(
   return typeof toolCall.index === 'number' ? toolCall.index : fallbackIndex;
 }
 
-function getToolCallKey(
+function getToolCallPositionKey(
   stepId: string,
   toolCall: ResponseToolCallFragment,
   fallbackIndex: number
@@ -154,9 +154,36 @@ function getToolCallKey(
   if (stepId !== '') {
     return `${stepId}:${index}`;
   }
-  return toolCall.id != null && toolCall.id !== ''
-    ? toolCall.id
-    : `tool:${index}`;
+  return `tool:${index}`;
+}
+
+function getToolCallIdKey(
+  toolCall: ResponseToolCallFragment
+): string | undefined {
+  return toolCall.id != null && toolCall.id !== '' ? toolCall.id : undefined;
+}
+
+function getExistingFunctionCall(
+  config: ResponsesHandlerConfig,
+  idKey: string | undefined,
+  positionKey: string
+): ResponseFunctionCallItem | undefined {
+  return idKey == null
+    ? config.tracker.functionCalls.get(positionKey)
+    : (config.tracker.functionCalls.get(idKey) ??
+        config.tracker.functionCalls.get(positionKey));
+}
+
+function trackFunctionCallKeys(
+  config: ResponsesHandlerConfig,
+  item: ResponseFunctionCallItem,
+  idKey: string | undefined,
+  positionKey: string
+): void {
+  config.tracker.functionCalls.set(positionKey, item);
+  if (idKey != null) {
+    config.tracker.functionCalls.set(idKey, item);
+  }
 }
 
 function getToolCallName(toolCall: ResponseToolCallFragment): string {
@@ -180,12 +207,14 @@ async function ensureFunctionCall(
   toolCall: ResponseToolCallFragment,
   fallbackIndex: number
 ): Promise<ResponseFunctionCallItem> {
-  const key = getToolCallKey(stepId, toolCall, fallbackIndex);
-  const existing = config.tracker.functionCalls.get(key);
+  const positionKey = getToolCallPositionKey(stepId, toolCall, fallbackIndex);
+  const idKey = getToolCallIdKey(toolCall);
+  const existing = getExistingFunctionCall(config, idKey, positionKey);
   const name = getToolCallName(toolCall);
   if (existing) {
-    if (toolCall.id != null && toolCall.id !== '') {
-      existing.call_id = toolCall.id;
+    trackFunctionCallKeys(config, existing, idKey, positionKey);
+    if (idKey != null) {
+      existing.call_id = idKey;
     }
     if (name !== '') {
       existing.name = name;
@@ -195,12 +224,12 @@ async function ensureFunctionCall(
   const item: ResponseFunctionCallItem = {
     type: 'function_call',
     id: createItemId('fc'),
-    call_id: toolCall.id ?? key,
+    call_id: idKey ?? positionKey,
     name,
     arguments: '',
     status: 'in_progress',
   };
-  config.tracker.functionCalls.set(key, item);
+  trackFunctionCallKeys(config, item, idKey, positionKey);
   config.tracker.items.push(item);
   await writeResponseEvent(config.writer, {
     type: 'response.output_item.added',
@@ -405,7 +434,7 @@ export function createResponsesEventHandlers(
           }
           item.content[0].text += text;
           await writeResponseEvent(config.writer, {
-            type: 'response.reasoning.delta',
+            type: 'response.reasoning_text.delta',
             sequence_number: config.tracker.nextSequence(),
             item_id: item.id,
             output_index: config.tracker.items.indexOf(item),
@@ -494,7 +523,7 @@ export async function emitResponseCompleted(
   if (config.tracker.reasoning) {
     config.tracker.reasoning.status = 'completed';
   }
-  for (const item of config.tracker.functionCalls.values()) {
+  for (const item of new Set(config.tracker.functionCalls.values())) {
     item.status = 'completed';
   }
   await writeResponseEvent(config.writer, {

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -88,6 +88,7 @@ export interface ResponseTracker {
   message: ResponseMessageItem | undefined;
   reasoning: ResponseReasoningItem | undefined;
   functionCalls: Map<string, ResponseFunctionCallItem>;
+  functionCallsByStep: Map<string, Array<ResponseFunctionCallItem | undefined>>;
   responseCreated: boolean;
   usage: {
     inputTokens: number;
@@ -115,6 +116,7 @@ export function createResponseTracker(): ResponseTracker {
     message: undefined,
     reasoning: undefined,
     functionCalls: new Map(),
+    functionCallsByStep: new Map(),
     responseCreated: false,
     usage: {
       inputTokens: 0,
@@ -168,12 +170,61 @@ function getToolCallIdKey(
 function getExistingFunctionCall(
   config: ResponsesHandlerConfig,
   idKey: string | undefined,
-  positionKey: string
+  positionKey: string | undefined,
+  stepId: string,
+  toolCall: ResponseToolCallFragment
 ): ResponseFunctionCallItem | undefined {
-  return idKey == null
-    ? config.tracker.functionCalls.get(positionKey)
-    : (config.tracker.functionCalls.get(idKey) ??
-        config.tracker.functionCalls.get(positionKey));
+  const keyed =
+    idKey == null
+      ? undefined
+      : (config.tracker.functionCalls.get(idKey) ??
+        (positionKey == null
+          ? undefined
+          : config.tracker.functionCalls.get(positionKey)));
+  if (keyed != null) {
+    return keyed;
+  }
+  const positioned =
+    positionKey == null
+      ? undefined
+      : config.tracker.functionCalls.get(positionKey);
+  if (positioned != null) {
+    return positioned;
+  }
+  if (stepId === '') {
+    return undefined;
+  }
+  return findFunctionCallByStep(config, stepId, toolCall);
+}
+
+function findFunctionCallByStep(
+  config: ResponsesHandlerConfig,
+  stepId: string,
+  toolCall: ResponseToolCallFragment
+): ResponseFunctionCallItem | undefined {
+  const items = config.tracker.functionCallsByStep.get(stepId);
+  if (items == null) {
+    return undefined;
+  }
+  const index = typeof toolCall.index === 'number' ? toolCall.index : undefined;
+  if (index != null && items[index] != null) {
+    return items[index];
+  }
+  const name = getToolCallName(toolCall);
+  let fallback: ResponseFunctionCallItem | undefined;
+  for (const item of items) {
+    if (item == null || item.status === 'completed') {
+      continue;
+    }
+    if (name !== '' && item.name !== name) {
+      continue;
+    }
+    if (fallback != null) {
+      return undefined;
+    }
+    fallback = item;
+  }
+  return fallback;
 }
 
 function trackFunctionCallKeys(
@@ -186,6 +237,20 @@ function trackFunctionCallKeys(
   if (idKey != null) {
     config.tracker.functionCalls.set(idKey, item);
   }
+}
+
+function trackFunctionCallStep(
+  config: ResponsesHandlerConfig,
+  stepId: string,
+  item: ResponseFunctionCallItem,
+  fallbackIndex: number
+): void {
+  if (stepId === '') {
+    return;
+  }
+  const items = config.tracker.functionCallsByStep.get(stepId) ?? [];
+  items[fallbackIndex] = item;
+  config.tracker.functionCallsByStep.set(stepId, items);
 }
 
 function getToolCallName(toolCall: ResponseToolCallFragment): string {
@@ -212,10 +277,17 @@ async function ensureFunctionCall(
   await ensureResponseCreated(config);
   const positionKey = getToolCallPositionKey(stepId, toolCall, fallbackIndex);
   const idKey = getToolCallIdKey(toolCall);
-  const existing = getExistingFunctionCall(config, idKey, positionKey);
+  const existing = getExistingFunctionCall(
+    config,
+    idKey,
+    positionKey,
+    stepId,
+    toolCall
+  );
   const name = getToolCallName(toolCall);
   if (existing) {
     trackFunctionCallKeys(config, existing, idKey, positionKey);
+    trackFunctionCallStep(config, stepId, existing, fallbackIndex);
     if (idKey != null) {
       existing.call_id = idKey;
     }
@@ -233,6 +305,7 @@ async function ensureFunctionCall(
     status: 'in_progress',
   };
   trackFunctionCallKeys(config, item, idKey, positionKey);
+  trackFunctionCallStep(config, stepId, item, fallbackIndex);
   config.tracker.items.push(item);
   await writeResponseEvent(config.writer, {
     type: 'response.output_item.added',
@@ -265,15 +338,23 @@ async function emitFunctionCallArgumentsDelta(params: {
 async function completeFunctionCall(
   config: ResponsesHandlerConfig,
   stepId: string,
-  toolCall: ResponseToolCallFragment,
-  fallbackIndex: number
+  toolCall: ResponseToolCallFragment
 ): Promise<void> {
-  const item = await ensureFunctionCall(
-    config,
-    stepId,
-    toolCall,
-    fallbackIndex
-  );
+  const fallbackIndex =
+    typeof toolCall.index === 'number' ? toolCall.index : undefined;
+  const positionKey =
+    fallbackIndex == null
+      ? undefined
+      : getToolCallPositionKey(stepId, toolCall, fallbackIndex);
+  const item =
+    getExistingFunctionCall(
+      config,
+      getToolCallIdKey(toolCall),
+      positionKey,
+      stepId,
+      toolCall
+    ) ??
+    (await ensureFunctionCall(config, stepId, toolCall, fallbackIndex ?? 0));
   if (item.status === 'completed') {
     return;
   }
@@ -361,6 +442,32 @@ export async function ensureResponseCreated(
     type: 'response.created',
     sequence_number: config.tracker.nextSequence(),
     response: buildResponse(config.context, config.tracker),
+  });
+}
+
+async function emitOutputContentDone(
+  config: ResponsesHandlerConfig,
+  item: ResponseMessageItem | ResponseReasoningItem
+): Promise<void> {
+  const outputIndex = config.tracker.items.indexOf(item);
+  if (item.type === 'message') {
+    await writeResponseEvent(config.writer, {
+      type: 'response.output_text.done',
+      sequence_number: config.tracker.nextSequence(),
+      item_id: item.id,
+      output_index: outputIndex,
+      content_index: 0,
+      text: item.content[0].text,
+    });
+    return;
+  }
+  await writeResponseEvent(config.writer, {
+    type: 'response.reasoning_text.done',
+    sequence_number: config.tracker.nextSequence(),
+    item_id: item.id,
+    output_index: outputIndex,
+    content_index: 0,
+    text: item.content[0].text,
   });
 }
 
@@ -513,8 +620,7 @@ export function createResponsesEventHandlers(
         await completeFunctionCall(
           config,
           completed.result.id ?? '',
-          completed.result.tool_call,
-          completed.result.index ?? 0
+          completed.result.tool_call
         );
       },
     },
@@ -540,6 +646,9 @@ export async function emitResponseCompleted(
   for (const item of config.tracker.items) {
     if (item.status === 'completed') {
       continue;
+    }
+    if (item.type === 'message' || item.type === 'reasoning') {
+      await emitOutputContentDone(config, item);
     }
     item.status = 'completed';
     await writeResponseEvent(config.writer, {

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -1,4 +1,5 @@
 import { GraphEvents } from '@/common';
+import type { UsageMetadata } from '@langchain/core/messages';
 import type * as t from '@/types';
 
 export interface ResponsesCompatibleWriter {
@@ -118,6 +119,10 @@ export function createResponseTracker(): ResponseTracker {
     nextSequence: () => tracker.sequenceNumber++,
   };
   return tracker;
+}
+
+function getTokenCount(value: number | null | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 export function buildResponse(
@@ -260,12 +265,14 @@ export function createResponsesEventHandlers(
     },
     [GraphEvents.CHAT_MODEL_END]: {
       handle: (_event, data): void => {
-        const usage = (data as t.ModelEndData)?.output?.usage_metadata;
+        const usage = (data as t.ModelEndData)?.output?.usage_metadata as
+          | Partial<UsageMetadata>
+          | undefined;
         if (!usage) {
           return;
         }
-        config.tracker.usage.inputTokens += usage.input_tokens;
-        config.tracker.usage.outputTokens += usage.output_tokens;
+        config.tracker.usage.inputTokens += getTokenCount(usage.input_tokens);
+        config.tracker.usage.outputTokens += getTokenCount(usage.output_tokens);
       },
     },
   };

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -150,10 +150,13 @@ function getToolCallKey(
   toolCall: ResponseToolCallFragment,
   fallbackIndex: number
 ): string {
-  if (toolCall.id != null && toolCall.id !== '') {
-    return toolCall.id;
+  const index = getToolCallIndex(toolCall, fallbackIndex);
+  if (stepId !== '') {
+    return `${stepId}:${index}`;
   }
-  return `${stepId}:${getToolCallIndex(toolCall, fallbackIndex)}`;
+  return toolCall.id != null && toolCall.id !== ''
+    ? toolCall.id
+    : `tool:${index}`;
 }
 
 function getToolCallName(toolCall: ResponseToolCallFragment): string {
@@ -181,6 +184,9 @@ async function ensureFunctionCall(
   const existing = config.tracker.functionCalls.get(key);
   const name = getToolCallName(toolCall);
   if (existing) {
+    if (toolCall.id != null && toolCall.id !== '') {
+      existing.call_id = toolCall.id;
+    }
     if (name !== '') {
       existing.name = name;
     }
@@ -259,6 +265,7 @@ async function completeFunctionCall(
     item_id: item.id,
     output_index: config.tracker.items.indexOf(item),
     call_id: item.call_id,
+    name: item.name,
     arguments: item.arguments,
   });
   item.status = 'completed';
@@ -447,6 +454,7 @@ export function createResponsesEventHandlers(
         const completed = data as {
           result?: {
             id?: string;
+            index?: number;
             type?: string;
             tool_call?: ResponseToolCallFragment;
           };
@@ -458,7 +466,7 @@ export function createResponsesEventHandlers(
           config,
           completed.result.id ?? '',
           completed.result.tool_call,
-          0
+          completed.result.index ?? 0
         );
       },
     },

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -517,14 +517,17 @@ export function createResponsesEventHandlers(
 export async function emitResponseCompleted(
   config: ResponsesHandlerConfig
 ): Promise<void> {
-  if (config.tracker.message) {
-    config.tracker.message.status = 'completed';
-  }
-  if (config.tracker.reasoning) {
-    config.tracker.reasoning.status = 'completed';
-  }
-  for (const item of new Set(config.tracker.functionCalls.values())) {
+  for (const item of config.tracker.items) {
+    if (item.status === 'completed') {
+      continue;
+    }
     item.status = 'completed';
+    await writeResponseEvent(config.writer, {
+      type: 'response.output_item.done',
+      sequence_number: config.tracker.nextSequence(),
+      output_index: config.tracker.items.indexOf(item),
+      item,
+    });
   }
   await writeResponseEvent(config.writer, {
     type: 'response.completed',

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -87,6 +87,7 @@ export interface ResponseTracker {
   items: ResponseOutputItem[];
   message: ResponseMessageItem | undefined;
   reasoning: ResponseReasoningItem | undefined;
+  functionCalls: Map<string, ResponseFunctionCallItem>;
   usage: {
     inputTokens: number;
     outputTokens: number;
@@ -112,6 +113,7 @@ export function createResponseTracker(): ResponseTracker {
     items: [],
     message: undefined,
     reasoning: undefined,
+    functionCalls: new Map(),
     usage: {
       inputTokens: 0,
       outputTokens: 0,
@@ -123,6 +125,149 @@ export function createResponseTracker(): ResponseTracker {
 
 function getTokenCount(value: number | null | undefined): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+interface ResponseToolCallFragment {
+  index?: number;
+  id?: string;
+  name?: string;
+  args?: string | object;
+  function?: {
+    name?: string;
+    arguments?: string | object;
+  };
+}
+
+function getToolCallIndex(
+  toolCall: ResponseToolCallFragment,
+  fallbackIndex: number
+): number {
+  return typeof toolCall.index === 'number' ? toolCall.index : fallbackIndex;
+}
+
+function getToolCallKey(
+  stepId: string,
+  toolCall: ResponseToolCallFragment,
+  fallbackIndex: number
+): string {
+  if (toolCall.id != null && toolCall.id !== '') {
+    return toolCall.id;
+  }
+  return `${stepId}:${getToolCallIndex(toolCall, fallbackIndex)}`;
+}
+
+function getToolCallName(toolCall: ResponseToolCallFragment): string {
+  return toolCall.name ?? toolCall.function?.name ?? '';
+}
+
+function getToolCallArguments(toolCall: ResponseToolCallFragment): string {
+  const args = toolCall.args ?? toolCall.function?.arguments;
+  if (args == null) {
+    return '';
+  }
+  if (typeof args === 'string') {
+    return args;
+  }
+  return JSON.stringify(args);
+}
+
+async function ensureFunctionCall(
+  config: ResponsesHandlerConfig,
+  stepId: string,
+  toolCall: ResponseToolCallFragment,
+  fallbackIndex: number
+): Promise<ResponseFunctionCallItem> {
+  const key = getToolCallKey(stepId, toolCall, fallbackIndex);
+  const existing = config.tracker.functionCalls.get(key);
+  const name = getToolCallName(toolCall);
+  if (existing) {
+    if (name !== '') {
+      existing.name = name;
+    }
+    return existing;
+  }
+  const item: ResponseFunctionCallItem = {
+    type: 'function_call',
+    id: createItemId('fc'),
+    call_id: toolCall.id ?? key,
+    name,
+    arguments: '',
+    status: 'in_progress',
+  };
+  config.tracker.functionCalls.set(key, item);
+  config.tracker.items.push(item);
+  await writeResponseEvent(config.writer, {
+    type: 'response.output_item.added',
+    sequence_number: config.tracker.nextSequence(),
+    output_index: config.tracker.items.length - 1,
+    item,
+  });
+  return item;
+}
+
+async function emitFunctionCallArgumentsDelta(params: {
+  config: ResponsesHandlerConfig;
+  item: ResponseFunctionCallItem;
+  delta: string;
+}): Promise<void> {
+  if (params.delta === '') {
+    return;
+  }
+  params.item.arguments += params.delta;
+  await writeResponseEvent(params.config.writer, {
+    type: 'response.function_call_arguments.delta',
+    sequence_number: params.config.tracker.nextSequence(),
+    item_id: params.item.id,
+    output_index: params.config.tracker.items.indexOf(params.item),
+    call_id: params.item.call_id,
+    delta: params.delta,
+  });
+}
+
+async function completeFunctionCall(
+  config: ResponsesHandlerConfig,
+  stepId: string,
+  toolCall: ResponseToolCallFragment,
+  fallbackIndex: number
+): Promise<void> {
+  const item = await ensureFunctionCall(
+    config,
+    stepId,
+    toolCall,
+    fallbackIndex
+  );
+  if (item.status === 'completed') {
+    return;
+  }
+  const finalArguments = getToolCallArguments(toolCall);
+  if (
+    finalArguments !== '' &&
+    finalArguments !== item.arguments &&
+    finalArguments.startsWith(item.arguments)
+  ) {
+    await emitFunctionCallArgumentsDelta({
+      config,
+      item,
+      delta: finalArguments.slice(item.arguments.length),
+    });
+  } else if (finalArguments !== '') {
+    item.arguments = finalArguments;
+  }
+  await writeResponseEvent(config.writer, {
+    type: 'response.function_call_arguments.done',
+    sequence_number: config.tracker.nextSequence(),
+    item_id: item.id,
+    output_index: config.tracker.items.indexOf(item),
+    call_id: item.call_id,
+    arguments: item.arguments,
+  });
+  item.status = 'completed';
+  await writeResponseEvent(config.writer, {
+    type: 'response.output_item.done',
+    sequence_number: config.tracker.nextSequence(),
+    output_index: config.tracker.items.indexOf(item),
+    item,
+  });
 }
 
 export function buildResponse(
@@ -263,6 +408,60 @@ export function createResponsesEventHandlers(
         }
       },
     },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: async (_event, data): Promise<void> => {
+        const runStep = data as t.RunStep;
+        if (runStep.stepDetails.type !== 'tool_calls') {
+          return;
+        }
+        const toolCalls = runStep.stepDetails.tool_calls ?? [];
+        for (let index = 0; index < toolCalls.length; index++) {
+          await ensureFunctionCall(config, runStep.id, toolCalls[index], index);
+        }
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: async (_event, data): Promise<void> => {
+        const runStepDelta = data as t.RunStepDeltaEvent;
+        if (runStepDelta.delta.type !== 'tool_calls') {
+          return;
+        }
+        const toolCalls = runStepDelta.delta.tool_calls ?? [];
+        for (let index = 0; index < toolCalls.length; index++) {
+          const item = await ensureFunctionCall(
+            config,
+            runStepDelta.id,
+            toolCalls[index],
+            index
+          );
+          await emitFunctionCallArgumentsDelta({
+            config,
+            item,
+            delta: getToolCallArguments(toolCalls[index]),
+          });
+        }
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: async (_event, data): Promise<void> => {
+        const completed = data as {
+          result?: {
+            id?: string;
+            type?: string;
+            tool_call?: ResponseToolCallFragment;
+          };
+        };
+        if (!completed.result?.tool_call) {
+          return;
+        }
+        await completeFunctionCall(
+          config,
+          completed.result.id ?? '',
+          completed.result.tool_call,
+          0
+        );
+      },
+    },
     [GraphEvents.CHAT_MODEL_END]: {
       handle: (_event, data): void => {
         const usage = (data as t.ModelEndData)?.output?.usage_metadata as
@@ -286,6 +485,9 @@ export async function emitResponseCompleted(
   }
   if (config.tracker.reasoning) {
     config.tracker.reasoning.status = 'completed';
+  }
+  for (const item of config.tracker.functionCalls.values()) {
+    item.status = 'completed';
   }
   await writeResponseEvent(config.writer, {
     type: 'response.completed',

--- a/src/run.ts
+++ b/src/run.ts
@@ -47,6 +47,37 @@ export const defaultOmitOptions = new Set([
   'additionalModelRequestFields',
 ]);
 
+const CUSTOM_GRAPH_EVENTS = new Set<string>([
+  GraphEvents.ON_AGENT_UPDATE,
+  GraphEvents.ON_RUN_STEP,
+  GraphEvents.ON_RUN_STEP_DELTA,
+  GraphEvents.ON_RUN_STEP_COMPLETED,
+  GraphEvents.ON_MESSAGE_DELTA,
+  GraphEvents.ON_REASONING_DELTA,
+  GraphEvents.ON_TOOL_EXECUTE,
+  GraphEvents.ON_SUMMARIZE_START,
+  GraphEvents.ON_SUMMARIZE_DELTA,
+  GraphEvents.ON_SUMMARIZE_COMPLETE,
+  GraphEvents.ON_SUBAGENT_UPDATE,
+  GraphEvents.ON_AGENT_LOG,
+  GraphEvents.ON_CUSTOM_EVENT,
+]);
+
+const DIRECT_DISPATCHED_STEP_EVENTS = new Set<string>([
+  GraphEvents.ON_RUN_STEP,
+  GraphEvents.ON_RUN_STEP_DELTA,
+  GraphEvents.ON_MESSAGE_DELTA,
+  GraphEvents.ON_REASONING_DELTA,
+]);
+
+function getStepScopedEventId(data: unknown): string | undefined {
+  if (data == null || typeof data !== 'object') {
+    return undefined;
+  }
+  const candidate = data as { id?: unknown };
+  return typeof candidate.id === 'string' ? candidate.id : undefined;
+}
+
 export class Run<_T extends t.BaseGraphState> {
   id: string;
   private tokenCounter?: t.TokenCounter;
@@ -444,13 +475,15 @@ export class Run<_T extends t.BaseGraphState> {
       tags?: string[],
       metadata?: Record<string, unknown>
     ): Promise<void> => {
-      // ON_RUN_STEP is dispatched directly via handler registry in
-      // Graph.dispatchRunStep (primary, reliable path).  Skip the
-      // callback-based dispatch to prevent double handling.
+      // Step-scoped SDK events are dispatched directly via the handler
+      // registry first. Skip callback-based echoes to prevent double
+      // handling when LangGraph invokes custom callbacks more than once.
+      const stepScopedEventId = getStepScopedEventId(data);
       if (
-        eventName === GraphEvents.ON_RUN_STEP &&
+        DIRECT_DISPATCHED_STEP_EVENTS.has(eventName) &&
         this.Graph != null &&
-        this.Graph.handlerDispatchedStepIds.has((data as t.RunStep).id)
+        stepScopedEventId != null &&
+        this.Graph.hasHandlerDispatchedEvent(eventName, stepScopedEventId)
       ) {
         return;
       }
@@ -630,7 +663,7 @@ export class Run<_T extends t.BaseGraphState> {
         const eventName: t.EventName = info.event;
 
         /** Skip custom events as they're handled by our callback */
-        if (eventName === GraphEvents.ON_CUSTOM_EVENT) {
+        if (CUSTOM_GRAPH_EVENTS.has(eventName)) {
           continue;
         }
 

--- a/src/scripts/compare_pi_vs_ours.ts
+++ b/src/scripts/compare_pi_vs_ours.ts
@@ -1,7 +1,7 @@
 /**
  * src/scripts/compare_pi_vs_ours.ts
  *
- * Side-by-side runs: pi-mono's `pi` CLI vs our local engine, same
+ * Side-by-side runs: pi-mono's `pi` CLI vs our AgentSession facade, same
  * task, same model, two parallel temp workspaces. We track:
  *
  *   - tool calls (name + args length, ordered)
@@ -10,7 +10,8 @@
  *   - whether the final on-disk state matches the expected outcome
  *
  * The tasks intentionally probe areas where we expect the local
- * engine to behave differently:
+ * engine to behave differently, while the preflight probes compare the
+ * programmatic session DX now exposed by the SDK:
  *
  *   T1 simple-edit       — both should one-shot
  *   T2 fuzzy-edit        — model emits an `oldText` with off-by-
@@ -32,25 +33,35 @@ config();
 import { spawn } from 'child_process';
 import { homedir, tmpdir } from 'os';
 import { join, resolve } from 'path';
-import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'fs/promises';
 import { performance } from 'perf_hooks';
-import { HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { MemorySaver } from '@langchain/langgraph';
 import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  AgentSessionCheckpointing,
+  AgentSessionConfig,
+  AgentSessionRunResult,
+} from '@/session';
 import type * as t from '@/types';
-import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
-import { ToolEndHandler, ModelEndHandler } from '@/events';
 import { getLLMConfig } from '@/utils/llmConfig';
-import { GraphEvents, Providers } from '@/common';
-import { Run } from '@/run';
+import { Providers, StepTypes } from '@/common';
+import { createAgentSession } from '@/session';
 
 const PROVIDER = Providers.ANTHROPIC;
 const MODEL = 'claude-sonnet-4-5';
 const PI_BIN =
   process.env.PI_BIN ??
-  resolve(
-    homedir(),
-    'Projects/pi-mono/packages/coding-agent/dist/cli.js'
-  );
+  resolve(homedir(), 'Projects/pi-mono/packages/coding-agent/dist/cli.js');
 
 interface Task {
   name: string;
@@ -95,6 +106,21 @@ interface RunOutcome {
   finalAssistant: string;
   errored: boolean;
   errorMessage?: string;
+  sessionEvents?: number;
+  sessionEntries?: number;
+  sessionPath?: string;
+}
+
+interface DxProbeResult {
+  ok: boolean;
+  detail: string;
+}
+
+interface DxProbe {
+  feature: string;
+  pi: string;
+  ours: string;
+  run: () => Promise<DxProbeResult>;
 }
 
 const TASKS: Task[] = [
@@ -102,8 +128,7 @@ const TASKS: Task[] = [
     name: 'T1 simple-edit',
     description: 'Single literal substitution in an existing file.',
     seed: {
-      'greet.py':
-        'def greet(name):\n    return f"Hello, {name}!"\n',
+      'greet.py': 'def greet(name):\n    return f"Hello, {name}!"\n',
     },
     prompt:
       'Edit greet.py: change the greeting from "Hello" to "Hi". ' +
@@ -163,12 +188,11 @@ const TASKS: Task[] = [
         null,
         2
       ),
-      'broken.ts':
-        'export const port: number = "not a number";\n',
+      'broken.ts': 'export const port: number = "not a number";\n',
     },
     prompt:
       'broken.ts has a type error. Fix it so the project typechecks cleanly. ' +
-      'After fixing, verify by running the project\'s typecheck (or `compile_check` if available). ' +
+      "After fixing, verify by running the project's typecheck (or `compile_check` if available). " +
       'Reply with "done".',
     verify: async (cwd) => {
       const text = await readFile(join(cwd, 'broken.ts'), 'utf8').catch(
@@ -224,8 +248,12 @@ const TASKS: Task[] = [
       'Rename the exported function `calc_total` to `calculateTotal` across src/lib.ts, ' +
       'src/index.ts, and src/index.test.ts. Update every reference. Reply "done" when finished.',
     verify: async (cwd) => {
-      const lib = await readFile(join(cwd, 'src/lib.ts'), 'utf8').catch(() => '');
-      const idx = await readFile(join(cwd, 'src/index.ts'), 'utf8').catch(() => '');
+      const lib = await readFile(join(cwd, 'src/lib.ts'), 'utf8').catch(
+        () => ''
+      );
+      const idx = await readFile(join(cwd, 'src/index.ts'), 'utf8').catch(
+        () => ''
+      );
       const tst = await readFile(join(cwd, 'src/index.test.ts'), 'utf8').catch(
         () => ''
       );
@@ -240,9 +268,7 @@ const TASKS: Task[] = [
       const ok = allRenamed && noOldName;
       return {
         ok,
-        detail: ok
-          ? ''
-          : `lib:\n${lib}\nindex:\n${idx}\ntest:\n${tst}`,
+        detail: ok ? '' : `lib:\n${lib}\nindex:\n${idx}\ntest:\n${tst}`,
       };
     },
   },
@@ -252,7 +278,6 @@ const TASKS: Task[] = [
       'Reads a PNG and describes it. Ours embeds via attachReadAttachments + image_url block; pi has no equivalent and is skipped.',
     seed: {},
     setup: async (cwd) => {
-      const { copyFile } = await import('fs/promises');
       // Use a real PNG (Anthropic refuses tiny 1x1 PNGs with "Could not
       // process image"). Try a few well-known macOS app icons; fall back to
       // any *.png we can find under /System.
@@ -277,7 +302,6 @@ const TASKS: Task[] = [
       // The verify step is soft — we just check the file is still on disk
       // (the agent shouldn't have deleted it) and the script-level error
       // tracking will fail this task if Anthropic refused the request.
-      const { stat } = await import('fs/promises');
       try {
         await stat(join(cwd, 'sample.png'));
         return { ok: true, detail: '' };
@@ -430,58 +454,23 @@ async function runPi(task: Task, cwd: string): Promise<RunOutcome> {
 /* Our local-engine runner                                             */
 /* ------------------------------------------------------------------ */
 
-async function runOurs(
-  task: Task,
-  cwd: string,
-  overrides: Partial<t.LocalExecutionConfig> = {}
-): Promise<RunOutcome> {
-  const start = performance.now();
-  const conversation: BaseMessage[] = [];
-  const observedToolCalls: ToolCallObservation[] = [];
-  let inputTokens = 0;
-  let outputTokens = 0;
-  let cacheReadTokens = 0;
-  let cacheWriteTokens = 0;
-
-  const { aggregateContent } = createContentAggregator();
-  const customHandlers = {
-    [GraphEvents.TOOL_END]: new ToolEndHandler(),
-    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
-    [GraphEvents.CHAT_MODEL_STREAM]: new ChatModelStreamHandler(),
-    // ON_RUN_STEP must be forwarded too — without it the aggregator's
-    // `stepMap` is empty when ON_RUN_STEP_COMPLETED arrives and you
-    // get a "No run step or runId found for completed step event"
-    // warn for every tool call. The harness doesn't actually use the
-    // aggregated content, but feeding both events keeps logs clean.
-    [GraphEvents.ON_RUN_STEP]: {
-      handle: (
-        event: GraphEvents.ON_RUN_STEP,
-        data: t.StreamEventData
-      ): void => {
-        aggregateContent({ event, data: data as t.RunStep });
-      },
-    },
-    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
-      handle: (
-        event: GraphEvents.ON_RUN_STEP_COMPLETED,
-        data: t.StreamEventData
-      ): void => {
-        aggregateContent({
-          event,
-          data: data as unknown as { result: t.ToolEndEvent },
-        });
-      },
-    },
-  };
-
+function createOursSessionConfig(params: {
+  cwd: string;
+  sessionPath?: string;
+  overrides?: Partial<t.LocalExecutionConfig>;
+  checkpointing?: AgentSessionCheckpointing;
+  ephemeral?: boolean;
+  humanInTheLoop?: t.HumanInTheLoopConfig;
+  graphConfig?: t.RunConfig['graphConfig'];
+}): AgentSessionConfig {
   const llmConfig = getLLMConfig(PROVIDER);
-  const runConfig: t.RunConfig = {
-    runId: `compare-${Date.now()}`,
-    graphConfig: {
+  return {
+    cwd: params.cwd,
+    sessionPath: params.sessionPath,
+    ephemeral: params.ephemeral,
+    checkpointing: params.checkpointing ?? false,
+    graphConfig: params.graphConfig ?? {
       type: 'standard',
-      // NB: in the legacy path Run.createLegacyGraph rebuilds
-      // `clientOptions` from llmConfig (it ignores graphConfig.clientOptions),
-      // so promptCache lives here and not on a separate clientOptions field.
       llmConfig: { ...llmConfig, model: MODEL, promptCache: true },
       instructions:
         'You are a coding assistant with local file tools. Use read_file, ' +
@@ -490,106 +479,199 @@ async function runOurs(
     toolExecution: {
       engine: 'local',
       local: {
-        cwd,
+        cwd: params.cwd,
         postEditSyntaxCheck: 'auto',
         timeoutMs: 30_000,
-        ...overrides,
+        ...params.overrides,
       },
     },
-    returnContent: true,
+    humanInTheLoop: params.humanInTheLoop,
     skipCleanup: true,
-    customHandlers,
   };
+}
 
+function getToolCallName(toolCall: t.AgentToolCall): string {
+  return 'function' in toolCall
+    ? toolCall.function.name
+    : (toolCall.name ?? '?');
+}
+
+function getToolCallArgs(toolCall: t.AgentToolCall): unknown {
+  return 'function' in toolCall ? toolCall.function.arguments : toolCall.args;
+}
+
+function collectToolCallsFromSteps(steps: t.RunStep[]): ToolCallObservation[] {
+  const calls: ToolCallObservation[] = [];
+  for (const step of steps) {
+    if (step.stepDetails.type !== StepTypes.TOOL_CALLS) {
+      continue;
+    }
+    for (const toolCall of step.stepDetails.tool_calls ?? []) {
+      calls.push({
+        name: getToolCallName(toolCall),
+        argsBytes: JSON.stringify(getToolCallArgs(toolCall) ?? {}).length,
+        isError: false,
+      });
+    }
+  }
+  return calls;
+}
+
+function collectToolCallsFromMessages(
+  messages: BaseMessage[]
+): ToolCallObservation[] {
+  const calls: ToolCallObservation[] = [];
+  for (const msg of messages) {
+    if (msg._getType() === 'ai') {
+      const ai = msg as unknown as {
+        tool_calls?: Array<{ name?: string; args?: unknown }>;
+      };
+      for (const toolCall of ai.tool_calls ?? []) {
+        calls.push({
+          name: toolCall.name ?? '?',
+          argsBytes: JSON.stringify(toolCall.args ?? {}).length,
+          isError: false,
+        });
+      }
+      continue;
+    }
+    if (
+      msg instanceof ToolMessage &&
+      msg.status === 'error' &&
+      calls.length > 0
+    ) {
+      calls[calls.length - 1].isError = true;
+    }
+  }
+  return calls;
+}
+
+function collectTokenUsage(messages: BaseMessage[]): {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+} {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+  for (const msg of messages) {
+    if (msg._getType() !== 'ai') {
+      continue;
+    }
+    const ai = msg as unknown as {
+      usage_metadata?: { input_tokens?: number; output_tokens?: number };
+    };
+    if (ai.usage_metadata == null) {
+      continue;
+    }
+    const reportedInput = ai.usage_metadata.input_tokens ?? 0;
+    outputTokens += ai.usage_metadata.output_tokens ?? 0;
+    const inputTokenDetails = (
+      ai.usage_metadata as unknown as {
+        input_token_details?: {
+          cache_read?: number;
+          cache_creation?: number;
+        };
+      }
+    ).input_token_details;
+    const cacheRead = inputTokenDetails?.cache_read ?? 0;
+    const cacheCreate = inputTokenDetails?.cache_creation ?? 0;
+    cacheReadTokens += cacheRead;
+    cacheWriteTokens += cacheCreate;
+    inputTokens += Math.max(0, reportedInput - cacheRead - cacheCreate);
+  }
+  return {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+  };
+}
+
+function getFinalAssistant(messages: BaseMessage[], fallback: string): string {
+  const lastAssistant = [...messages]
+    .reverse()
+    .find((message) => message._getType() === 'ai');
+  if (!lastAssistant) {
+    return fallback;
+  }
+  const content = lastAssistant.content;
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return fallback;
+  }
+  return content
+    .map((block) => ('text' in block ? block.text : ''))
+    .filter(Boolean)
+    .join(' ');
+}
+
+async function runOurs(
+  task: Task,
+  cwd: string,
+  overrides: Partial<t.LocalExecutionConfig> = {}
+): Promise<RunOutcome> {
+  const start = performance.now();
   let errored = false;
   let errorMessage: string | undefined;
+  let result: AgentSessionRunResult | undefined;
+  let finalResultPromise: Promise<AgentSessionRunResult> | undefined;
+  let sessionEvents = 0;
+  let sessionEntries = 0;
+  const sessionPath = join(cwd, '.librechat-agent-session.jsonl');
   try {
-    const run = await Run.create<t.IState>(runConfig);
-    conversation.push(new HumanMessage(task.prompt));
-    const streamConfig = {
-      configurable: { provider: PROVIDER, thread_id: `compare-${Date.now()}` },
-      streamMode: 'values',
-      version: 'v2' as const,
-    };
-    await run.processStream(
-      { messages: conversation },
-      streamConfig as Parameters<typeof run.processStream>[1]
+    const session = await createAgentSession(
+      createOursSessionConfig({
+        cwd,
+        sessionPath,
+        overrides,
+        checkpointing: false,
+      })
     );
-    const finalMessages = run.getRunMessages();
-    if (finalMessages) {
-      conversation.push(...finalMessages);
+    const stream = session.stream(task.prompt, {
+      runId: `compare-${Date.now()}`,
+      threadId: `compare-${Date.now()}`,
+      config: {
+        configurable: { provider: PROVIDER },
+      },
+    });
+    finalResultPromise = stream.finalResult();
+    for await (const event of stream) {
+      sessionEvents = Math.max(sessionEvents, event.sequence + 1);
     }
+    result = await finalResultPromise;
+    sessionEntries = session.getSessionStore()?.getEntries().length ?? 0;
   } catch (err) {
+    await finalResultPromise?.catch(() => undefined);
     errored = true;
     errorMessage = (err as Error).message.slice(0, 500);
   }
 
-  // Walk the conversation: tool calls live on AIMessage as `tool_calls`,
-  // tool results are ToolMessage entries (already chronologically next to them).
-  for (const msg of conversation) {
-    if (msg._getType() === 'ai') {
-      const ai = msg as unknown as {
-        tool_calls?: Array<{ name?: string; args?: unknown }>;
-        usage_metadata?: { input_tokens?: number; output_tokens?: number };
-      };
-      if (ai.tool_calls != null) {
-        for (const tc of ai.tool_calls) {
-          observedToolCalls.push({
-            name: tc.name ?? '?',
-            argsBytes: JSON.stringify(tc.args ?? {}).length,
-            isError: false,
-          });
-        }
-      }
-      if (ai.usage_metadata != null) {
-        const reportedInput = ai.usage_metadata.input_tokens ?? 0;
-        outputTokens += ai.usage_metadata.output_tokens ?? 0;
-        const idu =
-          (ai.usage_metadata as unknown as {
-            input_token_details?: {
-              cache_read?: number;
-              cache_creation?: number;
-            };
-          }).input_token_details;
-        const cacheRead = idu?.cache_read ?? 0;
-        const cacheCreate = idu?.cache_creation ?? 0;
-        cacheReadTokens += cacheRead;
-        cacheWriteTokens += cacheCreate;
-        // The Anthropic adapter at src/llm/anthropic/utils/message_outputs.ts:31
-        // reports usage_metadata.input_tokens as the TOTAL prompt
-        // (input + cache_creation + cache_read), not just the uncached
-        // portion. Subtract cached fields so `inputTokens` here is
-        // apples-to-apples with pi's `input` field (uncached only).
-        const trulyUncached = Math.max(
-          0,
-          reportedInput - cacheRead - cacheCreate
-        );
-        inputTokens += trulyUncached;
-      }
-    }
-    if (msg instanceof ToolMessage) {
-      if (msg.status === 'error' && observedToolCalls.length > 0) {
-        observedToolCalls[observedToolCalls.length - 1].isError = true;
-      }
-    }
+  const messages = result?.messages ?? [];
+  const usage = collectTokenUsage(messages);
+  let observedToolCalls = collectToolCallsFromSteps(result?.steps ?? []);
+  const messageToolCalls = collectToolCallsFromMessages(messages);
+  if (observedToolCalls.length === 0) {
+    observedToolCalls = messageToolCalls;
   }
-
-  const lastAssistant = [...conversation]
-    .reverse()
-    .find((m) => m._getType() === 'ai');
-  let finalAssistant = '';
-  if (lastAssistant) {
-    const c = lastAssistant.content;
-    finalAssistant =
-      typeof c === 'string'
-        ? c
-        : Array.isArray(c)
-          ? c
-            .map((b) => ('text' in b ? b.text : ''))
-            .filter(Boolean)
-            .join(' ')
-          : '';
+  for (let i = 0; i < observedToolCalls.length; i++) {
+    observedToolCalls[i].isError = messageToolCalls[i]?.isError ?? false;
   }
+  const inputTokens =
+    usage.inputTokens === 0 && result != null
+      ? result.usage.inputTokens
+      : usage.inputTokens;
+  const outputTokens =
+    usage.outputTokens === 0 && result != null
+      ? result.usage.outputTokens
+      : usage.outputTokens;
+  const cacheReadTokens = usage.cacheReadTokens;
+  const cacheWriteTokens = usage.cacheWriteTokens;
+  const finalAssistant = getFinalAssistant(messages, result?.text ?? '');
 
   // Sonnet 4.5 pricing (USD per 1M tokens). Pi computes its own cost; we
   // compute ours from the same per-turn breakdown so the cost columns are
@@ -615,7 +697,285 @@ async function runOurs(
     finalAssistant: finalAssistant.slice(0, 500),
     errored,
     errorMessage,
+    sessionEvents,
+    sessionEntries,
+    sessionPath,
   };
+}
+
+/* ------------------------------------------------------------------ */
+/* Programmatic DX probes                                              */
+/* ------------------------------------------------------------------ */
+
+async function withDxWorkspace<T>(
+  name: string,
+  run: (cwd: string) => Promise<T>
+): Promise<T> {
+  const cwd = await mkdtemp(join(tmpdir(), `lc-dx-${name}-`));
+  try {
+    return await run(cwd);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+async function probeSessionFacade(): Promise<DxProbeResult> {
+  return withDxWorkspace('facade', async (cwd) => {
+    const session = await createAgentSession(
+      createOursSessionConfig({
+        cwd,
+        sessionPath: join(cwd, 'facade.jsonl'),
+        checkpointing: false,
+      })
+    );
+    const methods: Array<keyof typeof session> = [
+      'run',
+      'stream',
+      'clone',
+      'fork',
+      'branch',
+      'compact',
+      'resumeInterrupt',
+    ];
+    const missing = methods.filter(
+      (method) => typeof session[method] !== 'function'
+    );
+    return {
+      ok: missing.length === 0,
+      detail:
+        missing.length === 0
+          ? 'session exposes run/stream plus lifecycle methods'
+          : `missing: ${missing.join(', ')}`,
+    };
+  });
+}
+
+async function probeJsonlTree(): Promise<DxProbeResult> {
+  return withDxWorkspace('jsonl', async (cwd) => {
+    const session = await createAgentSession(
+      createOursSessionConfig({
+        cwd,
+        sessionPath: join(cwd, 'tree.jsonl'),
+        checkpointing: false,
+      })
+    );
+    const store = session.getSessionStore();
+    if (!store) {
+      return { ok: false, detail: 'store was not created' };
+    }
+    const prompt = await store.appendMessage(
+      new HumanMessage('rename calc_total')
+    );
+    const reply = await store.appendMessage(new AIMessage('done'));
+    await store.setLabel(prompt.id, 'coding prompt');
+    const path = store.getPath(reply.id);
+    const entries = store.getEntries();
+    const ok =
+      path.length === 2 &&
+      store.getTree().length === 1 &&
+      store.getLabel(prompt.id) === 'coding prompt' &&
+      entries.some((entry) => entry.type === 'session_state');
+    return {
+      ok,
+      detail: `${entries.length} JSONL entries, active path length ${path.length}`,
+    };
+  });
+}
+
+async function probeForkCloneBranch(): Promise<DxProbeResult> {
+  return withDxWorkspace('branch', async (cwd) => {
+    const session = await createAgentSession(
+      createOursSessionConfig({
+        cwd,
+        sessionPath: join(cwd, 'branch.jsonl'),
+        checkpointing: false,
+      })
+    );
+    const store = session.getSessionStore();
+    if (!store) {
+      return { ok: false, detail: 'store was not created' };
+    }
+    const prompt = await store.appendMessage(new HumanMessage('turn one'));
+    const reply = await store.appendMessage(new AIMessage('reply one'));
+    const clone = await session.clone({ name: 'clone' });
+    const fork = await session.fork(reply.id, {
+      position: 'before',
+      name: 'fork-before-reply',
+    });
+    await session.branch(prompt.id, { position: 'at' });
+    const clonePathLength = clone.getSessionStore()?.getPath().length ?? 0;
+    const forkLeafId = fork.getSessionStore()?.getLeafEntry()?.id;
+    const activeLeafId = store.getLeafEntry()?.id;
+    const ok =
+      clonePathLength === 2 &&
+      forkLeafId === prompt.id &&
+      activeLeafId === prompt.id;
+    return {
+      ok,
+      detail:
+        `clone path ${clonePathLength}, fork leaf ${forkLeafId ?? 'none'}, ` +
+        `active leaf ${activeLeafId ?? 'none'}`,
+    };
+  });
+}
+
+async function probeResumeByPath(): Promise<DxProbeResult> {
+  return withDxWorkspace('resume', async (cwd) => {
+    const sessionPath = join(cwd, 'resume.jsonl');
+    const session = await createAgentSession(
+      createOursSessionConfig({ cwd, sessionPath, checkpointing: false })
+    );
+    const store = session.getSessionStore();
+    if (!store) {
+      return { ok: false, detail: 'store was not created' };
+    }
+    await store.appendMessage(new HumanMessage('persist me'));
+    const resumed = await createAgentSession(
+      createOursSessionConfig({ cwd, sessionPath, checkpointing: false })
+    );
+    const resumedMessages = resumed.getSessionStore()?.getMessages() ?? [];
+    const ok =
+      resumed.threadId === session.threadId && resumedMessages.length === 1;
+    return {
+      ok,
+      detail: `thread ${resumed.threadId}, messages ${resumedMessages.length}`,
+    };
+  });
+}
+
+async function probeCheckpointComposition(): Promise<DxProbeResult> {
+  return withDxWorkspace('checkpointing', async (cwd) => {
+    const checkpointer = new MemorySaver();
+    const injected = await createAgentSession(
+      createOursSessionConfig({
+        cwd,
+        ephemeral: true,
+        checkpointing: { checkpointer },
+      })
+    );
+    const disabled = await createAgentSession(
+      createOursSessionConfig({
+        cwd,
+        ephemeral: true,
+        checkpointing: false,
+        humanInTheLoop: { enabled: true },
+      })
+    );
+    const ok =
+      injected.getCheckpointer() === checkpointer &&
+      injected.getSessionStore() == null &&
+      disabled.getCheckpointer() == null &&
+      disabled.getSessionStore() == null;
+    return {
+      ok,
+      detail: ok
+        ? 'custom checkpointer injected; JSONL/checkpointing can both be disabled'
+        : 'composition check failed',
+    };
+  });
+}
+
+async function probeMultiAgentWrapping(): Promise<DxProbeResult> {
+  return withDxWorkspace('multi', async (cwd) => {
+    const clientOptions = {
+      modelName: MODEL,
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    };
+    const session = await createAgentSession(
+      createOursSessionConfig({
+        cwd,
+        sessionPath: join(cwd, 'multi.jsonl'),
+        checkpointing: false,
+        graphConfig: {
+          type: 'multi-agent',
+          agents: [
+            {
+              agentId: 'supervisor',
+              provider: PROVIDER,
+              clientOptions,
+              instructions: 'Route coding work to the specialist.',
+            },
+            {
+              agentId: 'coder',
+              provider: PROVIDER,
+              clientOptions,
+              instructions: 'Make precise code changes.',
+            },
+          ],
+          edges: [
+            {
+              from: 'supervisor',
+              to: 'coder',
+              description: 'Delegate implementation work',
+              edgeType: 'handoff',
+            },
+          ],
+        },
+      })
+    );
+    const ok =
+      session.getSessionStore() != null &&
+      typeof session.stream === 'function' &&
+      typeof session.run === 'function';
+    return {
+      ok,
+      detail:
+        'AgentSession accepted a multi-agent handoff graph without special harness code',
+    };
+  });
+}
+
+const DX_PROBES: DxProbe[] = [
+  {
+    feature: 'Session facade',
+    pi: 'SDK sessions expose a high-level run loop',
+    ours: 'createAgentSession().run/stream wraps existing Run',
+    run: probeSessionFacade,
+  },
+  {
+    feature: 'Append-only JSONL tree',
+    pi: 'Native session JSONL tree',
+    ours: 'JsonlSessionStore v1 with entries, labels, state',
+    run: probeJsonlTree,
+  },
+  {
+    feature: 'Clone/fork/branch',
+    pi: 'Clone, fork, and branch from tree positions',
+    ours: 'clone(), fork(before/at), branch(before/at)',
+    run: probeForkCloneBranch,
+  },
+  {
+    feature: 'Resume',
+    pi: 'Resume by session id/path',
+    ours: 'resume/open by exact JSONL path with stable threadId',
+    run: probeResumeByPath,
+  },
+  {
+    feature: 'Composable state',
+    pi: 'Session log is separate from execution provider state',
+    ours: 'JSONL optional; LangGraph checkpointer injectable or off',
+    run: probeCheckpointComposition,
+  },
+  {
+    feature: 'Multi-agent/subagent surface',
+    pi: 'Coding-agent session loop',
+    ours: 'Same AgentSession facade wraps multi-agent graphs and tools',
+    run: probeMultiAgentWrapping,
+  },
+];
+
+async function runDxProbes(): Promise<boolean> {
+  console.log('\n================ DX SESSION PROBES ================');
+  let allPassed = true;
+  for (const probe of DX_PROBES) {
+    const result = await probe.run();
+    allPassed &&= result.ok;
+    console.log(`\n[${result.ok ? 'ok' : 'fail'}] ${probe.feature}`);
+    console.log(`  pi:   ${probe.pi}`);
+    console.log(`  ours: ${probe.ours}`);
+    console.log(`  live: ${result.detail}`);
+  }
+  return allPassed;
 }
 
 /* ------------------------------------------------------------------ */
@@ -623,7 +983,6 @@ async function runOurs(
 /* ------------------------------------------------------------------ */
 
 async function setupWorkspace(task: Task): Promise<string> {
-  const { mkdir } = await import('fs/promises');
   const dir = await mkdtemp(join(tmpdir(), 'lc-compare-'));
   for (const [relPath, content] of Object.entries(task.seed)) {
     const abs = join(dir, relPath);
@@ -642,7 +1001,6 @@ async function setupWorkspace(task: Task): Promise<string> {
 }
 
 async function symlinkRepoNodeModules(cwd: string): Promise<void> {
-  const { symlink } = await import('fs/promises');
   const repo = resolve(process.cwd(), 'node_modules');
   await symlink(repo, join(cwd, 'node_modules'), 'dir').catch(() => {
     /* fall through; tsc just won't be available */
@@ -655,9 +1013,7 @@ function summariseToolCalls(calls: ToolCallObservation[]): string {
   for (const c of calls) {
     grouped.set(c.name, (grouped.get(c.name) ?? 0) + 1);
   }
-  const inline = [...grouped.entries()]
-    .map(([n, c]) => `${n}×${c}`)
-    .join(', ');
+  const inline = [...grouped.entries()].map(([n, c]) => `${n}×${c}`).join(', ');
   const errors = calls.filter((c) => c.isError).length;
   return `${calls.length} call(s) [${inline}]${errors > 0 ? ` (${errors} errored)` : ''}`;
 }
@@ -677,10 +1033,28 @@ function avg(xs: number[]): number {
   return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length;
 }
 
+function selectTasks(tasks: Task[]): Task[] {
+  const raw = process.env.COMPARE_TASKS;
+  if (raw == null || raw.trim() === '') {
+    return tasks;
+  }
+  const requested = raw
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+  return tasks.filter((task) => {
+    const name = task.name.toLowerCase();
+    return requested.some((token) => name === token || name.startsWith(token));
+  });
+}
+
 async function runOnce(
   task: Task,
   side: 'pi' | 'ours'
-): Promise<{ outcome: RunOutcome; verify: { ok: boolean; detail: string } } | null> {
+): Promise<{
+  outcome: RunOutcome;
+  verify: { ok: boolean; detail: string };
+} | null> {
   if (task.skip === side) return null;
   const cwd = await setupWorkspace(task);
   const outcome =
@@ -702,10 +1076,28 @@ async function runOnce(
 
 async function main(): Promise<void> {
   const ITERS = Math.max(1, Number(process.env.COMPARE_ITERS ?? '1'));
+  const DX_ONLY = process.env.COMPARE_DX_ONLY === '1';
+  const selectedTasks = selectTasks(TASKS);
   console.log(`pi binary: ${PI_BIN}`);
   console.log(`model:     ${MODEL}`);
   console.log(`provider:  ${PROVIDER}`);
   console.log(`iters:     ${ITERS}`);
+  console.log(`dx only:   ${DX_ONLY ? 'yes' : 'no'}`);
+  console.log(
+    `tasks:     ${
+      DX_ONLY ? 'DX probes' : selectedTasks.map((task) => task.name).join(', ')
+    }`
+  );
+  const dxPassed = await runDxProbes();
+  if (DX_ONLY) {
+    process.exitCode = dxPassed ? 0 : 1;
+    return;
+  }
+  if (selectedTasks.length === 0) {
+    throw new Error(
+      `No tasks matched COMPARE_TASKS=${process.env.COMPARE_TASKS}`
+    );
+  }
 
   const results: Array<{
     task: Task;
@@ -713,7 +1105,7 @@ async function main(): Promise<void> {
     ours: AggregatedSide;
   }> = [];
 
-  for (const task of TASKS) {
+  for (const task of selectedTasks) {
     console.log(`\n========== ${task.name} ==========`);
     console.log(task.description);
 
@@ -733,7 +1125,9 @@ async function main(): Promise<void> {
             `cacheR=${piRes.outcome.cacheReadTokens} cacheW=${piRes.outcome.cacheWriteTokens} ` +
             `$${piRes.outcome.cost.toFixed(4)}`
         );
-        if (piRes.outcome.errored) console.log(`  err: ${piRes.outcome.errorMessage}`);
+        if (piRes.outcome.errored) {
+          console.log(`  err: ${piRes.outcome.errorMessage}`);
+        }
       } else {
         console.log(`[pi]${tag} (skipped)`);
       }
@@ -746,9 +1140,12 @@ async function main(): Promise<void> {
           `[ours]${tag} ${oursRes.outcome.errored ? 'ERROR' : oursRes.verify.ok ? 'ok' : 'fail'} ` +
             `${fmtMs(oursRes.outcome.wallMs)} ${summariseToolCalls(oursRes.outcome.toolCalls)} ` +
             `in=${oursRes.outcome.inputTokens} out=${oursRes.outcome.outputTokens} ` +
-            `cacheR=${oursRes.outcome.cacheReadTokens} cacheW=${oursRes.outcome.cacheWriteTokens}`
+            `cacheR=${oursRes.outcome.cacheReadTokens} cacheW=${oursRes.outcome.cacheWriteTokens} ` +
+            `events=${oursRes.outcome.sessionEvents ?? 0} jsonl=${oursRes.outcome.sessionEntries ?? 0}`
         );
-        if (oursRes.outcome.errored) console.log(`  err: ${oursRes.outcome.errorMessage}`);
+        if (oursRes.outcome.errored) {
+          console.log(`  err: ${oursRes.outcome.errorMessage}`);
+        }
       } else {
         console.log(`[ours]${tag} (skipped)`);
       }
@@ -798,22 +1195,40 @@ async function main(): Promise<void> {
     cols.push([r.task.name, 'verify', fmtVerify(r.pi), fmtVerify(r.ours)]);
     cols.push(['', 'wall', fmtSideMs(r.pi), fmtSideMs(r.ours)]);
     cols.push(['', 'tool calls', fmtSideCalls(r.pi), fmtSideCalls(r.ours)]);
-    cols.push(['', 'input new', fmtSide(r.pi, 'inputTokens'), fmtSide(r.ours, 'inputTokens')]);
-    cols.push(['', 'cache read', fmtSide(r.pi, 'cacheReadTokens'), fmtSide(r.ours, 'cacheReadTokens')]);
-    cols.push(['', 'cache write', fmtSide(r.pi, 'cacheWriteTokens'), fmtSide(r.ours, 'cacheWriteTokens')]);
-    cols.push(['', 'output tok', fmtSide(r.pi, 'outputTokens'), fmtSide(r.ours, 'outputTokens')]);
+    cols.push([
+      '',
+      'input new',
+      fmtSide(r.pi, 'inputTokens'),
+      fmtSide(r.ours, 'inputTokens'),
+    ]);
+    cols.push([
+      '',
+      'cache read',
+      fmtSide(r.pi, 'cacheReadTokens'),
+      fmtSide(r.ours, 'cacheReadTokens'),
+    ]);
+    cols.push([
+      '',
+      'cache write',
+      fmtSide(r.pi, 'cacheWriteTokens'),
+      fmtSide(r.ours, 'cacheWriteTokens'),
+    ]);
+    cols.push([
+      '',
+      'output tok',
+      fmtSide(r.pi, 'outputTokens'),
+      fmtSide(r.ours, 'outputTokens'),
+    ]);
     cols.push(['', 'cost', fmtCost(r.pi), fmtCost(r.ours)]);
+    cols.push(['', 'session events', 'N/A', fmtSide(r.ours, 'sessionEvents')]);
+    cols.push(['', 'jsonl entries', 'N/A', fmtSide(r.ours, 'sessionEntries')]);
   }
 
   const widths = [0, 0, 0, 0].map((_, i) =>
     Math.max(...cols.map((row) => row[i].length))
   );
   for (const row of cols) {
-    console.log(
-      row
-        .map((cell, i) => cell.padEnd(widths[i]))
-        .join('  ')
-    );
+    console.log(row.map((cell, i) => cell.padEnd(widths[i])).join('  '));
   }
 
   // Aggregate verify counts across all iters of all non-skipped tasks.
@@ -824,7 +1239,11 @@ async function main(): Promise<void> {
   console.log(
     `\nOverall: pi ${piPassed}/${piVerifies.length}, ours ${oursPassed}/${oursVerifies.length}.`
   );
-  if (piPassed < piVerifies.length || oursPassed < oursVerifies.length) {
+  if (
+    !dxPassed ||
+    piPassed < piVerifies.length ||
+    oursPassed < oursVerifies.length
+  ) {
     process.exitCode = 1;
   }
 }

--- a/src/scripts/session_live.ts
+++ b/src/scripts/session_live.ts
@@ -264,6 +264,7 @@ async function runSessionLifecycleSmoke(params: {
     cwd: process.cwd(),
     sessionPath: basePath,
     name: 'live-session-base',
+    checkpointing: true,
     graphConfig: {
       type: 'standard',
       llmConfig: params.llmConfig,
@@ -284,6 +285,20 @@ async function runSessionLifecycleSmoke(params: {
   logPass('standard session run', preview(firstText));
 
   const store = getStore(session);
+  const firstCheckpoint = await session.getLatestCheckpoint();
+  assertLive(
+    firstCheckpoint?.threadId === session.threadId,
+    'LangGraph checkpoint reference missing after run'
+  );
+  assertLive(
+    store.getCheckpoints(session.threadId).length > 0,
+    'JSONL checkpoint journal entry missing'
+  );
+  logPass(
+    'LangGraph checkpoint state',
+    firstCheckpoint.checkpointId ?? 'latest'
+  );
+
   const forkPoint = store.getForkPoints()[0];
   assertLive(forkPoint != null, 'no user fork point recorded');
   await store.setLabel(forkPoint.id, 'first user turn');
@@ -354,6 +369,12 @@ async function runSessionLifecycleSmoke(params: {
       typeof compactedMessages[0].content === 'string' &&
       compactedMessages[0].content.trim() !== '',
     'manual compaction summary not active'
+  );
+  assertLive(
+    branchStore
+      .getCheckpoints(session.threadId)
+      .some((entry) => entry.data.source === 'reset'),
+    'checkpoint reset entry missing after compact'
   );
   logPass('manual compact', `${compactedMessages.length} active messages`);
 

--- a/src/scripts/session_live.ts
+++ b/src/scripts/session_live.ts
@@ -1,0 +1,527 @@
+import { config } from 'dotenv';
+import { existsSync } from 'fs';
+import { mkdtemp } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  AgentSession,
+  AgentSessionRunResult,
+  SessionMessageEntry,
+} from '@/session';
+import type * as t from '@/types';
+import {
+  createOpenAIHandlers,
+  createOpenAIStreamTracker,
+  sendOpenAIFinalChunk,
+} from '@/openai';
+import {
+  createResponseTracker,
+  createResponsesEventHandlers,
+  emitResponseCompleted,
+} from '@/responses';
+import { Constants, GraphEvents, Providers } from '@/common';
+import { createAgentSession } from '@/session';
+import { Calculator } from '@/tools/Calculator';
+import { getLLMConfig } from '@/utils/llmConfig';
+
+const DEFAULT_ENV_PATH = '/Users/danny/Projects/agents/.env';
+const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<Providers, string>> = {
+  [Providers.OPENAI]: 'gpt-4.1-mini',
+  [Providers.ANTHROPIC]: 'claude-haiku-4-5',
+};
+
+function getArgValue(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  if (index === -1 || index + 1 >= process.argv.length) {
+    return undefined;
+  }
+  return process.argv[index + 1];
+}
+
+const envPath =
+  getArgValue('--env') ?? process.env.LIVE_ENV_PATH ?? DEFAULT_ENV_PATH;
+
+if (existsSync(envPath)) {
+  config({ path: envPath });
+}
+config();
+
+function assertLive(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Live session smoke failed: ${message}`);
+  }
+}
+
+function normalizeProvider(value: string | undefined): Providers | undefined {
+  if (value == null || value === '') {
+    return undefined;
+  }
+  if (value === Providers.ANTHROPIC || value.toLowerCase() === 'anthropic') {
+    return Providers.ANTHROPIC;
+  }
+  if (
+    value === Providers.OPENAI ||
+    value.toLowerCase() === 'openai' ||
+    value.toLowerCase() === 'openai'
+  ) {
+    return Providers.OPENAI;
+  }
+  throw new Error(`Unsupported live provider: ${value}`);
+}
+
+function resolveProvider(): Providers {
+  const requested = normalizeProvider(
+    getArgValue('--provider') ?? process.env.LIVE_PROVIDER
+  );
+  if (requested) {
+    return requested;
+  }
+  if (process.env.ANTHROPIC_API_KEY) {
+    return Providers.ANTHROPIC;
+  }
+  if (process.env.OPENAI_API_KEY) {
+    return Providers.OPENAI;
+  }
+  throw new Error(
+    'Missing ANTHROPIC_API_KEY or OPENAI_API_KEY. Pass --env or LIVE_ENV_PATH.'
+  );
+}
+
+function apiKeyForProvider(provider: Providers): string {
+  const envName =
+    provider === Providers.ANTHROPIC ? 'ANTHROPIC_API_KEY' : 'OPENAI_API_KEY';
+  const apiKey = process.env[envName];
+  if (apiKey == null || apiKey === '') {
+    throw new Error(`Missing ${envName} for provider ${provider}`);
+  }
+  return apiKey;
+}
+
+function createLiveLLMConfig(provider: Providers): t.LLMConfig {
+  const apiKey = apiKeyForProvider(provider);
+  const model =
+    getArgValue('--model') ??
+    process.env.LIVE_MODEL ??
+    DEFAULT_MODEL_BY_PROVIDER[provider] ??
+    getLLMConfig(provider).model;
+  const openAIFields =
+    provider === Providers.OPENAI ? { openAIApiKey: apiKey } : {};
+
+  return {
+    ...getLLMConfig(provider),
+    ...openAIFields,
+    apiKey,
+    model,
+    modelName: model,
+    streaming: true,
+    streamUsage: true,
+    temperature: 0,
+  } as t.LLMConfig;
+}
+
+function createAgentInputs(params: {
+  agentId: string;
+  provider: Providers;
+  llmConfig: t.LLMConfig;
+  instructions: string;
+}): t.AgentInputs {
+  const { provider: _provider, ...clientOptions } = params.llmConfig;
+  return {
+    agentId: params.agentId,
+    provider: params.provider,
+    clientOptions: clientOptions as t.ClientOptions,
+    instructions: params.instructions,
+    maxContextTokens: 8000,
+  };
+}
+
+function contentToText(content: BaseMessage['content']): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  const chunks: string[] = [];
+  for (const part of content) {
+    if (typeof part === 'string') {
+      chunks.push(part);
+      continue;
+    }
+    if (part.type === 'text' && typeof part.text === 'string') {
+      chunks.push(part.text);
+      continue;
+    }
+    if ('think' in part && typeof part.think === 'string') {
+      chunks.push(part.think);
+    }
+  }
+  return chunks.join('');
+}
+
+function resultText(result: AgentSessionRunResult): string {
+  if (result.text.trim() !== '') {
+    return result.text.trim();
+  }
+  const aiMessage = [...result.messages]
+    .reverse()
+    .find((message) => message._getType() === 'ai');
+  return aiMessage ? contentToText(aiMessage.content).trim() : '';
+}
+
+function resultMessagesText(result: AgentSessionRunResult): string {
+  return result.messages
+    .map((message) => contentToText(message.content))
+    .filter((text) => text.trim() !== '')
+    .join('\n')
+    .trim();
+}
+
+function preview(text: string): string {
+  return text.replace(/\s+/g, ' ').slice(0, 180);
+}
+
+function logPass(label: string, detail: string): void {
+  console.log(`[PASS] ${label}: ${detail}`);
+}
+
+function messageName(message: BaseMessage): string | undefined {
+  return (message as BaseMessage & { name?: string }).name;
+}
+
+function hasSubagentToolMessage(messages: BaseMessage[]): boolean {
+  return messages.some(
+    (message) =>
+      message._getType() === 'tool' &&
+      messageName(message) === Constants.SUBAGENT
+  );
+}
+
+function getStore(
+  session: AgentSession
+): NonNullable<ReturnType<AgentSession['getSessionStore']>> {
+  const store = session.getSessionStore();
+  assertLive(store != null, 'expected JSONL-backed session store');
+  return store;
+}
+
+async function runAdapterSmoke(): Promise<void> {
+  const openAIWrites: string[] = [];
+  const openAITracker = createOpenAIStreamTracker();
+  const openAIHandlers = createOpenAIHandlers({
+    writer: { write: (data) => void openAIWrites.push(data) },
+    context: { requestId: 'chatcmpl_live', model: 'agent-live', created: 1 },
+    tracker: openAITracker,
+  });
+  await openAIHandlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+    GraphEvents.ON_MESSAGE_DELTA,
+    {
+      id: 'msg_live',
+      delta: { content: [{ type: 'text', text: 'adapter text' }] },
+    } satisfies t.MessageDeltaEvent
+  );
+  await sendOpenAIFinalChunk({
+    writer: { write: (data) => void openAIWrites.push(data) },
+    context: { requestId: 'chatcmpl_live', model: 'agent-live', created: 1 },
+    tracker: openAITracker,
+  });
+  assertLive(
+    openAIWrites.join('').includes('"content":"adapter text"'),
+    'OpenAI-compatible adapter did not stream text'
+  );
+
+  const responseWrites: string[] = [];
+  const responseTracker = createResponseTracker();
+  const responseHandlers = createResponsesEventHandlers({
+    writer: { write: (data) => void responseWrites.push(data) },
+    context: { responseId: 'resp_live', model: 'agent-live', createdAt: 1 },
+    tracker: responseTracker,
+  });
+  await responseHandlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+    GraphEvents.ON_MESSAGE_DELTA,
+    {
+      id: 'msg_live',
+      delta: { content: [{ type: 'text', text: 'response text' }] },
+    } satisfies t.MessageDeltaEvent
+  );
+  await emitResponseCompleted({
+    writer: { write: (data) => void responseWrites.push(data) },
+    context: { responseId: 'resp_live', model: 'agent-live', createdAt: 1 },
+    tracker: responseTracker,
+  });
+  assertLive(
+    responseWrites.join('').includes('response.completed'),
+    'Responses-compatible adapter did not complete'
+  );
+  logPass('adapter smoke', 'OpenAI chat and Responses writers emitted events');
+}
+
+async function runSessionLifecycleSmoke(params: {
+  root: string;
+  provider: Providers;
+  llmConfig: t.LLMConfig;
+}): Promise<void> {
+  const basePath = join(params.root, 'base-session.jsonl');
+  const session = await createAgentSession({
+    cwd: process.cwd(),
+    sessionPath: basePath,
+    name: 'live-session-base',
+    graphConfig: {
+      type: 'standard',
+      llmConfig: params.llmConfig,
+      instructions:
+        'You are a concise SDK smoke-test assistant. Obey exact output-token requests.',
+      tools: [new Calculator()],
+      maxContextTokens: 8000,
+    },
+    returnContent: true,
+  });
+
+  const first = await session.run(
+    'Use the calculator tool to compute (18 * 7) + 13. Include the token SESSION_BASE_OK.'
+  );
+  const firstText = resultText(first);
+  assertLive(firstText.includes('SESSION_BASE_OK'), 'base run marker missing');
+  assertLive(firstText.includes('139'), 'calculator result missing');
+  logPass('standard session run', preview(firstText));
+
+  const store = getStore(session);
+  const forkPoint = store.getForkPoints()[0];
+  assertLive(forkPoint != null, 'no user fork point recorded');
+  await store.setLabel(forkPoint.id, 'first user turn');
+  assertLive(
+    store.getLabel(forkPoint.id) === 'first user turn',
+    'label round-trip failed'
+  );
+  logPass(
+    'JSONL persistence',
+    `${store.getEntries().length} entries at ${store.path}`
+  );
+
+  const clone = await session.clone({
+    cwd: params.root,
+    name: 'live-session-clone',
+  });
+  const cloneResult = await clone.run(
+    'Continue this cloned session and include the token SESSION_CLONE_OK.'
+  );
+  assertLive(
+    resultText(cloneResult).includes('SESSION_CLONE_OK'),
+    'clone run marker missing'
+  );
+  logPass('clone', getStore(clone).path);
+
+  const forkBefore = await session.fork(forkPoint.id, {
+    cwd: params.root,
+    name: 'live-session-fork-before',
+    position: 'before',
+  });
+  const forkResult = await forkBefore.run(
+    'This replacement branch should not know the prior arithmetic. Include SESSION_FORK_OK.'
+  );
+  assertLive(
+    resultText(forkResult).includes('SESSION_FORK_OK'),
+    'fork-before run marker missing'
+  );
+  logPass('fork before entry', getStore(forkBefore).path);
+
+  await session.branch(forkPoint.id, {
+    position: 'before',
+    summarizeAbandoned: {
+      instructions: 'Summary of abandoned live branch before branch switch.',
+    },
+  });
+  const branchResult = await session.run(
+    'This is an in-place alternate branch. Include SESSION_BRANCH_OK.'
+  );
+  assertLive(
+    resultText(branchResult).includes('SESSION_BRANCH_OK'),
+    'branch run marker missing'
+  );
+  const branchStore = getStore(session);
+  assertLive(
+    branchStore.getEntries().some((entry) => entry.type === 'compaction'),
+    'branch abandoned-summary compaction entry missing'
+  );
+  logPass('branch in place', `${branchStore.getTree().length} root branch(es)`);
+
+  await session.compact({
+    instructions:
+      'Write a concise checkpoint summary of this live session branch.',
+    retainRecentTurns: 0,
+  });
+  const compactedMessages = branchStore.getMessages();
+  assertLive(
+    compactedMessages[0]?._getType() === 'system' &&
+      typeof compactedMessages[0].content === 'string' &&
+      compactedMessages[0].content.trim() !== '',
+    'manual compaction summary not active'
+  );
+  logPass('manual compact', `${compactedMessages.length} active messages`);
+
+  const resumed = await createAgentSession({
+    cwd: process.cwd(),
+    ephemeral: true,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: params.llmConfig,
+      instructions:
+        'You are a concise SDK smoke-test assistant. Obey exact output-token requests.',
+      maxContextTokens: 8000,
+    },
+    returnContent: true,
+  });
+  await resumed.resumeSession(basePath);
+  assertLive(
+    getStore(resumed).getMessages().length === branchStore.getMessages().length,
+    'resumeSession did not restore active message path'
+  );
+
+  const stream = resumed.stream(
+    'Reply with the exact token SESSION_STREAM_OK and no extra words.'
+  );
+  let streamedText = '';
+  for await (const chunk of stream.toTextStream()) {
+    streamedText += chunk;
+  }
+  const streamResult = await stream.finalResult();
+  const finalStreamText = streamedText || resultText(streamResult);
+  assertLive(
+    finalStreamText.includes('SESSION_STREAM_OK'),
+    'stream helper marker missing'
+  );
+  logPass('resume and stream helpers', preview(finalStreamText));
+}
+
+async function runMultiAgentSmoke(params: {
+  root: string;
+  provider: Providers;
+  llmConfig: t.LLMConfig;
+}): Promise<void> {
+  const agents: t.AgentInputs[] = [
+    createAgentInputs({
+      agentId: 'session_architect',
+      provider: params.provider,
+      llmConfig: params.llmConfig,
+      instructions:
+        'You are Agent A. Start with AGENT_A and give one JSONL session-tree DX benefit in one sentence.',
+    }),
+    createAgentInputs({
+      agentId: 'session_reviewer',
+      provider: params.provider,
+      llmConfig: params.llmConfig,
+      instructions:
+        'You are Agent B. Start with AGENT_B and add one implementation caution. End with MULTI_AGENT_OK.',
+    }),
+  ];
+  const result = await (
+    await createAgentSession({
+      cwd: process.cwd(),
+      sessionPath: join(params.root, 'multi-agent-session.jsonl'),
+      name: 'live-session-multi-agent',
+      graphConfig: {
+        type: 'multi-agent',
+        agents,
+        edges: [
+          {
+            from: 'session_architect',
+            to: 'session_reviewer',
+            edgeType: 'direct',
+            description: 'Review the architect output',
+          },
+        ],
+      },
+      returnContent: true,
+    })
+  ).run('Run the two-agent SDK session DX review.');
+
+  const aiCount = result.messages.filter(
+    (message) => message._getType() === 'ai'
+  ).length;
+  const text = resultText(result) || resultMessagesText(result);
+  assertLive(
+    aiCount >= 2,
+    'multi-agent direct edge did not produce two AI turns'
+  );
+  assertLive(text !== '', 'multi-agent graph produced empty text');
+  logPass('multi-agent direct graph', preview(text));
+}
+
+async function runSubagentSmoke(params: {
+  root: string;
+  provider: Providers;
+  llmConfig: t.LLMConfig;
+}): Promise<void> {
+  const analystConfig = createAgentInputs({
+    agentId: 'jsonl_analyst',
+    provider: params.provider,
+    llmConfig: params.llmConfig,
+    instructions:
+      'You are an isolated JSONL analyst. Give exactly two concise tradeoffs and include SUBAGENT_CHILD_OK.',
+  });
+  const supervisor = createAgentInputs({
+    agentId: 'supervisor',
+    provider: params.provider,
+    llmConfig: params.llmConfig,
+    instructions:
+      'You are a supervisor. You must use the subagent tool exactly once for JSONL tradeoff analysis, then summarize it and include SUBAGENT_PARENT_OK.',
+  });
+  supervisor.subagentConfigs = [
+    {
+      type: 'jsonl_analyst',
+      name: 'JSONL Analyst',
+      description: 'Analyzes JSONL session-tree tradeoffs.',
+      agentInputs: analystConfig,
+    },
+  ];
+
+  const session = await createAgentSession({
+    cwd: process.cwd(),
+    sessionPath: join(params.root, 'subagent-session.jsonl'),
+    name: 'live-session-subagent',
+    graphConfig: {
+      type: 'standard',
+      agents: [supervisor],
+    },
+    returnContent: true,
+  });
+  const result = await session.run(
+    'Delegate to jsonl_analyst using the subagent tool. Ask for two tradeoffs of JSONL session trees for CI replay, then summarize.'
+  );
+  const storedMessages = getStore(session).getMessages();
+  assertLive(
+    hasSubagentToolMessage(result.messages) ||
+      hasSubagentToolMessage(storedMessages),
+    'subagent tool message missing'
+  );
+  const text = resultText(result) || resultMessagesText(result);
+  assertLive(text !== '', 'subagent delegation produced empty text');
+  logPass('subagent delegation', preview(text));
+}
+
+async function main(): Promise<void> {
+  const provider = resolveProvider();
+  const llmConfig = createLiveLLMConfig(provider);
+  const root = await mkdtemp(join(tmpdir(), 'lc-agent-session-live-'));
+  console.log('Live AgentSession smoke test');
+  console.log(`Provider: ${provider}`);
+  console.log(`Model: ${llmConfig.model}`);
+  console.log(
+    `Env path: ${existsSync(envPath) ? envPath : 'default process env'}`
+  );
+  console.log(`Artifacts: ${root}\n`);
+
+  await runAdapterSmoke();
+  await runSessionLifecycleSmoke({ root, provider, llmConfig });
+  await runMultiAgentSmoke({ root, provider, llmConfig });
+  await runSubagentSmoke({ root, provider, llmConfig });
+
+  console.log('\nAll live session smoke checks passed.');
+  console.log(`Session JSONL artifacts kept at: ${root}`);
+}
+
+main().catch((error: Error) => {
+  console.error(error.message);
+  if (error.stack) {
+    console.error(error.stack);
+  }
+  process.exitCode = 1;
+});

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -112,16 +112,14 @@ function normalizeConfig(config: AgentSessionConfig): {
 }
 
 function isMissingSessionError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
+  if (error == null || typeof error !== 'object') {
     return false;
   }
-  if (error.message.startsWith('Session not found:')) {
+  const candidate = error as { code?: string; message?: string };
+  if (candidate.code === 'ENOENT') {
     return true;
   }
-  if (!('code' in error)) {
-    return false;
-  }
-  return (error as { code?: string }).code === 'ENOENT';
+  return candidate.message?.startsWith('Session not found:') === true;
 }
 
 async function createStore(params: {
@@ -136,7 +134,7 @@ async function createStore(params: {
   }
   if (params.sessionPath != null && params.sessionPath !== '') {
     try {
-      return await JsonlSessionStore.open(params.sessionPath);
+      return await JsonlSessionStore.openPath(params.sessionPath);
     } catch (error) {
       if (!isMissingSessionError(error)) {
         throw error;

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1,8 +1,11 @@
+import { MemorySaver } from '@langchain/langgraph';
 import { HumanMessage, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import type { HookRegistry } from '@/hooks';
 import type {
   AgentSessionConfig,
+  AgentSessionCheckpointing,
   AgentSessionInput,
   AgentSessionRunOptions,
   AgentSessionRunResult,
@@ -33,17 +36,24 @@ function isBaseMessage(value: unknown): value is BaseMessage {
   );
 }
 
-function normalizeInput(input: AgentSessionInput): BaseMessage[] {
+interface NormalizedSessionInput {
+  messages: BaseMessage[];
+  state: t.IState;
+}
+
+function normalizeInput(input: AgentSessionInput): NormalizedSessionInput {
   if (typeof input === 'string') {
-    return [new HumanMessage(input)];
+    const messages = [new HumanMessage(input)];
+    return { messages, state: { messages } };
   }
   if (Array.isArray(input)) {
-    return input;
+    return { messages: input, state: { messages: input } };
   }
   if (isBaseMessage(input)) {
-    return [input];
+    const messages = [input];
+    return { messages, state: { messages } };
   }
-  return input.messages;
+  return { messages: input.messages, state: input };
 }
 
 function contentToText(
@@ -67,6 +77,7 @@ function normalizeConfig(config: AgentSessionConfig): {
   sessionPath?: string;
   name?: string;
   ephemeral?: boolean;
+  checkpointing?: AgentSessionCheckpointing;
 } {
   if ('runConfig' in config) {
     return {
@@ -75,6 +86,7 @@ function normalizeConfig(config: AgentSessionConfig): {
       sessionPath: config.sessionPath,
       name: config.name,
       ephemeral: config.ephemeral,
+      checkpointing: config.checkpointing,
     };
   }
   const {
@@ -82,6 +94,7 @@ function normalizeConfig(config: AgentSessionConfig): {
     sessionPath,
     name,
     ephemeral,
+    checkpointing,
     sessionId: _sessionId,
     ...runConfig
   } = config;
@@ -94,6 +107,7 @@ function normalizeConfig(config: AgentSessionConfig): {
     sessionPath,
     name,
     ephemeral,
+    checkpointing,
   };
 }
 
@@ -174,6 +188,88 @@ function applyInitialSummaryToGraphConfig(
       graphConfig.initialSummary,
       initialSummary
     ),
+  };
+}
+
+interface SessionCheckpointingState {
+  checkpointer?: BaseCheckpointSaver;
+}
+
+function isCheckpointSaver(value: unknown): value is BaseCheckpointSaver {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<BaseCheckpointSaver>;
+  return (
+    typeof candidate.getTuple === 'function' &&
+    typeof candidate.list === 'function' &&
+    typeof candidate.put === 'function' &&
+    typeof candidate.putWrites === 'function' &&
+    typeof candidate.deleteThread === 'function'
+  );
+}
+
+function getGraphCheckpointer(
+  graphConfig: t.RunConfig['graphConfig']
+): BaseCheckpointSaver | undefined {
+  const checkpointer = graphConfig.compileOptions?.checkpointer;
+  return isCheckpointSaver(checkpointer) ? checkpointer : undefined;
+}
+
+function createCheckpointingState(
+  runConfig: t.RunConfig,
+  checkpointing: AgentSessionCheckpointing | undefined
+): SessionCheckpointingState {
+  const graphCheckpointer = getGraphCheckpointer(runConfig.graphConfig);
+  if (checkpointing === false) {
+    return { checkpointer: graphCheckpointer };
+  }
+  if (typeof checkpointing === 'object') {
+    if (checkpointing.enabled === false) {
+      return { checkpointer: graphCheckpointer };
+    }
+    return {
+      checkpointer:
+        checkpointing.checkpointer ?? graphCheckpointer ?? new MemorySaver(),
+    };
+  }
+  if (checkpointing === true || runConfig.humanInTheLoop?.enabled === true) {
+    return { checkpointer: graphCheckpointer ?? new MemorySaver() };
+  }
+  return { checkpointer: graphCheckpointer };
+}
+
+function applyCheckpointerToGraphConfig(
+  graphConfig: t.RunConfig['graphConfig'],
+  checkpointer: BaseCheckpointSaver | undefined
+): t.RunConfig['graphConfig'] {
+  if (!checkpointer) {
+    return graphConfig;
+  }
+  if (graphConfig.compileOptions?.checkpointer === checkpointer) {
+    return graphConfig;
+  }
+  return {
+    ...graphConfig,
+    compileOptions: {
+      ...(graphConfig.compileOptions ?? {}),
+      checkpointer,
+    },
+  };
+}
+
+function createCallerConfig(
+  threadId: string,
+  options: AgentSessionRunOptions
+): Partial<RunnableConfig> & { version: 'v1' | 'v2' } {
+  return {
+    recursionLimit: 50,
+    ...(options.config ?? {}),
+    configurable: {
+      ...(options.config?.configurable ?? {}),
+      thread_id: threadId,
+    },
+    version: options.config?.version ?? 'v2',
   };
 }
 
@@ -432,6 +528,7 @@ export class AgentSession {
   private runConfig: t.RunConfig;
   private store: JsonlSessionStore | undefined;
   private calibrationRatio: number | undefined;
+  private checkpointing: SessionCheckpointingState;
   cwd: string;
   threadId: string;
 
@@ -439,12 +536,14 @@ export class AgentSession {
     runConfig: t.RunConfig;
     cwd: string;
     threadId: string;
+    checkpointing: SessionCheckpointingState;
     store?: JsonlSessionStore;
   }) {
     this.runConfig = params.runConfig;
     this.cwd = params.cwd;
     this.threadId = params.threadId;
     this.store = params.store;
+    this.checkpointing = params.checkpointing;
   }
 
   static async create(config: AgentSessionConfig): Promise<AgentSession> {
@@ -464,6 +563,10 @@ export class AgentSession {
       runConfig: normalized.runConfig,
       cwd: normalized.cwd,
       threadId: store?.header.id ?? explicitSessionId ?? createSessionId(),
+      checkpointing: createCheckpointingState(
+        normalized.runConfig,
+        normalized.checkpointing
+      ),
       store,
     });
   }
@@ -476,6 +579,10 @@ export class AgentSession {
     return this.store;
   }
 
+  getCheckpointer(): BaseCheckpointSaver | undefined {
+    return this.checkpointing.checkpointer;
+  }
+
   private async runInternal(
     input: AgentSessionInput,
     options: AgentSessionRunOptions = {},
@@ -483,7 +590,9 @@ export class AgentSession {
   ): Promise<AgentSessionRunResult> {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
-    const inputMessages = normalizeInput(input);
+    const normalizedInput = normalizeInput(input);
+    const inputMessages = normalizedInput.messages;
+    const callerConfig = createCallerConfig(threadId, options);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     for (const message of inputMessages) {
       const entry = await this.store?.appendMessage(message, parentId);
@@ -521,9 +630,12 @@ export class AgentSession {
       const runConfig: t.RunConfig = {
         ...this.runConfig,
         runId,
-        graphConfig: applyInitialSummaryToGraphConfig(
-          this.runConfig.graphConfig,
-          sessionState.initialSummary
+        graphConfig: applyCheckpointerToGraphConfig(
+          applyInitialSummaryToGraphConfig(
+            this.runConfig.graphConfig,
+            sessionState.initialSummary
+          ),
+          this.checkpointing.checkpointer
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
@@ -534,17 +646,8 @@ export class AgentSession {
         sessionState.messages.length > 0
           ? sessionState.messages
           : inputMessages;
-      const callerConfig: Partial<RunnableConfig> & { version: 'v1' | 'v2' } = {
-        recursionLimit: 50,
-        ...(options.config ?? {}),
-        configurable: {
-          ...(options.config?.configurable ?? {}),
-          thread_id: threadId,
-        },
-        version: options.config?.version ?? 'v2',
-      };
       const content = await run.processStream(
-        { messages },
+        { ...normalizedInput.state, messages },
         callerConfig,
         options.streamOptions
       );
@@ -655,6 +758,7 @@ export class AgentSession {
       runConfig: this.runConfig,
       cwd: store.header.cwd,
       threadId: store.header.id,
+      checkpointing: this.checkpointing,
       store,
     });
   }
@@ -671,6 +775,7 @@ export class AgentSession {
       runConfig: this.runConfig,
       cwd: store.header.cwd,
       threadId: store.header.id,
+      checkpointing: this.checkpointing,
       store,
     });
   }
@@ -786,6 +891,7 @@ export class AgentSession {
   ): Promise<AgentSessionRunResult> {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
+    const callerConfig = createCallerConfig(threadId, options);
     const handlerResult = createRunHandlers({
       runId,
       threadId,
@@ -794,18 +900,15 @@ export class AgentSession {
     const run = await Run.create<t.IState>({
       ...this.runConfig,
       runId,
+      graphConfig: applyCheckpointerToGraphConfig(
+        this.runConfig.graphConfig,
+        this.checkpointing.checkpointer
+      ),
       returnContent: true,
       calibrationRatio: this.calibrationRatio,
       customHandlers: handlerResult.handlers,
     });
-    const content = await run.resume(resumeValue, {
-      ...(options.config ?? {}),
-      configurable: {
-        ...(options.config?.configurable ?? {}),
-        thread_id: threadId,
-      },
-      version: options.config?.version ?? 'v2',
-    });
+    const content = await run.resume(resumeValue, callerConfig);
     const runMessages = run.getRunMessages() ?? [];
     for (const message of runMessages) {
       await this.store?.appendMessage(message);

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1,11 +1,16 @@
 import { MemorySaver } from '@langchain/langgraph';
 import { HumanMessage, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
-import type { BaseCheckpointSaver } from '@langchain/langgraph';
+import type {
+  BaseCheckpointSaver,
+  CheckpointTuple,
+} from '@langchain/langgraph';
 import type { HookRegistry } from '@/hooks';
 import type {
   AgentSessionConfig,
   AgentSessionCheckpointing,
+  AgentSessionCheckpointLookupOptions,
+  AgentSessionCheckpointReference,
   AgentSessionInput,
   AgentSessionRunOptions,
   AgentSessionRunResult,
@@ -208,6 +213,7 @@ function applyInitialSummaryToGraphConfig(
 }
 
 interface SessionCheckpointingState {
+  enabled: boolean;
   checkpointer?: BaseCheckpointSaver;
 }
 
@@ -238,21 +244,34 @@ function createCheckpointingState(
 ): SessionCheckpointingState {
   const graphCheckpointer = getGraphCheckpointer(runConfig.graphConfig);
   if (checkpointing === false) {
-    return { checkpointer: graphCheckpointer };
+    return {
+      enabled: false,
+      checkpointer: graphCheckpointer,
+    };
   }
   if (typeof checkpointing === 'object') {
     if (checkpointing.enabled === false) {
-      return { checkpointer: graphCheckpointer };
+      return {
+        enabled: false,
+        checkpointer: graphCheckpointer,
+      };
     }
     return {
+      enabled: true,
       checkpointer:
         checkpointing.checkpointer ?? graphCheckpointer ?? new MemorySaver(),
     };
   }
   if (checkpointing === true || runConfig.humanInTheLoop?.enabled === true) {
-    return { checkpointer: graphCheckpointer ?? new MemorySaver() };
+    return {
+      enabled: true,
+      checkpointer: graphCheckpointer ?? new MemorySaver(),
+    };
   }
-  return { checkpointer: graphCheckpointer };
+  return {
+    enabled: graphCheckpointer != null,
+    checkpointer: graphCheckpointer,
+  };
 }
 
 function applyCheckpointerToGraphConfig(
@@ -274,10 +293,21 @@ function applyCheckpointerToGraphConfig(
   };
 }
 
+function getConfigString(
+  config: RunnableConfig | undefined,
+  key: string
+): string | undefined {
+  const configurable = config?.configurable as
+    | Partial<Record<string, unknown>>
+    | undefined;
+  const value = configurable?.[key];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
 function createCallerConfig(
   threadId: string,
   options: AgentSessionRunOptions
-): Partial<RunnableConfig> & { version: 'v1' | 'v2' } {
+): RunnableConfig & { version: 'v1' | 'v2' } {
   return {
     recursionLimit: 50,
     ...(options.config ?? {}),
@@ -286,6 +316,78 @@ function createCallerConfig(
       thread_id: threadId,
     },
     version: options.config?.version ?? 'v2',
+  };
+}
+
+function createCheckpointLookupConfig(config: RunnableConfig): RunnableConfig {
+  const threadId = getConfigString(config, 'thread_id');
+  if (threadId == null) {
+    return config;
+  }
+  const checkpointNs = getConfigString(config, 'checkpoint_ns') ?? '';
+  const checkpointId = getConfigString(config, 'checkpoint_id');
+  return {
+    configurable: {
+      ...config.configurable,
+      thread_id: threadId,
+      checkpoint_ns: checkpointNs,
+      ...(checkpointId != null ? { checkpoint_id: checkpointId } : {}),
+    },
+  };
+}
+
+function createLatestCheckpointLookupConfig(
+  config: RunnableConfig
+): RunnableConfig {
+  const lookup = createCheckpointLookupConfig(config);
+  const { checkpoint_id: _checkpointId, ...configurable } =
+    lookup.configurable ?? {};
+  return { configurable };
+}
+
+async function getLatestCheckpointTuple(
+  checkpointer: BaseCheckpointSaver | undefined,
+  config: RunnableConfig
+): Promise<CheckpointTuple | undefined> {
+  if (!checkpointer) {
+    return undefined;
+  }
+  const lookupConfig = createLatestCheckpointLookupConfig(config);
+  const tuple = await checkpointer.getTuple(lookupConfig);
+  if (tuple) {
+    return tuple;
+  }
+  for await (const checkpoint of checkpointer.list(lookupConfig, {
+    limit: 1,
+  })) {
+    return checkpoint;
+  }
+  return undefined;
+}
+
+async function getSelectedCheckpointTuple(
+  checkpointer: BaseCheckpointSaver | undefined,
+  config: RunnableConfig
+): Promise<CheckpointTuple | undefined> {
+  return checkpointer?.getTuple(createCheckpointLookupConfig(config));
+}
+
+function createCheckpointReference(params: {
+  threadId: string;
+  tuple: CheckpointTuple;
+}): AgentSessionCheckpointReference {
+  const checkpointNs =
+    getConfigString(params.tuple.config, 'checkpoint_ns') ?? '';
+  const parentCheckpointId = getConfigString(
+    params.tuple.parentConfig,
+    'checkpoint_id'
+  );
+  return {
+    provider: 'langgraph',
+    threadId: params.threadId,
+    checkpointId: params.tuple.checkpoint.id,
+    checkpointNs,
+    ...(parentCheckpointId != null ? { parentCheckpointId } : {}),
   };
 }
 
@@ -614,6 +716,92 @@ export class AgentSession {
     return this.checkpointing.checkpointer;
   }
 
+  async getLatestCheckpoint(
+    options: AgentSessionCheckpointLookupOptions = {}
+  ): Promise<AgentSessionCheckpointReference | undefined> {
+    const threadId = options.threadId ?? this.threadId;
+    const baseConfig = options.config ?? {};
+    const config = createCheckpointLookupConfig({
+      ...baseConfig,
+      configurable: {
+        ...(baseConfig.configurable ?? {}),
+        thread_id: threadId,
+        ...(options.checkpointNs != null
+          ? { checkpoint_ns: options.checkpointNs }
+          : {}),
+      },
+    });
+    const tuple = await getLatestCheckpointTuple(
+      this.checkpointing.checkpointer,
+      config
+    );
+    return tuple ? createCheckpointReference({ threadId, tuple }) : undefined;
+  }
+
+  private async hasCheckpointState(config: RunnableConfig): Promise<boolean> {
+    if (!this.checkpointing.enabled) {
+      return false;
+    }
+    const tuple = await getSelectedCheckpointTuple(
+      this.checkpointing.checkpointer,
+      config
+    );
+    return tuple != null;
+  }
+
+  private async recordCheckpoint(params: {
+    source: 'run' | 'resume';
+    runId: string;
+    threadId: string;
+    config: RunnableConfig;
+  }): Promise<void> {
+    if (!this.checkpointing.enabled) {
+      return;
+    }
+    const tuple = await getLatestCheckpointTuple(
+      this.checkpointing.checkpointer,
+      params.config
+    );
+    if (!tuple) {
+      return;
+    }
+    const reference = createCheckpointReference({
+      threadId: params.threadId,
+      tuple,
+    });
+    await this.store?.appendCheckpoint({
+      source: params.source,
+      runId: params.runId,
+      threadId: params.threadId,
+      checkpointId: reference.checkpointId,
+      checkpointNs: reference.checkpointNs,
+      parentCheckpointId: reference.parentCheckpointId,
+    });
+  }
+
+  private getCheckpointThreadIds(): string[] {
+    const threadIds = new Set<string>([this.threadId]);
+    for (const checkpoint of this.store?.getCheckpoints() ?? []) {
+      threadIds.add(checkpoint.data.threadId);
+    }
+    return [...threadIds];
+  }
+
+  private async resetCheckpointThreads(reason: string): Promise<void> {
+    const checkpointer = this.checkpointing.checkpointer;
+    if (!this.checkpointing.enabled || checkpointer == null) {
+      return;
+    }
+    for (const threadId of this.getCheckpointThreadIds()) {
+      await checkpointer.deleteThread(threadId);
+      await this.store?.appendCheckpoint({
+        source: 'reset',
+        threadId,
+        reason,
+      });
+    }
+  }
+
   private async runInternal(
     input: AgentSessionInput,
     options: AgentSessionRunOptions = {},
@@ -624,6 +812,7 @@ export class AgentSession {
     const normalizedInput = normalizeInput(input);
     const inputMessages = normalizedInput.messages;
     const callerConfig = createCallerConfig(threadId, options);
+    const useCheckpointState = await this.hasCheckpointState(callerConfig);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     for (const message of inputMessages) {
       const entry = await this.store?.appendMessage(message, parentId);
@@ -673,10 +862,10 @@ export class AgentSession {
         customHandlers: handlerResult.handlers,
       };
       const run = await Run.create<t.IState>(runConfig);
-      const messages =
-        sessionState.messages.length > 0
-          ? sessionState.messages
-          : inputMessages;
+      let messages = inputMessages;
+      if (!useCheckpointState && sessionState.messages.length > 0) {
+        messages = sessionState.messages;
+      }
       const content = await run.processStream(
         { ...normalizedInput.state, messages },
         callerConfig,
@@ -708,6 +897,12 @@ export class AgentSession {
           threadId,
         });
       }
+      await this.recordCheckpoint({
+        source: 'run',
+        runId,
+        threadId,
+        config: callerConfig,
+      });
       const contentParts = (content ?? handlerResult.contentParts).filter(
         (part): part is t.MessageContentComplex => part != null
       );
@@ -730,6 +925,12 @@ export class AgentSession {
       await this.store?.appendRunEvent('run.failed', error, {
         runId,
         threadId,
+      });
+      await this.recordCheckpoint({
+        source: 'run',
+        runId,
+        threadId,
+        config: callerConfig,
       });
       throw error;
     }
@@ -824,6 +1025,7 @@ export class AgentSession {
       entryId,
       options.position ?? 'at'
     );
+    const previousLeafId = store.getLeafEntry()?.id ?? null;
     let leafId = target?.id ?? null;
     const summarizeAbandoned = options.summarizeAbandoned;
     if (summarizeAbandoned !== undefined && summarizeAbandoned !== false) {
@@ -837,11 +1039,18 @@ export class AgentSession {
       );
       leafId = summary?.id ?? leafId;
     }
+    if (leafId === previousLeafId) {
+      return;
+    }
     await store.setLeaf(leafId);
+    await this.resetCheckpointThreads('branch');
   }
 
   async compact(options: SessionCompactOptions = {}): Promise<void> {
-    await this.compactActivePath(options, null);
+    const summary = await this.compactActivePath(options, null);
+    if (summary) {
+      await this.resetCheckpointThreads('compact');
+    }
   }
 
   private async compactActivePath(
@@ -945,42 +1154,88 @@ export class AgentSession {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
     const callerConfig = createCallerConfig(threadId, options);
+    await this.store?.appendRunEvent('run.started', undefined, {
+      runId,
+      threadId,
+    });
     const handlerResult = createRunHandlers({
       runId,
       threadId,
       userHandlers: this.runConfig.customHandlers,
     });
-    const run = await Run.create<t.IState>({
-      ...this.runConfig,
-      runId,
-      graphConfig: applyCheckpointerToGraphConfig(
-        this.runConfig.graphConfig,
-        this.checkpointing.checkpointer
-      ),
-      returnContent: true,
-      calibrationRatio: this.calibrationRatio,
-      customHandlers: handlerResult.handlers,
-    });
-    const content = await run.resume(resumeValue, callerConfig);
-    const runMessages = run.getRunMessages() ?? [];
-    for (const message of runMessages) {
-      await this.store?.appendMessage(message);
+    const sessionState = createSessionRunState(this.store?.getPath() ?? []);
+    try {
+      const run = await Run.create<t.IState>({
+        ...this.runConfig,
+        runId,
+        graphConfig: applyCheckpointerToGraphConfig(
+          applyInitialSummaryToGraphConfig(
+            this.runConfig.graphConfig,
+            sessionState.initialSummary
+          ),
+          this.checkpointing.checkpointer
+        ),
+        returnContent: true,
+        calibrationRatio: this.calibrationRatio,
+        customHandlers: handlerResult.handlers,
+      });
+      const content = await run.resume(resumeValue, callerConfig);
+      const runMessages = run.getRunMessages() ?? [];
+      for (const message of runMessages) {
+        await this.store?.appendMessage(message);
+      }
+      this.calibrationRatio = run.getCalibrationRatio();
+      const interrupt = run.getInterrupt();
+      const haltedReason = run.getHaltReason();
+      if (interrupt) {
+        await this.store?.appendRunEvent('run.interrupted', interrupt, {
+          runId,
+          threadId,
+        });
+      } else if (haltedReason != null && haltedReason !== '') {
+        await this.store?.appendRunEvent('run.halted', haltedReason, {
+          runId,
+          threadId,
+        });
+      } else {
+        await this.store?.appendRunEvent('run.completed', undefined, {
+          runId,
+          threadId,
+        });
+      }
+      await this.recordCheckpoint({
+        source: 'resume',
+        runId,
+        threadId,
+        config: callerConfig,
+      });
+      const contentParts = (content ?? handlerResult.contentParts).filter(
+        (part): part is t.MessageContentComplex => part != null
+      );
+      return {
+        text: contentToText(contentParts),
+        content: contentParts,
+        messages: runMessages,
+        usage: handlerResult.usage,
+        steps: handlerResult.steps,
+        interrupt,
+        haltedReason,
+        runId,
+        threadId,
+      };
+    } catch (error) {
+      await this.store?.appendRunEvent('run.failed', error, {
+        runId,
+        threadId,
+      });
+      await this.recordCheckpoint({
+        source: 'resume',
+        runId,
+        threadId,
+        config: callerConfig,
+      });
+      throw error;
     }
-    this.calibrationRatio = run.getCalibrationRatio();
-    const contentParts = (content ?? handlerResult.contentParts).filter(
-      (part): part is t.MessageContentComplex => part != null
-    );
-    return {
-      text: contentToText(contentParts),
-      content: contentParts,
-      messages: runMessages,
-      usage: handlerResult.usage,
-      steps: handlerResult.steps,
-      interrupt: run.getInterrupt(),
-      haltedReason: run.getHaltReason(),
-      runId,
-      threadId,
-    };
   }
 }
 

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -301,6 +301,21 @@ function isMessageEntry(
   return entry.type === 'message';
 }
 
+function getSessionBranchTarget(
+  store: JsonlSessionStore,
+  entryId: string,
+  position: 'before' | 'at'
+): SessionEntry | undefined {
+  const entry = store.getEntry(entryId);
+  if (!entry) {
+    throw new Error(`Entry not found: ${entryId}`);
+  }
+  if (position === 'at') {
+    return entry;
+  }
+  return entry.parentId == null ? undefined : store.getEntry(entry.parentId);
+}
+
 function createAgentInputFromGraphConfig(
   graphConfig: t.RunConfig['graphConfig'],
   initialSummary: InitialSummary | undefined,
@@ -784,21 +799,39 @@ export class AgentSession {
     entryId: string,
     options: SessionBranchOptions = {}
   ): Promise<void> {
-    if (!this.store) {
+    const store = this.store;
+    if (!store) {
       throw new Error('Cannot branch an ephemeral session');
     }
+    const target = getSessionBranchTarget(
+      store,
+      entryId,
+      options.position ?? 'at'
+    );
+    let leafId = target?.id ?? null;
     const summarizeAbandoned = options.summarizeAbandoned;
     if (summarizeAbandoned !== undefined && summarizeAbandoned !== false) {
       const instructions =
         typeof summarizeAbandoned === 'object'
           ? summarizeAbandoned.instructions
           : undefined;
-      await this.compact({ instructions, retainRecentTurns: 0 });
+      const summary = await this.compactActivePath(
+        { instructions, retainRecentTurns: 0 },
+        leafId
+      );
+      leafId = summary?.id ?? leafId;
     }
-    await this.store.branch(entryId, options);
+    await store.setLeaf(leafId);
   }
 
   async compact(options: SessionCompactOptions = {}): Promise<void> {
+    await this.compactActivePath(options, null);
+  }
+
+  private async compactActivePath(
+    options: SessionCompactOptions = {},
+    parentId: string | null
+  ): Promise<Extract<SessionEntry, { type: 'summary' }> | undefined> {
     const store = this.store;
     if (!store) {
       throw new Error('Cannot compact an ephemeral session');
@@ -807,7 +840,7 @@ export class AgentSession {
     const sessionState = createSessionRunState(activePath);
     const messageEntries = activePath.filter(isMessageEntry);
     if (sessionState.messages.length === 0) {
-      return;
+      return undefined;
     }
     const compactRunId = createRunId();
     const agentContext = AgentContext.fromConfig(
@@ -851,7 +884,7 @@ export class AgentSession {
       summaryText = contextSummaryText;
     }
     if (summaryText === '') {
-      return;
+      return undefined;
     }
     const retainedMessages = filterRemoveMessages(
       summarizedState.messages ?? []
@@ -871,18 +904,22 @@ export class AgentSession {
       retainedEntryIds,
       summarizedEntryIds: summarized.map((entry) => entry.id),
       instructions: options.instructions,
-      parentId: null,
+      parentId,
     });
-    let parentId: string | null = summary.id;
+    let retainedParentId: string | null = summary.id;
     for (const message of retainedMessages) {
-      const retainedMessage = await store.appendMessage(message, parentId);
-      parentId = retainedMessage.id;
+      const retainedMessage = await store.appendMessage(
+        message,
+        retainedParentId
+      );
+      retainedParentId = retainedMessage.id;
     }
     await store.appendCompactionEntry({
       summaryEntryId: summary.id,
       retainedEntryIds,
       summarizedEntryIds: summarized.map((entry) => entry.id),
     });
+    return summary;
   }
 
   async resumeInterrupt<TResume>(

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -434,6 +434,17 @@ function getSessionBranchTarget(
   return entry.parentId == null ? undefined : store.getEntry(entry.parentId);
 }
 
+function getPathAfterEntry(
+  path: SessionEntry[],
+  entryId: string | null
+): SessionEntry[] {
+  if (entryId == null) {
+    return path;
+  }
+  const index = path.findIndex((entry) => entry.id === entryId);
+  return index === -1 ? [] : path.slice(index + 1);
+}
+
 function createAgentInputFromGraphConfig(
   graphConfig: t.RunConfig['graphConfig'],
   initialSummary: InitialSummary | undefined,
@@ -1033,9 +1044,14 @@ export class AgentSession {
         typeof summarizeAbandoned === 'object'
           ? summarizeAbandoned.instructions
           : undefined;
+      const abandonedPath = getPathAfterEntry(
+        store.getPath(previousLeafId ?? undefined),
+        leafId
+      );
       const summary = await this.compactActivePath(
         { instructions, retainRecentTurns: 0 },
-        leafId
+        leafId,
+        abandonedPath
       );
       leafId = summary?.id ?? leafId;
     }
@@ -1055,13 +1071,14 @@ export class AgentSession {
 
   private async compactActivePath(
     options: SessionCompactOptions = {},
-    parentId: string | null
+    parentId: string | null,
+    path?: SessionEntry[]
   ): Promise<Extract<SessionEntry, { type: 'summary' }> | undefined> {
     const store = this.store;
     if (!store) {
       throw new Error('Cannot compact an ephemeral session');
     }
-    const activePath = store.getPath();
+    const activePath = path ?? store.getPath();
     const sessionState = createSessionRunState(activePath);
     const messageEntries = activePath.filter(isMessageEntry);
     if (sessionState.messages.length === 0) {

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -434,15 +434,25 @@ function getSessionBranchTarget(
   return entry.parentId == null ? undefined : store.getEntry(entry.parentId);
 }
 
-function getPathAfterEntry(
-  path: SessionEntry[],
-  entryId: string | null
+function getAbandonedPathForBranch(
+  store: JsonlSessionStore,
+  previousLeafId: string | null,
+  targetLeafId: string | null
 ): SessionEntry[] {
-  if (entryId == null) {
-    return path;
+  const previousPath = store.getPath(previousLeafId ?? undefined);
+  if (previousPath.length === 0) {
+    return [];
   }
-  const index = path.findIndex((entry) => entry.id === entryId);
-  return index === -1 ? [] : path.slice(index + 1);
+  const targetPath = targetLeafId == null ? [] : store.getPath(targetLeafId);
+  const maxSharedLength = Math.min(previousPath.length, targetPath.length);
+  let sharedLength = 0;
+  while (
+    sharedLength < maxSharedLength &&
+    previousPath[sharedLength].id === targetPath[sharedLength].id
+  ) {
+    sharedLength++;
+  }
+  return previousPath.slice(sharedLength);
 }
 
 function createAgentInputFromGraphConfig(
@@ -870,7 +880,10 @@ export class AgentSession {
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
-        customHandlers: handlerResult.handlers,
+        customHandlers: {
+          ...(this.runConfig.customHandlers ?? {}),
+          ...handlerResult.handlers,
+        },
       };
       const run = await Run.create<t.IState>(runConfig);
       let messages = inputMessages;
@@ -1044,8 +1057,9 @@ export class AgentSession {
         typeof summarizeAbandoned === 'object'
           ? summarizeAbandoned.instructions
           : undefined;
-      const abandonedPath = getPathAfterEntry(
-        store.getPath(previousLeafId ?? undefined),
+      const abandonedPath = getAbandonedPathForBranch(
+        store,
+        previousLeafId,
         leafId
       );
       const summary = await this.compactActivePath(
@@ -1194,7 +1208,10 @@ export class AgentSession {
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
-        customHandlers: handlerResult.handlers,
+        customHandlers: {
+          ...(this.runConfig.customHandlers ?? {}),
+          ...handlerResult.handlers,
+        },
       });
       const content = await run.resume(resumeValue, callerConfig);
       const runMessages = run.getRunMessages() ?? [];

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -111,6 +111,19 @@ function normalizeConfig(config: AgentSessionConfig): {
   };
 }
 
+function isMissingSessionError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if (error.message.startsWith('Session not found:')) {
+    return true;
+  }
+  if (!('code' in error)) {
+    return false;
+  }
+  return (error as { code?: string }).code === 'ENOENT';
+}
+
 async function createStore(params: {
   cwd: string;
   sessionPath?: string;
@@ -122,14 +135,19 @@ async function createStore(params: {
     return undefined;
   }
   if (params.sessionPath != null && params.sessionPath !== '') {
-    return JsonlSessionStore.open(params.sessionPath).catch(() =>
-      JsonlSessionStore.create({
+    try {
+      return await JsonlSessionStore.open(params.sessionPath);
+    } catch (error) {
+      if (!isMissingSessionError(error)) {
+        throw error;
+      }
+      return JsonlSessionStore.create({
         path: params.sessionPath,
         cwd: params.cwd,
         name: params.name,
         sessionId: params.sessionId,
-      })
-    );
+      });
+    }
   }
   return JsonlSessionStore.create({
     cwd: params.cwd,

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -215,6 +215,7 @@ function applyInitialSummaryToGraphConfig(
 interface SessionCheckpointingState {
   enabled: boolean;
   checkpointer?: BaseCheckpointSaver;
+  disableGraphCheckpointer?: boolean;
 }
 
 function isCheckpointSaver(value: unknown): value is BaseCheckpointSaver {
@@ -246,14 +247,14 @@ function createCheckpointingState(
   if (checkpointing === false) {
     return {
       enabled: false,
-      checkpointer: graphCheckpointer,
+      disableGraphCheckpointer: true,
     };
   }
   if (typeof checkpointing === 'object') {
     if (checkpointing.enabled === false) {
       return {
         enabled: false,
-        checkpointer: graphCheckpointer,
+        disableGraphCheckpointer: true,
       };
     }
     return {
@@ -274,6 +275,20 @@ function createCheckpointingState(
   };
 }
 
+function removeCheckpointerFromGraphConfig(
+  graphConfig: t.RunConfig['graphConfig']
+): t.RunConfig['graphConfig'] {
+  if (graphConfig.compileOptions?.checkpointer == null) {
+    return graphConfig;
+  }
+  const { checkpointer: _checkpointer, ...compileOptions } =
+    graphConfig.compileOptions;
+  return {
+    ...graphConfig,
+    compileOptions,
+  };
+}
+
 function applyCheckpointerToGraphConfig(
   graphConfig: t.RunConfig['graphConfig'],
   checkpointer: BaseCheckpointSaver | undefined
@@ -291,6 +306,19 @@ function applyCheckpointerToGraphConfig(
       checkpointer,
     },
   };
+}
+
+function applyCheckpointingToGraphConfig(
+  graphConfig: t.RunConfig['graphConfig'],
+  checkpointing: SessionCheckpointingState
+): t.RunConfig['graphConfig'] {
+  if (checkpointing.disableGraphCheckpointer === true) {
+    return removeCheckpointerFromGraphConfig(graphConfig);
+  }
+  return applyCheckpointerToGraphConfig(
+    graphConfig,
+    checkpointing.checkpointer
+  );
 }
 
 function getConfigString(
@@ -830,14 +858,17 @@ export class AgentSession {
   ): Promise<AgentSessionRunResult> {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
+    const isSessionThread = threadId === this.threadId;
     const normalizedInput = normalizeInput(input);
     const inputMessages = normalizedInput.messages;
     const callerConfig = createCallerConfig(threadId, options);
     const useCheckpointState = await this.hasCheckpointState(callerConfig);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
-    for (const message of inputMessages) {
-      const entry = await this.store?.appendMessage(message, parentId);
-      parentId = entry?.id ?? parentId;
+    if (isSessionThread) {
+      for (const message of inputMessages) {
+        const entry = await this.store?.appendMessage(message, parentId);
+        parentId = entry?.id ?? parentId;
+      }
     }
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
@@ -866,17 +897,19 @@ export class AgentSession {
       handlerResult.events.push(streamEvent);
       onEvent?.(streamEvent);
     };
-    const sessionState = createSessionRunState(this.store?.getPath() ?? []);
+    const sessionState = createSessionRunState(
+      isSessionThread ? (this.store?.getPath() ?? []) : []
+    );
     try {
       const runConfig: t.RunConfig = {
         ...this.runConfig,
         runId,
-        graphConfig: applyCheckpointerToGraphConfig(
+        graphConfig: applyCheckpointingToGraphConfig(
           applyInitialSummaryToGraphConfig(
             this.runConfig.graphConfig,
             sessionState.initialSummary
           ),
-          this.checkpointing.checkpointer
+          this.checkpointing
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
@@ -896,8 +929,10 @@ export class AgentSession {
         options.streamOptions
       );
       const runMessages = run.getRunMessages() ?? [];
-      for (const message of runMessages) {
-        await this.store?.appendMessage(message);
+      if (isSessionThread) {
+        for (const message of runMessages) {
+          await this.store?.appendMessage(message);
+        }
       }
       this.calibrationRatio = run.getCalibrationRatio();
       const interrupt = run.getInterrupt();
@@ -1199,12 +1234,12 @@ export class AgentSession {
       const run = await Run.create<t.IState>({
         ...this.runConfig,
         runId,
-        graphConfig: applyCheckpointerToGraphConfig(
+        graphConfig: applyCheckpointingToGraphConfig(
           applyInitialSummaryToGraphConfig(
             this.runConfig.graphConfig,
             sessionState.initialSummary
           ),
-          this.checkpointing.checkpointer
+          this.checkpointing
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -429,7 +429,11 @@ function createSessionRunState(entries: SessionEntry[]): {
     if (entry.type === 'summary') {
       initialSummary = {
         text: entry.data.text,
-        tokenCount: 0,
+        tokenCount:
+          typeof entry.data.tokenCount === 'number' &&
+          Number.isFinite(entry.data.tokenCount)
+            ? entry.data.tokenCount
+            : 0,
       };
       messages.length = 0;
       continue;
@@ -586,6 +590,15 @@ function getSummaryText(summary: t.SummaryContentBlock | undefined): string {
     typeof firstBlock.text === 'string'
     ? firstBlock.text
     : '';
+}
+
+function getSummaryTokenCount(
+  summary: t.SummaryContentBlock | undefined
+): number {
+  return typeof summary?.tokenCount === 'number' &&
+    Number.isFinite(summary.tokenCount)
+    ? summary.tokenCount
+    : 0;
 }
 
 function filterRemoveMessages(messages: BaseMessage[]): BaseMessage[] {
@@ -1140,7 +1153,8 @@ export class AgentSession {
         sessionState.initialSummary,
         options.retainRecentTurns,
         options.instructions
-      )
+      ),
+      this.runConfig.tokenCounter
     );
     const graph = createManualCompactGraph({
       runId: compactRunId,
@@ -1192,6 +1206,7 @@ export class AgentSession {
     );
     const summary = await store.appendEntryForCompaction({
       text: summaryText,
+      tokenCount: getSummaryTokenCount(graph.completedSummary),
       retainedEntryIds,
       summarizedEntryIds: summarized.map((entry) => entry.id),
       instructions: options.instructions,

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1219,6 +1219,7 @@ export class AgentSession {
   ): Promise<AgentSessionRunResult> {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
+    const isSessionThread = threadId === this.threadId;
     const callerConfig = createCallerConfig(threadId, options);
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
@@ -1229,7 +1230,9 @@ export class AgentSession {
       threadId,
       userHandlers: this.runConfig.customHandlers,
     });
-    const sessionState = createSessionRunState(this.store?.getPath() ?? []);
+    const sessionState = createSessionRunState(
+      isSessionThread ? (this.store?.getPath() ?? []) : []
+    );
     try {
       const run = await Run.create<t.IState>({
         ...this.runConfig,
@@ -1250,8 +1253,10 @@ export class AgentSession {
       });
       const content = await run.resume(resumeValue, callerConfig);
       const runMessages = run.getRunMessages() ?? [];
-      for (const message of runMessages) {
-        await this.store?.appendMessage(message);
+      if (isSessionThread) {
+        for (const message of runMessages) {
+          await this.store?.appendMessage(message);
+        }
       }
       this.calibrationRatio = run.getCalibrationRatio();
       const interrupt = run.getInterrupt();

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -751,9 +751,12 @@ export class AgentSession {
     const retainedMessages = filterRemoveMessages(
       summarizedState.messages ?? []
     );
-    const retainedEntryIds = messageEntries
-      .slice(-retainedMessages.length)
-      .map((entry) => entry.id);
+    let retainedEntryIds: string[] = [];
+    if (retainedMessages.length > 0) {
+      retainedEntryIds = messageEntries
+        .slice(-retainedMessages.length)
+        .map((entry) => entry.id);
+    }
     const retainedEntryIdSet = new Set(retainedEntryIds);
     const summarized = messageEntries.filter(
       (entry) => !retainedEntryIdSet.has(entry.id)
@@ -807,6 +810,7 @@ export class AgentSession {
     for (const message of runMessages) {
       await this.store?.appendMessage(message);
     }
+    this.calibrationRatio = run.getCalibrationRatio();
     const contentParts = (content ?? handlerResult.contentParts).filter(
       (part): part is t.MessageContentComplex => part != null
     );

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1,0 +1,831 @@
+import { HumanMessage, BaseMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { HookRegistry } from '@/hooks';
+import type {
+  AgentSessionConfig,
+  AgentSessionInput,
+  AgentSessionRunOptions,
+  AgentSessionRunResult,
+  AgentSessionStream,
+  AgentSessionStreamEvent,
+  SessionBranchOptions,
+  SessionCompactOptions,
+  SessionEntry,
+  SessionForkOptions,
+} from './types';
+import type * as t from '@/types';
+import { AgentContext } from '@/agents/AgentContext';
+import { ContentTypes, GraphEvents } from '@/common';
+import { Run } from '@/run';
+import { createRunId, createSessionId } from './ids';
+import { deserializeMessage } from './messageSerialization';
+import { JsonlSessionStore } from './JsonlSessionStore';
+import { createRunHandlers } from './handlers';
+import { createSummarizeNode } from '@/summarization/node';
+
+function isBaseMessage(value: unknown): value is BaseMessage {
+  return (
+    value instanceof BaseMessage ||
+    (value != null &&
+      typeof value === 'object' &&
+      '_getType' in value &&
+      typeof (value as { _getType?: unknown })._getType === 'function')
+  );
+}
+
+function normalizeInput(input: AgentSessionInput): BaseMessage[] {
+  if (typeof input === 'string') {
+    return [new HumanMessage(input)];
+  }
+  if (Array.isArray(input)) {
+    return input;
+  }
+  if (isBaseMessage(input)) {
+    return [input];
+  }
+  return input.messages;
+}
+
+function contentToText(
+  content: Array<t.MessageContentComplex | undefined>
+): string {
+  const chunks: string[] = [];
+  for (const part of content) {
+    if (!part) {
+      continue;
+    }
+    if (part.type === ContentTypes.TEXT && typeof part.text === 'string') {
+      chunks.push(part.text);
+    }
+  }
+  return chunks.join('');
+}
+
+function normalizeConfig(config: AgentSessionConfig): {
+  runConfig: t.RunConfig;
+  cwd: string;
+  sessionPath?: string;
+  name?: string;
+  ephemeral?: boolean;
+} {
+  if ('runConfig' in config) {
+    return {
+      runConfig: config.runConfig,
+      cwd: config.cwd ?? process.cwd(),
+      sessionPath: config.sessionPath,
+      name: config.name,
+      ephemeral: config.ephemeral,
+    };
+  }
+  const {
+    cwd,
+    sessionPath,
+    name,
+    ephemeral,
+    sessionId: _sessionId,
+    ...runConfig
+  } = config;
+  return {
+    runConfig: {
+      ...runConfig,
+      runId: config.runId ?? createRunId(),
+    },
+    cwd: cwd ?? process.cwd(),
+    sessionPath,
+    name,
+    ephemeral,
+  };
+}
+
+async function createStore(params: {
+  cwd: string;
+  sessionPath?: string;
+  name?: string;
+  sessionId?: string;
+  ephemeral?: boolean;
+}): Promise<JsonlSessionStore | undefined> {
+  if (params.ephemeral === true) {
+    return undefined;
+  }
+  if (params.sessionPath != null && params.sessionPath !== '') {
+    return JsonlSessionStore.open(params.sessionPath).catch(() =>
+      JsonlSessionStore.create({
+        path: params.sessionPath,
+        cwd: params.cwd,
+        name: params.name,
+        sessionId: params.sessionId,
+      })
+    );
+  }
+  return JsonlSessionStore.create({
+    cwd: params.cwd,
+    name: params.name,
+    sessionId: params.sessionId,
+  });
+}
+
+type InitialSummary = NonNullable<t.AgentInputs['initialSummary']>;
+
+function mergeInitialSummary(
+  existing: InitialSummary | undefined,
+  sessionSummary: InitialSummary | undefined
+): InitialSummary | undefined {
+  if (!existing) {
+    return sessionSummary;
+  }
+  if (!sessionSummary) {
+    return existing;
+  }
+  if (existing.text === sessionSummary.text) {
+    return existing;
+  }
+  return {
+    text: `${existing.text}\n\n${sessionSummary.text}`,
+    tokenCount: existing.tokenCount + sessionSummary.tokenCount,
+  };
+}
+
+function applyInitialSummaryToAgent(
+  agent: t.AgentInputs,
+  initialSummary: InitialSummary | undefined
+): t.AgentInputs {
+  const merged = mergeInitialSummary(agent.initialSummary, initialSummary);
+  return merged ? { ...agent, initialSummary: merged } : agent;
+}
+
+function applyInitialSummaryToGraphConfig(
+  graphConfig: t.RunConfig['graphConfig'],
+  initialSummary: InitialSummary | undefined
+): t.RunConfig['graphConfig'] {
+  if (!initialSummary) {
+    return graphConfig;
+  }
+  if ('agents' in graphConfig) {
+    return {
+      ...graphConfig,
+      agents: graphConfig.agents.map((agent) =>
+        applyInitialSummaryToAgent(agent, initialSummary)
+      ),
+    };
+  }
+  return {
+    ...graphConfig,
+    initialSummary: mergeInitialSummary(
+      graphConfig.initialSummary,
+      initialSummary
+    ),
+  };
+}
+
+function createSessionRunState(entries: SessionEntry[]): {
+  messages: BaseMessage[];
+  initialSummary?: InitialSummary;
+} {
+  const messages: BaseMessage[] = [];
+  let initialSummary: InitialSummary | undefined;
+  for (const entry of entries) {
+    if (entry.type === 'summary') {
+      initialSummary = {
+        text: entry.data.text,
+        tokenCount: 0,
+      };
+      messages.length = 0;
+      continue;
+    }
+    if (entry.type === 'message') {
+      messages.push(deserializeMessage(entry.data.message));
+    }
+  }
+  return { messages, initialSummary };
+}
+
+function isMessageEntry(
+  entry: SessionEntry
+): entry is Extract<SessionEntry, { type: 'message' }> {
+  return entry.type === 'message';
+}
+
+function createAgentInputFromGraphConfig(
+  graphConfig: t.RunConfig['graphConfig'],
+  initialSummary: InitialSummary | undefined,
+  retainRecentTurns: number | undefined,
+  instructions: string | undefined
+): t.AgentInputs {
+  let agent: t.AgentInputs;
+  if ('agents' in graphConfig) {
+    if (graphConfig.agents.length === 0) {
+      throw new Error('Cannot compact a session with no agents');
+    }
+    agent = graphConfig.agents[0];
+  } else {
+    const {
+      type: _type,
+      llmConfig,
+      signal: _signal,
+      tools = [],
+      ...agentInputs
+    } = graphConfig;
+    const { provider, ...clientOptions } = llmConfig;
+    agent = {
+      ...agentInputs,
+      tools,
+      provider,
+      clientOptions,
+      agentId: 'default',
+    };
+  }
+  const summarizationConfig: t.SummarizationConfig = {
+    ...(agent.summarizationConfig ?? {}),
+    ...(instructions != null && instructions !== ''
+      ? { prompt: instructions }
+      : {}),
+    retainRecent: {
+      ...(agent.summarizationConfig?.retainRecent ?? {}),
+      ...(retainRecentTurns != null ? { turns: retainRecentTurns } : {}),
+    },
+  };
+  return {
+    ...applyInitialSummaryToAgent(agent, initialSummary),
+    summarizationEnabled: true,
+    summarizationConfig,
+  };
+}
+
+function createManualCompactGraph(params: {
+  runId: string;
+  customHandlers?: Record<string, t.EventHandler>;
+  hooks?: HookRegistry;
+}): {
+  graph: Parameters<typeof createSummarizeNode>[0]['graph'];
+  completedSummary?: t.SummaryContentBlock;
+} {
+  const contentData: t.RunStep[] = [];
+  const contentIndexMap = new Map<string, number>();
+  const result: {
+    graph: Parameters<typeof createSummarizeNode>[0]['graph'];
+    completedSummary?: t.SummaryContentBlock;
+  } = {
+    graph: {
+      contentData,
+      contentIndexMap,
+      runId: params.runId,
+      isMultiAgent: false,
+      hookRegistry: params.hooks,
+      dispatchRunStep: async (runStep): Promise<void> => {
+        contentData.push(runStep);
+        contentIndexMap.set(runStep.id, runStep.index);
+        await params.customHandlers?.[GraphEvents.ON_RUN_STEP]?.handle(
+          GraphEvents.ON_RUN_STEP,
+          runStep
+        );
+      },
+      dispatchRunStepCompleted: async (stepId, completed): Promise<void> => {
+        const runStep = contentData.find((step) => step.id === stepId);
+        const resultWithStep = {
+          ...completed,
+          id: stepId,
+          index: runStep?.index ?? 0,
+        };
+        if (completed.type === 'summary') {
+          result.completedSummary = completed.summary;
+        }
+        await params.customHandlers?.[
+          GraphEvents.ON_RUN_STEP_COMPLETED
+        ]?.handle(GraphEvents.ON_RUN_STEP_COMPLETED, {
+          result: resultWithStep,
+        } as unknown as Parameters<t.EventHandler['handle']>[1]);
+      },
+    },
+  };
+  return result;
+}
+
+function getSummaryText(summary: t.SummaryContentBlock | undefined): string {
+  const firstBlock = summary?.content?.[0];
+  return firstBlock != null &&
+    typeof firstBlock === 'object' &&
+    'text' in firstBlock &&
+    typeof firstBlock.text === 'string'
+    ? firstBlock.text
+    : '';
+}
+
+function filterRemoveMessages(messages: BaseMessage[]): BaseMessage[] {
+  return messages.filter((message) => message._getType() !== 'remove');
+}
+
+class LiveAgentSessionStream implements AgentSessionStream {
+  private resultPromise: Promise<AgentSessionRunResult> | undefined;
+  private readonly events: AgentSessionStreamEvent[] = [];
+  private readonly waiters: Array<{
+    resolve: (result: IteratorResult<AgentSessionStreamEvent>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  private closed = false;
+  private failed = false;
+  private error: unknown;
+
+  setResultPromise(resultPromise: Promise<AgentSessionRunResult>): void {
+    this.resultPromise = resultPromise;
+  }
+
+  push(event: AgentSessionStreamEvent): void {
+    if (this.closed) {
+      return;
+    }
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve({ value: event, done: false });
+      return;
+    }
+    this.events.push(event);
+  }
+
+  complete(): void {
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.resolve({
+        value: undefined as unknown as AgentSessionStreamEvent,
+        done: true,
+      });
+    }
+  }
+
+  fail(error: unknown): void {
+    this.error = error;
+    this.failed = true;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(error);
+    }
+  }
+
+  private nextEvent(): Promise<IteratorResult<AgentSessionStreamEvent>> {
+    const event = this.events.shift();
+    if (event !== undefined) {
+      return Promise.resolve({ value: event, done: false });
+    }
+    if (this.failed) {
+      return Promise.reject(this.error);
+    }
+    if (this.closed) {
+      return Promise.resolve({
+        value: undefined as unknown as AgentSessionStreamEvent,
+        done: true,
+      });
+    }
+    return new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<AgentSessionStreamEvent> {
+    for (;;) {
+      const next = await this.nextEvent();
+      if (next.done === true) {
+        return;
+      }
+      yield next.value;
+    }
+  }
+
+  async *toTextStream(): AsyncIterable<string> {
+    for await (const event of this) {
+      if (event.type !== 'message.delta' || event.data == null) {
+        continue;
+      }
+      const data = event.data;
+      if (typeof data === 'object' && !Array.isArray(data)) {
+        const delta = data.delta;
+        if (
+          delta != null &&
+          typeof delta === 'object' &&
+          !Array.isArray(delta)
+        ) {
+          const content = delta.content;
+          if (Array.isArray(content)) {
+            for (const part of content) {
+              if (
+                part != null &&
+                typeof part === 'object' &&
+                !Array.isArray(part) &&
+                typeof part.text === 'string'
+              ) {
+                yield part.text;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  finalResult(): Promise<AgentSessionRunResult> {
+    if (!this.resultPromise) {
+      return Promise.reject(new Error('Session stream has not started'));
+    }
+    return this.resultPromise;
+  }
+}
+
+export class AgentSession {
+  private runConfig: t.RunConfig;
+  private store: JsonlSessionStore | undefined;
+  private calibrationRatio: number | undefined;
+  cwd: string;
+  threadId: string;
+
+  private constructor(params: {
+    runConfig: t.RunConfig;
+    cwd: string;
+    threadId: string;
+    store?: JsonlSessionStore;
+  }) {
+    this.runConfig = params.runConfig;
+    this.cwd = params.cwd;
+    this.threadId = params.threadId;
+    this.store = params.store;
+  }
+
+  static async create(config: AgentSessionConfig): Promise<AgentSession> {
+    const normalized = normalizeConfig(config);
+    const explicitSessionId =
+      'sessionId' in config && typeof config.sessionId === 'string'
+        ? config.sessionId
+        : undefined;
+    const store = await createStore({
+      cwd: normalized.cwd,
+      sessionPath: normalized.sessionPath,
+      name: normalized.name,
+      sessionId: explicitSessionId,
+      ephemeral: normalized.ephemeral,
+    });
+    return new AgentSession({
+      runConfig: normalized.runConfig,
+      cwd: normalized.cwd,
+      threadId: store?.header.id ?? explicitSessionId ?? createSessionId(),
+      store,
+    });
+  }
+
+  get sessionPath(): string | undefined {
+    return this.store?.path;
+  }
+
+  getSessionStore(): JsonlSessionStore | undefined {
+    return this.store;
+  }
+
+  private async runInternal(
+    input: AgentSessionInput,
+    options: AgentSessionRunOptions = {},
+    onEvent?: (event: AgentSessionStreamEvent) => void
+  ): Promise<AgentSessionRunResult> {
+    const runId = options.runId ?? createRunId();
+    const threadId = options.threadId ?? this.threadId;
+    const inputMessages = normalizeInput(input);
+    let parentId = this.store?.getLeafEntry()?.id ?? null;
+    for (const message of inputMessages) {
+      const entry = await this.store?.appendMessage(message, parentId);
+      parentId = entry?.id ?? parentId;
+    }
+    await this.store?.appendRunEvent('run.started', undefined, {
+      runId,
+      threadId,
+    });
+
+    const handlerResult = createRunHandlers({
+      runId,
+      threadId,
+      userHandlers: this.runConfig.customHandlers,
+      onEvent,
+    });
+    const emitTerminalEvent = (
+      event: Omit<
+        AgentSessionStreamEvent,
+        'sequence' | 'runId' | 'threadId' | 'timestamp'
+      >
+    ): void => {
+      const streamEvent: AgentSessionStreamEvent = {
+        ...event,
+        sequence: handlerResult.events.length,
+        runId,
+        threadId,
+        timestamp: new Date().toISOString(),
+      };
+      handlerResult.events.push(streamEvent);
+      onEvent?.(streamEvent);
+    };
+    const sessionState = createSessionRunState(this.store?.getPath() ?? []);
+    try {
+      const runConfig: t.RunConfig = {
+        ...this.runConfig,
+        runId,
+        graphConfig: applyInitialSummaryToGraphConfig(
+          this.runConfig.graphConfig,
+          sessionState.initialSummary
+        ),
+        returnContent: true,
+        calibrationRatio: this.calibrationRatio,
+        customHandlers: handlerResult.handlers,
+      };
+      const run = await Run.create<t.IState>(runConfig);
+      const messages =
+        sessionState.messages.length > 0
+          ? sessionState.messages
+          : inputMessages;
+      const callerConfig: Partial<RunnableConfig> & { version: 'v1' | 'v2' } = {
+        recursionLimit: 50,
+        ...(options.config ?? {}),
+        configurable: {
+          ...(options.config?.configurable ?? {}),
+          thread_id: threadId,
+        },
+        version: options.config?.version ?? 'v2',
+      };
+      const content = await run.processStream(
+        { messages },
+        callerConfig,
+        options.streamOptions
+      );
+      const runMessages = run.getRunMessages() ?? [];
+      for (const message of runMessages) {
+        await this.store?.appendMessage(message);
+      }
+      this.calibrationRatio = run.getCalibrationRatio();
+      const interrupt = run.getInterrupt();
+      const haltedReason = run.getHaltReason();
+      if (interrupt) {
+        emitTerminalEvent({ type: 'run.interrupted' });
+        await this.store?.appendRunEvent('run.interrupted', interrupt, {
+          runId,
+          threadId,
+        });
+      } else if (haltedReason != null && haltedReason !== '') {
+        emitTerminalEvent({ type: 'run.halted', data: haltedReason });
+        await this.store?.appendRunEvent('run.halted', haltedReason, {
+          runId,
+          threadId,
+        });
+      } else {
+        emitTerminalEvent({ type: 'run.completed' });
+        await this.store?.appendRunEvent('run.completed', undefined, {
+          runId,
+          threadId,
+        });
+      }
+      const contentParts = (content ?? handlerResult.contentParts).filter(
+        (part): part is t.MessageContentComplex => part != null
+      );
+      return {
+        text: contentToText(contentParts),
+        content: contentParts,
+        messages: runMessages,
+        usage: handlerResult.usage,
+        steps: handlerResult.steps,
+        interrupt,
+        haltedReason,
+        runId,
+        threadId,
+      };
+    } catch (error) {
+      emitTerminalEvent({
+        type: 'run.failed',
+        data: error instanceof Error ? error.message : String(error),
+      });
+      await this.store?.appendRunEvent('run.failed', error, {
+        runId,
+        threadId,
+      });
+      throw error;
+    }
+  }
+
+  async run(
+    input: AgentSessionInput,
+    options: AgentSessionRunOptions = {}
+  ): Promise<AgentSessionRunResult> {
+    return this.runInternal(input, options);
+  }
+
+  stream(
+    input: AgentSessionInput,
+    options: AgentSessionRunOptions = {}
+  ): AgentSessionStream {
+    const stream = new LiveAgentSessionStream();
+    const resultPromise = this.runInternal(input, options, (event) => {
+      stream.push(event);
+    }).then(
+      (result) => {
+        stream.complete();
+        return result;
+      },
+      (error: unknown) => {
+        stream.fail(error);
+        throw error;
+      }
+    );
+    stream.setResultPromise(resultPromise);
+    return stream;
+  }
+
+  async resumeSession(pathOrId?: string): Promise<AgentSession> {
+    if (pathOrId == null || pathOrId === '') {
+      const sessions = await JsonlSessionStore.list(this.cwd);
+      if (sessions.length === 0) {
+        throw new Error(`No sessions found for ${this.cwd}`);
+      }
+      this.store = await JsonlSessionStore.open(sessions[0].path);
+      this.cwd = this.store.header.cwd;
+      this.threadId = this.store.header.id;
+      return this;
+    }
+    this.store = await JsonlSessionStore.open(pathOrId);
+    this.cwd = this.store.header.cwd;
+    this.threadId = this.store.header.id;
+    return this;
+  }
+
+  async clone(options: SessionForkOptions = {}): Promise<AgentSession> {
+    if (!this.store) {
+      throw new Error('Cannot clone an ephemeral session');
+    }
+    const store = await this.store.clone(options);
+    return new AgentSession({
+      runConfig: this.runConfig,
+      cwd: store.header.cwd,
+      threadId: store.header.id,
+      store,
+    });
+  }
+
+  async fork(
+    entryId: string,
+    options: SessionForkOptions = {}
+  ): Promise<AgentSession> {
+    if (!this.store) {
+      throw new Error('Cannot fork an ephemeral session');
+    }
+    const store = await this.store.fork(entryId, options);
+    return new AgentSession({
+      runConfig: this.runConfig,
+      cwd: store.header.cwd,
+      threadId: store.header.id,
+      store,
+    });
+  }
+
+  async branch(
+    entryId: string,
+    options: SessionBranchOptions = {}
+  ): Promise<void> {
+    if (!this.store) {
+      throw new Error('Cannot branch an ephemeral session');
+    }
+    const summarizeAbandoned = options.summarizeAbandoned;
+    if (summarizeAbandoned !== undefined && summarizeAbandoned !== false) {
+      const instructions =
+        typeof summarizeAbandoned === 'object'
+          ? summarizeAbandoned.instructions
+          : undefined;
+      await this.compact({ instructions, retainRecentTurns: 0 });
+    }
+    await this.store.branch(entryId, options);
+  }
+
+  async compact(options: SessionCompactOptions = {}): Promise<void> {
+    const store = this.store;
+    if (!store) {
+      throw new Error('Cannot compact an ephemeral session');
+    }
+    const activePath = store.getPath();
+    const sessionState = createSessionRunState(activePath);
+    const messageEntries = activePath.filter(isMessageEntry);
+    if (sessionState.messages.length === 0) {
+      return;
+    }
+    const compactRunId = createRunId();
+    const agentContext = AgentContext.fromConfig(
+      createAgentInputFromGraphConfig(
+        this.runConfig.graphConfig,
+        sessionState.initialSummary,
+        options.retainRecentTurns,
+        options.instructions
+      )
+    );
+    const graph = createManualCompactGraph({
+      runId: compactRunId,
+      customHandlers: this.runConfig.customHandlers,
+      hooks: this.runConfig.hooks,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: graph.graph,
+      generateStepId: (stepKey): [string, number] => [
+        `${stepKey}-${compactRunId}`,
+        graph.graph.contentData.length,
+      ],
+    });
+    const summarizedState = await summarizeNode(
+      {
+        messages: sessionState.messages,
+        summarizationRequest: {
+          remainingContextTokens: agentContext.maxContextTokens ?? 0,
+          agentId: agentContext.agentId,
+        },
+      },
+      {
+        configurable: { thread_id: this.threadId },
+        metadata: { run_id: compactRunId },
+      }
+    );
+    const completedSummaryText = getSummaryText(graph.completedSummary);
+    const contextSummaryText = agentContext.getSummaryText();
+    let summaryText = completedSummaryText;
+    if (summaryText === '' && contextSummaryText != null) {
+      summaryText = contextSummaryText;
+    }
+    if (summaryText === '') {
+      return;
+    }
+    const retainedMessages = filterRemoveMessages(
+      summarizedState.messages ?? []
+    );
+    const retainedEntryIds = messageEntries
+      .slice(-retainedMessages.length)
+      .map((entry) => entry.id);
+    const retainedEntryIdSet = new Set(retainedEntryIds);
+    const summarized = messageEntries.filter(
+      (entry) => !retainedEntryIdSet.has(entry.id)
+    );
+    const summary = await store.appendEntryForCompaction({
+      text: summaryText,
+      retainedEntryIds,
+      summarizedEntryIds: summarized.map((entry) => entry.id),
+      instructions: options.instructions,
+      parentId: null,
+    });
+    let parentId: string | null = summary.id;
+    for (const message of retainedMessages) {
+      const retainedMessage = await store.appendMessage(message, parentId);
+      parentId = retainedMessage.id;
+    }
+    await store.appendCompactionEntry({
+      summaryEntryId: summary.id,
+      retainedEntryIds,
+      summarizedEntryIds: summarized.map((entry) => entry.id),
+    });
+  }
+
+  async resumeInterrupt<TResume>(
+    resumeValue: TResume,
+    options: AgentSessionRunOptions = {}
+  ): Promise<AgentSessionRunResult> {
+    const runId = options.runId ?? createRunId();
+    const threadId = options.threadId ?? this.threadId;
+    const handlerResult = createRunHandlers({
+      runId,
+      threadId,
+      userHandlers: this.runConfig.customHandlers,
+    });
+    const run = await Run.create<t.IState>({
+      ...this.runConfig,
+      runId,
+      returnContent: true,
+      calibrationRatio: this.calibrationRatio,
+      customHandlers: handlerResult.handlers,
+    });
+    const content = await run.resume(resumeValue, {
+      ...(options.config ?? {}),
+      configurable: {
+        ...(options.config?.configurable ?? {}),
+        thread_id: threadId,
+      },
+      version: options.config?.version ?? 'v2',
+    });
+    const runMessages = run.getRunMessages() ?? [];
+    for (const message of runMessages) {
+      await this.store?.appendMessage(message);
+    }
+    const contentParts = (content ?? handlerResult.contentParts).filter(
+      (part): part is t.MessageContentComplex => part != null
+    );
+    return {
+      text: contentToText(contentParts),
+      content: contentParts,
+      messages: runMessages,
+      usage: handlerResult.usage,
+      steps: handlerResult.steps,
+      interrupt: run.getInterrupt(),
+      haltedReason: run.getHaltReason(),
+      runId,
+      threadId,
+    };
+  }
+}
+
+export function createAgentSession(
+  config: AgentSessionConfig
+): Promise<AgentSession> {
+  return AgentSession.create(config);
+}

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -139,7 +139,12 @@ export class JsonlSessionStore {
 
   static async open(pathOrId: string): Promise<JsonlSessionStore> {
     const path = await JsonlSessionStore.resolvePath(pathOrId);
-    const raw = await readFile(path, 'utf8');
+    return JsonlSessionStore.openPath(path);
+  }
+
+  static async openPath(path: string): Promise<JsonlSessionStore> {
+    const resolved = resolve(path);
+    const raw = await readFile(resolved, 'utf8');
     const parsed = raw
       .split('\n')
       .map((line) => parseLine(line))
@@ -148,12 +153,12 @@ export class JsonlSessionStore {
       (line): line is SessionHeader => line.type === 'session'
     );
     if (!header) {
-      throw new Error(`Invalid session file: ${path}`);
+      throw new Error(`Invalid session file: ${resolved}`);
     }
     const entries = parsed.filter(
       (line): line is SessionEntry => line.type !== 'session'
     );
-    return new JsonlSessionStore({ path, header, entries });
+    return new JsonlSessionStore({ path: resolved, header, entries });
   }
 
   static async resolvePath(pathOrId: string): Promise<string> {

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -7,6 +7,7 @@ import {
   readFile,
   readdir,
   stat,
+  writeFile,
 } from 'fs/promises';
 import type {
   CreateSessionFileOptions,
@@ -128,7 +129,10 @@ export class JsonlSessionStore {
         : createSessionPath({ ...options, sessionId });
     const header = createHeader({ ...options, sessionId });
     await mkdir(dirname(path), { recursive: true });
-    await appendFile(path, `${JSON.stringify(header)}\n`, 'utf8');
+    await writeFile(path, `${JSON.stringify(header)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
     return new JsonlSessionStore({ path, header, entries: [] });
   }
 

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -1,4 +1,5 @@
 import { homedir } from 'os';
+import { createHash } from 'crypto';
 import { basename, dirname, isAbsolute, join, resolve } from 'path';
 import {
   access,
@@ -44,7 +45,7 @@ const DEFAULT_SESSION_ROOT = join(
 
 function sanitizeCwd(cwd: string): string {
   const normalized = resolve(cwd);
-  return `--${normalized.replace(/[^a-zA-Z0-9._-]/g, '-')}`;
+  return createHash('sha256').update(normalized).digest('hex');
 }
 
 function createSessionPath(options: CreateSessionFileOptions): string {

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -1,0 +1,497 @@
+import { homedir } from 'os';
+import { basename, dirname, isAbsolute, join, resolve } from 'path';
+import {
+  access,
+  appendFile,
+  mkdir,
+  readFile,
+  readdir,
+  stat,
+} from 'fs/promises';
+import type {
+  CreateSessionFileOptions,
+  SessionBranchOptions,
+  SessionEntry,
+  SessionForkOptions,
+  SessionHeader,
+  SessionLabelEntry,
+  SessionListItem,
+  SessionMessageEntry,
+  SessionCompactionEntry,
+  SessionRunEventEntry,
+  SessionSummaryEntry,
+  SessionStateEntry,
+  SessionTreeNode,
+} from './types';
+import type { BaseMessage } from '@langchain/core/messages';
+import { SystemMessage } from '@langchain/core/messages';
+import { createEntryId, createSessionId, createTimestamp } from './ids';
+import {
+  deserializeMessage,
+  getMessageRole,
+  serializeMessage,
+  toJsonValue,
+} from './messageSerialization';
+
+const SESSION_VERSION = 1;
+const DEFAULT_SESSION_ROOT = join(
+  homedir(),
+  '.librechat',
+  'agents',
+  'sessions'
+);
+
+function sanitizeCwd(cwd: string): string {
+  const normalized = resolve(cwd);
+  return `--${normalized.replace(/[^a-zA-Z0-9._-]/g, '-')}`;
+}
+
+function createSessionPath(options: CreateSessionFileOptions): string {
+  const sessionId = options.sessionId ?? createSessionId();
+  const fileName = `${new Date().toISOString().replace(/[:.]/g, '-')}_${sessionId}.jsonl`;
+  return join(DEFAULT_SESSION_ROOT, sanitizeCwd(options.cwd), fileName);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseLine(line: string): SessionHeader | SessionEntry | undefined {
+  if (line.trim() === '') {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(line) as SessionHeader | SessionEntry;
+    if (parsed.type === 'session') {
+      return parsed;
+    }
+    if ('id' in parsed && 'parentId' in parsed && 'data' in parsed) {
+      return parsed;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function createHeader(options: CreateSessionFileOptions): SessionHeader {
+  return {
+    type: 'session',
+    version: SESSION_VERSION,
+    id: options.sessionId ?? createSessionId(),
+    timestamp: createTimestamp(),
+    cwd: resolve(options.cwd),
+    ...(options.name != null && options.name !== ''
+      ? { name: options.name }
+      : {}),
+    ...(options.parentSession != null && options.parentSession !== ''
+      ? { parentSession: options.parentSession }
+      : {}),
+  };
+}
+
+function sortEntries(entries: SessionEntry[]): SessionEntry[] {
+  return [...entries].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+}
+
+export class JsonlSessionStore {
+  readonly path: string;
+  readonly header: SessionHeader;
+  private entries: SessionEntry[];
+
+  private constructor(params: {
+    path: string;
+    header: SessionHeader;
+    entries: SessionEntry[];
+  }) {
+    this.path = params.path;
+    this.header = params.header;
+    this.entries = sortEntries(params.entries);
+  }
+
+  static getDefaultRoot(): string {
+    return DEFAULT_SESSION_ROOT;
+  }
+
+  static async create(
+    options: CreateSessionFileOptions & { path?: string }
+  ): Promise<JsonlSessionStore> {
+    const sessionId = options.sessionId ?? createSessionId();
+    const path =
+      options.path != null && options.path !== ''
+        ? resolve(options.path)
+        : createSessionPath({ ...options, sessionId });
+    const header = createHeader({ ...options, sessionId });
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, `${JSON.stringify(header)}\n`, 'utf8');
+    return new JsonlSessionStore({ path, header, entries: [] });
+  }
+
+  static async open(pathOrId: string): Promise<JsonlSessionStore> {
+    const path = await JsonlSessionStore.resolvePath(pathOrId);
+    const raw = await readFile(path, 'utf8');
+    const parsed = raw
+      .split('\n')
+      .map((line) => parseLine(line))
+      .filter((line): line is SessionHeader | SessionEntry => line != null);
+    const header = parsed.find(
+      (line): line is SessionHeader => line.type === 'session'
+    );
+    if (!header) {
+      throw new Error(`Invalid session file: ${path}`);
+    }
+    const entries = parsed.filter(
+      (line): line is SessionEntry => line.type !== 'session'
+    );
+    return new JsonlSessionStore({ path, header, entries });
+  }
+
+  static async resolvePath(pathOrId: string): Promise<string> {
+    const candidate = isAbsolute(pathOrId) ? pathOrId : resolve(pathOrId);
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+    const sessions = await JsonlSessionStore.listAll();
+    const matches = sessions.filter(
+      (item) =>
+        item.id.startsWith(pathOrId) || basename(item.path).includes(pathOrId)
+    );
+    if (matches.length === 1) {
+      return matches[0].path;
+    }
+    if (matches.length > 1) {
+      throw new Error(`Session id "${pathOrId}" is ambiguous`);
+    }
+    throw new Error(`Session not found: ${pathOrId}`);
+  }
+
+  static async list(cwd: string): Promise<SessionListItem[]> {
+    const dir = join(DEFAULT_SESSION_ROOT, sanitizeCwd(cwd));
+    return JsonlSessionStore.listDirectory(dir);
+  }
+
+  static async listAll(
+    root: string = DEFAULT_SESSION_ROOT
+  ): Promise<SessionListItem[]> {
+    if (!(await pathExists(root))) {
+      return [];
+    }
+    const dirs = await readdir(root, { withFileTypes: true });
+    const lists = await Promise.all(
+      dirs
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => JsonlSessionStore.listDirectory(join(root, entry.name)))
+    );
+    return lists.flat().sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  }
+
+  private static async listDirectory(dir: string): Promise<SessionListItem[]> {
+    if (!(await pathExists(dir))) {
+      return [];
+    }
+    const files = await readdir(dir, { withFileTypes: true });
+    const candidates = files
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.jsonl'))
+      .map((entry) => join(dir, entry.name));
+    const items = await Promise.all(
+      candidates.map(async (path): Promise<SessionListItem | undefined> => {
+        try {
+          const store = await JsonlSessionStore.open(path);
+          return {
+            id: store.header.id,
+            path,
+            cwd: store.header.cwd,
+            timestamp: store.header.timestamp,
+            name: store.header.name,
+            leafId: store.getLeafEntry()?.id ?? null,
+          };
+        } catch {
+          return undefined;
+        }
+      })
+    );
+    return items
+      .filter((item): item is SessionListItem => item != null)
+      .sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  }
+
+  getEntries(): SessionEntry[] {
+    return [...this.entries];
+  }
+
+  getEntry(id: string): SessionEntry | undefined {
+    return this.entries.find((entry) => entry.id === id);
+  }
+
+  getChildren(id: string): SessionEntry[] {
+    return this.entries.filter((entry) => entry.parentId === id);
+  }
+
+  getTree(): SessionTreeNode[] {
+    const byParent = new Map<string | null, SessionEntry[]>();
+    for (const entry of this.entries) {
+      const siblings = byParent.get(entry.parentId) ?? [];
+      siblings.push(entry);
+      byParent.set(entry.parentId, siblings);
+    }
+    const build = (parentId: string | null): SessionTreeNode[] =>
+      (byParent.get(parentId) ?? []).map((entry) => ({
+        entry,
+        children: build(entry.id),
+      }));
+    return build(null);
+  }
+
+  getLeafEntry(): SessionEntry | undefined {
+    const state = [...this.entries]
+      .reverse()
+      .find(
+        (entry): entry is SessionStateEntry => entry.type === 'session_state'
+      );
+    if (state) {
+      return state.data.leafId == null
+        ? undefined
+        : this.getEntry(state.data.leafId);
+    }
+    return [...this.entries]
+      .reverse()
+      .find((entry) => entry.type === 'message' || entry.type === 'summary');
+  }
+
+  getPath(
+    entryId: string | undefined = this.getLeafEntry()?.id
+  ): SessionEntry[] {
+    if (entryId == null || entryId === '') {
+      return [];
+    }
+    const byId = new Map(this.entries.map((entry) => [entry.id, entry]));
+    const path: SessionEntry[] = [];
+    let current: SessionEntry | undefined = byId.get(entryId);
+    while (current) {
+      path.push(current);
+      current =
+        current.parentId == null ? undefined : byId.get(current.parentId);
+    }
+    return path.reverse();
+  }
+
+  getMessages(entryId?: string): BaseMessage[] {
+    const messages: BaseMessage[] = [];
+    for (const entry of this.getPath(entryId)) {
+      if (entry.type === 'message') {
+        messages.push(deserializeMessage(entry.data.message));
+      } else if (entry.type === 'summary') {
+        messages.push(new SystemMessage(entry.data.text));
+      }
+    }
+    return messages;
+  }
+
+  getForkPoints(): SessionMessageEntry[] {
+    return this.entries.filter(
+      (entry): entry is SessionMessageEntry =>
+        entry.type === 'message' && entry.data.role === 'user'
+    );
+  }
+
+  getLabel(entryId: string): string | undefined {
+    return [...this.entries]
+      .reverse()
+      .find(
+        (entry): entry is SessionLabelEntry =>
+          entry.type === 'label' && entry.data.targetEntryId === entryId
+      )?.data.label;
+  }
+
+  async setLabel(entryId: string, label: string): Promise<SessionLabelEntry> {
+    return this.appendEntry<SessionLabelEntry>({
+      type: 'label',
+      parentId: this.getLeafEntry()?.id ?? null,
+      data: { targetEntryId: entryId, label },
+    });
+  }
+
+  async appendMessage(
+    message: BaseMessage,
+    parentId: string | null = this.getLeafEntry()?.id ?? null
+  ): Promise<SessionMessageEntry> {
+    const entry = await this.appendEntry<SessionMessageEntry>({
+      type: 'message',
+      parentId,
+      data: {
+        role: getMessageRole(message),
+        message: serializeMessage(message),
+      },
+    });
+    await this.setLeaf(entry.id);
+    return entry;
+  }
+
+  async appendRunEvent(
+    event: string,
+    payload?: unknown,
+    params?: { runId?: string; threadId?: string }
+  ): Promise<SessionRunEventEntry> {
+    return this.appendEntry<SessionRunEventEntry>({
+      type: 'run_event',
+      parentId: this.getLeafEntry()?.id ?? null,
+      data: {
+        event,
+        ...(params?.runId != null && params.runId !== ''
+          ? { runId: params.runId }
+          : {}),
+        ...(params?.threadId != null && params.threadId !== ''
+          ? { threadId: params.threadId }
+          : {}),
+        ...(typeof payload !== 'undefined'
+          ? { payload: toJsonValue(payload) }
+          : {}),
+      },
+    });
+  }
+
+  async setLeaf(leafId: string | null): Promise<SessionStateEntry> {
+    return this.appendEntry<SessionStateEntry>({
+      type: 'session_state',
+      parentId: leafId,
+      data: { leafId },
+    });
+  }
+
+  async appendEntryForCompaction(params: {
+    text: string;
+    retainedEntryIds: string[];
+    summarizedEntryIds: string[];
+    instructions?: string;
+    parentId?: string | null;
+  }): Promise<SessionSummaryEntry> {
+    const entry = await this.appendEntry<SessionSummaryEntry>({
+      type: 'summary',
+      parentId:
+        'parentId' in params
+          ? (params.parentId ?? null)
+          : (this.getLeafEntry()?.id ?? null),
+      data: {
+        text: params.text,
+        retainedEntryIds: params.retainedEntryIds,
+        summarizedEntryIds: params.summarizedEntryIds,
+        ...(params.instructions != null && params.instructions !== ''
+          ? { instructions: params.instructions }
+          : {}),
+      },
+    });
+    await this.setLeaf(entry.id);
+    return entry;
+  }
+
+  async appendCompactionEntry(params: {
+    summaryEntryId: string;
+    retainedEntryIds: string[];
+    summarizedEntryIds: string[];
+  }): Promise<SessionCompactionEntry> {
+    return this.appendEntry<SessionCompactionEntry>({
+      type: 'compaction',
+      parentId: this.getLeafEntry()?.id ?? null,
+      data: {
+        summaryEntryId: params.summaryEntryId,
+        retainedEntryIds: params.retainedEntryIds,
+        summarizedEntryIds: params.summarizedEntryIds,
+      },
+    });
+  }
+
+  async branch(
+    entryId: string,
+    options: SessionBranchOptions = {}
+  ): Promise<SessionEntry | undefined> {
+    const target = this.getBranchTarget(entryId, options.position ?? 'at');
+    await this.setLeaf(target?.id ?? null);
+    return target;
+  }
+
+  async createBranchedSession(
+    entryId: string | undefined = this.getLeafEntry()?.id,
+    options: SessionForkOptions = {}
+  ): Promise<JsonlSessionStore> {
+    const target =
+      entryId != null && entryId !== ''
+        ? this.getBranchTarget(entryId, options.position ?? 'at')
+        : this.getLeafEntry();
+    const newStore = await JsonlSessionStore.create({
+      cwd: options.cwd ?? this.header.cwd,
+      name: options.name ?? this.header.name,
+      parentSession: this.path,
+    });
+    const pathEntries = target ? this.getPath(target.id) : [];
+    for (const entry of pathEntries) {
+      await newStore.appendExistingEntry(entry);
+    }
+    await newStore.setLeaf(target?.id ?? null);
+    return newStore;
+  }
+
+  async clone(options: SessionForkOptions = {}): Promise<JsonlSessionStore> {
+    return this.createBranchedSession(this.getLeafEntry()?.id, {
+      ...options,
+      position: 'at',
+    });
+  }
+
+  async fork(
+    entryId: string,
+    options: SessionForkOptions = {}
+  ): Promise<JsonlSessionStore> {
+    return this.createBranchedSession(entryId, {
+      ...options,
+      position: options.position ?? 'before',
+    });
+  }
+
+  private getBranchTarget(
+    entryId: string,
+    position: 'before' | 'at'
+  ): SessionEntry | undefined {
+    const entry = this.getEntry(entryId);
+    if (!entry) {
+      throw new Error(`Entry not found: ${entryId}`);
+    }
+    if (position === 'at') {
+      return entry;
+    }
+    return entry.parentId == null ? undefined : this.getEntry(entry.parentId);
+  }
+
+  private async appendExistingEntry(entry: SessionEntry): Promise<void> {
+    this.entries.push(entry);
+    await appendFile(this.path, `${JSON.stringify(entry)}\n`, 'utf8');
+  }
+
+  private async appendEntry<TEntry extends SessionEntry>(params: {
+    type: TEntry['type'];
+    parentId: string | null;
+    data: TEntry['data'];
+  }): Promise<TEntry> {
+    const entry = {
+      type: params.type,
+      id: createEntryId(),
+      parentId: params.parentId,
+      timestamp: createTimestamp(),
+      data: params.data,
+    } as TEntry;
+    this.entries.push(entry);
+    await appendFile(this.path, `${JSON.stringify(entry)}\n`, 'utf8');
+    return entry;
+  }
+
+  async existsOnDisk(): Promise<boolean> {
+    const fileStat = await stat(this.path).catch(() => undefined);
+    return fileStat?.isFile() === true;
+  }
+}
+
+export const SessionManager = JsonlSessionStore;

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -376,11 +376,18 @@ export class JsonlSessionStore {
 
   async appendEntryForCompaction(params: {
     text: string;
+    tokenCount?: number;
     retainedEntryIds: string[];
     summarizedEntryIds: string[];
     instructions?: string;
     parentId?: string | null;
   }): Promise<SessionSummaryEntry> {
+    const tokenCount =
+      typeof params.tokenCount === 'number' &&
+      Number.isFinite(params.tokenCount) &&
+      params.tokenCount >= 0
+        ? params.tokenCount
+        : undefined;
     const entry = await this.appendEntry<SessionSummaryEntry>({
       type: 'summary',
       parentId:
@@ -389,6 +396,7 @@ export class JsonlSessionStore {
           : (this.getLeafEntry()?.id ?? null),
       data: {
         text: params.text,
+        ...(tokenCount != null ? { tokenCount } : {}),
         retainedEntryIds: params.retainedEntryIds,
         summarizedEntryIds: params.summarizedEntryIds,
         ...(params.instructions != null && params.instructions !== ''

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -19,6 +19,7 @@ import type {
   SessionLabelEntry,
   SessionListItem,
   SessionMessageEntry,
+  SessionCheckpointEntry,
   SessionCompactionEntry,
   SessionRunEventEntry,
   SessionSummaryEntry,
@@ -413,6 +414,62 @@ export class JsonlSessionStore {
         summarizedEntryIds: params.summarizedEntryIds,
       },
     });
+  }
+
+  async appendCheckpoint(params: {
+    source: SessionCheckpointEntry['data']['source'];
+    threadId: string;
+    runId?: string;
+    checkpointId?: string;
+    checkpointNs?: string;
+    parentCheckpointId?: string;
+    reason?: string;
+  }): Promise<SessionCheckpointEntry> {
+    return this.appendEntry<SessionCheckpointEntry>({
+      type: 'checkpoint',
+      parentId: this.getLeafEntry()?.id ?? null,
+      data: {
+        provider: 'langgraph',
+        source: params.source,
+        threadId: params.threadId,
+        ...(params.runId != null && params.runId !== ''
+          ? { runId: params.runId }
+          : {}),
+        ...(params.checkpointId != null && params.checkpointId !== ''
+          ? { checkpointId: params.checkpointId }
+          : {}),
+        ...(params.checkpointNs != null
+          ? { checkpointNs: params.checkpointNs }
+          : {}),
+        ...(params.parentCheckpointId != null &&
+        params.parentCheckpointId !== ''
+          ? { parentCheckpointId: params.parentCheckpointId }
+          : {}),
+        ...(params.reason != null && params.reason !== ''
+          ? { reason: params.reason }
+          : {}),
+      },
+    });
+  }
+
+  getCheckpoints(threadId?: string): SessionCheckpointEntry[] {
+    return this.entries.filter(
+      (entry): entry is SessionCheckpointEntry =>
+        entry.type === 'checkpoint' &&
+        (threadId == null || entry.data.threadId === threadId)
+    );
+  }
+
+  getLatestCheckpoint(threadId?: string): SessionCheckpointEntry | undefined {
+    const checkpoints = this.getCheckpoints(threadId);
+    for (let i = checkpoints.length - 1; i >= 0; i--) {
+      const checkpoint = checkpoints[i];
+      if (checkpoint.data.source === 'reset') {
+        return undefined;
+      }
+      return checkpoint;
+    }
+    return undefined;
   }
 
   async branch(

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1,7 +1,11 @@
 import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  HumanMessage,
+  RemoveMessage,
+} from '@langchain/core/messages';
 import { MemorySaver } from '@langchain/langgraph';
 import { JsonlSessionStore, createAgentSession } from '@/session';
 import { toJsonValue } from '@/session/messageSerialization';
@@ -110,6 +114,25 @@ describe('JsonlSessionStore', () => {
       'hello',
       'hi',
     ]);
+  });
+
+  it('round-trips remove messages in persisted sessions', async () => {
+    const path = join(dir, 'remove.jsonl');
+    const store = await JsonlSessionStore.create({ path, cwd: dir });
+
+    await store.appendMessage(
+      new HumanMessage({ id: 'message-a', content: 'a' })
+    );
+    await store.appendMessage(new RemoveMessage({ id: 'message-a' }));
+
+    const reopened = await JsonlSessionStore.open(path);
+    const messages = reopened.getMessages();
+
+    expect(messages.map((message) => message._getType())).toEqual([
+      'human',
+      'remove',
+    ]);
+    expect((messages[1] as RemoveMessage).id).toBe('message-a');
   });
 
   it('fails when creating a session file that already exists', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -384,17 +384,20 @@ describe('JsonlSessionStore', () => {
       },
     });
 
-    expect(store?.getLeafEntry()?.id).toBe(first?.id);
-    expect(
-      store
-        ?.getEntries()
-        .some(
-          (entry) =>
-            entry.type === 'summary' &&
-            entry.data.text === 'summary of abandoned branch' &&
-            entry.data.instructions === 'summarize abandoned branch'
-        )
-    ).toBe(true);
+    const activePath = store?.getPath();
+    const summary = activePath?.at(-1);
+    expect(activePath?.map((entry) => entry.id)).toEqual([
+      first?.id,
+      summary?.id,
+    ]);
+    expect(summary).toMatchObject({
+      type: 'summary',
+      parentId: first?.id,
+      data: {
+        text: 'summary of abandoned branch',
+        instructions: 'summarize abandoned branch',
+      },
+    });
     expect(
       store?.getEntries().some((entry) => entry.type === 'compaction')
     ).toBe(true);

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1,0 +1,212 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { JsonlSessionStore, createAgentSession } from '@/session';
+import * as providers from '@/llm/providers';
+
+function mockSummarizer(response: string): void {
+  jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+    class {
+      constructor() {
+        return {
+          invoke: jest.fn().mockResolvedValue({ content: response }),
+        };
+      }
+    } as never
+  );
+}
+
+describe('JsonlSessionStore', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'lc-agent-session-'));
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('stores messages as an append-only tree and restores the active path', async () => {
+    const path = join(dir, 'session.jsonl');
+    const store = await JsonlSessionStore.create({
+      path,
+      cwd: dir,
+      sessionId: 'session-a',
+    });
+
+    const user = await store.appendMessage(new HumanMessage('hello'));
+    const assistant = await store.appendMessage(new AIMessage('hi'));
+
+    const reopened = await JsonlSessionStore.open(path);
+
+    expect(reopened.header.id).toBe('session-a');
+    expect(reopened.getLeafEntry()?.id).toBe(assistant.id);
+    expect(reopened.getPath().map((entry) => entry.id)).toEqual([
+      user.id,
+      assistant.id,
+    ]);
+    expect(reopened.getMessages().map((message) => message.content)).toEqual([
+      'hello',
+      'hi',
+    ]);
+  });
+
+  it('branches in place without deleting abandoned children', async () => {
+    const store = await JsonlSessionStore.create({
+      path: join(dir, 'branch.jsonl'),
+      cwd: dir,
+    });
+    const first = await store.appendMessage(new HumanMessage('one'));
+    const abandoned = await store.appendMessage(new AIMessage('abandoned'));
+
+    await store.branch(first.id);
+    const alternate = await store.appendMessage(new AIMessage('alternate'));
+
+    expect(
+      store
+        .getChildren(first.id)
+        .filter((entry) => entry.type === 'message')
+        .map((entry) => entry.id)
+        .sort()
+    ).toEqual([abandoned.id, alternate.id].sort());
+    expect(store.getPath().map((entry) => entry.id)).toEqual([
+      first.id,
+      alternate.id,
+    ]);
+  });
+
+  it('clones and forks active paths into new session files', async () => {
+    const store = await JsonlSessionStore.create({
+      path: join(dir, 'source.jsonl'),
+      cwd: dir,
+    });
+    const first = await store.appendMessage(new HumanMessage('first'));
+    const second = await store.appendMessage(new AIMessage('second'));
+
+    const clone = await store.clone({ cwd: dir });
+    const fork = await store.fork(second.id, { cwd: dir, position: 'before' });
+
+    expect(clone.header.parentSession).toBe(store.path);
+    expect(clone.getPath().map((entry) => entry.id)).toEqual([
+      first.id,
+      second.id,
+    ]);
+    expect(fork.getPath().map((entry) => entry.id)).toEqual([first.id]);
+  });
+
+  it('tracks labels and compaction entries', async () => {
+    const store = await JsonlSessionStore.create({
+      path: join(dir, 'labels.jsonl'),
+      cwd: dir,
+    });
+    const message = await store.appendMessage(new HumanMessage('hello'));
+
+    await store.setLabel(message.id, 'checkpoint');
+    const summary = await store.appendEntryForCompaction({
+      text: 'summary',
+      retainedEntryIds: [message.id],
+      summarizedEntryIds: [],
+    });
+    const compaction = await store.appendCompactionEntry({
+      summaryEntryId: summary.id,
+      retainedEntryIds: [message.id],
+      summarizedEntryIds: [],
+    });
+
+    expect(store.getLabel(message.id)).toBe('checkpoint');
+    expect(summary.data.text).toBe('summary');
+    expect(compaction.data.summaryEntryId).toBe(summary.id);
+  });
+
+  it('creates high-level sessions with a JSONL store by default', async () => {
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.getSessionStore()?.header.cwd).toBe(dir);
+    expect(session.sessionPath).toContain('.jsonl');
+  });
+
+  it('compacts into a summary plus retained active path', async () => {
+    mockSummarizer('summary of old work');
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    await store?.appendMessage(new HumanMessage('old'));
+    await store?.appendMessage(new AIMessage('old answer'));
+    await store?.appendMessage(new HumanMessage('recent'));
+
+    await session.compact({
+      instructions: 'summary of old work',
+      retainRecentTurns: 1,
+    });
+
+    expect(store?.getMessages().map((message) => message.content)).toEqual([
+      'summary of old work',
+      'recent',
+    ]);
+  });
+
+  it('summarizes an abandoned branch before switching in place', async () => {
+    mockSummarizer('summary of abandoned branch');
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const first = await store?.appendMessage(new HumanMessage('first'));
+    await store?.appendMessage(new AIMessage('abandoned answer'));
+
+    await session.branch(first?.id ?? '', {
+      position: 'at',
+      summarizeAbandoned: {
+        instructions: 'summarize abandoned branch',
+      },
+    });
+
+    expect(store?.getLeafEntry()?.id).toBe(first?.id);
+    expect(
+      store
+        ?.getEntries()
+        .some(
+          (entry) =>
+            entry.type === 'summary' &&
+            entry.data.text === 'summary of abandoned branch' &&
+            entry.data.instructions === 'summarize abandoned branch'
+        )
+    ).toBe(true);
+    expect(
+      store?.getEntries().some((entry) => entry.type === 'compaction')
+    ).toBe(true);
+  });
+});

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -666,6 +666,44 @@ describe('JsonlSessionStore', () => {
     ).toEqual(['history']);
   });
 
+  it('does not persist resumed override thread messages into the session path', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('override resumed');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+
+    await session.resumeInterrupt([], { threadId: 'thread_override' });
+
+    expect(mockRun.resume).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({
+        configurable: expect.objectContaining({
+          thread_id: 'thread_override',
+        }),
+      })
+    );
+    expect(
+      session
+        .getSessionStore()
+        ?.getPath()
+        .filter((entry) => entry.type === 'message')
+        .map((entry) => entry.data.message.content)
+    ).toEqual(['history']);
+  });
+
   it('uses only new input when LangGraph checkpoint state already exists', async () => {
     const checkpointer = new MemorySaver();
     const mockRun = createMockRun('checkpointed output');

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -12,6 +12,7 @@ import type { Checkpoint, CheckpointMetadata } from '@langchain/langgraph';
 import { JsonlSessionStore, createAgentSession } from '@/session';
 import { toJsonValue } from '@/session/messageSerialization';
 import * as providers from '@/llm/providers';
+import { GraphEvents } from '@/common';
 import type * as t from '@/types';
 import { Run } from '@/run';
 
@@ -455,6 +456,38 @@ describe('JsonlSessionStore', () => {
       'history',
       'fresh',
     ]);
+  });
+
+  it('preserves custom handlers outside the session event adapter set', async () => {
+    const mockRun = createMockRun('handled');
+    const capturedConfigs = mockRunCreate(mockRun);
+    const agentLogHandler: t.EventHandler = { handle: jest.fn() };
+    const messageDeltaHandler: t.EventHandler = { handle: jest.fn() };
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+      customHandlers: {
+        [GraphEvents.ON_AGENT_LOG]: agentLogHandler,
+        [GraphEvents.ON_MESSAGE_DELTA]: messageDeltaHandler,
+      },
+    });
+
+    await session.run('start');
+
+    expect(capturedConfigs[0].customHandlers?.[GraphEvents.ON_AGENT_LOG]).toBe(
+      agentLogHandler
+    );
+    expect(
+      capturedConfigs[0].customHandlers?.[GraphEvents.ON_MESSAGE_DELTA]
+    ).not.toBe(messageDeltaHandler);
   });
 
   it('shares a session-level LangGraph checkpointer for HITL resume', async () => {
@@ -952,5 +985,47 @@ describe('JsonlSessionStore', () => {
     expect(
       store?.getEntries().some((entry) => entry.type === 'compaction')
     ).toBe(true);
+  });
+
+  it('summarizes a sibling branch before switching branches', async () => {
+    mockSummarizer('summary of sibling branch');
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const first = await store?.appendMessage(new HumanMessage('first'));
+    const inactive = await store?.appendMessage(new AIMessage('inactive'));
+    await store?.branch(first?.id ?? '');
+    const activeSibling = await store?.appendMessage(new AIMessage('active'));
+
+    await session.branch(inactive?.id ?? '', {
+      position: 'at',
+      summarizeAbandoned: true,
+    });
+
+    const activePath = store?.getPath();
+    const summary = activePath?.at(-1);
+    expect(activePath?.map((entry) => entry.id)).toEqual([
+      first?.id,
+      inactive?.id,
+      summary?.id,
+    ]);
+    expect(summary).toMatchObject({
+      type: 'summary',
+      parentId: inactive?.id,
+      data: {
+        text: 'summary of sibling branch',
+        summarizedEntryIds: [activeSibling?.id],
+      },
+    });
   });
 });

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
@@ -112,6 +112,26 @@ describe('JsonlSessionStore', () => {
     ]);
   });
 
+  it('fails when creating a session file that already exists', async () => {
+    const path = join(dir, 'existing.jsonl');
+    await JsonlSessionStore.create({
+      path,
+      cwd: dir,
+      sessionId: 'session-a',
+    });
+
+    await expect(
+      JsonlSessionStore.create({
+        path,
+        cwd: dir,
+        sessionId: 'session-b',
+      })
+    ).rejects.toMatchObject({ code: 'EEXIST' });
+
+    const raw = await readFile(path, 'utf8');
+    expect(raw.match(/"type":"session"/g)).toHaveLength(1);
+  });
+
   it('branches in place without deleting abandoned children', async () => {
     const store = await JsonlSessionStore.create({
       path: join(dir, 'branch.jsonl'),
@@ -211,6 +231,29 @@ describe('JsonlSessionStore', () => {
 
     expect(session.getSessionStore()?.header.cwd).toBe(dir);
     expect(session.sessionPath).toContain('.jsonl');
+  });
+
+  it('surfaces invalid explicit session files instead of replacing them', async () => {
+    const sessionPath = join(dir, 'invalid.jsonl');
+    await writeFile(sessionPath, 'not jsonl\n', 'utf8');
+
+    await expect(
+      createAgentSession({
+        cwd: dir,
+        sessionPath,
+        runId: 'template-run',
+        graphConfig: {
+          type: 'standard',
+          llmConfig: {
+            provider: 'openAI' as never,
+            model: 'test-model',
+          },
+          instructions: 'test',
+        },
+      })
+    ).rejects.toThrow('Invalid session file');
+
+    expect(await readFile(sessionPath, 'utf8')).toBe('not jsonl\n');
   });
 
   it('preserves non-message state while applying session history', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -529,6 +529,33 @@ describe('JsonlSessionStore', () => {
     expect(session.getCheckpointer()).toBeUndefined();
   });
 
+  it('removes graph checkpointers when checkpointing is disabled', async () => {
+    const graphCheckpointer = new MemorySaver();
+    const mockRun = createMockRun('disabled');
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: false,
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+        compileOptions: { checkpointer: graphCheckpointer },
+      },
+    });
+
+    await session.run('start');
+
+    expect(session.getCheckpointer()).toBeUndefined();
+    expect(
+      capturedConfigs[0].graphConfig.compileOptions?.checkpointer
+    ).toBeUndefined();
+  });
+
   it('reuses the session-level checkpointer across HITL resume', async () => {
     const mockRun = createMockRun('resumed');
     const capturedConfigs = mockRunCreate(mockRun);
@@ -604,6 +631,39 @@ describe('JsonlSessionStore', () => {
     expect(
       getProcessedMessages(mockRun).map((message) => message.content)
     ).toEqual(['history', 'next']);
+  });
+
+  it('does not replay session history when overriding thread id without checkpoint state', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('override output');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+
+    await session.run('fresh turn', { threadId: 'thread_override' });
+
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['fresh turn']);
+    expect(
+      session
+        .getSessionStore()
+        ?.getPath()
+        .filter((entry) => entry.type === 'message')
+        .map((entry) => entry.data.message.content)
+    ).toEqual(['history']);
   });
 
   it('uses only new input when LangGraph checkpoint state already exists', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { MemorySaver } from '@langchain/langgraph';
@@ -130,6 +130,37 @@ describe('JsonlSessionStore', () => {
 
     const raw = await readFile(path, 'utf8');
     expect(raw.match(/"type":"session"/g)).toHaveLength(1);
+  });
+
+  it('keeps default session roots distinct for similar cwd strings', async () => {
+    const cwdA = join(dir, 'foo/bar');
+    const cwdB = join(dir, 'foo-bar');
+    const storeA = await JsonlSessionStore.create({
+      cwd: cwdA,
+      sessionId: 'cwd-a',
+    });
+    const storeB = await JsonlSessionStore.create({
+      cwd: cwdB,
+      sessionId: 'cwd-b',
+    });
+
+    try {
+      const [itemsA, itemsB] = await Promise.all([
+        JsonlSessionStore.list(cwdA),
+        JsonlSessionStore.list(cwdB),
+      ]);
+
+      expect(dirname(storeA.path)).not.toBe(dirname(storeB.path));
+      expect(itemsA.map((item) => item.id)).toContain('cwd-a');
+      expect(itemsA.map((item) => item.id)).not.toContain('cwd-b');
+      expect(itemsB.map((item) => item.id)).toContain('cwd-b');
+      expect(itemsB.map((item) => item.id)).not.toContain('cwd-a');
+    } finally {
+      await Promise.all([
+        rm(storeA.path, { force: true }),
+        rm(storeB.path, { force: true }),
+      ]);
+    }
   });
 
   it('branches in place without deleting abandoned children', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -489,6 +489,39 @@ describe('JsonlSessionStore', () => {
     ]);
   });
 
+  it('restores persisted summary token counts into run config', async () => {
+    const mockRun = createMockRun('with summary');
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendEntryForCompaction({
+      text: 'stored summary',
+      tokenCount: 123,
+      retainedEntryIds: [],
+      summarizedEntryIds: [],
+    });
+
+    await session.run('fresh');
+
+    const { graphConfig } = capturedConfigs[0];
+    const initialSummary =
+      'initialSummary' in graphConfig ? graphConfig.initialSummary : undefined;
+    expect(initialSummary).toEqual({
+      text: 'stored summary',
+      tokenCount: 123,
+    });
+  });
+
   it('preserves custom handlers outside the session event adapter set', async () => {
     const mockRun = createMockRun('handled');
     const capturedConfigs = mockRunCreate(mockRun);
@@ -987,9 +1020,11 @@ describe('JsonlSessionStore', () => {
 
   it('compacts into a summary plus retained active path', async () => {
     mockSummarizer('summary of old work');
+    const tokenCounter: t.TokenCounter = () => 7;
     const session = await createAgentSession({
       cwd: dir,
       runId: 'template-run',
+      tokenCounter,
       graphConfig: {
         type: 'standard',
         llmConfig: {
@@ -1013,6 +1048,10 @@ describe('JsonlSessionStore', () => {
       'summary of old work',
       'recent',
     ]);
+    const summary = store
+      ?.getEntries()
+      .find((entry) => entry.type === 'summary');
+    expect(summary?.data.tokenCount).toBeGreaterThan(0);
   });
 
   it('records no retained ids when compaction retains zero messages', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -356,6 +356,37 @@ describe('JsonlSessionStore', () => {
     ).toBe(true);
   });
 
+  it('replaces circular object references in JSONL payloads', () => {
+    interface CircularPayload {
+      label: string;
+      self?: CircularPayload;
+      child?: { parent?: CircularPayload };
+    }
+    const circular: CircularPayload = { label: 'root' };
+    circular.self = circular;
+    circular.child = { parent: circular };
+
+    expect(toJsonValue(circular)).toMatchObject({
+      label: 'root',
+      self: '[Circular]',
+      child: { parent: '[Circular]' },
+    });
+  });
+
+  it('replaces circular Error causes in JSONL payloads', () => {
+    const error = new Error('request failed');
+    Object.defineProperty(error, 'cause', {
+      value: error,
+      configurable: true,
+    });
+
+    expect(toJsonValue(error)).toMatchObject({
+      name: 'Error',
+      message: 'request failed',
+      cause: '[Circular]',
+    });
+  });
+
   it('creates high-level sessions with a JSONL store by default', async () => {
     const session = await createAgentSession({
       cwd: dir,

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -923,7 +923,9 @@ describe('JsonlSessionStore', () => {
     });
     const store = session.getSessionStore();
     const first = await store?.appendMessage(new HumanMessage('first'));
-    await store?.appendMessage(new AIMessage('abandoned answer'));
+    const abandoned = await store?.appendMessage(
+      new AIMessage('abandoned answer')
+    );
 
     await session.branch(first?.id ?? '', {
       position: 'at',
@@ -943,6 +945,7 @@ describe('JsonlSessionStore', () => {
       parentId: first?.id,
       data: {
         text: 'summary of abandoned branch',
+        summarizedEntryIds: [abandoned?.id],
         instructions: 'summarize abandoned branch',
       },
     });

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -287,6 +287,34 @@ describe('JsonlSessionStore', () => {
     expect(await readFile(sessionPath, 'utf8')).toBe('not jsonl\n');
   });
 
+  it('creates an explicit session path without fuzzy matching existing sessions', async () => {
+    const existing = await JsonlSessionStore.create({
+      path: join(dir, 'matching-existing.jsonl'),
+      cwd: dir,
+      sessionId: 'explicit-target-existing',
+    });
+    await existing.appendMessage(new HumanMessage('existing history'));
+    const sessionPath = join(dir, 'explicit-target.jsonl');
+
+    const session = await createAgentSession({
+      cwd: dir,
+      sessionPath,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.sessionPath).toBe(sessionPath);
+    expect(session.getSessionStore()?.header.id).not.toBe(existing.header.id);
+    expect(session.getSessionStore()?.getMessages()).toEqual([]);
+  });
+
   it('preserves non-message state while applying session history', async () => {
     const mockRun = createMockRun('stateful output');
     mockRunCreate(mockRun);

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -3,7 +3,55 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { JsonlSessionStore, createAgentSession } from '@/session';
+import { toJsonValue } from '@/session/messageSerialization';
 import * as providers from '@/llm/providers';
+import type * as t from '@/types';
+import { Run } from '@/run';
+
+type MockRun = {
+  processStream: jest.MockedFunction<Run<t.IState>['processStream']>;
+  resume: jest.MockedFunction<Run<t.IState>['resume']>;
+  getRunMessages: jest.MockedFunction<Run<t.IState>['getRunMessages']>;
+  getCalibrationRatio: jest.MockedFunction<
+    Run<t.IState>['getCalibrationRatio']
+  >;
+  getInterrupt: jest.MockedFunction<Run<t.IState>['getInterrupt']>;
+  getHaltReason: jest.MockedFunction<Run<t.IState>['getHaltReason']>;
+};
+
+function createMockRun(outputText = 'ok'): MockRun {
+  return {
+    processStream: jest
+      .fn<
+        ReturnType<Run<t.IState>['processStream']>,
+        Parameters<Run<t.IState>['processStream']>
+      >()
+      .mockResolvedValue([{ type: 'text', text: outputText }]),
+    resume: jest
+      .fn<
+        ReturnType<Run<t.IState>['resume']>,
+        Parameters<Run<t.IState>['resume']>
+      >()
+      .mockResolvedValue([{ type: 'text', text: outputText }]),
+    getRunMessages: jest.fn(() => [new AIMessage(outputText)]),
+    getCalibrationRatio: jest.fn(() => 1),
+    getInterrupt: jest.fn(() => undefined),
+    getHaltReason: jest.fn(() => undefined),
+  };
+}
+
+function mockRunCreate(mockRun: MockRun): t.RunConfig[] {
+  const capturedConfigs: t.RunConfig[] = [];
+  jest.spyOn(Run, 'create').mockImplementation((async <
+    T extends t.BaseGraphState,
+  >(
+    config: t.RunConfig
+  ): Promise<Run<T>> => {
+    capturedConfigs.push(config);
+    return mockRun as unknown as Run<T>;
+  }) as never);
+  return capturedConfigs;
+}
 
 function mockSummarizer(response: string): void {
   jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
@@ -121,6 +169,22 @@ describe('JsonlSessionStore', () => {
     expect(compaction.data.summaryEntryId).toBe(summary.id);
   });
 
+  it('preserves Error details in JSONL payloads', () => {
+    const error = new Error('resume failed');
+    const payload = toJsonValue(error);
+
+    expect(payload).toMatchObject({
+      name: 'Error',
+      message: 'resume failed',
+    });
+    expect(
+      typeof payload === 'object' &&
+        payload != null &&
+        !Array.isArray(payload) &&
+        typeof payload.stack === 'string'
+    ).toBe(true);
+  });
+
   it('creates high-level sessions with a JSONL store by default', async () => {
     const session = await createAgentSession({
       cwd: dir,
@@ -167,6 +231,60 @@ describe('JsonlSessionStore', () => {
       'summary of old work',
       'recent',
     ]);
+  });
+
+  it('records no retained ids when compaction retains zero messages', async () => {
+    mockSummarizer('summary of everything');
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const user = await store?.appendMessage(new HumanMessage('old'));
+    const assistant = await store?.appendMessage(new AIMessage('old answer'));
+
+    await session.compact({ retainRecentTurns: 0 });
+
+    const summary = store
+      ?.getEntries()
+      .find((entry) => entry.type === 'summary');
+    const compaction = store
+      ?.getEntries()
+      .find((entry) => entry.type === 'compaction');
+    expect(summary?.data.retainedEntryIds).toEqual([]);
+    expect(summary?.data.summarizedEntryIds).toEqual([user?.id, assistant?.id]);
+    expect(compaction?.data.retainedEntryIds).toEqual([]);
+  });
+
+  it('carries calibration ratio forward after resumeInterrupt', async () => {
+    const mockRun = createMockRun('resumed');
+    mockRun.getCalibrationRatio.mockReturnValue(2);
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.resumeInterrupt([]);
+    await session.run('after resume');
+
+    expect(capturedConfigs[1].calibrationRatio).toBe(2);
   });
 
   it('summarizes an abandoned branch before switching in place', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { MemorySaver } from '@langchain/langgraph';
 import { JsonlSessionStore, createAgentSession } from '@/session';
 import { toJsonValue } from '@/session/messageSerialization';
 import * as providers from '@/llm/providers';
@@ -51,6 +52,15 @@ function mockRunCreate(mockRun: MockRun): t.RunConfig[] {
     return mockRun as unknown as Run<T>;
   }) as never);
   return capturedConfigs;
+}
+
+function getProcessedState(mockRun: MockRun): t.IState {
+  expect(mockRun.processStream).toHaveBeenCalled();
+  const input = mockRun.processStream.mock.calls[0][0];
+  if (!('messages' in input)) {
+    throw new Error('Expected processStream to receive message state');
+  }
+  return input;
 }
 
 function mockSummarizer(response: string): void {
@@ -201,6 +211,68 @@ describe('JsonlSessionStore', () => {
 
     expect(session.getSessionStore()?.header.cwd).toBe(dir);
     expect(session.sessionPath).toContain('.jsonl');
+  });
+
+  it('preserves non-message state while applying session history', async () => {
+    const mockRun = createMockRun('stateful output');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+    const input: t.IState & { selectedAgent: string } = {
+      messages: [new HumanMessage('fresh')],
+      selectedAgent: 'subagent-a',
+    };
+
+    await session.run(input);
+
+    const processedState = getProcessedState(mockRun) as t.IState & {
+      selectedAgent?: string;
+    };
+    expect(processedState.selectedAgent).toBe('subagent-a');
+    expect(processedState.messages.map((message) => message.content)).toEqual([
+      'history',
+      'fresh',
+    ]);
+  });
+
+  it('reuses a session-level checkpointer for HITL resume', async () => {
+    const mockRun = createMockRun('resumed');
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      humanInTheLoop: { enabled: true },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await session.run('start');
+    await session.resumeInterrupt([]);
+
+    const checkpointer =
+      capturedConfigs[0].graphConfig.compileOptions?.checkpointer;
+    expect(checkpointer).toBeInstanceOf(MemorySaver);
+    expect(session.getCheckpointer()).toBe(checkpointer);
+    expect(capturedConfigs[1].graphConfig.compileOptions?.checkpointer).toBe(
+      checkpointer
+    );
   });
 
   it('compacts into a summary plus retained active path', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -7,6 +7,8 @@ import {
   RemoveMessage,
 } from '@langchain/core/messages';
 import { MemorySaver } from '@langchain/langgraph';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { Checkpoint, CheckpointMetadata } from '@langchain/langgraph';
 import { JsonlSessionStore, createAgentSession } from '@/session';
 import { toJsonValue } from '@/session/messageSerialization';
 import * as providers from '@/llm/providers';
@@ -65,6 +67,41 @@ function getProcessedState(mockRun: MockRun): t.IState {
     throw new Error('Expected processStream to receive message state');
   }
   return input;
+}
+
+function getProcessedMessages(mockRun: MockRun): BaseMessage[] {
+  return getProcessedState(mockRun).messages;
+}
+
+async function putCheckpoint(params: {
+  checkpointer: MemorySaver;
+  threadId: string;
+  id: string;
+  checkpointNs?: string;
+}): Promise<void> {
+  const checkpoint: Checkpoint = {
+    v: 4,
+    id: params.id,
+    ts: new Date().toISOString(),
+    channel_values: {},
+    channel_versions: {},
+    versions_seen: {},
+  };
+  const metadata: CheckpointMetadata = {
+    source: 'loop',
+    step: 0,
+    parents: {},
+  };
+  await params.checkpointer.put(
+    {
+      configurable: {
+        thread_id: params.threadId,
+        checkpoint_ns: params.checkpointNs ?? '',
+      },
+    },
+    checkpoint,
+    metadata
+  );
 }
 
 function mockSummarizer(response: string): void {
@@ -253,6 +290,55 @@ describe('JsonlSessionStore', () => {
     expect(compaction.data.summaryEntryId).toBe(summary.id);
   });
 
+  it('records LangGraph checkpoint references without moving the active leaf', async () => {
+    const store = await JsonlSessionStore.create({
+      path: join(dir, 'checkpoints.jsonl'),
+      cwd: dir,
+    });
+    const message = await store.appendMessage(new HumanMessage('hello'));
+
+    const checkpoint = await store.appendCheckpoint({
+      source: 'run',
+      threadId: store.header.id,
+      runId: 'run_checkpoint',
+      checkpointId: 'checkpoint_1',
+      checkpointNs: '',
+    });
+
+    expect(checkpoint.data.provider).toBe('langgraph');
+    expect(store.getLeafEntry()?.id).toBe(message.id);
+    expect(store.getLatestCheckpoint(store.header.id)?.id).toBe(checkpoint.id);
+  });
+
+  it('treats reset checkpoints as latest checkpoint barriers', async () => {
+    const store = await JsonlSessionStore.create({
+      path: join(dir, 'checkpoint-reset.jsonl'),
+      cwd: dir,
+    });
+    await store.appendCheckpoint({
+      source: 'run',
+      threadId: store.header.id,
+      runId: 'run_before_reset',
+      checkpointId: 'checkpoint_before_reset',
+    });
+    await store.appendCheckpoint({
+      source: 'reset',
+      threadId: store.header.id,
+      reason: 'branch',
+    });
+
+    expect(store.getLatestCheckpoint(store.header.id)).toBeUndefined();
+
+    const checkpoint = await store.appendCheckpoint({
+      source: 'run',
+      threadId: store.header.id,
+      runId: 'run_after_reset',
+      checkpointId: 'checkpoint_after_reset',
+    });
+
+    expect(store.getLatestCheckpoint(store.header.id)?.id).toBe(checkpoint.id);
+  });
+
   it('preserves Error details in JSONL payloads', () => {
     const error = new Error('resume failed');
     const payload = toJsonValue(error);
@@ -371,7 +457,46 @@ describe('JsonlSessionStore', () => {
     ]);
   });
 
-  it('reuses a session-level checkpointer for HITL resume', async () => {
+  it('shares a session-level LangGraph checkpointer for HITL resume', async () => {
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      humanInTheLoop: { enabled: true },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.getCheckpointer()).toBeInstanceOf(MemorySaver);
+  });
+
+  it('keeps stores and checkpointing optional for high-level sessions', async () => {
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      ephemeral: true,
+      checkpointing: false,
+      humanInTheLoop: { enabled: true },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.getSessionStore()).toBeUndefined();
+    expect(session.getCheckpointer()).toBeUndefined();
+  });
+
+  it('reuses the session-level checkpointer across HITL resume', async () => {
     const mockRun = createMockRun('resumed');
     const capturedConfigs = mockRunCreate(mockRun);
     const session = await createAgentSession({
@@ -398,6 +523,304 @@ describe('JsonlSessionStore', () => {
     expect(capturedConfigs[1].graphConfig.compileOptions?.checkpointer).toBe(
       checkpointer
     );
+  });
+
+  it('preserves a caller-supplied session checkpointer', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.getCheckpointer()).toBe(checkpointer);
+  });
+
+  it('injects the session checkpointer and replays JSONL history before checkpoints exist', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('first output');
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+
+    await session.run('next');
+
+    expect(capturedConfigs[0].graphConfig.compileOptions?.checkpointer).toBe(
+      checkpointer
+    );
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['history', 'next']);
+  });
+
+  it('uses only new input when LangGraph checkpoint state already exists', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('checkpointed output');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_existing',
+    });
+
+    await session.run('fresh turn', { runId: 'run_checkpointed' });
+
+    const checkpoints = session
+      .getSessionStore()
+      ?.getCheckpoints(session.threadId);
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['fresh turn']);
+    expect(checkpoints?.at(-1)?.data).toMatchObject({
+      source: 'run',
+      runId: 'run_checkpointed',
+      checkpointId: 'checkpoint_existing',
+    });
+  });
+
+  it('replays JSONL history when the requested checkpoint namespace has no state', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('namespace output');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_other_namespace',
+      checkpointNs: 'other',
+    });
+
+    await session.run('fresh turn', {
+      config: { configurable: { checkpoint_ns: 'requested' } },
+    });
+
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['history', 'fresh turn']);
+  });
+
+  it('looks up the latest checkpoint in the requested namespace', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_requested_namespace',
+      checkpointNs: 'requested',
+    });
+
+    await expect(session.getLatestCheckpoint()).resolves.toBeUndefined();
+    await expect(
+      session.getLatestCheckpoint({ checkpointNs: 'requested' })
+    ).resolves.toMatchObject({
+      checkpointId: 'checkpoint_requested_namespace',
+      checkpointNs: 'requested',
+    });
+  });
+
+  it('resets stale checkpoint state when branching changes the active JSONL path', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const first = await store?.appendMessage(new HumanMessage('first'));
+    await store?.appendMessage(new AIMessage('second'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_to_reset',
+    });
+
+    await session.branch(first?.id ?? '', { position: 'at' });
+
+    const tuple = await checkpointer.getTuple({
+      configurable: { thread_id: session.threadId },
+    });
+    expect(tuple).toBeUndefined();
+    expect(store?.getCheckpoints(session.threadId).at(-1)?.data).toMatchObject({
+      source: 'reset',
+      reason: 'branch',
+    });
+  });
+
+  it('keeps checkpoint state when branching to the active JSONL leaf', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const active = await store?.appendMessage(new HumanMessage('current'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_to_keep',
+    });
+
+    await session.branch(active?.id ?? '', { position: 'at' });
+
+    const tuple = await checkpointer.getTuple({
+      configurable: { thread_id: session.threadId },
+    });
+    expect(tuple?.checkpoint.id).toBe('checkpoint_to_keep');
+    expect(
+      store
+        ?.getCheckpoints(session.threadId)
+        .some((checkpoint) => checkpoint.data.source === 'reset')
+    ).toBe(false);
+  });
+
+  it('resets overridden thread checkpoints when branching changes the active path', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const first = await store?.appendMessage(new HumanMessage('first'));
+    await store?.appendMessage(new AIMessage('second'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: 'thread_override',
+      id: 'checkpoint_override',
+    });
+    await store?.appendCheckpoint({
+      source: 'run',
+      threadId: 'thread_override',
+      runId: 'run_override',
+      checkpointId: 'checkpoint_override',
+    });
+
+    await session.branch(first?.id ?? '', { position: 'at' });
+
+    const tuple = await checkpointer.getTuple({
+      configurable: { thread_id: 'thread_override' },
+    });
+    const reset = store
+      ?.getCheckpoints('thread_override')
+      .find((checkpoint) => checkpoint.data.source === 'reset');
+    expect(tuple).toBeUndefined();
+    expect(reset?.data.reason).toBe('branch');
+  });
+
+  it('records run.failed when resumeInterrupt throws', async () => {
+    const mockRun = createMockRun('unused');
+    mockRun.resume.mockRejectedValue(new Error('resume failed'));
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      humanInTheLoop: { enabled: true },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await expect(
+      session.resumeInterrupt([{ type: 'approve' }], {
+        runId: 'run_resume_failure',
+      })
+    ).rejects.toThrow('resume failed');
+
+    const events = session
+      .getSessionStore()
+      ?.getEntries()
+      .filter((entry) => entry.type === 'run_event')
+      .map((entry) => entry.data.event);
+    expect(events).toEqual(['run.started', 'run.failed']);
   });
 
   it('compacts into a summary plus retained active path', async () => {

--- a/src/session/__tests__/handlers.test.ts
+++ b/src/session/__tests__/handlers.test.ts
@@ -1,0 +1,88 @@
+import { GraphEvents, StepTypes } from '@/common';
+import { composeEventHandlers } from '@/events';
+import { createRunHandlers } from '@/session';
+import type { AgentSessionStreamEvent } from '@/session';
+import type * as t from '@/types';
+
+describe('createRunHandlers', () => {
+  it('emits live session events through the same graph handlers before user handlers', async () => {
+    const liveEvents: AgentSessionStreamEvent[] = [];
+    let liveEventCountSeenByUserHandler = 0;
+    const handlerResult = createRunHandlers({
+      runId: 'run_live',
+      threadId: 'thread_live',
+      onEvent: (event) => {
+        liveEvents.push(event);
+      },
+      userHandlers: {
+        [GraphEvents.ON_MESSAGE_DELTA]: {
+          handle: (): void => {
+            liveEventCountSeenByUserHandler = liveEvents.length;
+          },
+        },
+      },
+    });
+
+    await handlerResult.handlers[GraphEvents.ON_RUN_STEP].handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        stepIndex: 0,
+        id: 'message_step',
+        type: StepTypes.MESSAGE_CREATION,
+        index: 0,
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'message_step' },
+        },
+        usage: null,
+      } satisfies t.RunStep
+    );
+    await handlerResult.handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'message_step',
+        delta: { content: [{ type: 'text', text: 'hello' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+
+    expect(liveEvents.map((event) => event.type)).toEqual([
+      'run.started',
+      'message.delta',
+    ]);
+    expect(liveEventCountSeenByUserHandler).toBe(2);
+    expect(handlerResult.contentParts[0]).toEqual({
+      type: 'text',
+      text: 'hello',
+    });
+  });
+
+  it('composes adapter and host handlers in order for the same graph event', async () => {
+    const calls: string[] = [];
+    const handlers = composeEventHandlers(
+      {
+        [GraphEvents.ON_MESSAGE_DELTA]: {
+          handle: (): void => {
+            calls.push('adapter');
+          },
+        },
+      },
+      {
+        [GraphEvents.ON_MESSAGE_DELTA]: {
+          handle: (): void => {
+            calls.push('host');
+          },
+        },
+      }
+    );
+
+    await handlers[GraphEvents.ON_MESSAGE_DELTA].handle(
+      GraphEvents.ON_MESSAGE_DELTA,
+      {
+        id: 'message_step',
+        delta: { content: [{ type: 'text', text: 'hello' }] },
+      } satisfies t.MessageDeltaEvent
+    );
+
+    expect(calls).toEqual(['adapter', 'host']);
+  });
+});

--- a/src/session/__tests__/handlers.test.ts
+++ b/src/session/__tests__/handlers.test.ts
@@ -85,4 +85,31 @@ describe('createRunHandlers', () => {
 
     expect(calls).toEqual(['adapter', 'host']);
   });
+
+  it('accumulates partial usage metadata without corrupting totals', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const handlerResult = createRunHandlers({
+      runId: 'run_usage',
+      threadId: 'thread_usage',
+    });
+
+    await handlerResult.handlers[GraphEvents.CHAT_MODEL_END].handle(
+      GraphEvents.CHAT_MODEL_END,
+      {
+        output: { usage_metadata: { input_tokens: 4 } },
+      } as t.ModelEndData
+    );
+    await handlerResult.handlers[GraphEvents.CHAT_MODEL_END].handle(
+      GraphEvents.CHAT_MODEL_END,
+      {
+        output: { usage_metadata: { output_tokens: 6 } },
+      } as t.ModelEndData
+    );
+
+    expect(handlerResult.usage).toEqual({
+      inputTokens: 4,
+      outputTokens: 6,
+      totalTokens: 10,
+    });
+  });
 });

--- a/src/session/__tests__/handlers.test.ts
+++ b/src/session/__tests__/handlers.test.ts
@@ -1,4 +1,4 @@
-import { GraphEvents, StepTypes } from '@/common';
+import { ContentTypes, GraphEvents, StepTypes } from '@/common';
 import { composeEventHandlers } from '@/events';
 import { createRunHandlers } from '@/session';
 import type { AgentSessionStreamEvent } from '@/session';
@@ -111,5 +111,51 @@ describe('createRunHandlers', () => {
       outputTokens: 6,
       totalTokens: 10,
     });
+  });
+
+  it('does not emit tool completion events for summary completions', async () => {
+    const liveEvents: AgentSessionStreamEvent[] = [];
+    const handlerResult = createRunHandlers({
+      runId: 'run_summary',
+      threadId: 'thread_summary',
+      onEvent: (event) => {
+        liveEvents.push(event);
+      },
+    });
+    const summary: t.SummaryContentBlock = {
+      type: ContentTypes.SUMMARY,
+      content: [{ type: ContentTypes.TEXT, text: 'summary text' }],
+      tokenCount: 4,
+    };
+
+    await handlerResult.handlers[GraphEvents.ON_RUN_STEP].handle(
+      GraphEvents.ON_RUN_STEP,
+      {
+        stepIndex: 0,
+        id: 'summary_step',
+        type: StepTypes.MESSAGE_CREATION,
+        index: 0,
+        stepDetails: {
+          type: StepTypes.MESSAGE_CREATION,
+          message_creation: { message_id: 'summary_step' },
+        },
+        summary,
+        usage: null,
+      } satisfies t.RunStep
+    );
+    await handlerResult.handlers[GraphEvents.ON_RUN_STEP_COMPLETED].handle(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: 'summary_step',
+          index: 0,
+          type: 'summary',
+          summary,
+        },
+      }
+    );
+
+    expect(liveEvents.map((event) => event.type)).toEqual(['run.started']);
+    expect(handlerResult.contentParts[0]).toBe(summary);
   });
 });

--- a/src/session/handlers.ts
+++ b/src/session/handlers.ts
@@ -1,3 +1,4 @@
+import type { UsageMetadata } from '@langchain/core/messages';
 import { GraphEvents } from '@/common';
 import { ModelEndHandler, ToolEndHandler } from '@/events';
 import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
@@ -28,16 +29,26 @@ function createEventFactory(params: {
   });
 }
 
+function getTokenCount(value: number | null | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
 function updateUsage(usage: AgentSessionUsage, data: t.ModelEndData): void {
-  const metadata = data?.output?.usage_metadata;
+  const metadata = data?.output?.usage_metadata as
+    | Partial<UsageMetadata>
+    | undefined;
   if (!metadata) {
     return;
   }
-  const inputTokens = metadata.input_tokens;
-  const outputTokens = metadata.output_tokens;
+  const inputTokens = getTokenCount(metadata.input_tokens);
+  const outputTokens = getTokenCount(metadata.output_tokens);
+  const totalTokens =
+    metadata.total_tokens == null
+      ? inputTokens + outputTokens
+      : getTokenCount(metadata.total_tokens);
   usage.inputTokens += inputTokens;
   usage.outputTokens += outputTokens;
-  usage.totalTokens += inputTokens + outputTokens;
+  usage.totalTokens += totalTokens;
 }
 
 async function callUserHandler(params: {

--- a/src/session/handlers.ts
+++ b/src/session/handlers.ts
@@ -1,7 +1,7 @@
 import type { UsageMetadata } from '@langchain/core/messages';
 import { GraphEvents } from '@/common';
 import { ModelEndHandler, ToolEndHandler } from '@/events';
-import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
+import { createContentAggregator } from '@/stream';
 import type * as t from '@/types';
 import type {
   AgentSessionHandlersResult,
@@ -92,7 +92,6 @@ export function createRunHandlers(params: {
     events.push(event);
     params.onEvent?.(event);
   };
-  const chatModelStreamHandler = new ChatModelStreamHandler();
   const toolEndHandler = new ToolEndHandler();
   const modelEndHandler = new ModelEndHandler();
 
@@ -101,12 +100,6 @@ export function createRunHandlers(params: {
   const handlers: Record<string, t.EventHandler> = {
     [GraphEvents.CHAT_MODEL_STREAM]: {
       handle: async (event, data, metadata, graph): Promise<void> => {
-        await chatModelStreamHandler.handle(
-          event,
-          data as t.StreamEventData,
-          metadata,
-          graph
-        );
         await callUserHandler({
           userHandlers: params.userHandlers,
           event,

--- a/src/session/handlers.ts
+++ b/src/session/handlers.ts
@@ -1,0 +1,260 @@
+import { GraphEvents } from '@/common';
+import { ModelEndHandler, ToolEndHandler } from '@/events';
+import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
+import type * as t from '@/types';
+import type {
+  AgentSessionHandlersResult,
+  AgentSessionStreamEvent,
+  AgentSessionUsage,
+} from './types';
+import { createTimestamp } from './ids';
+import { toJsonValue } from './messageSerialization';
+
+function createEventFactory(params: {
+  runId: string;
+  threadId: string;
+}): (
+  type: AgentSessionStreamEvent['type'],
+  data?: unknown
+) => AgentSessionStreamEvent {
+  let sequence = 0;
+  return (type, data) => ({
+    type,
+    sequence: sequence++,
+    runId: params.runId,
+    threadId: params.threadId,
+    timestamp: createTimestamp(),
+    ...(typeof data !== 'undefined' ? { data: toJsonValue(data) } : {}),
+  });
+}
+
+function updateUsage(usage: AgentSessionUsage, data: t.ModelEndData): void {
+  const metadata = data?.output?.usage_metadata;
+  if (!metadata) {
+    return;
+  }
+  const inputTokens = metadata.input_tokens;
+  const outputTokens = metadata.output_tokens;
+  usage.inputTokens += inputTokens;
+  usage.outputTokens += outputTokens;
+  usage.totalTokens += inputTokens + outputTokens;
+}
+
+async function callUserHandler(params: {
+  userHandlers?: Record<string, t.EventHandler>;
+  event: string;
+  data: Parameters<t.EventHandler['handle']>[1];
+  metadata?: Record<string, unknown>;
+  graph?: Parameters<t.EventHandler['handle']>[3];
+}): Promise<void> {
+  const handler = params.userHandlers?.[params.event];
+  if (!handler) {
+    return;
+  }
+  await handler.handle(
+    params.event,
+    params.data,
+    params.metadata,
+    params.graph
+  );
+}
+
+export function createRunHandlers(params: {
+  runId: string;
+  threadId: string;
+  userHandlers?: Record<string, t.EventHandler>;
+  onEvent?: (event: AgentSessionStreamEvent) => void;
+}): AgentSessionHandlersResult {
+  const { contentParts, aggregateContent } = createContentAggregator();
+  const steps: t.RunStep[] = [];
+  const usage: AgentSessionUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+  const events: AgentSessionStreamEvent[] = [];
+  const createEvent = createEventFactory({
+    runId: params.runId,
+    threadId: params.threadId,
+  });
+  const emitEvent = (event: AgentSessionStreamEvent): void => {
+    events.push(event);
+    params.onEvent?.(event);
+  };
+  const chatModelStreamHandler = new ChatModelStreamHandler();
+  const toolEndHandler = new ToolEndHandler();
+  const modelEndHandler = new ModelEndHandler();
+
+  emitEvent(createEvent('run.started'));
+
+  const handlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_STREAM]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        await chatModelStreamHandler.handle(
+          event,
+          data as t.StreamEventData,
+          metadata,
+          graph
+        );
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.CHAT_MODEL_END]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        await modelEndHandler.handle(
+          event,
+          data as t.ModelEndData,
+          metadata,
+          graph
+        );
+        updateUsage(usage, data as t.ModelEndData);
+        emitEvent(createEvent('usage.updated', usage));
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.TOOL_END]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        await toolEndHandler.handle(
+          event,
+          data as t.StreamEventData,
+          metadata,
+          graph
+        );
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        const runStep = data as t.RunStep;
+        steps.push(runStep);
+        aggregateContent({ event: GraphEvents.ON_RUN_STEP, data: runStep });
+        if (runStep.stepDetails.type === 'tool_calls') {
+          emitEvent(createEvent('tool.started', runStep));
+        }
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        const delta = data as t.RunStepDeltaEvent;
+        aggregateContent({ event: GraphEvents.ON_RUN_STEP_DELTA, data: delta });
+        emitEvent(createEvent('tool.delta', delta));
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        const completed = data as unknown as {
+          result:
+            | t.ToolEndEvent
+            | (t.SummaryCompleted & { id: string; index: number });
+        };
+        aggregateContent({
+          event: GraphEvents.ON_RUN_STEP_COMPLETED,
+          data: completed as { result: t.ToolEndEvent },
+        });
+        emitEvent(createEvent('tool.completed', completed));
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        const delta = data as t.MessageDeltaEvent;
+        aggregateContent({ event: GraphEvents.ON_MESSAGE_DELTA, data: delta });
+        emitEvent(createEvent('message.delta', delta));
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        const delta = data as t.ReasoningDeltaEvent;
+        aggregateContent({
+          event: GraphEvents.ON_REASONING_DELTA,
+          data: delta,
+        });
+        emitEvent(createEvent('reasoning.delta', delta));
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_SUMMARIZE_DELTA]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        aggregateContent({
+          event: GraphEvents.ON_SUMMARIZE_DELTA,
+          data: data as t.SummarizeDeltaData,
+        });
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+    [GraphEvents.ON_SUMMARIZE_COMPLETE]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        aggregateContent({
+          event: GraphEvents.ON_SUMMARIZE_COMPLETE,
+          data: data as t.SummarizeCompleteEvent,
+        });
+        await callUserHandler({
+          userHandlers: params.userHandlers,
+          event,
+          data,
+          metadata,
+          graph,
+        });
+      },
+    },
+  };
+
+  return { contentParts, steps, usage, events, handlers };
+}

--- a/src/session/handlers.ts
+++ b/src/session/handlers.ts
@@ -11,6 +11,16 @@ import type {
 import { createTimestamp } from './ids';
 import { toJsonValue } from './messageSerialization';
 
+type CompletedRunStepResult =
+  | t.ToolEndEvent
+  | (t.SummaryCompleted & { id: string; index: number });
+
+function isToolCompletion(
+  result: CompletedRunStepResult
+): result is t.ToolEndEvent {
+  return 'tool_call' in result;
+}
+
 function createEventFactory(params: {
   runId: string;
   threadId: string;
@@ -178,16 +188,14 @@ export function createRunHandlers(params: {
     },
     [GraphEvents.ON_RUN_STEP_COMPLETED]: {
       handle: async (event, data, metadata, graph): Promise<void> => {
-        const completed = data as unknown as {
-          result:
-            | t.ToolEndEvent
-            | (t.SummaryCompleted & { id: string; index: number });
-        };
+        const completed = data as unknown as { result: CompletedRunStepResult };
         aggregateContent({
           event: GraphEvents.ON_RUN_STEP_COMPLETED,
           data: completed as { result: t.ToolEndEvent },
         });
-        emitEvent(createEvent('tool.completed', completed));
+        if (isToolCompletion(completed.result)) {
+          emitEvent(createEvent('tool.completed', completed));
+        }
         await callUserHandler({
           userHandlers: params.userHandlers,
           event,

--- a/src/session/ids.ts
+++ b/src/session/ids.ts
@@ -1,0 +1,17 @@
+import { randomUUID } from 'crypto';
+
+export function createSessionId(): string {
+  return randomUUID();
+}
+
+export function createEntryId(): string {
+  return randomUUID().replace(/-/g, '').slice(0, 12);
+}
+
+export function createRunId(): string {
+  return randomUUID();
+}
+
+export function createTimestamp(): string {
+  return new Date().toISOString();
+}

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -8,6 +8,8 @@ export {
 } from './messageSerialization';
 export type {
   AgentSessionConfig,
+  AgentSessionCheckpointing,
+  AgentSessionCheckpointingOptions,
   AgentSessionHandlersResult,
   AgentSessionInput,
   AgentSessionRunOptions,

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -1,0 +1,39 @@
+export { AgentSession, createAgentSession } from './AgentSession';
+export { JsonlSessionStore, SessionManager } from './JsonlSessionStore';
+export { createRunHandlers } from './handlers';
+export {
+  serializeMessage,
+  deserializeMessage,
+  extractTextFromContent,
+} from './messageSerialization';
+export type {
+  AgentSessionConfig,
+  AgentSessionHandlersResult,
+  AgentSessionInput,
+  AgentSessionRunOptions,
+  AgentSessionRunResult,
+  AgentSessionStream,
+  AgentSessionStreamEvent,
+  AgentSessionUsage,
+  CreateSessionFileOptions,
+  JsonObject,
+  JsonPrimitive,
+  JsonValue,
+  SerializedSessionMessage,
+  SessionBranchOptions,
+  SessionCompactOptions,
+  SessionCompactionEntry,
+  SessionEntry,
+  SessionEntryBase,
+  SessionEntryType,
+  SessionForkOptions,
+  SessionHeader,
+  SessionLabelEntry,
+  SessionListItem,
+  SessionMessageEntry,
+  SessionPosition,
+  SessionRunEventEntry,
+  SessionStateEntry,
+  SessionSummaryEntry,
+  SessionTreeNode,
+} from './types';

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -8,6 +8,8 @@ export {
 } from './messageSerialization';
 export type {
   AgentSessionConfig,
+  AgentSessionCheckpointLookupOptions,
+  AgentSessionCheckpointReference,
   AgentSessionCheckpointing,
   AgentSessionCheckpointingOptions,
   AgentSessionHandlersResult,
@@ -24,6 +26,7 @@ export type {
   SerializedSessionMessage,
   SessionBranchOptions,
   SessionCompactOptions,
+  SessionCheckpointEntry,
   SessionCompactionEntry,
   SessionEntry,
   SessionEntryBase,

--- a/src/session/messageSerialization.ts
+++ b/src/session/messageSerialization.ts
@@ -1,6 +1,7 @@
 import {
   AIMessage,
   HumanMessage,
+  RemoveMessage,
   SystemMessage,
   ToolMessage,
   BaseMessage,
@@ -140,6 +141,14 @@ export function deserializeMessage(
     return new ToolMessage({
       ...common,
       tool_call_id: serialized.toolCallId ?? '',
+    });
+  }
+  if (serialized.messageType === 'remove') {
+    return new RemoveMessage({
+      additional_kwargs: serialized.additionalKwargs,
+      response_metadata: serialized.responseMetadata,
+      id: serialized.id ?? '',
+      name: serialized.name,
     });
   }
   return new HumanMessage(common);

--- a/src/session/messageSerialization.ts
+++ b/src/session/messageSerialization.ts
@@ -1,0 +1,158 @@
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+  BaseMessage,
+} from '@langchain/core/messages';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { UsageMetadata } from '@langchain/core/messages';
+import type { JsonObject, JsonValue, SerializedSessionMessage } from './types';
+
+type MessageExtras = {
+  id?: string;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: ToolCall[];
+  usage_metadata?: UsageMetadata;
+  additional_kwargs?: unknown;
+  response_metadata?: unknown;
+};
+
+function isJsonPrimitive(
+  value: unknown
+): value is string | number | boolean | null {
+  return (
+    value == null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+export function toJsonValue(value: unknown): JsonValue {
+  if (isJsonPrimitive(value)) {
+    return Number.isNaN(value) ? null : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => toJsonValue(item));
+  }
+  if (value !== null && typeof value === 'object') {
+    const result: JsonObject = {};
+    for (const [key, nested] of Object.entries(value)) {
+      if (typeof nested !== 'undefined') {
+        result[key] = toJsonValue(nested);
+      }
+    }
+    return result;
+  }
+  return String(value);
+}
+
+function toJsonObject(value: unknown): JsonObject | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return toJsonValue(value) as JsonObject;
+}
+
+function fromJsonValue(value: JsonValue): unknown {
+  return value;
+}
+
+export function serializeMessage(
+  message: BaseMessage
+): SerializedSessionMessage {
+  const extras = message as BaseMessage & MessageExtras;
+  const serialized: SerializedSessionMessage = {
+    messageType: message._getType(),
+    content: toJsonValue(message.content),
+  };
+  const additionalKwargs = toJsonObject(extras.additional_kwargs);
+  const responseMetadata = toJsonObject(extras.response_metadata);
+  const usageMetadata = toJsonObject(extras.usage_metadata);
+  if (additionalKwargs) {
+    serialized.additionalKwargs = additionalKwargs;
+  }
+  if (responseMetadata) {
+    serialized.responseMetadata = responseMetadata;
+  }
+  if (usageMetadata) {
+    serialized.usageMetadata = usageMetadata;
+  }
+  if (extras.id != null && extras.id !== '') {
+    serialized.id = extras.id;
+  }
+  if (extras.name != null && extras.name !== '') {
+    serialized.name = extras.name;
+  }
+  if (extras.tool_call_id != null && extras.tool_call_id !== '') {
+    serialized.toolCallId = extras.tool_call_id;
+  }
+  if (extras.tool_calls) {
+    serialized.toolCalls = toJsonValue(extras.tool_calls);
+  }
+  return serialized;
+}
+
+export function deserializeMessage(
+  serialized: SerializedSessionMessage
+): BaseMessage {
+  const common = {
+    content: fromJsonValue(serialized.content) as BaseMessage['content'],
+    additional_kwargs: serialized.additionalKwargs,
+    response_metadata: serialized.responseMetadata,
+    id: serialized.id,
+    name: serialized.name,
+  };
+  if (serialized.messageType === 'human') {
+    return new HumanMessage(common);
+  }
+  if (serialized.messageType === 'ai') {
+    return new AIMessage({
+      ...common,
+      tool_calls: serialized.toolCalls as ToolCall[] | undefined,
+      usage_metadata: serialized.usageMetadata as UsageMetadata | undefined,
+    });
+  }
+  if (serialized.messageType === 'system') {
+    return new SystemMessage(common);
+  }
+  if (serialized.messageType === 'tool') {
+    return new ToolMessage({
+      ...common,
+      tool_call_id: serialized.toolCallId ?? '',
+    });
+  }
+  return new HumanMessage(common);
+}
+
+export function getMessageRole(message: BaseMessage): string {
+  const type = message._getType();
+  if (type === 'human') {
+    return 'user';
+  }
+  if (type === 'ai') {
+    return 'assistant';
+  }
+  return type;
+}
+
+export function extractTextFromContent(content: JsonValue): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return '';
+  }
+  const chunks: string[] = [];
+  for (const part of content) {
+    if (part != null && typeof part === 'object' && !Array.isArray(part)) {
+      const text = part.text;
+      if (typeof text === 'string') {
+        chunks.push(text);
+      }
+    }
+  }
+  return chunks.join('');
+}

--- a/src/session/messageSerialization.ts
+++ b/src/session/messageSerialization.ts
@@ -20,6 +20,8 @@ type MessageExtras = {
   response_metadata?: unknown;
 };
 
+const CIRCULAR_REFERENCE = '[Circular]';
+
 function isJsonPrimitive(
   value: unknown
 ): value is string | number | boolean | null {
@@ -31,14 +33,24 @@ function isJsonPrimitive(
   );
 }
 
-export function toJsonValue(value: unknown): JsonValue {
+function toJsonValueInternal(value: unknown, seen: WeakSet<object>): JsonValue {
   if (isJsonPrimitive(value)) {
     return Number.isNaN(value) ? null : value;
   }
   if (Array.isArray(value)) {
-    return value.map((item) => toJsonValue(item));
+    if (seen.has(value)) {
+      return CIRCULAR_REFERENCE;
+    }
+    seen.add(value);
+    const result = value.map((item) => toJsonValueInternal(item, seen));
+    seen.delete(value);
+    return result;
   }
   if (value instanceof Error) {
+    if (seen.has(value)) {
+      return CIRCULAR_REFERENCE;
+    }
+    seen.add(value);
     const result: JsonObject = {
       name: value.name,
       message: value.message,
@@ -47,25 +59,35 @@ export function toJsonValue(value: unknown): JsonValue {
       result.stack = value.stack;
     }
     if ('cause' in value && typeof value.cause !== 'undefined') {
-      result.cause = toJsonValue(value.cause);
+      result.cause = toJsonValueInternal(value.cause, seen);
     }
     for (const [key, nested] of Object.entries(value)) {
       if (typeof nested !== 'undefined') {
-        result[key] = toJsonValue(nested);
+        result[key] = toJsonValueInternal(nested, seen);
       }
     }
+    seen.delete(value);
     return result;
   }
   if (value !== null && typeof value === 'object') {
+    if (seen.has(value)) {
+      return CIRCULAR_REFERENCE;
+    }
+    seen.add(value);
     const result: JsonObject = {};
     for (const [key, nested] of Object.entries(value)) {
       if (typeof nested !== 'undefined') {
-        result[key] = toJsonValue(nested);
+        result[key] = toJsonValueInternal(nested, seen);
       }
     }
+    seen.delete(value);
     return result;
   }
   return String(value);
+}
+
+export function toJsonValue(value: unknown): JsonValue {
+  return toJsonValueInternal(value, new WeakSet<object>());
 }
 
 function toJsonObject(value: unknown): JsonObject | undefined {

--- a/src/session/messageSerialization.ts
+++ b/src/session/messageSerialization.ts
@@ -37,6 +37,24 @@ export function toJsonValue(value: unknown): JsonValue {
   if (Array.isArray(value)) {
     return value.map((item) => toJsonValue(item));
   }
+  if (value instanceof Error) {
+    const result: JsonObject = {
+      name: value.name,
+      message: value.message,
+    };
+    if (value.stack != null && value.stack !== '') {
+      result.stack = value.stack;
+    }
+    if ('cause' in value && typeof value.cause !== 'undefined') {
+      result.cause = toJsonValue(value.cause);
+    }
+    for (const [key, nested] of Object.entries(value)) {
+      if (typeof nested !== 'undefined') {
+        result[key] = toJsonValue(nested);
+      }
+    }
+    return result;
+  }
   if (value !== null && typeof value === 'object') {
     const result: JsonObject = {};
     for (const [key, nested] of Object.entries(value)) {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -67,6 +67,7 @@ export type SessionSummaryEntry = SessionEntryBase<
   'summary',
   {
     text: string;
+    tokenCount?: number;
     retainedEntryIds: JsonValue[];
     summarizedEntryIds: JsonValue[];
     instructions?: string;

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,5 +1,6 @@
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import type * as t from '@/types';
 
 export type JsonPrimitive = string | number | boolean | null;
@@ -163,6 +164,15 @@ export interface AgentSessionUsage {
   totalTokens: number;
 }
 
+export interface AgentSessionCheckpointingOptions {
+  enabled?: boolean;
+  checkpointer?: BaseCheckpointSaver;
+}
+
+export type AgentSessionCheckpointing =
+  | boolean
+  | AgentSessionCheckpointingOptions;
+
 export type AgentSessionInput = string | BaseMessage | BaseMessage[] | t.IState;
 
 export interface AgentSessionRunOptions {
@@ -214,6 +224,7 @@ export type AgentSessionConfig =
       sessionId?: string;
       name?: string;
       ephemeral?: boolean;
+      checkpointing?: AgentSessionCheckpointing;
     }
   | ({
       runId?: string;
@@ -222,6 +233,7 @@ export type AgentSessionConfig =
       sessionId?: string;
       name?: string;
       ephemeral?: boolean;
+      checkpointing?: AgentSessionCheckpointing;
     } & Omit<t.RunConfig, 'runId'>);
 
 export interface CreateSessionFileOptions {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -20,6 +20,7 @@ export type SessionEntryType =
   | 'message'
   | 'summary'
   | 'compaction'
+  | 'checkpoint'
   | 'label'
   | 'run_event'
   | 'session_state';
@@ -81,6 +82,20 @@ export type SessionCompactionEntry = SessionEntryBase<
   }
 >;
 
+export type SessionCheckpointEntry = SessionEntryBase<
+  'checkpoint',
+  {
+    provider: 'langgraph';
+    source: 'run' | 'resume' | 'reset';
+    threadId: string;
+    runId?: string;
+    checkpointId?: string;
+    checkpointNs?: string;
+    parentCheckpointId?: string;
+    reason?: string;
+  }
+>;
+
 export type SessionLabelEntry = SessionEntryBase<
   'label',
   {
@@ -110,6 +125,7 @@ export type SessionEntry =
   | SessionMessageEntry
   | SessionSummaryEntry
   | SessionCompactionEntry
+  | SessionCheckpointEntry
   | SessionLabelEntry
   | SessionRunEventEntry
   | SessionStateEntry;
@@ -162,6 +178,20 @@ export interface AgentSessionUsage {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
+}
+
+export interface AgentSessionCheckpointReference {
+  provider: 'langgraph';
+  threadId: string;
+  checkpointId?: string;
+  checkpointNs?: string;
+  parentCheckpointId?: string;
+}
+
+export interface AgentSessionCheckpointLookupOptions {
+  threadId?: string;
+  checkpointNs?: string;
+  config?: RunnableConfig;
 }
 
 export interface AgentSessionCheckpointingOptions {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,0 +1,232 @@
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | {
+      [key: string]: JsonValue;
+    };
+
+export type JsonObject = {
+  [key: string]: JsonValue;
+};
+
+export type SessionEntryType =
+  | 'message'
+  | 'summary'
+  | 'compaction'
+  | 'label'
+  | 'run_event'
+  | 'session_state';
+
+export interface SessionHeader {
+  type: 'session';
+  version: 1;
+  id: string;
+  timestamp: string;
+  cwd: string;
+  name?: string;
+  parentSession?: string;
+}
+
+export interface SessionEntryBase<TType extends SessionEntryType, TData> {
+  type: TType;
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  data: TData;
+}
+
+export interface SerializedSessionMessage {
+  messageType: string;
+  content: JsonValue;
+  additionalKwargs?: JsonObject;
+  responseMetadata?: JsonObject;
+  id?: string;
+  name?: string;
+  toolCallId?: string;
+  toolCalls?: JsonValue;
+  usageMetadata?: JsonObject;
+}
+
+export type SessionMessageEntry = SessionEntryBase<
+  'message',
+  {
+    role: string;
+    message: SerializedSessionMessage;
+  }
+>;
+
+export type SessionSummaryEntry = SessionEntryBase<
+  'summary',
+  {
+    text: string;
+    retainedEntryIds: JsonValue[];
+    summarizedEntryIds: JsonValue[];
+    instructions?: string;
+  }
+>;
+
+export type SessionCompactionEntry = SessionEntryBase<
+  'compaction',
+  {
+    summaryEntryId: string;
+    retainedEntryIds: JsonValue[];
+    summarizedEntryIds: JsonValue[];
+  }
+>;
+
+export type SessionLabelEntry = SessionEntryBase<
+  'label',
+  {
+    targetEntryId: string;
+    label: string;
+  }
+>;
+
+export type SessionRunEventEntry = SessionEntryBase<
+  'run_event',
+  {
+    event: string;
+    runId?: string;
+    threadId?: string;
+    payload?: JsonValue;
+  }
+>;
+
+export type SessionStateEntry = SessionEntryBase<
+  'session_state',
+  {
+    leafId: string | null;
+  }
+>;
+
+export type SessionEntry =
+  | SessionMessageEntry
+  | SessionSummaryEntry
+  | SessionCompactionEntry
+  | SessionLabelEntry
+  | SessionRunEventEntry
+  | SessionStateEntry;
+
+export interface SessionTreeNode {
+  entry: SessionEntry;
+  children: SessionTreeNode[];
+}
+
+export interface SessionListItem {
+  id: string;
+  path: string;
+  cwd: string;
+  timestamp: string;
+  name?: string;
+  leafId?: string | null;
+}
+
+export type SessionPosition = 'before' | 'at';
+
+export interface SessionForkOptions {
+  position?: SessionPosition;
+  cwd?: string;
+  name?: string;
+}
+
+export interface SessionBranchOptions {
+  position?: SessionPosition;
+  summarizeAbandoned?: boolean | { instructions?: string };
+}
+
+export interface SessionCompactOptions {
+  instructions?: string;
+  retainRecentTurns?: number;
+}
+
+export interface AgentSessionRunResult {
+  text: string;
+  content: t.MessageContentComplex[];
+  messages: BaseMessage[];
+  usage: AgentSessionUsage;
+  steps: t.RunStep[];
+  interrupt: t.RunInterruptResult | undefined;
+  haltedReason: string | undefined;
+  runId: string;
+  threadId: string;
+}
+
+export interface AgentSessionUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export type AgentSessionInput = string | BaseMessage | BaseMessage[] | t.IState;
+
+export interface AgentSessionRunOptions {
+  runId?: string;
+  threadId?: string;
+  config?: Partial<RunnableConfig> & { version?: 'v1' | 'v2' };
+  streamOptions?: t.EventStreamOptions;
+}
+
+export interface AgentSessionStreamEvent {
+  type:
+    | 'run.started'
+    | 'message.delta'
+    | 'reasoning.delta'
+    | 'tool.started'
+    | 'tool.delta'
+    | 'tool.completed'
+    | 'usage.updated'
+    | 'run.completed'
+    | 'run.failed'
+    | 'run.interrupted'
+    | 'run.halted';
+  sequence: number;
+  runId: string;
+  threadId: string;
+  timestamp: string;
+  data?: JsonValue;
+}
+
+export interface AgentSessionStream
+  extends AsyncIterable<AgentSessionStreamEvent> {
+  toTextStream(): AsyncIterable<string>;
+  finalResult(): Promise<AgentSessionRunResult>;
+}
+
+export interface AgentSessionHandlersResult {
+  contentParts: Array<t.MessageContentComplex | undefined>;
+  steps: t.RunStep[];
+  usage: AgentSessionUsage;
+  events: AgentSessionStreamEvent[];
+  handlers: Record<string, t.EventHandler>;
+}
+
+export type AgentSessionConfig =
+  | {
+      runConfig: t.RunConfig;
+      cwd?: string;
+      sessionPath?: string;
+      sessionId?: string;
+      name?: string;
+      ephemeral?: boolean;
+    }
+  | ({
+      runId?: string;
+      cwd?: string;
+      sessionPath?: string;
+      sessionId?: string;
+      name?: string;
+      ephemeral?: boolean;
+    } & Omit<t.RunConfig, 'runId'>);
+
+export interface CreateSessionFileOptions {
+  cwd: string;
+  name?: string;
+  parentSession?: string;
+  sessionId?: string;
+}

--- a/src/specs/custom-event-await.test.ts
+++ b/src/specs/custom-event-await.test.ts
@@ -22,6 +22,95 @@ describe('Custom event handler awaitHandlers behavior', () => {
     version: 'v2' as const,
   };
 
+  it('does not redispatch SDK custom events yielded by streamEvents', async () => {
+    const handledEvents: GraphEvents[] = [];
+    const customHandlers: Record<string | GraphEvents, t.EventHandler> = {
+      [GraphEvents.ON_MESSAGE_DELTA]: {
+        handle: (event: GraphEvents): void => {
+          handledEvents.push(event);
+        },
+      },
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: 'test-custom-events-skip-stream-loop',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      skipCleanup: true,
+      customHandlers,
+    });
+
+    async function* streamEvents(): AsyncGenerator<t.StreamEvent> {
+      yield {
+        event: GraphEvents.ON_MESSAGE_DELTA,
+        name: 'custom-event',
+        run_id: 'custom-event-run',
+        metadata: {},
+        data: {},
+      };
+    }
+
+    run.graphRunnable = { streamEvents } as unknown as t.CompiledStateWorkflow;
+
+    await run.processStream({ messages: [new HumanMessage('hello')] }, config);
+
+    expect(handledEvents).toEqual([]);
+  });
+
+  it('dispatches message deltas through the graph handler registry', async () => {
+    const handledEvents: Array<{
+      data: t.MessageDeltaEvent;
+      metadata?: Record<string, unknown>;
+    }> = [];
+    const customHandlers: Record<string | GraphEvents, t.EventHandler> = {
+      [GraphEvents.ON_MESSAGE_DELTA]: {
+        handle: (_event, data, metadata): void => {
+          handledEvents.push({
+            data: data as t.MessageDeltaEvent,
+            metadata,
+          });
+        },
+      },
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: 'test-message-delta-direct-dispatch',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      skipCleanup: true,
+      customHandlers,
+    });
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const metadata = { thread_id: 'thread_direct', langgraph_step: 1 };
+    run.Graph.config = { configurable: { thread_id: 'thread_direct' } };
+    await run.Graph.dispatchMessageDelta(
+      'step_direct',
+      {
+        content: [{ type: ContentTypes.TEXT, text: 'hello' }],
+      },
+      metadata
+    );
+
+    expect(handledEvents).toEqual([
+      {
+        data: {
+          id: 'step_direct',
+          delta: {
+            content: [{ type: ContentTypes.TEXT, text: 'hello' }],
+          },
+        },
+        metadata,
+      },
+    ]);
+  });
+
   it('should fully aggregate all content before processStream returns', async () => {
     const longResponse =
       'The quick brown fox jumps over the lazy dog and then runs across the field to find shelter from the rain';

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -428,7 +428,7 @@ const hasAnthropic = process.env.ANTHROPIC_API_KEY != null;
 
     // Turn 7: absolute minimum context if still nothing
     if (spies.onSummarizeStartSpy.mock.calls.length === 0) {
-      ({ run, contentParts } = await createRun(2200));
+      ({ run, contentParts } = await createRun(1200));
       await runTurn({ run, conversationHistory }, 'What is 1+1?', streamConfig);
       logTurn('T7', conversationHistory);
     }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -273,25 +273,33 @@ hasToolCallChunks: ${hasToolCallChunks}
       return;
     } else if (typeof content === 'string') {
       if (agentContext.currentTokenType === ContentTypes.TEXT) {
-        await graph.dispatchMessageDelta(stepId, {
-          content: [
-            {
-              type: ContentTypes.TEXT,
-              text: content,
-            },
-          ],
-        });
+        await graph.dispatchMessageDelta(
+          stepId,
+          {
+            content: [
+              {
+                type: ContentTypes.TEXT,
+                text: content,
+              },
+            ],
+          },
+          metadata
+        );
       } else if (agentContext.currentTokenType === 'think_and_text') {
         const { text, thinking } = parseThinkingContent(content);
         if (thinking) {
-          await graph.dispatchReasoningDelta(stepId, {
-            content: [
-              {
-                type: ContentTypes.THINK,
-                think: thinking,
-              },
-            ],
-          });
+          await graph.dispatchReasoningDelta(
+            stepId,
+            {
+              content: [
+                {
+                  type: ContentTypes.THINK,
+                  think: thinking,
+                },
+              ],
+            },
+            metadata
+          );
         }
         if (text) {
           agentContext.currentTokenType = ContentTypes.TEXT;
@@ -310,31 +318,43 @@ hasToolCallChunks: ${hasToolCallChunks}
           );
 
           const newStepId = graph.getStepIdByKey(newStepKey);
-          await graph.dispatchMessageDelta(newStepId, {
-            content: [
-              {
-                type: ContentTypes.TEXT,
-                text: text,
-              },
-            ],
-          });
+          await graph.dispatchMessageDelta(
+            newStepId,
+            {
+              content: [
+                {
+                  type: ContentTypes.TEXT,
+                  text: text,
+                },
+              ],
+            },
+            metadata
+          );
         }
       } else {
-        await graph.dispatchReasoningDelta(stepId, {
-          content: [
-            {
-              type: ContentTypes.THINK,
-              think: content,
-            },
-          ],
-        });
+        await graph.dispatchReasoningDelta(
+          stepId,
+          {
+            content: [
+              {
+                type: ContentTypes.THINK,
+                think: content,
+              },
+            ],
+          },
+          metadata
+        );
       }
     } else if (
       content.every((c) => c.type?.startsWith(ContentTypes.TEXT) ?? false)
     ) {
-      await graph.dispatchMessageDelta(stepId, {
-        content,
-      });
+      await graph.dispatchMessageDelta(
+        stepId,
+        {
+          content,
+        },
+        metadata
+      );
     } else if (
       content.every(
         (c) =>
@@ -344,16 +364,21 @@ hasToolCallChunks: ${hasToolCallChunks}
           c.type === 'redacted_thinking'
       )
     ) {
-      await graph.dispatchReasoningDelta(stepId, {
-        content: content.map((c) => ({
-          type: ContentTypes.THINK,
-          think:
-            (c as t.ThinkingContentText).thinking ??
-            (c as Partial<t.GoogleReasoningContentText>).reasoning ??
-            (c as Partial<t.BedrockReasoningContentText>).reasoningText?.text ??
-            '',
-        })),
-      });
+      await graph.dispatchReasoningDelta(
+        stepId,
+        {
+          content: content.map((c) => ({
+            type: ContentTypes.THINK,
+            think:
+              (c as t.ThinkingContentText).thinking ??
+              (c as Partial<t.GoogleReasoningContentText>).reasoning ??
+              (c as Partial<t.BedrockReasoningContentText>).reasoningText
+                ?.text ??
+              '',
+          })),
+        },
+        metadata
+      );
     }
   }
   handleReasoning(

--- a/src/tools/__tests__/handlers.test.ts
+++ b/src/tools/__tests__/handlers.test.ts
@@ -134,7 +134,8 @@ describe('handleToolCallChunks', () => {
     expect(graph.dispatchRunStepDelta).toHaveBeenCalledTimes(1);
     expect(graph.dispatchRunStepDelta).toHaveBeenCalledWith(
       'prev-step-id',
-      expect.objectContaining({ type: StepTypes.TOOL_CALLS })
+      expect.objectContaining({ type: StepTypes.TOOL_CALLS }),
+      defaultMetadata
     );
   });
 

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -118,10 +118,14 @@ export async function handleToolCallChunks({
     );
   }
 
-  await graph.dispatchRunStepDelta(stepId, {
-    type: StepTypes.TOOL_CALLS,
-    tool_calls: toolCallChunks,
-  });
+  await graph.dispatchRunStepDelta(
+    stepId,
+    {
+      type: StepTypes.TOOL_CALLS,
+      tool_calls: toolCallChunks,
+    },
+    metadata
+  );
 }
 
 export const handleToolCalls = async (


### PR DESCRIPTION
## Summary

I added a programmatic session DX layer that packages the existing agents SDK runtime for scripts, CI, and LibreChat-compatible adapter usage.

- Added `createAgentSession`, `AgentSession`, and `JsonlSessionStore` as a high-level SDK layer over `Run`.
- Stored durable session state as append-only JSONL entries with message, summary, compaction, label, run event, and active leaf records.
- Implemented resume, clone, fork, in-place branch, manual compaction, live stream helpers, and interrupt resume plumbing without removing the low-level `Run` API.
- Reused existing graph event handlers, summarization node, `AgentContext.initialSummary`, hooks, provider handling, and content aggregation instead of adding parallel prompt/runtime behavior.
- Added experimental `@librechat/agents/openai` and `@librechat/agents/responses` adapter subpaths with transport-agnostic writer interfaces.
- Added `composeEventHandlers` so LibreChat and programmatic callers can combine compatibility adapters with host callbacks cleanly.
- Added docs and a live smoke script that exercises sessions, JSONL lifecycle operations, streaming, adapters, multi-agent flows, and subagent delegation.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
- [x] Documentation update

## Testing

I ran the focused unit checks, type checking, linting, build, and live provider smoke test using credentials from the main worktree.

```bash
npx tsc --noEmit
npx eslint src/session src/openai src/responses src/events.ts
npx jest src/session/__tests__/JsonlSessionStore.test.ts src/session/__tests__/handlers.test.ts src/openai/__tests__/openai.test.ts src/responses/__tests__/responses.test.ts --runInBand
npm run session:live -- --provider anthropic
npm run build
```

### **Test Configuration**:

- macOS local worktree
- Node-based script runner via existing `tsconfig-paths-bootstrap.mjs` loader
- Live smoke used `/Users/danny/Projects/agents/.env`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
