### PR TITLE
🧵 feat: Add Session Checkpointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ branched in place, compacted, and inspected later.
 import { Providers, createAgentSession } from '@librechat/agents';
 
 const session = await createAgentSession({
+  checkpointing: true,
   graphConfig: {
     type: 'standard',
     instructions: 'You are a concise coding assistant.',
@@ -71,6 +72,14 @@ const result = await session.run('Summarize this repository.');
 console.log(result.text);
 console.log(session.sessionPath); // durable .jsonl session file
 ```
+
+When `checkpointing` is enabled, the session injects a shared LangGraph
+checkpointer into `compileOptions`, records checkpoint IDs in JSONL, and uses
+checkpoint state for later turns on the same `thread_id`. When HITL is enabled
+(`humanInTheLoop: { enabled: true }`), sessions also get a `MemorySaver` by
+default so `resumeInterrupt()` can reuse the same saver instead of relying on a
+per-run fallback. JSONL still owns portable replay, clone, fork, and audit
+records.
 
 Sessions expose tree operations inspired by Pi-style workflows:
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -279,9 +279,7 @@ export abstract class Graph<
   private _compiledToolNodes: Set<{
     clearDirectPathTurns(): void;
   }> = new Set();
-  public getOrCreateFileCheckpointer():
-    | t.LocalFileCheckpointer
-    | undefined {
+  public getOrCreateFileCheckpointer(): t.LocalFileCheckpointer | undefined {
     // Return the cached instance unconditionally if one exists. The
     // toolExecution check below decides whether to *create* a new
     // one — `clearHeavyState` nulls `this.toolExecution` at end-of-
@@ -301,9 +299,7 @@ export abstract class Graph<
     // cleanup hooks fire). The bundle factory itself accepts a pre-
     // supplied checkpointer when present, so re-injecting this one
     // into every ToolNode is idempotent.
-    const bundle = createLocalCodingToolBundle(
-      this.toolExecution.local ?? {}
-    );
+    const bundle = createLocalCodingToolBundle(this.toolExecution.local ?? {});
     this._fileCheckpointer = bundle.checkpointer;
     return this._fileCheckpointer;
   }
@@ -1663,7 +1659,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({
         reducer: (a, b) => {
-          if (!a.length) {
+          if (!this.messages.length) {
             this.startIndex = a.length + b.length;
           }
           const result = messagesStateReducer(a, b);

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -723,7 +723,7 @@ export class MultiAgentGraph extends StandardGraph {
     const StateAnnotation = Annotation.Root({
       messages: Annotation<BaseMessage[]>({
         reducer: (a, b) => {
-          if (!a.length) {
+          if (!this.messages.length) {
             this.startIndex = a.length + b.length;
           }
           const result = messagesStateReducer(a, b);

--- a/src/scripts/session_live.ts
+++ b/src/scripts/session_live.ts
@@ -264,6 +264,7 @@ async function runSessionLifecycleSmoke(params: {
     cwd: process.cwd(),
     sessionPath: basePath,
     name: 'live-session-base',
+    checkpointing: true,
     graphConfig: {
       type: 'standard',
       llmConfig: params.llmConfig,
@@ -284,6 +285,20 @@ async function runSessionLifecycleSmoke(params: {
   logPass('standard session run', preview(firstText));
 
   const store = getStore(session);
+  const firstCheckpoint = await session.getLatestCheckpoint();
+  assertLive(
+    firstCheckpoint?.threadId === session.threadId,
+    'LangGraph checkpoint reference missing after run'
+  );
+  assertLive(
+    store.getCheckpoints(session.threadId).length > 0,
+    'JSONL checkpoint journal entry missing'
+  );
+  logPass(
+    'LangGraph checkpoint state',
+    firstCheckpoint.checkpointId ?? 'latest'
+  );
+
   const forkPoint = store.getForkPoints()[0];
   assertLive(forkPoint != null, 'no user fork point recorded');
   await store.setLabel(forkPoint.id, 'first user turn');
@@ -354,6 +369,12 @@ async function runSessionLifecycleSmoke(params: {
       typeof compactedMessages[0].content === 'string' &&
       compactedMessages[0].content.trim() !== '',
     'manual compaction summary not active'
+  );
+  assertLive(
+    branchStore
+      .getCheckpoints(session.threadId)
+      .some((entry) => entry.data.source === 'reset'),
+    'checkpoint reset entry missing after compact'
   );
   logPass('manual compact', `${compactedMessages.length} active messages`);
 

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1,8 +1,15 @@
+import { MemorySaver } from '@langchain/langgraph';
 import { HumanMessage, BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type {
+  BaseCheckpointSaver,
+  CheckpointTuple,
+} from '@langchain/langgraph';
 import type { HookRegistry } from '@/hooks';
 import type {
   AgentSessionConfig,
+  AgentSessionCheckpointing,
+  AgentSessionCheckpointReference,
   AgentSessionInput,
   AgentSessionRunOptions,
   AgentSessionRunResult,
@@ -67,6 +74,7 @@ function normalizeConfig(config: AgentSessionConfig): {
   sessionPath?: string;
   name?: string;
   ephemeral?: boolean;
+  checkpointing?: AgentSessionCheckpointing;
 } {
   if ('runConfig' in config) {
     return {
@@ -75,6 +83,7 @@ function normalizeConfig(config: AgentSessionConfig): {
       sessionPath: config.sessionPath,
       name: config.name,
       ephemeral: config.ephemeral,
+      checkpointing: config.checkpointing,
     };
   }
   const {
@@ -82,6 +91,7 @@ function normalizeConfig(config: AgentSessionConfig): {
     sessionPath,
     name,
     ephemeral,
+    checkpointing,
     sessionId: _sessionId,
     ...runConfig
   } = config;
@@ -94,6 +104,7 @@ function normalizeConfig(config: AgentSessionConfig): {
     sessionPath,
     name,
     ephemeral,
+    checkpointing,
   };
 }
 
@@ -174,6 +185,139 @@ function applyInitialSummaryToGraphConfig(
       graphConfig.initialSummary,
       initialSummary
     ),
+  };
+}
+
+interface SessionCheckpointingState {
+  enabled: boolean;
+  checkpointer?: BaseCheckpointSaver;
+}
+
+function isCheckpointSaver(value: unknown): value is BaseCheckpointSaver {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<BaseCheckpointSaver>;
+  return (
+    typeof candidate.getTuple === 'function' &&
+    typeof candidate.list === 'function' &&
+    typeof candidate.put === 'function' &&
+    typeof candidate.putWrites === 'function' &&
+    typeof candidate.deleteThread === 'function'
+  );
+}
+
+function getGraphCheckpointer(
+  graphConfig: t.RunConfig['graphConfig']
+): BaseCheckpointSaver | undefined {
+  const checkpointer = graphConfig.compileOptions?.checkpointer;
+  return isCheckpointSaver(checkpointer) ? checkpointer : undefined;
+}
+
+function createCheckpointingState(
+  runConfig: t.RunConfig,
+  checkpointing: AgentSessionCheckpointing | undefined
+): SessionCheckpointingState {
+  const graphCheckpointer = getGraphCheckpointer(runConfig.graphConfig);
+  if (checkpointing === false) {
+    return {
+      enabled: false,
+      checkpointer: graphCheckpointer,
+    };
+  }
+  if (typeof checkpointing === 'object') {
+    if (checkpointing.enabled === false) {
+      return {
+        enabled: false,
+        checkpointer: graphCheckpointer,
+      };
+    }
+    return {
+      enabled: true,
+      checkpointer:
+        checkpointing.checkpointer ?? graphCheckpointer ?? new MemorySaver(),
+    };
+  }
+  if (checkpointing === true || runConfig.humanInTheLoop?.enabled === true) {
+    return {
+      enabled: true,
+      checkpointer: graphCheckpointer ?? new MemorySaver(),
+    };
+  }
+  return {
+    enabled: graphCheckpointer != null,
+    checkpointer: graphCheckpointer,
+  };
+}
+
+function applyCheckpointerToGraphConfig(
+  graphConfig: t.RunConfig['graphConfig'],
+  checkpointer: BaseCheckpointSaver | undefined
+): t.RunConfig['graphConfig'] {
+  if (!checkpointer) {
+    return graphConfig;
+  }
+  if (graphConfig.compileOptions?.checkpointer === checkpointer) {
+    return graphConfig;
+  }
+  return {
+    ...graphConfig,
+    compileOptions: {
+      ...(graphConfig.compileOptions ?? {}),
+      checkpointer,
+    },
+  };
+}
+
+function getConfigString(
+  config: RunnableConfig | undefined,
+  key: string
+): string | undefined {
+  const configurable = config?.configurable as
+    | Partial<Record<string, unknown>>
+    | undefined;
+  const value = configurable?.[key];
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+async function getLatestCheckpointTuple(
+  checkpointer: BaseCheckpointSaver | undefined,
+  threadId: string
+): Promise<CheckpointTuple | undefined> {
+  if (!checkpointer) {
+    return undefined;
+  }
+  const config: RunnableConfig = {
+    configurable: {
+      thread_id: threadId,
+    },
+  };
+  const tuple = await checkpointer.getTuple(config);
+  if (tuple) {
+    return tuple;
+  }
+  for await (const checkpoint of checkpointer.list(config, { limit: 1 })) {
+    return checkpoint;
+  }
+  return undefined;
+}
+
+function createCheckpointReference(params: {
+  threadId: string;
+  tuple: CheckpointTuple;
+}): AgentSessionCheckpointReference {
+  const checkpointNs =
+    getConfigString(params.tuple.config, 'checkpoint_ns') ?? '';
+  const parentCheckpointId = getConfigString(
+    params.tuple.parentConfig,
+    'checkpoint_id'
+  );
+  return {
+    provider: 'langgraph',
+    threadId: params.threadId,
+    checkpointId: params.tuple.checkpoint.id,
+    checkpointNs,
+    ...(parentCheckpointId != null ? { parentCheckpointId } : {}),
   };
 }
 
@@ -432,6 +576,7 @@ export class AgentSession {
   private runConfig: t.RunConfig;
   private store: JsonlSessionStore | undefined;
   private calibrationRatio: number | undefined;
+  private checkpointing: SessionCheckpointingState;
   cwd: string;
   threadId: string;
 
@@ -439,12 +584,14 @@ export class AgentSession {
     runConfig: t.RunConfig;
     cwd: string;
     threadId: string;
+    checkpointing: SessionCheckpointingState;
     store?: JsonlSessionStore;
   }) {
     this.runConfig = params.runConfig;
     this.cwd = params.cwd;
     this.threadId = params.threadId;
     this.store = params.store;
+    this.checkpointing = params.checkpointing;
   }
 
   static async create(config: AgentSessionConfig): Promise<AgentSession> {
@@ -464,6 +611,10 @@ export class AgentSession {
       runConfig: normalized.runConfig,
       cwd: normalized.cwd,
       threadId: store?.header.id ?? explicitSessionId ?? createSessionId(),
+      checkpointing: createCheckpointingState(
+        normalized.runConfig,
+        normalized.checkpointing
+      ),
       store,
     });
   }
@@ -476,6 +627,75 @@ export class AgentSession {
     return this.store;
   }
 
+  getCheckpointer(): BaseCheckpointSaver | undefined {
+    return this.checkpointing.checkpointer;
+  }
+
+  async getLatestCheckpoint(): Promise<
+    AgentSessionCheckpointReference | undefined
+    > {
+    const tuple = await getLatestCheckpointTuple(
+      this.checkpointing.checkpointer,
+      this.threadId
+    );
+    return tuple
+      ? createCheckpointReference({ threadId: this.threadId, tuple })
+      : undefined;
+  }
+
+  private async hasCheckpointState(threadId: string): Promise<boolean> {
+    if (!this.checkpointing.enabled) {
+      return false;
+    }
+    const tuple = await getLatestCheckpointTuple(
+      this.checkpointing.checkpointer,
+      threadId
+    );
+    return tuple != null;
+  }
+
+  private async recordCheckpoint(params: {
+    source: 'run' | 'resume';
+    runId: string;
+    threadId: string;
+  }): Promise<void> {
+    if (!this.checkpointing.enabled) {
+      return;
+    }
+    const tuple = await getLatestCheckpointTuple(
+      this.checkpointing.checkpointer,
+      params.threadId
+    );
+    if (!tuple) {
+      return;
+    }
+    const reference = createCheckpointReference({
+      threadId: params.threadId,
+      tuple,
+    });
+    await this.store?.appendCheckpoint({
+      source: params.source,
+      runId: params.runId,
+      threadId: params.threadId,
+      checkpointId: reference.checkpointId,
+      checkpointNs: reference.checkpointNs,
+      parentCheckpointId: reference.parentCheckpointId,
+    });
+  }
+
+  private async resetCheckpointThread(reason: string): Promise<void> {
+    const checkpointer = this.checkpointing.checkpointer;
+    if (!this.checkpointing.enabled || checkpointer == null) {
+      return;
+    }
+    await checkpointer.deleteThread(this.threadId);
+    await this.store?.appendCheckpoint({
+      source: 'reset',
+      threadId: this.threadId,
+      reason,
+    });
+  }
+
   private async runInternal(
     input: AgentSessionInput,
     options: AgentSessionRunOptions = {},
@@ -484,6 +704,7 @@ export class AgentSession {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
     const inputMessages = normalizeInput(input);
+    const useCheckpointState = await this.hasCheckpointState(threadId);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     for (const message of inputMessages) {
       const entry = await this.store?.appendMessage(message, parentId);
@@ -521,19 +742,22 @@ export class AgentSession {
       const runConfig: t.RunConfig = {
         ...this.runConfig,
         runId,
-        graphConfig: applyInitialSummaryToGraphConfig(
-          this.runConfig.graphConfig,
-          sessionState.initialSummary
+        graphConfig: applyCheckpointerToGraphConfig(
+          applyInitialSummaryToGraphConfig(
+            this.runConfig.graphConfig,
+            sessionState.initialSummary
+          ),
+          this.checkpointing.checkpointer
         ),
         returnContent: true,
         calibrationRatio: this.calibrationRatio,
         customHandlers: handlerResult.handlers,
       };
       const run = await Run.create<t.IState>(runConfig);
-      const messages =
-        sessionState.messages.length > 0
-          ? sessionState.messages
-          : inputMessages;
+      let messages = inputMessages;
+      if (!useCheckpointState && sessionState.messages.length > 0) {
+        messages = sessionState.messages;
+      }
       const callerConfig: Partial<RunnableConfig> & { version: 'v1' | 'v2' } = {
         recursionLimit: 50,
         ...(options.config ?? {}),
@@ -574,6 +798,7 @@ export class AgentSession {
           threadId,
         });
       }
+      await this.recordCheckpoint({ source: 'run', runId, threadId });
       const contentParts = (content ?? handlerResult.contentParts).filter(
         (part): part is t.MessageContentComplex => part != null
       );
@@ -597,6 +822,7 @@ export class AgentSession {
         runId,
         threadId,
       });
+      await this.recordCheckpoint({ source: 'run', runId, threadId });
       throw error;
     }
   }
@@ -655,6 +881,7 @@ export class AgentSession {
       runConfig: this.runConfig,
       cwd: store.header.cwd,
       threadId: store.header.id,
+      checkpointing: this.checkpointing,
       store,
     });
   }
@@ -671,6 +898,7 @@ export class AgentSession {
       runConfig: this.runConfig,
       cwd: store.header.cwd,
       threadId: store.header.id,
+      checkpointing: this.checkpointing,
       store,
     });
   }
@@ -691,6 +919,7 @@ export class AgentSession {
       await this.compact({ instructions, retainRecentTurns: 0 });
     }
     await this.store.branch(entryId, options);
+    await this.resetCheckpointThread('branch');
   }
 
   async compact(options: SessionCompactOptions = {}): Promise<void> {
@@ -775,6 +1004,7 @@ export class AgentSession {
       retainedEntryIds,
       summarizedEntryIds: summarized.map((entry) => entry.id),
     });
+    await this.resetCheckpointThread('compact');
   }
 
   async resumeInterrupt<TResume>(
@@ -783,14 +1013,26 @@ export class AgentSession {
   ): Promise<AgentSessionRunResult> {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
+    await this.store?.appendRunEvent('run.started', undefined, {
+      runId,
+      threadId,
+    });
     const handlerResult = createRunHandlers({
       runId,
       threadId,
       userHandlers: this.runConfig.customHandlers,
     });
+    const sessionState = createSessionRunState(this.store?.getPath() ?? []);
     const run = await Run.create<t.IState>({
       ...this.runConfig,
       runId,
+      graphConfig: applyCheckpointerToGraphConfig(
+        applyInitialSummaryToGraphConfig(
+          this.runConfig.graphConfig,
+          sessionState.initialSummary
+        ),
+        this.checkpointing.checkpointer
+      ),
       returnContent: true,
       calibrationRatio: this.calibrationRatio,
       customHandlers: handlerResult.handlers,
@@ -807,6 +1049,25 @@ export class AgentSession {
     for (const message of runMessages) {
       await this.store?.appendMessage(message);
     }
+    const interrupt = run.getInterrupt();
+    const haltedReason = run.getHaltReason();
+    if (interrupt) {
+      await this.store?.appendRunEvent('run.interrupted', interrupt, {
+        runId,
+        threadId,
+      });
+    } else if (haltedReason != null && haltedReason !== '') {
+      await this.store?.appendRunEvent('run.halted', haltedReason, {
+        runId,
+        threadId,
+      });
+    } else {
+      await this.store?.appendRunEvent('run.completed', undefined, {
+        runId,
+        threadId,
+      });
+    }
+    await this.recordCheckpoint({ source: 'resume', runId, threadId });
     const contentParts = (content ?? handlerResult.contentParts).filter(
       (part): part is t.MessageContentComplex => part != null
     );
@@ -816,8 +1077,8 @@ export class AgentSession {
       messages: runMessages,
       usage: handlerResult.usage,
       steps: handlerResult.steps,
-      interrupt: run.getInterrupt(),
-      haltedReason: run.getHaltReason(),
+      interrupt,
+      haltedReason,
       runId,
       threadId,
     };

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -280,26 +280,72 @@ function getConfigString(
   return typeof value === 'string' && value !== '' ? value : undefined;
 }
 
+function createCallerConfig(
+  threadId: string,
+  options: AgentSessionRunOptions
+): RunnableConfig & { version: 'v1' | 'v2' } {
+  return {
+    recursionLimit: 50,
+    ...(options.config ?? {}),
+    configurable: {
+      ...(options.config?.configurable ?? {}),
+      thread_id: threadId,
+    },
+    version: options.config?.version ?? 'v2',
+  };
+}
+
+function createCheckpointLookupConfig(config: RunnableConfig): RunnableConfig {
+  const threadId = getConfigString(config, 'thread_id');
+  if (threadId == null) {
+    return config;
+  }
+  const checkpointNs = getConfigString(config, 'checkpoint_ns') ?? '';
+  const checkpointId = getConfigString(config, 'checkpoint_id');
+  return {
+    configurable: {
+      ...config.configurable,
+      thread_id: threadId,
+      checkpoint_ns: checkpointNs,
+      ...(checkpointId != null ? { checkpoint_id: checkpointId } : {}),
+    },
+  };
+}
+
+function createLatestCheckpointLookupConfig(
+  config: RunnableConfig
+): RunnableConfig {
+  const lookup = createCheckpointLookupConfig(config);
+  const { checkpoint_id: _checkpointId, ...configurable } =
+    lookup.configurable ?? {};
+  return { configurable };
+}
+
 async function getLatestCheckpointTuple(
   checkpointer: BaseCheckpointSaver | undefined,
-  threadId: string
+  config: RunnableConfig
 ): Promise<CheckpointTuple | undefined> {
   if (!checkpointer) {
     return undefined;
   }
-  const config: RunnableConfig = {
-    configurable: {
-      thread_id: threadId,
-    },
-  };
-  const tuple = await checkpointer.getTuple(config);
+  const lookupConfig = createLatestCheckpointLookupConfig(config);
+  const tuple = await checkpointer.getTuple(lookupConfig);
   if (tuple) {
     return tuple;
   }
-  for await (const checkpoint of checkpointer.list(config, { limit: 1 })) {
+  for await (const checkpoint of checkpointer.list(lookupConfig, {
+    limit: 1,
+  })) {
     return checkpoint;
   }
   return undefined;
+}
+
+async function getSelectedCheckpointTuple(
+  checkpointer: BaseCheckpointSaver | undefined,
+  config: RunnableConfig
+): Promise<CheckpointTuple | undefined> {
+  return checkpointer?.getTuple(createCheckpointLookupConfig(config));
 }
 
 function createCheckpointReference(params: {
@@ -634,22 +680,27 @@ export class AgentSession {
   async getLatestCheckpoint(): Promise<
     AgentSessionCheckpointReference | undefined
     > {
+    const config = createCheckpointLookupConfig({
+      configurable: {
+        thread_id: this.threadId,
+      },
+    });
     const tuple = await getLatestCheckpointTuple(
       this.checkpointing.checkpointer,
-      this.threadId
+      config
     );
     return tuple
       ? createCheckpointReference({ threadId: this.threadId, tuple })
       : undefined;
   }
 
-  private async hasCheckpointState(threadId: string): Promise<boolean> {
+  private async hasCheckpointState(config: RunnableConfig): Promise<boolean> {
     if (!this.checkpointing.enabled) {
       return false;
     }
-    const tuple = await getLatestCheckpointTuple(
+    const tuple = await getSelectedCheckpointTuple(
       this.checkpointing.checkpointer,
-      threadId
+      config
     );
     return tuple != null;
   }
@@ -658,13 +709,14 @@ export class AgentSession {
     source: 'run' | 'resume';
     runId: string;
     threadId: string;
+    config: RunnableConfig;
   }): Promise<void> {
     if (!this.checkpointing.enabled) {
       return;
     }
     const tuple = await getLatestCheckpointTuple(
       this.checkpointing.checkpointer,
-      params.threadId
+      params.config
     );
     if (!tuple) {
       return;
@@ -704,7 +756,8 @@ export class AgentSession {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
     const inputMessages = normalizeInput(input);
-    const useCheckpointState = await this.hasCheckpointState(threadId);
+    const callerConfig = createCallerConfig(threadId, options);
+    const useCheckpointState = await this.hasCheckpointState(callerConfig);
     let parentId = this.store?.getLeafEntry()?.id ?? null;
     for (const message of inputMessages) {
       const entry = await this.store?.appendMessage(message, parentId);
@@ -758,15 +811,6 @@ export class AgentSession {
       if (!useCheckpointState && sessionState.messages.length > 0) {
         messages = sessionState.messages;
       }
-      const callerConfig: Partial<RunnableConfig> & { version: 'v1' | 'v2' } = {
-        recursionLimit: 50,
-        ...(options.config ?? {}),
-        configurable: {
-          ...(options.config?.configurable ?? {}),
-          thread_id: threadId,
-        },
-        version: options.config?.version ?? 'v2',
-      };
       const content = await run.processStream(
         { messages },
         callerConfig,
@@ -798,7 +842,12 @@ export class AgentSession {
           threadId,
         });
       }
-      await this.recordCheckpoint({ source: 'run', runId, threadId });
+      await this.recordCheckpoint({
+        source: 'run',
+        runId,
+        threadId,
+        config: callerConfig,
+      });
       const contentParts = (content ?? handlerResult.contentParts).filter(
         (part): part is t.MessageContentComplex => part != null
       );
@@ -822,7 +871,12 @@ export class AgentSession {
         runId,
         threadId,
       });
-      await this.recordCheckpoint({ source: 'run', runId, threadId });
+      await this.recordCheckpoint({
+        source: 'run',
+        runId,
+        threadId,
+        config: callerConfig,
+      });
       throw error;
     }
   }
@@ -1013,6 +1067,7 @@ export class AgentSession {
   ): Promise<AgentSessionRunResult> {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
+    const callerConfig = createCallerConfig(threadId, options);
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
       threadId,
@@ -1023,65 +1078,77 @@ export class AgentSession {
       userHandlers: this.runConfig.customHandlers,
     });
     const sessionState = createSessionRunState(this.store?.getPath() ?? []);
-    const run = await Run.create<t.IState>({
-      ...this.runConfig,
-      runId,
-      graphConfig: applyCheckpointerToGraphConfig(
-        applyInitialSummaryToGraphConfig(
-          this.runConfig.graphConfig,
-          sessionState.initialSummary
+    try {
+      const run = await Run.create<t.IState>({
+        ...this.runConfig,
+        runId,
+        graphConfig: applyCheckpointerToGraphConfig(
+          applyInitialSummaryToGraphConfig(
+            this.runConfig.graphConfig,
+            sessionState.initialSummary
+          ),
+          this.checkpointing.checkpointer
         ),
-        this.checkpointing.checkpointer
-      ),
-      returnContent: true,
-      calibrationRatio: this.calibrationRatio,
-      customHandlers: handlerResult.handlers,
-    });
-    const content = await run.resume(resumeValue, {
-      ...(options.config ?? {}),
-      configurable: {
-        ...(options.config?.configurable ?? {}),
-        thread_id: threadId,
-      },
-      version: options.config?.version ?? 'v2',
-    });
-    const runMessages = run.getRunMessages() ?? [];
-    for (const message of runMessages) {
-      await this.store?.appendMessage(message);
+        returnContent: true,
+        calibrationRatio: this.calibrationRatio,
+        customHandlers: handlerResult.handlers,
+      });
+      const content = await run.resume(resumeValue, callerConfig);
+      const runMessages = run.getRunMessages() ?? [];
+      for (const message of runMessages) {
+        await this.store?.appendMessage(message);
+      }
+      const interrupt = run.getInterrupt();
+      const haltedReason = run.getHaltReason();
+      if (interrupt) {
+        await this.store?.appendRunEvent('run.interrupted', interrupt, {
+          runId,
+          threadId,
+        });
+      } else if (haltedReason != null && haltedReason !== '') {
+        await this.store?.appendRunEvent('run.halted', haltedReason, {
+          runId,
+          threadId,
+        });
+      } else {
+        await this.store?.appendRunEvent('run.completed', undefined, {
+          runId,
+          threadId,
+        });
+      }
+      await this.recordCheckpoint({
+        source: 'resume',
+        runId,
+        threadId,
+        config: callerConfig,
+      });
+      const contentParts = (content ?? handlerResult.contentParts).filter(
+        (part): part is t.MessageContentComplex => part != null
+      );
+      return {
+        text: contentToText(contentParts),
+        content: contentParts,
+        messages: runMessages,
+        usage: handlerResult.usage,
+        steps: handlerResult.steps,
+        interrupt,
+        haltedReason,
+        runId,
+        threadId,
+      };
+    } catch (error) {
+      await this.store?.appendRunEvent('run.failed', error, {
+        runId,
+        threadId,
+      });
+      await this.recordCheckpoint({
+        source: 'resume',
+        runId,
+        threadId,
+        config: callerConfig,
+      });
+      throw error;
     }
-    const interrupt = run.getInterrupt();
-    const haltedReason = run.getHaltReason();
-    if (interrupt) {
-      await this.store?.appendRunEvent('run.interrupted', interrupt, {
-        runId,
-        threadId,
-      });
-    } else if (haltedReason != null && haltedReason !== '') {
-      await this.store?.appendRunEvent('run.halted', haltedReason, {
-        runId,
-        threadId,
-      });
-    } else {
-      await this.store?.appendRunEvent('run.completed', undefined, {
-        runId,
-        threadId,
-      });
-    }
-    await this.recordCheckpoint({ source: 'resume', runId, threadId });
-    const contentParts = (content ?? handlerResult.contentParts).filter(
-      (part): part is t.MessageContentComplex => part != null
-    );
-    return {
-      text: contentToText(contentParts),
-      content: contentParts,
-      messages: runMessages,
-      usage: handlerResult.usage,
-      steps: handlerResult.steps,
-      interrupt,
-      haltedReason,
-      runId,
-      threadId,
-    };
   }
 }
 

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1021,6 +1021,7 @@ export class AgentSession {
       entryId,
       options.position ?? 'at'
     );
+    const previousLeafId = store.getLeafEntry()?.id ?? null;
     let leafId = target?.id ?? null;
     const summarizeAbandoned = options.summarizeAbandoned;
     if (summarizeAbandoned !== undefined && summarizeAbandoned !== false) {
@@ -1033,6 +1034,9 @@ export class AgentSession {
         leafId
       );
       leafId = summary?.id ?? leafId;
+    }
+    if (leafId === previousLeafId) {
+      return;
     }
     await store.setLeaf(leafId);
     await this.resetCheckpointThreads('branch');

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -757,17 +757,27 @@ export class AgentSession {
     });
   }
 
-  private async resetCheckpointThread(reason: string): Promise<void> {
+  private getCheckpointThreadIds(): string[] {
+    const threadIds = new Set<string>([this.threadId]);
+    for (const checkpoint of this.store?.getCheckpoints() ?? []) {
+      threadIds.add(checkpoint.data.threadId);
+    }
+    return [...threadIds];
+  }
+
+  private async resetCheckpointThreads(reason: string): Promise<void> {
     const checkpointer = this.checkpointing.checkpointer;
     if (!this.checkpointing.enabled || checkpointer == null) {
       return;
     }
-    await checkpointer.deleteThread(this.threadId);
-    await this.store?.appendCheckpoint({
-      source: 'reset',
-      threadId: this.threadId,
-      reason,
-    });
+    for (const threadId of this.getCheckpointThreadIds()) {
+      await checkpointer.deleteThread(threadId);
+      await this.store?.appendCheckpoint({
+        source: 'reset',
+        threadId,
+        reason,
+      });
+    }
   }
 
   private async runInternal(
@@ -1007,13 +1017,13 @@ export class AgentSession {
       leafId = summary?.id ?? leafId;
     }
     await store.setLeaf(leafId);
-    await this.resetCheckpointThread('branch');
+    await this.resetCheckpointThreads('branch');
   }
 
   async compact(options: SessionCompactOptions = {}): Promise<void> {
     const summary = await this.compactActivePath(options, null);
     if (summary) {
-      await this.resetCheckpointThread('compact');
+      await this.resetCheckpointThreads('compact');
     }
   }
 

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -9,6 +9,7 @@ import type { HookRegistry } from '@/hooks';
 import type {
   AgentSessionConfig,
   AgentSessionCheckpointing,
+  AgentSessionCheckpointLookupOptions,
   AgentSessionCheckpointReference,
   AgentSessionInput,
   AgentSessionRunOptions,
@@ -715,21 +716,26 @@ export class AgentSession {
     return this.checkpointing.checkpointer;
   }
 
-  async getLatestCheckpoint(): Promise<
-    AgentSessionCheckpointReference | undefined
-    > {
+  async getLatestCheckpoint(
+    options: AgentSessionCheckpointLookupOptions = {}
+  ): Promise<AgentSessionCheckpointReference | undefined> {
+    const threadId = options.threadId ?? this.threadId;
+    const baseConfig = options.config ?? {};
     const config = createCheckpointLookupConfig({
+      ...baseConfig,
       configurable: {
-        thread_id: this.threadId,
+        ...(baseConfig.configurable ?? {}),
+        thread_id: threadId,
+        ...(options.checkpointNs != null
+          ? { checkpoint_ns: options.checkpointNs }
+          : {}),
       },
     });
     const tuple = await getLatestCheckpointTuple(
       this.checkpointing.checkpointer,
       config
     );
-    return tuple
-      ? createCheckpointReference({ threadId: this.threadId, tuple })
-      : undefined;
+    return tuple ? createCheckpointReference({ threadId, tuple }) : undefined;
   }
 
   private async hasCheckpointState(config: RunnableConfig): Promise<boolean> {

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -17,6 +17,7 @@ import type {
   SessionLabelEntry,
   SessionListItem,
   SessionMessageEntry,
+  SessionCheckpointEntry,
   SessionCompactionEntry,
   SessionRunEventEntry,
   SessionSummaryEntry,
@@ -403,6 +404,56 @@ export class JsonlSessionStore {
         summarizedEntryIds: params.summarizedEntryIds,
       },
     });
+  }
+
+  async appendCheckpoint(params: {
+    source: SessionCheckpointEntry['data']['source'];
+    threadId: string;
+    runId?: string;
+    checkpointId?: string;
+    checkpointNs?: string;
+    parentCheckpointId?: string;
+    reason?: string;
+  }): Promise<SessionCheckpointEntry> {
+    return this.appendEntry<SessionCheckpointEntry>({
+      type: 'checkpoint',
+      parentId: this.getLeafEntry()?.id ?? null,
+      data: {
+        provider: 'langgraph',
+        source: params.source,
+        threadId: params.threadId,
+        ...(params.runId != null && params.runId !== ''
+          ? { runId: params.runId }
+          : {}),
+        ...(params.checkpointId != null && params.checkpointId !== ''
+          ? { checkpointId: params.checkpointId }
+          : {}),
+        ...(params.checkpointNs != null
+          ? { checkpointNs: params.checkpointNs }
+          : {}),
+        ...(params.parentCheckpointId != null &&
+        params.parentCheckpointId !== ''
+          ? { parentCheckpointId: params.parentCheckpointId }
+          : {}),
+        ...(params.reason != null && params.reason !== ''
+          ? { reason: params.reason }
+          : {}),
+      },
+    });
+  }
+
+  getCheckpoints(threadId?: string): SessionCheckpointEntry[] {
+    return this.entries.filter(
+      (entry): entry is SessionCheckpointEntry =>
+        entry.type === 'checkpoint' &&
+        (threadId == null || entry.data.threadId === threadId)
+    );
+  }
+
+  getLatestCheckpoint(threadId?: string): SessionCheckpointEntry | undefined {
+    return [...this.getCheckpoints(threadId)]
+      .reverse()
+      .find((entry) => entry.data.source !== 'reset');
   }
 
   async branch(

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -3,8 +3,96 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { MemorySaver } from '@langchain/langgraph';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { Checkpoint, CheckpointMetadata } from '@langchain/langgraph';
 import { JsonlSessionStore, createAgentSession } from '@/session';
 import * as providers from '@/llm/providers';
+import type * as t from '@/types';
+import { Run } from '@/run';
+
+type MockRun = {
+  processStream: jest.MockedFunction<Run<t.IState>['processStream']>;
+  resume: jest.MockedFunction<Run<t.IState>['resume']>;
+  getRunMessages: jest.MockedFunction<Run<t.IState>['getRunMessages']>;
+  getCalibrationRatio: jest.MockedFunction<
+    Run<t.IState>['getCalibrationRatio']
+  >;
+  getInterrupt: jest.MockedFunction<Run<t.IState>['getInterrupt']>;
+  getHaltReason: jest.MockedFunction<Run<t.IState>['getHaltReason']>;
+};
+
+function createMockRun(outputText = 'ok'): MockRun {
+  return {
+    processStream: jest
+      .fn<
+        ReturnType<Run<t.IState>['processStream']>,
+        Parameters<Run<t.IState>['processStream']>
+      >()
+      .mockResolvedValue([{ type: 'text', text: outputText }]),
+    resume: jest
+      .fn<
+        ReturnType<Run<t.IState>['resume']>,
+        Parameters<Run<t.IState>['resume']>
+      >()
+      .mockResolvedValue([{ type: 'text', text: outputText }]),
+    getRunMessages: jest.fn(() => [new AIMessage(outputText)]),
+    getCalibrationRatio: jest.fn(() => 1),
+    getInterrupt: jest.fn(() => undefined),
+    getHaltReason: jest.fn(() => undefined),
+  };
+}
+
+function mockRunCreate(mockRun: MockRun): t.RunConfig[] {
+  const capturedConfigs: t.RunConfig[] = [];
+  jest.spyOn(Run, 'create').mockImplementation((async <
+    T extends t.BaseGraphState,
+  >(
+    config: t.RunConfig
+  ): Promise<Run<T>> => {
+    capturedConfigs.push(config);
+    return mockRun as unknown as Run<T>;
+  }) as never);
+  return capturedConfigs;
+}
+
+function getProcessedMessages(mockRun: MockRun): BaseMessage[] {
+  expect(mockRun.processStream).toHaveBeenCalled();
+  const input = mockRun.processStream.mock.calls[0][0];
+  if (!('messages' in input)) {
+    throw new Error('Expected processStream to receive message state');
+  }
+  return input.messages;
+}
+
+async function putCheckpoint(params: {
+  checkpointer: MemorySaver;
+  threadId: string;
+  id: string;
+}): Promise<void> {
+  const checkpoint: Checkpoint = {
+    v: 4,
+    id: params.id,
+    ts: new Date().toISOString(),
+    channel_values: {},
+    channel_versions: {},
+    versions_seen: {},
+  };
+  const metadata: CheckpointMetadata = {
+    source: 'loop',
+    step: 0,
+    parents: {},
+  };
+  await params.checkpointer.put(
+    {
+      configurable: {
+        thread_id: params.threadId,
+        checkpoint_ns: '',
+      },
+    },
+    checkpoint,
+    metadata
+  );
+}
 
 function mockSummarizer(response: string): void {
   jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
@@ -195,6 +283,110 @@ describe('JsonlSessionStore', () => {
     });
 
     expect(session.getCheckpointer()).toBe(checkpointer);
+  });
+
+  it('injects the session checkpointer and replays JSONL history before checkpoints exist', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('first output');
+    const capturedConfigs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+
+    await session.run('next');
+
+    expect(capturedConfigs[0].graphConfig.compileOptions?.checkpointer).toBe(
+      checkpointer
+    );
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['history', 'next']);
+  });
+
+  it('uses only new input when LangGraph checkpoint state already exists', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('checkpointed output');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_existing',
+    });
+
+    await session.run('fresh turn', { runId: 'run_checkpointed' });
+
+    const checkpoints = session
+      .getSessionStore()
+      ?.getCheckpoints(session.threadId);
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['fresh turn']);
+    expect(checkpoints?.at(-1)?.data).toMatchObject({
+      source: 'run',
+      runId: 'run_checkpointed',
+      checkpointId: 'checkpoint_existing',
+    });
+  });
+
+  it('resets stale checkpoint state when branching changes the active JSONL path', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const first = await store?.appendMessage(new HumanMessage('first'));
+    await store?.appendMessage(new AIMessage('second'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_to_reset',
+    });
+
+    await session.branch(first?.id ?? '', { position: 'at' });
+
+    const tuple = await checkpointer.getTuple({
+      configurable: { thread_id: session.threadId },
+    });
+    expect(tuple).toBeUndefined();
+    expect(store?.getCheckpoints(session.threadId).at(-1)?.data).toMatchObject({
+      source: 'reset',
+      reason: 'branch',
+    });
   });
 
   it('compacts into a summary plus retained active path', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -579,6 +579,42 @@ describe('JsonlSessionStore', () => {
     });
   });
 
+  it('keeps checkpoint state when branching to the active JSONL leaf', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const active = await store?.appendMessage(new HumanMessage('current'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_to_keep',
+    });
+
+    await session.branch(active?.id ?? '', { position: 'at' });
+
+    const tuple = await checkpointer.getTuple({
+      configurable: { thread_id: session.threadId },
+    });
+    expect(tuple?.checkpoint.id).toBe('checkpoint_to_keep');
+    expect(
+      store
+        ?.getCheckpoints(session.threadId)
+        .some((checkpoint) => checkpoint.data.source === 'reset')
+    ).toBe(false);
+  });
+
   it('resets overridden thread checkpoints when branching changes the active path', async () => {
     const checkpointer = new MemorySaver();
     const session = await createAgentSession({

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -536,6 +536,48 @@ describe('JsonlSessionStore', () => {
     });
   });
 
+  it('resets overridden thread checkpoints when branching changes the active path', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    const first = await store?.appendMessage(new HumanMessage('first'));
+    await store?.appendMessage(new AIMessage('second'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: 'thread_override',
+      id: 'checkpoint_override',
+    });
+    await store?.appendCheckpoint({
+      source: 'run',
+      threadId: 'thread_override',
+      runId: 'run_override',
+      checkpointId: 'checkpoint_override',
+    });
+
+    await session.branch(first?.id ?? '', { position: 'at' });
+
+    const tuple = await checkpointer.getTuple({
+      configurable: { thread_id: 'thread_override' },
+    });
+    const reset = store
+      ?.getCheckpoints('thread_override')
+      .find((checkpoint) => checkpoint.data.source === 'reset');
+    expect(tuple).toBeUndefined();
+    expect(reset?.data.reason).toBe('branch');
+  });
+
   it('records run.failed when resumeInterrupt throws', async () => {
     const mockRun = createMockRun('unused');
     mockRun.resume.mockRejectedValue(new Error('resume failed'));

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -68,6 +68,7 @@ async function putCheckpoint(params: {
   checkpointer: MemorySaver;
   threadId: string;
   id: string;
+  checkpointNs?: string;
 }): Promise<void> {
   const checkpoint: Checkpoint = {
     v: 4,
@@ -86,7 +87,7 @@ async function putCheckpoint(params: {
     {
       configurable: {
         thread_id: params.threadId,
-        checkpoint_ns: '',
+        checkpoint_ns: params.checkpointNs ?? '',
       },
     },
     checkpoint,
@@ -353,6 +354,40 @@ describe('JsonlSessionStore', () => {
     });
   });
 
+  it('replays JSONL history when the requested checkpoint namespace has no state', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('namespace output');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendMessage(new HumanMessage('history'));
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_other_namespace',
+      checkpointNs: 'other',
+    });
+
+    await session.run('fresh turn', {
+      config: { configurable: { checkpoint_ns: 'requested' } },
+    });
+
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['history', 'fresh turn']);
+  });
+
   it('resets stale checkpoint state when branching changes the active JSONL path', async () => {
     const checkpointer = new MemorySaver();
     const session = await createAgentSession({
@@ -387,6 +422,38 @@ describe('JsonlSessionStore', () => {
       source: 'reset',
       reason: 'branch',
     });
+  });
+
+  it('records run.failed when resumeInterrupt throws', async () => {
+    const mockRun = createMockRun('unused');
+    mockRun.resume.mockRejectedValue(new Error('resume failed'));
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      humanInTheLoop: { enabled: true },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    await expect(
+      session.resumeInterrupt([{ type: 'approve' }], {
+        runId: 'run_resume_failure',
+      })
+    ).rejects.toThrow('resume failed');
+
+    const events = session
+      .getSessionStore()
+      ?.getEntries()
+      .filter((entry) => entry.type === 'run_event')
+      .map((entry) => entry.data.event);
+    expect(events).toEqual(['run.started', 'run.failed']);
   });
 
   it('compacts into a summary plus retained active path', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { MemorySaver } from '@langchain/langgraph';
 import { JsonlSessionStore, createAgentSession } from '@/session';
 import * as providers from '@/llm/providers';
 
@@ -121,6 +122,26 @@ describe('JsonlSessionStore', () => {
     expect(compaction.data.summaryEntryId).toBe(summary.id);
   });
 
+  it('records LangGraph checkpoint references without moving the active leaf', async () => {
+    const store = await JsonlSessionStore.create({
+      path: join(dir, 'checkpoints.jsonl'),
+      cwd: dir,
+    });
+    const message = await store.appendMessage(new HumanMessage('hello'));
+
+    const checkpoint = await store.appendCheckpoint({
+      source: 'run',
+      threadId: store.header.id,
+      runId: 'run_checkpoint',
+      checkpointId: 'checkpoint_1',
+      checkpointNs: '',
+    });
+
+    expect(checkpoint.data.provider).toBe('langgraph');
+    expect(store.getLeafEntry()?.id).toBe(message.id);
+    expect(store.getLatestCheckpoint(store.header.id)?.id).toBe(checkpoint.id);
+  });
+
   it('creates high-level sessions with a JSONL store by default', async () => {
     const session = await createAgentSession({
       cwd: dir,
@@ -137,6 +158,43 @@ describe('JsonlSessionStore', () => {
 
     expect(session.getSessionStore()?.header.cwd).toBe(dir);
     expect(session.sessionPath).toContain('.jsonl');
+  });
+
+  it('shares a session-level LangGraph checkpointer for HITL resume', async () => {
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      humanInTheLoop: { enabled: true },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.getCheckpointer()).toBeInstanceOf(MemorySaver);
+  });
+
+  it('preserves a caller-supplied session checkpointer', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.getCheckpointer()).toBe(checkpointer);
   });
 
   it('compacts into a summary plus retained active path', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -452,6 +452,27 @@ describe('JsonlSessionStore', () => {
     expect(session.getCheckpointer()).toBeInstanceOf(MemorySaver);
   });
 
+  it('keeps stores and checkpointing optional for high-level sessions', async () => {
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      ephemeral: true,
+      checkpointing: false,
+      humanInTheLoop: { enabled: true },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+
+    expect(session.getSessionStore()).toBeUndefined();
+    expect(session.getCheckpointer()).toBeUndefined();
+  });
+
   it('reuses the session-level checkpointer across HITL resume', async () => {
     const mockRun = createMockRun('resumed');
     const capturedConfigs = mockRunCreate(mockRun);
@@ -600,6 +621,37 @@ describe('JsonlSessionStore', () => {
     expect(
       getProcessedMessages(mockRun).map((message) => message.content)
     ).toEqual(['history', 'fresh turn']);
+  });
+
+  it('looks up the latest checkpoint in the requested namespace', async () => {
+    const checkpointer = new MemorySaver();
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_requested_namespace',
+      checkpointNs: 'requested',
+    });
+
+    await expect(session.getLatestCheckpoint()).resolves.toBeUndefined();
+    await expect(
+      session.getLatestCheckpoint({ checkpointNs: 'requested' })
+    ).resolves.toMatchObject({
+      checkpointId: 'checkpoint_requested_namespace',
+      checkpointNs: 'requested',
+    });
   });
 
   it('resets stale checkpoint state when branching changes the active JSONL path', async () => {

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -8,6 +8,9 @@ export {
 } from './messageSerialization';
 export type {
   AgentSessionConfig,
+  AgentSessionCheckpointReference,
+  AgentSessionCheckpointing,
+  AgentSessionCheckpointingOptions,
   AgentSessionHandlersResult,
   AgentSessionInput,
   AgentSessionRunOptions,
@@ -22,6 +25,7 @@ export type {
   SerializedSessionMessage,
   SessionBranchOptions,
   SessionCompactOptions,
+  SessionCheckpointEntry,
   SessionCompactionEntry,
   SessionEntry,
   SessionEntryBase,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -188,6 +188,12 @@ export interface AgentSessionCheckpointReference {
   parentCheckpointId?: string;
 }
 
+export interface AgentSessionCheckpointLookupOptions {
+  threadId?: string;
+  checkpointNs?: string;
+  config?: RunnableConfig;
+}
+
 export interface AgentSessionCheckpointingOptions {
   enabled?: boolean;
   checkpointer?: BaseCheckpointSaver;

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -1,5 +1,6 @@
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { BaseCheckpointSaver } from '@langchain/langgraph';
 import type * as t from '@/types';
 
 export type JsonPrimitive = string | number | boolean | null;
@@ -19,6 +20,7 @@ export type SessionEntryType =
   | 'message'
   | 'summary'
   | 'compaction'
+  | 'checkpoint'
   | 'label'
   | 'run_event'
   | 'session_state';
@@ -80,6 +82,20 @@ export type SessionCompactionEntry = SessionEntryBase<
   }
 >;
 
+export type SessionCheckpointEntry = SessionEntryBase<
+  'checkpoint',
+  {
+    provider: 'langgraph';
+    source: 'run' | 'resume' | 'reset';
+    threadId: string;
+    runId?: string;
+    checkpointId?: string;
+    checkpointNs?: string;
+    parentCheckpointId?: string;
+    reason?: string;
+  }
+>;
+
 export type SessionLabelEntry = SessionEntryBase<
   'label',
   {
@@ -109,6 +125,7 @@ export type SessionEntry =
   | SessionMessageEntry
   | SessionSummaryEntry
   | SessionCompactionEntry
+  | SessionCheckpointEntry
   | SessionLabelEntry
   | SessionRunEventEntry
   | SessionStateEntry;
@@ -163,6 +180,23 @@ export interface AgentSessionUsage {
   totalTokens: number;
 }
 
+export interface AgentSessionCheckpointReference {
+  provider: 'langgraph';
+  threadId: string;
+  checkpointId?: string;
+  checkpointNs?: string;
+  parentCheckpointId?: string;
+}
+
+export interface AgentSessionCheckpointingOptions {
+  enabled?: boolean;
+  checkpointer?: BaseCheckpointSaver;
+}
+
+export type AgentSessionCheckpointing =
+  | boolean
+  | AgentSessionCheckpointingOptions;
+
 export type AgentSessionInput = string | BaseMessage | BaseMessage[] | t.IState;
 
 export interface AgentSessionRunOptions {
@@ -214,6 +248,7 @@ export type AgentSessionConfig =
       sessionId?: string;
       name?: string;
       ephemeral?: boolean;
+      checkpointing?: AgentSessionCheckpointing;
     }
   | ({
       runId?: string;
@@ -222,6 +257,7 @@ export type AgentSessionConfig =
       sessionId?: string;
       name?: string;
       ephemeral?: boolean;
+      checkpointing?: AgentSessionCheckpointing;
     } & Omit<t.RunConfig, 'runId'>);
 
 export interface CreateSessionFileOptions {


### PR DESCRIPTION
## Summary

I added LangGraph checkpointing support to the new programmatic session layer so executable graph state can be reused while JSONL remains the portable session journal.

- Added opt-in `checkpointing` configuration for `AgentSession`, including caller-supplied checkpointers and a session-level `MemorySaver` when HITL is enabled.
- Recorded LangGraph checkpoint references as JSONL `checkpoint` entries and exposed `getCheckpointer()`, `getLatestCheckpoint()`, and store checkpoint accessors.
- Reused checkpoint state for follow-up turns when a checkpoint exists, while bootstrapping from JSONL when it does not.
- Reset stale checkpoint state when in-place branch or manual compaction changes the active JSONL path.
- Adjusted standard and multi-agent graph message reducers so run-output boundaries remain correct when LangGraph starts from checkpointed prior state.
- Extended the live session smoke script to verify checkpoint references alongside run, clone, fork, branch, compact, resume/stream, multi-agent, and subagent flows.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- `npx tsc --noEmit`
- `npx eslint src/session src/openai src/responses src/events.ts src/graphs/Graph.ts src/graphs/MultiAgentGraph.ts --no-warn-ignored`
- `npx jest src/session/__tests__/JsonlSessionStore.test.ts src/session/__tests__/handlers.test.ts src/openai/__tests__/openai.test.ts src/responses/__tests__/responses.test.ts --runInBand`
- `npx jest src/session/__tests__/JsonlSessionStore.test.ts src/session/__tests__/handlers.test.ts --runInBand`
- `npm run build`
- `npm run session:live -- --provider anthropic`

### **Test Configuration**:

- Node/npm from the local workspace
- Live provider: Anthropic via `/Users/danny/Projects/agents/.env`
- Live model: `claude-haiku-4-5`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [x] I have made pertinent documentation changes
