### PR TITLE
🧵 fix: Keep Prompt Cache Context With User Turns

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -758,8 +758,13 @@ export class AgentContext {
       return messages.length;
     }
 
-    if (messages[lastIndex].getType() === 'human') {
-      return lastIndex;
+    for (let index = lastIndex; index >= 0; index--) {
+      if (messages[index].getType() === 'human') {
+        if (promptCacheProvider === Providers.OPENROUTER && index === 0) {
+          return 1;
+        }
+        return index;
+      }
     }
 
     return messages.length;

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -368,7 +368,7 @@ describe('AgentContext', () => {
       expect(result[4].content).toBe('Latest');
     });
 
-    it('does not place Anthropic dynamic instructions between tool calls and results', async () => {
+    it('keeps Anthropic dynamic instructions attached to the latest user turn during tool follow-up', async () => {
       const ctx = createBasicContext({
         agentConfig: {
           provider: Providers.ANTHROPIC,
@@ -401,10 +401,115 @@ describe('AgentContext', () => {
         }),
       ]);
 
-      expect(result[1].content).toBe('Use the tool');
-      expect((result[2] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
-      expect(result[3].getType()).toBe('tool');
-      expect(result[4].content).toBe('Dynamic instructions');
+      expect(result[1].content).toBe('Dynamic instructions');
+      expect(result[2].content).toBe('Use the tool');
+      expect((result[3] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+      expect(result[4].getType()).toBe('tool');
+    });
+
+    it('keeps Anthropic stable history cacheable before dynamic tool-follow-up context', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: {
+            model: 'claude-3-5-sonnet',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Earlier'),
+        new AIMessage('Earlier assistant response'),
+        new HumanMessage('Use the tool'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '2+2' },
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: '4',
+          name: 'calculator',
+          tool_call_id: 'call_1',
+        }),
+      ]);
+      const stableAssistant = result[2].content as TestSystemContentBlock[];
+
+      expect(result[1].content).toBe('Earlier');
+      expect(stableAssistant[0]).toMatchObject({
+        type: 'text',
+        text: 'Earlier assistant response',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[3].content).toBe('Dynamic instructions');
+      expect(result[4].content).toBe('Use the tool');
+      expect((result[5] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+      expect(result[6].getType()).toBe('tool');
+    });
+
+    it('keeps Anthropic dynamic context on latest no-tool turn after mixed prior turns', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: {
+            model: 'claude-3-5-sonnet',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('First turn, no tools'),
+        new AIMessage('First assistant response'),
+        new HumanMessage('Use the tool'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '2+2' },
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: '4',
+          name: 'calculator',
+          tool_call_id: 'call_1',
+        }),
+        new AIMessage('4'),
+        new HumanMessage('Now answer without tools'),
+      ]);
+      const firstAssistant = result[2].content as TestSystemContentBlock[];
+      const toolAnswer = result[6].content as TestSystemContentBlock[];
+
+      expect(result[1].content).toBe('First turn, no tools');
+      expect(firstAssistant[0]).toMatchObject({
+        type: 'text',
+        text: 'First assistant response',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[3].content).toBe('Use the tool');
+      expect((result[4] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+      expect(result[5].getType()).toBe('tool');
+      expect(toolAnswer[0]).toMatchObject({
+        type: 'text',
+        text: '4',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[7].content).toBe('Dynamic instructions');
+      expect(result[8].content).toBe('Now answer without tools');
     });
 
     it('caches stable OpenRouter history before dynamic instructions', async () => {
@@ -435,6 +540,150 @@ describe('AgentContext', () => {
       });
       expect(result[3].content).toBe('Dynamic instructions');
       expect(result[4].content).toBe('Latest');
+    });
+
+    it('keeps OpenRouter opening user message before dynamic tool-follow-up context', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.OPENROUTER,
+          clientOptions: {
+            model: 'anthropic/claude-haiku-4.5',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Use the tool'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '2+2' },
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: '4',
+          name: 'calculator',
+          tool_call_id: 'call_1',
+        }),
+      ]);
+
+      expect(result[1].content).toBe('Use the tool');
+      expect(result[2].content).toBe('Dynamic instructions');
+      expect((result[3] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+      expect(result[4].getType()).toBe('tool');
+    });
+
+    it('keeps OpenRouter stable history cacheable before dynamic tool-follow-up context', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.OPENROUTER,
+          clientOptions: {
+            model: 'anthropic/claude-haiku-4.5',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('Earlier'),
+        new AIMessage('Earlier assistant response'),
+        new HumanMessage('Use the tool'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '2+2' },
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: '4',
+          name: 'calculator',
+          tool_call_id: 'call_1',
+        }),
+      ]);
+      const stableAssistant = result[2].content as TestSystemContentBlock[];
+
+      expect(result[1].content).toBe('Earlier');
+      expect(stableAssistant[0]).toMatchObject({
+        type: 'text',
+        text: 'Earlier assistant response',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[3].content).toBe('Dynamic instructions');
+      expect(result[4].content).toBe('Use the tool');
+      expect((result[5] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+      expect(result[6].getType()).toBe('tool');
+    });
+
+    it('keeps OpenRouter dynamic context on latest no-tool turn after mixed prior turns', async () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.OPENROUTER,
+          clientOptions: {
+            model: 'anthropic/claude-haiku-4.5',
+            promptCache: true,
+          },
+          instructions: 'Stable instructions',
+          additional_instructions: 'Dynamic instructions',
+        },
+      });
+
+      const result = await ctx.systemRunnable!.invoke([
+        new HumanMessage('First turn, no tools'),
+        new AIMessage('First assistant response'),
+        new HumanMessage('Use the tool'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '2+2' },
+              type: 'tool_call',
+            },
+          ],
+        }),
+        new ToolMessage({
+          content: '4',
+          name: 'calculator',
+          tool_call_id: 'call_1',
+        }),
+        new AIMessage('4'),
+        new HumanMessage('Now answer without tools'),
+      ]);
+      const firstAssistant = result[2].content as TestSystemContentBlock[];
+      const toolAnswer = result[6].content as TestSystemContentBlock[];
+
+      expect(result[1].content).toBe('First turn, no tools');
+      expect(firstAssistant[0]).toMatchObject({
+        type: 'text',
+        text: 'First assistant response',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[3].content).toBe('Use the tool');
+      expect((result[4] as AIMessage).tool_calls?.[0]?.id).toBe('call_1');
+      expect(result[5].getType()).toBe('tool');
+      expect(toolAnswer[0]).toMatchObject({
+        type: 'text',
+        text: '4',
+        cache_control: { type: 'ephemeral' },
+      });
+      expect(result[7].content).toBe('Dynamic instructions');
+      expect(result[8].content).toBe('Now answer without tools');
     });
 
     it('adds OpenRouter body cache points when there is no dynamic tail', async () => {


### PR DESCRIPTION
## Summary

I fixed prompt-cache dynamic context placement so runtime context and memory stay attached to the latest real user turn during tool follow-up calls, while preserving stable prompt-cache prefixes for Anthropic and OpenRouter.

- Updated `AgentContext` to insert moved dynamic instructions before the most recent human message, even when the message list currently ends with assistant tool calls and tool results.
- Preserved the OpenRouter single-message placement behavior that keeps the initial user prompt before dynamic instructions.
- Added Anthropic and OpenRouter regression coverage for tool-follow-up turns, stable-history cache markers, and mixed no-tool/tool/no-tool turn history.
- Verified live prompt-cache behavior for Anthropic and OpenRouter, including tool-loop and mixed-turn cache-read scenarios matching the reported issue.

Root cause: prompt-cache dynamic context was moved into a `HumanMessage`, but the insertion point only checked whether the last message was human. After a tool result, the last message is a `ToolMessage`, so memory/runtime context was appended as a dynamic-only user turn and could confuse Claude.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `NODE_OPTIONS='--experimental-vm-modules' npx jest --runTestsByPath ./src/agents/__tests__/AgentContext.test.ts --runInBand`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`
- [x] `RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS=1 ANTHROPIC_PROMPT_CACHE_MODEL=claude-haiku-4-5 NODE_OPTIONS='--experimental-vm-modules' npx jest --runTestsByPath ./src/agents/__tests__/AgentContext.anthropic.live.test.ts --runInBand`
- [x] `RUN_OPENROUTER_PROMPT_CACHE_LIVE_TESTS=1 OPENROUTER_PROMPT_CACHE_MODEL=anthropic/claude-haiku-4.5 NODE_OPTIONS='--experimental-vm-modules' npx jest --runTestsByPath ./src/agents/__tests__/AgentContext.openrouter.live.test.ts --runInBand`
- [x] Custom live Anthropic/OpenRouter calculator tool-loop cache check: both providers returned `4`, and both second model calls read `14369` cached tokens.
- [x] Custom live Anthropic mixed no-tool/tool/no-tool cache probe: first turn wrote `18569`; tool turn read `18569` then `18910`; final no-tool turn after tool history read `18910`.
- [x] Custom live OpenRouter mixed no-tool/tool/no-tool cache probe: first turn wrote `18568`; tool turn read `18568` then `18909`; final no-tool turn after tool history read `18909`.

### **Test Configuration**:

- Node.js local agents workspace
- Anthropic model: `claude-haiku-4-5` for Jest live cache test; local mixed probe used the configured Anthropic prompt-cache model
- OpenRouter model: `anthropic/claude-haiku-4.5`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes