### PR TITLE
feat: prestart event-driven tools from stream

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1499,6 +1499,12 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     ]);
     expect(graph.eagerEventToolExecutions.has('call_weather')).toBe(true);
     expect(graph.eagerEventToolExecutions.has('call_stock')).toBe(false);
+    expect(graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 0))).toBe(
+      false
+    );
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 1))?.argsText
+    ).toBe('{"ticker":"C');
 
     await handler.handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -1551,6 +1557,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 
   it('does not seal a streamed tool when the same chunk also carries its own index', async () => {
@@ -1902,6 +1909,13 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
+    expect(graph.eagerEventToolCallChunks.has(chunkStateKey('agent_b', 0))).toBe(
+      false
+    );
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('agent_a', 0))?.argsText
+    ).toBe('{"city":"NYC"}');
+
     await handler.handle(
       GraphEvents.CHAT_MODEL_STREAM,
       {
@@ -1932,6 +1946,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       name: 'weather',
       args: { city: 'NYC' },
     });
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 
   it('does not prestart when batch-sensitive hooks are configured', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -311,6 +311,104 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(weatherExecution?.promise).toBe(calendarExecution?.promise);
   });
 
+  it('assigns same-tool eager turns in model emission order', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((request) => ({
+            toolCallId: request.id,
+            status: 'success' as const,
+            content: `${request.args.city} weather`,
+          }))
+        );
+      }
+    );
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather_1',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+            {
+              id: 'call_weather_2',
+              name: 'weather',
+              args: { city: 'Boston' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls.map((call) => call.turn)).toEqual([
+      0, 1,
+    ]);
+    expect(graph.eagerEventToolUsageCount.get('weather')).toBe(2);
+    expect(graph.eagerEventToolExecutions.get('call_weather_1')?.request.turn)
+      .toBe(0);
+    expect(graph.eagerEventToolExecutions.get('call_weather_2')?.request.turn)
+      .toBe(1);
+  });
+
+  it('skips eager for the whole batch if any call is not request-plannable', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([]);
+      }
+    );
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather_bad',
+              name: 'weather',
+              args: '{"city":',
+            },
+            {
+              id: 'call_weather_good',
+              name: 'weather',
+              args: { city: 'Boston' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+    expect(graph.eagerEventToolUsageCount.size).toBe(0);
+  });
+
   it('records complete chunk-only tool calls after creating a tool step', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1979,6 +1979,40 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolExecutions.size).toBe(0);
   });
 
+  it('does not buffer streamed chunks when eager execution is disabled', async () => {
+    const graph = createGraph({
+      eagerEventToolExecution: { enabled: false },
+    } as Partial<StandardGraph>);
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
+  });
+
   it('does not prestart local-engine direct coding tools', async () => {
     const graph = createGraph({
       toolExecution: {
@@ -2020,6 +2054,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       expect.anything()
     );
     expect(graph.eagerEventToolExecutions.size).toBe(0);
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 
   it('does not prestart streamed local-engine direct coding tools', async () => {
@@ -2084,6 +2119,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       expect.anything()
     );
     expect(graph.eagerEventToolExecutions.size).toBe(0);
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 
   it('does not prestart event tools in a mixed direct-tool batch', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -24,6 +24,7 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
     eagerEventToolExecution: { enabled: true },
     eagerEventToolExecutions: new Map(),
     eagerEventToolUsageCount: new Map(),
+    eagerEventToolCallChunks: new Map(),
     handlerRegistry,
     hookRegistry: undefined,
     humanInTheLoop: undefined,
@@ -134,6 +135,119 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       args: { city: 'NYC' },
     });
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
+  });
+
+  it('waits for streamed tool-call chunks to form complete JSON args', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: {},
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"city"',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"city"',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: ':"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
   });
 
   it('does not prestart when batch-sensitive hooks are configured', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -211,25 +211,6 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
           content: '',
           tool_call_chunks: [
             {
-              args: '{"city"',
-              index: 0,
-            },
-          ],
-        } as unknown as t.StreamChunk,
-      },
-      { langgraph_node: 'agent' },
-      graph
-    );
-
-    expect(toolExecuteCalls).toHaveLength(0);
-
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      {
-        chunk: {
-          content: '',
-          tool_call_chunks: [
-            {
               args: ':"NYC"}',
               index: 0,
             },
@@ -299,6 +280,111 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       id: 'call_stock',
       name: 'stock',
       args: { ticker: 'CH' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+  });
+
+  it('preserves repeated adjacent argument deltas', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_repeat',
+            status: 'success',
+            content: 'ok',
+          },
+        ]);
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_repeat',
+              name: 'weather',
+              args: '{"word":"b',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'o',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'o',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'k"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_repeat',
+      name: 'weather',
+      args: { word: 'book' },
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -248,6 +248,60 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: {},
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"ticker":"CH"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_stock',
+      name: 'stock',
+      args: { ticker: 'CH' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
   });
 
   it('does not prestart when batch-sensitive hooks are configured', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -9,7 +9,7 @@ import { ChatModelStreamHandler } from '@/stream';
 
 function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   const runSteps = new Map<string, t.RunStep>();
-  let currentStepId: string | undefined;
+  const stepIdsByKey = new Map<string, string>();
   let stepCounter = 0;
   const handlerRegistry = new HandlerRegistry();
   handlerRegistry.register(GraphEvents.ON_TOOL_EXECUTE, {
@@ -44,14 +44,15 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
       })
     ),
     getStepKey: jest.fn(() => 'step-key'),
-    getStepIdByKey: jest.fn(() => {
-      if (currentStepId == null) {
+    getStepIdByKey: jest.fn((stepKey: string) => {
+      const stepId = stepIdsByKey.get(stepKey);
+      if (stepId == null) {
         throw new Error('no current step');
       }
-      return currentStepId;
+      return stepId;
     }),
     getRunStep: jest.fn((stepId: string) => runSteps.get(stepId)),
-    dispatchRunStep: jest.fn(async (_stepKey: string, details: unknown) => {
+    dispatchRunStep: jest.fn(async (stepKey: string, details: unknown) => {
       const id = `step_${++stepCounter}`;
       if (
         (details as t.StepDetails).type === StepTypes.TOOL_CALLS &&
@@ -63,7 +64,7 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
           }
         }
       }
-      currentStepId = id;
+      stepIdsByKey.set(stepKey, id);
       runSteps.set(id, {
         id,
         type: (details as { type: t.RunStep['type'] }).type,
@@ -76,6 +77,10 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   };
 
   return graph as unknown as StandardGraph;
+}
+
+function chunkStateKey(stepKey: string, chunkKey: string | number): string {
+  return `${stepKey}\u0000${String(chunkKey)}`;
 }
 
 describe('ChatModelStreamHandler eager event tool execution', () => {
@@ -526,9 +531,10 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
-    expect(graph.eagerEventToolCallChunks.get('0')?.argsText).toBe(
-      '{"city":"NYC"}'
-    );
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"city":"NYC"}');
   });
 
   it('ignores duplicate handling of the same stream chunk object', async () => {
@@ -607,9 +613,226 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
-    expect(graph.eagerEventToolCallChunks.get('0')?.argsText).toBe(
-      '{"city":"NYC"}'
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"city":"NYC"}');
+  });
+
+  it('prestarts a completed streamed tool before later parallel tool args finish', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      }
     );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"N',
+              index: 0,
+            },
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"C',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'YC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+    });
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'H"}',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_stock',
+      name: 'stock',
+      args: { ticker: 'CH' },
+    });
+  });
+
+  it('scopes streamed chunk accumulation by step key', async () => {
+    const graph = createGraph({
+      getStepKey: jest.fn((metadata?: Record<string, unknown>) =>
+        String(metadata?.langgraph_node ?? 'step-key')
+      ),
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_agent_a',
+              name: 'weather',
+              args: '{"city":"N',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_a' },
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_agent_b',
+              name: 'weather',
+              args: '{"city":"S',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_b' },
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'F"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_b' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_agent_b',
+      name: 'weather',
+      args: { city: 'SF' },
+    });
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'YC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_a' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_agent_a',
+      name: 'weather',
+      args: { city: 'NYC' },
+    });
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('agent_a', 0))?.argsText
+    ).toBe('{"city":"NYC"}');
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('agent_b', 0))?.argsText
+    ).toBe('{"city":"SF"}');
   });
 
   it('does not prestart when batch-sensitive hooks are configured', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -12,6 +12,11 @@ import {
 import { HandlerRegistry } from '@/events';
 import * as events from '@/utils/events';
 import { ChatModelStreamHandler } from '@/stream';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
 
 function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   const runSteps = new Map<string, t.RunStep>();
@@ -92,6 +97,10 @@ function chunkStateKey(stepKey: string, chunkKey: string | number): string {
 }
 
 const finalToolCallResponseMetadata = { finish_reason: 'tool_calls' };
+const openAIResponsesToolCallMetadata = {
+  [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+    OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+};
 
 describe('ChatModelStreamHandler eager event tool execution', () => {
   afterEach(() => {
@@ -548,6 +557,230 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
         ?.argsText
     ).toBe('{"city":"NYC"}');
+  });
+
+  it('prestarts OpenAI Responses streamed tool calls on explicit arguments done', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '',
+              index: 0,
+            },
+          ],
+          response_metadata: openAIResponsesToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"city":"N',
+              index: 0,
+            },
+          ],
+          response_metadata: openAIResponsesToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+          response_metadata: {
+            ...openAIResponsesToolCallMetadata,
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+              kind: 'single',
+              id: 'call_weather',
+              index: 0,
+            },
+          },
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+    expect(graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 0))).toBe(
+      false
+    );
+  });
+
+  it('keeps OpenAI Chat Completions streamed chunks on the final tool_calls path', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"CH"}',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: { ticker: 'CH' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'call_weather',
+        args: { city: 'NYC' },
+        turn: 0,
+      }),
+      expect.objectContaining({
+        id: 'call_stock',
+        args: { ticker: 'CH' },
+        turn: 0,
+      }),
+    ]);
   });
 
   it('prestarts final tool calls even when the final chunk also has tool-call chunks', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -974,6 +974,53 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     ).toBe('oo');
   });
 
+  it('deduplicates repeated observed multi-character fragments', async () => {
+    const graph = createGraph();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_repeat',
+              name: 'weather',
+              args: '{"titl',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"titl',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"titl');
+  });
+
   it('does not prestart from cumulative streamed args before final tool calls', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
@@ -1104,6 +1151,70 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
+  });
+
+  it('merges overlapping cumulative streamed args without duplicating suffixes', async () => {
+    const graph = createGraph();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"tit',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"title":"alpha"',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'le":"alpha","city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"title":"alpha","city":"NYC"}');
   });
 
   it('preserves repeated deltas from a reused stream chunk object', async () => {
@@ -1303,8 +1414,18 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graphB.eagerEventToolExecutions.has('call_weather')).toBe(true);
   });
 
-  it('prestarts a completed event tool before later parallel tool args finish', async () => {
-    const graph = createGraph();
+  it('prestarts a completed streamed tool when a later tool call begins', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
     jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
       async (event, data): Promise<void> => {
@@ -1331,26 +1452,21 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       {
         chunk: {
           content: '',
-          tool_calls: [
+          tool_call_chunks: [
             {
               id: 'call_weather',
               name: 'weather',
-              args: { city: 'NYC' },
+              args: '{"city":"NYC"}',
+              index: 0,
             },
           ],
-          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       metadata,
       graph
     );
 
-    expect(toolExecuteCalls).toHaveLength(1);
-    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
-      id: 'call_weather',
-      name: 'weather',
-      args: { city: 'NYC' },
-    });
+    expect(toolExecuteCalls).toHaveLength(0);
 
     await handler.handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -1362,7 +1478,37 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               id: 'call_stock',
               name: 'stock',
               args: '{"ticker":"C',
-              index: 0,
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'call_weather',
+        name: 'weather',
+        args: { city: 'NYC' },
+        stepId: expect.stringMatching(/^step_/),
+        turn: 0,
+      }),
+    ]);
+    expect(graph.eagerEventToolExecutions.has('call_weather')).toBe(true);
+    expect(graph.eagerEventToolExecutions.has('call_stock')).toBe(false);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'H"}',
+              index: 1,
             },
           ],
         } as unknown as t.StreamChunk,
@@ -1379,6 +1525,11 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
         chunk: {
           content: '',
           tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
             {
               id: 'call_stock',
               name: 'stock',
@@ -1397,7 +1548,231 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       id: 'call_stock',
       name: 'stock',
       args: { ticker: 'CH' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
     });
+  });
+
+  it('does not seal a streamed tool when the same chunk also carries its own index', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '',
+              index: 0,
+            },
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"C',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'H"}',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+    });
+  });
+
+  it('preserves same-tool turns across per-call streamed eager starts', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.args.city}`,
+          }))
+        );
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather_1',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather_2',
+              name: 'weather',
+              args: '{"city":"B',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather_1',
+      name: 'weather',
+      args: { city: 'NYC' },
+      turn: 0,
+    });
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'oston"}',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather_1',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+            {
+              id: 'call_weather_2',
+              name: 'weather',
+              args: { city: 'Boston' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_weather_2',
+      name: 'weather',
+      args: { city: 'Boston' },
+      turn: 1,
+    });
+    expect(graph.eagerEventToolUsageCount.get('weather')).toBe(2);
   });
 
   it('scopes streamed chunk accumulation by step key', async () => {
@@ -1621,6 +1996,70 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('does not prestart streamed local-engine direct coding tools', async () => {
+    const graph = createGraph({
+      toolExecution: {
+        engine: 'local',
+      } as StandardGraph['toolExecution'],
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: Constants.EXECUTE_CODE }, { name: 'weather' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_code',
+              name: Constants.EXECUTE_CODE,
+              args: '{"code":"print(1)"}',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
       graph
     );
 

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -89,6 +89,8 @@ function chunkStateKey(stepKey: string, chunkKey: string | number): string {
   return `${stepKey}\u0000${String(chunkKey)}`;
 }
 
+const finalToolCallResponseMetadata = { finish_reason: 'tool_calls' };
+
 describe('ChatModelStreamHandler eager event tool execution', () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -126,6 +128,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { city: 'NYC' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent' },
@@ -146,6 +149,79 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       args: { city: 'NYC' },
     });
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
+  });
+
+  it('does not prestart parseable tool calls before a final tool-call signal', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'N' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.has('call_weather')).toBe(false);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
   });
 
   it('prestarts multiple complete event-driven tool calls as one batch', async () => {
@@ -195,6 +271,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { date: 'today' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent' },
@@ -379,6 +456,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { city: 'NYC' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent' },
@@ -453,6 +531,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { ticker: 'CH' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent' },
@@ -582,6 +661,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { word: 'book' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       metadata,
@@ -713,6 +793,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { city: 'NYC', unit: 'C' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       metadata,
@@ -905,6 +986,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
           args: { city: 'NYC' },
         },
       ],
+      response_metadata: finalToolCallResponseMetadata,
     } as unknown as t.StreamChunk;
 
     await handler.handle(
@@ -960,6 +1042,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { city: 'NYC' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       metadata,
@@ -1006,6 +1089,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { ticker: 'CH' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       metadata,
@@ -1140,6 +1224,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { city: 'SF' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent_b' },
@@ -1158,6 +1243,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { city: 'NYC' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent_a' },
@@ -1283,6 +1369,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
               args: { city: 'NYC' },
             },
           ],
+          response_metadata: finalToolCallResponseMetadata,
         } as unknown as t.StreamChunk,
       },
       { langgraph_node: 'agent' },

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -21,6 +21,7 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   handlerRegistry.register(GraphEvents.ON_TOOL_EXECUTE, {
     handle: async () => undefined,
   });
+  const eagerUsageCount = new Map<string, number>();
 
   const graph = {
     config: {
@@ -29,7 +30,8 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
     },
     eagerEventToolExecution: { enabled: true },
     eagerEventToolExecutions: new Map(),
-    eagerEventToolUsageCount: new Map(),
+    eagerEventToolUsageCount: eagerUsageCount,
+    getEagerEventToolUsageCount: jest.fn(() => eagerUsageCount),
     eagerEventToolCallChunks: new Map(),
     handlerRegistry,
     hookRegistry: undefined,
@@ -366,6 +368,98 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       .toBe(1);
   });
 
+  it('scopes eager turn reservation by agent', async () => {
+    const usageByAgent = new Map<string, Map<string, number>>();
+    const getUsageCount = (agentId?: string): Map<string, number> => {
+      const key = agentId ?? 'default';
+      let usage = usageByAgent.get(key);
+      if (usage == null) {
+        usage = new Map<string, number>();
+        usageByAgent.set(key, usage);
+      }
+      return usage;
+    };
+    const graph = createGraph({
+      getEagerEventToolUsageCount: jest.fn(getUsageCount),
+      getAgentContext: jest.fn(
+        (metadata?: Record<string, unknown>): AgentContext => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }],
+          graphTools: [],
+          agentId:
+            metadata?.langgraph_node === 'agent_2' ? 'agent_2' : 'agent_1',
+        }) as unknown as AgentContext
+      ),
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((request) => ({
+            toolCallId: request.id,
+            status: 'success' as const,
+            content: 'ok',
+          }))
+        );
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_agent_1_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_1' },
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_agent_2_weather',
+              name: 'weather',
+              args: { city: 'Boston' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_2' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls.map((call) => call.toolCalls[0].turn)).toEqual([
+      0, 0,
+    ]);
+    expect(usageByAgent.get('agent_1')?.get('weather')).toBe(1);
+    expect(usageByAgent.get('agent_2')?.get('weather')).toBe(1);
+    expect(graph.eagerEventToolExecutions.get('call_agent_1_weather')?.request.turn)
+      .toBe(0);
+    expect(graph.eagerEventToolExecutions.get('call_agent_2_weather')?.request.turn)
+      .toBe(0);
+  });
+
   it('skips eager for the whole batch if any call is not request-plannable', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
@@ -454,6 +548,63 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
         ?.argsText
     ).toBe('{"city":"NYC"}');
+  });
+
+  it('prestarts final tool calls even when the final chunk also has tool-call chunks', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              index: 0,
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      turn: 0,
+    });
+    expect(graph.eagerEventToolExecutions.has('call_weather')).toBe(true);
   });
 
   it('waits for final tool calls before prestarting streamed chunk calls', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1336,6 +1336,58 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolExecutions.size).toBe(0);
   });
 
+  it('does not prestart event tools in a mixed direct-tool batch', async () => {
+    const graph = createGraph({
+      toolExecution: {
+        engine: 'local',
+      } as StandardGraph['toolExecution'],
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [
+            { name: Constants.EXECUTE_CODE },
+            { name: 'weather' },
+          ],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_code',
+              name: Constants.EXECUTE_CODE,
+              args: { code: 'print(1)' },
+            },
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
   it('continues eager turns after normal event-dispatch usage', async () => {
     const graph = createGraph();
     graph.eagerEventToolUsageCount.set('weather', 1);

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -137,6 +137,56 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
   });
 
+  it('prestarts complete chunk-only tool calls after creating a tool step', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+    expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
+  });
+
   it('waits for streamed tool-call chunks to form complete JSON args', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -678,6 +678,53 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     });
   });
 
+  it('preserves identical incremental argument fragments', async () => {
+    const graph = createGraph();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_repeat',
+              name: 'weather',
+              args: 'o',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'o',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('oo');
+  });
+
   it('does not prestart from cumulative streamed args before final tool calls', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -440,6 +440,178 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     });
   });
 
+  it('prestarts from cumulative streamed argument chunks', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"ci',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"city":"N',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+    expect(graph.eagerEventToolCallChunks.get('0')?.argsText).toBe(
+      '{"city":"NYC"}'
+    );
+  });
+
+  it('ignores duplicate handling of the same stream chunk object', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const startChunk = {
+      content: '',
+      tool_call_chunks: [
+        {
+          id: 'call_weather',
+          name: 'weather',
+          args: '{"city"',
+          index: 0,
+        },
+      ],
+    } as unknown as t.StreamChunk;
+    const finalChunk = {
+      content: '',
+      tool_call_chunks: [
+        {
+          args: ':"NYC"}',
+          index: 0,
+        },
+      ],
+    } as unknown as t.StreamChunk;
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: startChunk },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: startChunk },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: finalChunk },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: finalChunk },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+    expect(graph.eagerEventToolCallChunks.get('0')?.argsText).toBe(
+      '{"city":"NYC"}'
+    );
+  });
+
   it('does not prestart when batch-sensitive hooks are configured', async () => {
     const graph = createGraph({ hookRegistry: {} as StandardGraph['hookRegistry'] });
     const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs';
 import type * as t from '@/types';
-import { Constants, GraphEvents, Providers, StepTypes } from '@/common';
+import {
+  Constants,
+  ContentTypes,
+  GraphEvents,
+  Providers,
+  StepTypes,
+} from '@/common';
 import { HandlerRegistry } from '@/events';
 import * as events from '@/utils/events';
 import { ChatModelStreamHandler } from '@/stream';
@@ -723,106 +729,112 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     });
   });
 
-  it('ignores duplicate handling of the same stream chunk object', async () => {
+  it('preserves repeated deltas from a reused stream chunk object', async () => {
     const graph = createGraph();
-    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
-        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
-          return;
-        }
-        const batch = data as t.ToolExecuteBatchRequest;
-        toolExecuteCalls.push(batch);
-        batch.resolve([
-          {
-            toolCallId: 'call_weather',
-            status: 'success',
-            content: 'sunny',
-          },
-        ]);
-      }
-    );
-
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
-    const startChunk = {
+    const reusableToolChunk: {
+      id?: string;
+      name?: string;
+      args: string;
+      index: number;
+    } = {
+      id: 'call_repeat',
+      name: 'weather',
+      args: '{"word":"b',
+      index: 0,
+    };
+    const reusableChunk = {
       content: '',
-      tool_call_chunks: [
-        {
-          id: 'call_weather',
-          name: 'weather',
-          args: '{"city"',
-          index: 0,
-        },
-      ],
-    } as unknown as t.StreamChunk;
-    const finalChunk = {
-      content: '',
-      tool_call_chunks: [
-        {
-          args: ':"NYC"}',
-          index: 0,
-        },
-      ],
+      tool_call_chunks: [reusableToolChunk],
     } as unknown as t.StreamChunk;
 
     await handler.handle(
       GraphEvents.CHAT_MODEL_STREAM,
-      { chunk: startChunk },
-      metadata,
-      graph
-    );
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      { chunk: startChunk },
-      metadata,
-      graph
-    );
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      { chunk: finalChunk },
-      metadata,
-      graph
-    );
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      { chunk: finalChunk },
+      { chunk: reusableChunk },
       metadata,
       graph
     );
 
-    expect(toolExecuteCalls).toHaveLength(0);
+    reusableToolChunk.id = undefined;
+    reusableToolChunk.name = undefined;
+    reusableToolChunk.args = 'o';
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: reusableChunk },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: reusableChunk },
+      metadata,
+      graph
+    );
+
+    reusableToolChunk.args = 'k"}';
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: reusableChunk },
+      metadata,
+      graph
+    );
+
     expect(
       graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
         ?.argsText
-    ).toBe('{"city":"NYC"}');
+    ).toBe('{"word":"book"}');
+  });
+
+  it('preserves repeated text deltas from a reused stream chunk object', async () => {
+    const dispatchMessageDelta = jest.fn<StandardGraph['dispatchMessageDelta']>(
+      async () => undefined
+    );
+    const graph = createGraph({
+      dispatchMessageDelta,
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          currentTokenType: ContentTypes.TEXT,
+          toolDefinitions: [],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const reusableChunk = { content: 'ha' } as unknown as t.StreamChunk;
 
     await handler.handle(
       GraphEvents.CHAT_MODEL_STREAM,
-      {
-        chunk: {
-          content: '',
-          tool_calls: [
-            {
-              id: 'call_weather',
-              name: 'weather',
-              args: { city: 'NYC' },
-            },
-          ],
-        } as unknown as t.StreamChunk,
-      },
+      { chunk: reusableChunk },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: reusableChunk },
       metadata,
       graph
     );
 
-    expect(toolExecuteCalls).toHaveLength(1);
-    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
-      id: 'call_weather',
-      name: 'weather',
-      args: { city: 'NYC' },
-      stepId: expect.stringMatching(/^step_/),
-      turn: 0,
-    });
+    expect(dispatchMessageDelta).toHaveBeenCalledTimes(2);
+    expect(dispatchMessageDelta).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/^step_/),
+      { content: [{ type: ContentTypes.TEXT, text: 'ha' }] },
+      metadata
+    );
+    expect(dispatchMessageDelta).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/^step_/),
+      { content: [{ type: ContentTypes.TEXT, text: 'ha' }] },
+      metadata
+    );
   });
 
   it('processes a reused chunk object when its streamed payload changes', async () => {
@@ -849,12 +861,6 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
 
     reusableToolChunk.args = ':"NYC"}';
 
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      { chunk: reusableChunk },
-      metadata,
-      graph
-    );
     await handler.handle(
       GraphEvents.CHAT_MODEL_STREAM,
       { chunk: reusableChunk },

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs';
 import type * as t from '@/types';
-import { GraphEvents, Providers, StepTypes } from '@/common';
+import { Constants, GraphEvents, Providers, StepTypes } from '@/common';
 import { HandlerRegistry } from '@/events';
 import * as events from '@/utils/events';
 import { ChatModelStreamHandler } from '@/stream';
@@ -1019,5 +1019,96 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       expect.anything()
     );
     expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('does not prestart local-engine direct coding tools', async () => {
+    const graph = createGraph({
+      toolExecution: {
+        engine: 'local',
+      } as StandardGraph['toolExecution'],
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: Constants.EXECUTE_CODE }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_code',
+              name: Constants.EXECUTE_CODE,
+              args: { code: 'print(1)' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('continues eager turns after normal event-dispatch usage', async () => {
+    const graph = createGraph();
+    graph.eagerEventToolUsageCount.set('weather', 1);
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather_2',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather_2',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather_2',
+      name: 'weather',
+      turn: 1,
+    });
+    expect(graph.eagerEventToolUsageCount.get('weather')).toBe(2);
   });
 });

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -44,8 +44,8 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
     prelimMessageIdsByStepKey: new Map(),
     getAgentContext: jest.fn(
       (): Partial<AgentContext> => ({
-        provider: Providers.OPENAI,
-        reasoningKey: 'reasoning_content',
+        provider: Providers.ANTHROPIC,
+        reasoningKey: 'reasoning',
         toolDefinitions: [{ name: 'weather' }],
         graphTools: [],
         agentId: 'agent_1',
@@ -230,8 +230,8 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     const graph = createGraph({
       getAgentContext: jest.fn(
         (): Partial<AgentContext> => ({
-          provider: Providers.OPENAI,
-          reasoningKey: 'reasoning_content',
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
           toolDefinitions: [{ name: 'weather' }, { name: 'calendar' }],
           graphTools: [],
           agentId: 'agent_1',
@@ -383,8 +383,8 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       getEagerEventToolUsageCount: jest.fn(getUsageCount),
       getAgentContext: jest.fn(
         (metadata?: Record<string, unknown>): AgentContext => ({
-          provider: Providers.OPENAI,
-          reasoningKey: 'reasoning_content',
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
           toolDefinitions: [{ name: 'weather' }],
           graphTools: [],
           agentId:
@@ -1418,8 +1418,8 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     const graph = createGraph({
       getAgentContext: jest.fn(
         (): Partial<AgentContext> => ({
-          provider: Providers.OPENAI,
-          reasoningKey: 'reasoning_content',
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
           toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
           graphTools: [],
           agentId: 'agent_1',
@@ -1564,8 +1564,8 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     const graph = createGraph({
       getAgentContext: jest.fn(
         (): Partial<AgentContext> => ({
-          provider: Providers.OPENAI,
-          reasoningKey: 'reasoning_content',
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
           toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
           graphTools: [],
           agentId: 'agent_1',

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -142,6 +142,92 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
   });
 
+  it('prestarts multiple complete event-driven tool calls as one batch', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }, { name: 'calendar' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((request) => ({
+            toolCallId: request.id,
+            status: 'success' as const,
+            content: `${request.name} result`,
+          }))
+        );
+      }
+    );
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+            {
+              id: 'call_calendar',
+              name: 'calendar',
+              args: { date: 'today' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toHaveLength(2);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'call_weather',
+        name: 'weather',
+        args: { city: 'NYC' },
+        stepId: expect.stringMatching(/^step_/),
+        turn: 0,
+      }),
+      expect.objectContaining({
+        id: 'call_calendar',
+        name: 'calendar',
+        args: { date: 'today' },
+        stepId: expect.stringMatching(/^step_/),
+        turn: 0,
+      }),
+    ]);
+    const weatherExecution = graph.eagerEventToolExecutions.get('call_weather');
+    const calendarExecution = graph.eagerEventToolExecutions.get('call_calendar');
+    expect(weatherExecution).toMatchObject({
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+    });
+    expect(calendarExecution).toMatchObject({
+      toolCallId: 'call_calendar',
+      toolName: 'calendar',
+      args: { date: 'today' },
+    });
+    expect(weatherExecution?.promise).toBe(calendarExecution?.promise);
+  });
+
   it('records complete chunk-only tool calls after creating a tool step', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -825,6 +825,100 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     });
   });
 
+  it('processes a reused chunk object when its streamed payload changes', async () => {
+    const graph = createGraph();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const reusableToolChunk = {
+      id: 'call_weather',
+      name: 'weather',
+      args: '{"city"',
+      index: 0,
+    };
+    const reusableChunk = {
+      content: '',
+      tool_call_chunks: [reusableToolChunk],
+    } as unknown as t.StreamChunk;
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: reusableChunk },
+      metadata,
+      graph
+    );
+
+    reusableToolChunk.args = ':"NYC"}';
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: reusableChunk },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: reusableChunk },
+      metadata,
+      graph
+    );
+
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"city":"NYC"}');
+  });
+
+  it('does not share chunk object de-duplication across graphs', async () => {
+    const graphA = createGraph();
+    const graphB = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((request) => ({
+            toolCallId: request.id,
+            status: 'success' as const,
+            content: `${request.id} result`,
+          }))
+        );
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const sharedChunk = {
+      content: '',
+      tool_calls: [
+        {
+          id: 'call_weather',
+          name: 'weather',
+          args: { city: 'NYC' },
+        },
+      ],
+    } as unknown as t.StreamChunk;
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: sharedChunk },
+      { langgraph_node: 'agent' },
+      graphA
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: sharedChunk },
+      { langgraph_node: 'agent' },
+      graphB
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(graphA.eagerEventToolExecutions.has('call_weather')).toBe(true);
+    expect(graphB.eagerEventToolExecutions.has('call_weather')).toBe(true);
+  });
+
   it('prestarts a completed event tool before later parallel tool args finish', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -142,7 +142,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
   });
 
-  it('prestarts complete chunk-only tool calls after creating a tool step', async () => {
+  it('records complete chunk-only tool calls after creating a tool step', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
     jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
@@ -181,18 +181,15 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
-    expect(toolExecuteCalls).toHaveLength(1);
-    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
-      id: 'call_weather',
-      name: 'weather',
-      args: { city: 'NYC' },
-      stepId: expect.stringMatching(/^step_/),
-      turn: 0,
-    });
+    expect(toolExecuteCalls).toHaveLength(0);
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"city":"NYC"}');
   });
 
-  it('waits for streamed tool-call chunks to form complete JSON args', async () => {
+  it('waits for final tool calls before prestarting streamed chunk calls', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
     jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
@@ -276,6 +273,26 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
     expect(toolExecuteCalls).toHaveLength(1);
     expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
       id: 'call_weather',
@@ -322,6 +339,26 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             {
               args: '{"ticker":"CH"}',
               index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: { ticker: 'CH' },
             },
           ],
         } as unknown as t.StreamChunk,
@@ -435,6 +472,30 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"word":"book"}');
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_repeat',
+              name: 'weather',
+              args: { word: 'book' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
     expect(toolExecuteCalls).toHaveLength(1);
     expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
       id: 'call_repeat',
@@ -445,7 +506,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     });
   });
 
-  it('prestarts from cumulative streamed argument chunks', async () => {
+  it('does not prestart from cumulative streamed args before final tool calls', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
     jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
@@ -523,18 +584,57 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"city":"NYC","unit":"C"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"city":"NYC","unit":"C"}');
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC', unit: 'C' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
     expect(toolExecuteCalls).toHaveLength(1);
     expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
       id: 'call_weather',
       name: 'weather',
-      args: { city: 'NYC' },
+      args: { city: 'NYC', unit: 'C' },
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
-    expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
-    ).toBe('{"city":"NYC"}');
   });
 
   it('ignores duplicate handling of the same stream chunk object', async () => {
@@ -605,6 +705,30 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
+        ?.argsText
+    ).toBe('{"city":"NYC"}');
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
     expect(toolExecuteCalls).toHaveLength(1);
     expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
       id: 'call_weather',
@@ -613,13 +737,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
-    expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
-    ).toBe('{"city":"NYC"}');
   });
 
-  it('prestarts a completed streamed tool before later parallel tool args finish', async () => {
+  it('prestarts a completed event tool before later parallel tool args finish', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
     jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
@@ -647,35 +767,11 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       {
         chunk: {
           content: '',
-          tool_call_chunks: [
+          tool_calls: [
             {
               id: 'call_weather',
               name: 'weather',
-              args: '{"city":"N',
-              index: 0,
-            },
-            {
-              id: 'call_stock',
-              name: 'stock',
-              args: '{"ticker":"C',
-              index: 1,
-            },
-          ],
-        } as unknown as t.StreamChunk,
-      },
-      metadata,
-      graph
-    );
-
-    await handler.handle(
-      GraphEvents.CHAT_MODEL_STREAM,
-      {
-        chunk: {
-          content: '',
-          tool_call_chunks: [
-            {
-              args: 'YC"}',
-              index: 0,
+              args: { city: 'NYC' },
             },
           ],
         } as unknown as t.StreamChunk,
@@ -698,8 +794,30 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
           content: '',
           tool_call_chunks: [
             {
-              args: 'H"}',
-              index: 1,
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"C',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: { ticker: 'CH' },
             },
           ],
         } as unknown as t.StreamChunk,
@@ -797,12 +915,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
-    expect(toolExecuteCalls).toHaveLength(1);
-    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
-      id: 'call_agent_b',
-      name: 'weather',
-      args: { city: 'SF' },
-    });
+    expect(toolExecuteCalls).toHaveLength(0);
 
     await handler.handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -821,18 +934,61 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
-    expect(toolExecuteCalls).toHaveLength(2);
-    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
-      id: 'call_agent_a',
-      name: 'weather',
-      args: { city: 'NYC' },
-    });
+    expect(toolExecuteCalls).toHaveLength(0);
     expect(
       graph.eagerEventToolCallChunks.get(chunkStateKey('agent_a', 0))?.argsText
     ).toBe('{"city":"NYC"}');
     expect(
       graph.eagerEventToolCallChunks.get(chunkStateKey('agent_b', 0))?.argsText
     ).toBe('{"city":"SF"}');
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_agent_b',
+              name: 'weather',
+              args: { city: 'SF' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_b' },
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_agent_a',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent_a' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_agent_b',
+      name: 'weather',
+      args: { city: 'SF' },
+    });
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_agent_a',
+      name: 'weather',
+      args: { city: 'NYC' },
+    });
   });
 
   it('does not prestart when batch-sensitive hooks are configured', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import type { AgentContext } from '@/agents/AgentContext';
+import type { StandardGraph } from '@/graphs';
+import type * as t from '@/types';
+import { GraphEvents, Providers, StepTypes } from '@/common';
+import { HandlerRegistry } from '@/events';
+import * as events from '@/utils/events';
+import { ChatModelStreamHandler } from '@/stream';
+
+function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
+  const runSteps = new Map<string, t.RunStep>();
+  let currentStepId: string | undefined;
+  let stepCounter = 0;
+  const handlerRegistry = new HandlerRegistry();
+  handlerRegistry.register(GraphEvents.ON_TOOL_EXECUTE, {
+    handle: async () => undefined,
+  });
+
+  const graph = {
+    config: {
+      configurable: { user_id: 'user_1' },
+      metadata: { run_id: 'run_1' },
+    },
+    eagerEventToolExecution: { enabled: true },
+    eagerEventToolExecutions: new Map(),
+    eagerEventToolUsageCount: new Map(),
+    handlerRegistry,
+    hookRegistry: undefined,
+    humanInTheLoop: undefined,
+    toolOutputReferences: undefined,
+    sessions: new Map(),
+    toolCallStepIds: new Map(),
+    messageIdsByStepKey: new Map(),
+    messageStepHasToolCalls: new Map(),
+    prelimMessageIdsByStepKey: new Map(),
+    getAgentContext: jest.fn(
+      (): Partial<AgentContext> => ({
+        provider: Providers.OPENAI,
+        reasoningKey: 'reasoning_content',
+        toolDefinitions: [{ name: 'weather' }],
+        graphTools: [],
+        agentId: 'agent_1',
+      })
+    ),
+    getStepKey: jest.fn(() => 'step-key'),
+    getStepIdByKey: jest.fn(() => {
+      if (currentStepId == null) {
+        throw new Error('no current step');
+      }
+      return currentStepId;
+    }),
+    getRunStep: jest.fn((stepId: string) => runSteps.get(stepId)),
+    dispatchRunStep: jest.fn(async (_stepKey: string, details: unknown) => {
+      const id = `step_${++stepCounter}`;
+      if (
+        (details as t.StepDetails).type === StepTypes.TOOL_CALLS &&
+        Array.isArray((details as t.ToolCallsDetails).tool_calls)
+      ) {
+        for (const toolCall of (details as t.ToolCallsDetails).tool_calls ?? []) {
+          if (toolCall.id != null && toolCall.id !== '') {
+            graph.toolCallStepIds.set(toolCall.id, id);
+          }
+        }
+      }
+      currentStepId = id;
+      runSteps.set(id, {
+        id,
+        type: (details as { type: t.RunStep['type'] }).type,
+        stepDetails: details as t.RunStep['stepDetails'],
+      } as t.RunStep);
+      return id;
+    }),
+    dispatchRunStepDelta: jest.fn(async () => undefined),
+    ...overrides,
+  };
+
+  return graph as unknown as StandardGraph;
+}
+
+describe('ChatModelStreamHandler eager event tool execution', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('prestarts a complete event-driven tool call from the stream', async () => {
+    const graph = createGraph();
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      }
+    );
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+    expect(graph.eagerEventToolExecutions.get('call_weather')).toMatchObject({
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+    });
+    expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
+  });
+
+  it('does not prestart when batch-sensitive hooks are configured', async () => {
+    const graph = createGraph({ hookRegistry: {} as StandardGraph['hookRegistry'] });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+});

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -160,6 +160,14 @@ export abstract class Graph<
    */
   toolOutputReferences: t.ToolOutputReferencesConfig | undefined;
   /**
+   * Run-scoped opt-in for eager event-driven tool execution. The stream
+   * handler may prestart eligible event-driven tools; ToolNode later
+   * consumes the settled promises while preserving final ToolMessage order.
+   */
+  eagerEventToolExecution: t.EagerEventToolExecutionConfig | undefined;
+  eagerEventToolExecutions: Map<string, t.EagerEventToolExecution> = new Map();
+  eagerEventToolUsageCount: Map<string, number> = new Map();
+  /**
    * Run-scoped execution backend for built-in code tools. Defaults to the
    * remote Code API sandbox when unset.
    */
@@ -198,6 +206,9 @@ export abstract class Graph<
     this.hookRegistry = undefined;
     this.humanInTheLoop = undefined;
     this.toolOutputReferences = undefined;
+    this.eagerEventToolExecution = undefined;
+    this.eagerEventToolExecutions.clear();
+    this.eagerEventToolUsageCount.clear();
     this.toolExecution = undefined;
     this.handlerDispatchedEventCounts.clear();
     /**
@@ -712,6 +723,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         toolRegistry: agentContext?.toolRegistry,
         hookRegistry: this.hookRegistry,
         humanInTheLoop: this.humanInTheLoop,
+        eagerEventToolExecution: this.eagerEventToolExecution,
+        eagerEventToolExecutions: this.eagerEventToolExecutions,
         toolExecution: this.toolExecution,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -424,6 +424,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * a stale reference on 2nd+ processStream calls.
      */
     this.toolCallStepIds.clear();
+    this.eagerEventToolExecutions.clear();
+    this.eagerEventToolUsageCount.clear();
     this.eagerEventToolCallChunks.clear();
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -167,6 +167,8 @@ export abstract class Graph<
   eagerEventToolExecution: t.EagerEventToolExecutionConfig | undefined;
   eagerEventToolExecutions: Map<string, t.EagerEventToolExecution> = new Map();
   eagerEventToolUsageCount: Map<string, number> = new Map();
+  eagerEventToolCallChunks: Map<string, t.EagerEventToolCallChunkState> =
+    new Map();
   /**
    * Run-scoped execution backend for built-in code tools. Defaults to the
    * remote Code API sandbox when unset.
@@ -209,6 +211,7 @@ export abstract class Graph<
     this.eagerEventToolExecution = undefined;
     this.eagerEventToolExecutions.clear();
     this.eagerEventToolUsageCount.clear();
+    this.eagerEventToolCallChunks.clear();
     this.toolExecution = undefined;
     this.handlerDispatchedEventCounts.clear();
     /**
@@ -421,6 +424,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      * a stale reference on 2nd+ processStream calls.
      */
     this.toolCallStepIds.clear();
+    this.eagerEventToolCallChunks.clear();
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
       new Set()

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -731,6 +731,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         humanInTheLoop: this.humanInTheLoop,
         eagerEventToolExecution: this.eagerEventToolExecution,
         eagerEventToolExecutions: this.eagerEventToolExecutions,
+        eagerEventToolUsageCount: this.eagerEventToolUsageCount,
         toolExecution: this.toolExecution,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -167,6 +167,10 @@ export abstract class Graph<
   eagerEventToolExecution: t.EagerEventToolExecutionConfig | undefined;
   eagerEventToolExecutions: Map<string, t.EagerEventToolExecution> = new Map();
   eagerEventToolUsageCount: Map<string, number> = new Map();
+  private eagerEventToolUsageCountsByAgentId: Map<
+    string,
+    Map<string, number>
+  > = new Map();
   eagerEventToolCallChunks: Map<string, t.EagerEventToolCallChunkState> =
     new Map();
   /**
@@ -210,7 +214,7 @@ export abstract class Graph<
     this.toolOutputReferences = undefined;
     this.eagerEventToolExecution = undefined;
     this.eagerEventToolExecutions.clear();
-    this.eagerEventToolUsageCount.clear();
+    this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
     this.toolExecution = undefined;
     this.handlerDispatchedEventCounts.clear();
@@ -242,6 +246,25 @@ export abstract class Graph<
     }
     this._compiledToolNodes.clear();
     this.sessions.clear();
+  }
+
+  getEagerEventToolUsageCount(agentId?: string): Map<string, number> {
+    if (agentId == null || agentId === '') {
+      return this.eagerEventToolUsageCount;
+    }
+    let usageCount = this.eagerEventToolUsageCountsByAgentId.get(agentId);
+    if (usageCount == null) {
+      usageCount = new Map<string, number>();
+      this.eagerEventToolUsageCountsByAgentId.set(agentId, usageCount);
+    }
+    return usageCount;
+  }
+
+  protected clearEagerEventToolUsageCounts(): void {
+    this.eagerEventToolUsageCount.clear();
+    for (const usageCount of this.eagerEventToolUsageCountsByAgentId.values()) {
+      usageCount.clear();
+    }
   }
 
   markHandlerDispatchedEvent(eventName: string, stepId: string): () => void {
@@ -425,7 +448,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
      */
     this.toolCallStepIds.clear();
     this.eagerEventToolExecutions.clear();
-    this.eagerEventToolUsageCount.clear();
+    this.clearEagerEventToolUsageCounts();
     this.eagerEventToolCallChunks.clear();
     this.handlerDispatchedStepIds = resetIfNotEmpty(
       this.handlerDispatchedStepIds,
@@ -731,7 +754,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         humanInTheLoop: this.humanInTheLoop,
         eagerEventToolExecution: this.eagerEventToolExecution,
         eagerEventToolExecutions: this.eagerEventToolExecutions,
-        eagerEventToolUsageCount: this.eagerEventToolUsageCount,
+        eagerEventToolUsageCount: this.getEagerEventToolUsageCount(
+          agentContext?.agentId
+        ),
         toolExecution: this.toolExecution,
         directToolNames: directToolNames.size > 0 ? directToolNames : undefined,
         maxContextTokens: agentContext?.maxContextTokens,

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -80,6 +80,7 @@ describe('LangGraph composition smoke tests', () => {
     });
     const executions = graph.eagerEventToolExecutions;
     const usageCount = graph.eagerEventToolUsageCount;
+    const scopedUsageCount = graph.getEagerEventToolUsageCount('agent');
     const chunks = graph.eagerEventToolCallChunks;
 
     graph.eagerEventToolExecutions.set(
@@ -87,15 +88,18 @@ describe('LangGraph composition smoke tests', () => {
       {} as t.EagerEventToolExecution
     );
     graph.eagerEventToolUsageCount.set('weather', 1);
+    scopedUsageCount.set('weather', 1);
     graph.eagerEventToolCallChunks.set('0', { argsText: '{"city":"NYC"}' });
 
     graph.resetValues();
 
     expect(graph.eagerEventToolExecutions).toBe(executions);
     expect(graph.eagerEventToolUsageCount).toBe(usageCount);
+    expect(graph.getEagerEventToolUsageCount('agent')).toBe(scopedUsageCount);
     expect(graph.eagerEventToolCallChunks).toBe(chunks);
     expect(graph.eagerEventToolExecutions.size).toBe(0);
     expect(graph.eagerEventToolUsageCount.size).toBe(0);
+    expect(scopedUsageCount.size).toBe(0);
     expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 

--- a/src/graphs/__tests__/composition.smoke.test.ts
+++ b/src/graphs/__tests__/composition.smoke.test.ts
@@ -73,6 +73,32 @@ const expectCompiledWorkflow = (
 };
 
 describe('LangGraph composition smoke tests', () => {
+  it('clears run-scoped eager tool state on reset', () => {
+    const graph = new StandardGraph({
+      runId: 'standard-eager-reset',
+      agents: [makeAgent('agent')],
+    });
+    const executions = graph.eagerEventToolExecutions;
+    const usageCount = graph.eagerEventToolUsageCount;
+    const chunks = graph.eagerEventToolCallChunks;
+
+    graph.eagerEventToolExecutions.set(
+      'call_weather',
+      {} as t.EagerEventToolExecution
+    );
+    graph.eagerEventToolUsageCount.set('weather', 1);
+    graph.eagerEventToolCallChunks.set('0', { argsText: '{"city":"NYC"}' });
+
+    graph.resetValues();
+
+    expect(graph.eagerEventToolExecutions).toBe(executions);
+    expect(graph.eagerEventToolUsageCount).toBe(usageCount);
+    expect(graph.eagerEventToolCallChunks).toBe(chunks);
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+    expect(graph.eagerEventToolUsageCount.size).toBe(0);
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
+  });
+
   it('compiles and invokes the standard single-agent graph', async () => {
     const graph = new StandardGraph({
       runId: 'standard-smoke',

--- a/src/llm/openai/contentBlocks.test.ts
+++ b/src/llm/openai/contentBlocks.test.ts
@@ -4,6 +4,12 @@ import {
   AIMessageChunk,
   type ContentBlock,
 } from '@langchain/core/messages';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import { _convertOpenAIResponsesDeltaToBaseMessageChunk } from './utils';
 
 describe('OpenAI content block translator compatibility', () => {
   describe('Chat Completions', () => {
@@ -107,6 +113,35 @@ describe('OpenAI content block translator compatibility', () => {
   });
 
   describe('Responses', () => {
+    test('marks Responses function call arguments done as an explicit tool-call seal', () => {
+      const chunk = _convertOpenAIResponsesDeltaToBaseMessageChunk({
+        type: 'response.function_call_arguments.done',
+        sequence_number: 3,
+        item_id: 'fc_123',
+        output_index: 1,
+        name: 'search',
+        arguments: '{"query":"weather"}',
+      } as Parameters<typeof _convertOpenAIResponsesDeltaToBaseMessageChunk>[0]);
+      const message = chunk?.message as AIMessageChunk | undefined;
+
+      expect(message?.tool_call_chunks).toEqual([
+        {
+          type: 'tool_call_chunk',
+          name: 'search',
+          args: '{"query":"weather"}',
+          index: 1,
+        },
+      ]);
+      expect(message?.response_metadata).toMatchObject({
+        [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+          OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+        [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+          kind: 'single',
+          index: 1,
+        },
+      });
+    });
+
     test('translates Responses messages to v1 content blocks', () => {
       const code = ['print(', 'hello', ')'].join(String.fromCharCode(39));
       const responseTextBlock = {

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -38,6 +38,11 @@ import type {
   ChatOpenAIReasoningSummary,
 } from '@langchain/openai';
 import { toLangChainContent } from '@/messages/langchain';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
 
 export type { OpenAICallOptions, OpenAIChatInput };
 
@@ -948,6 +953,8 @@ export function _convertOpenAIResponsesDeltaToBaseMessageChunk(
     chunk.type === 'response.output_item.added' &&
     chunk.item.type === 'function_call'
   ) {
+    response_metadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY] =
+      OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER;
     tool_call_chunks.push({
       type: 'tool_call_chunk',
       name: chunk.item.name,
@@ -988,9 +995,24 @@ export function _convertOpenAIResponsesDeltaToBaseMessageChunk(
       if (key !== 'id') response_metadata[key] = value;
     }
   } else if (chunk.type === 'response.function_call_arguments.delta') {
+    response_metadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY] =
+      OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER;
     tool_call_chunks.push({
       type: 'tool_call_chunk',
       args: chunk.delta,
+      index: chunk.output_index,
+    });
+  } else if (chunk.type === 'response.function_call_arguments.done') {
+    response_metadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY] =
+      OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER;
+    response_metadata[STREAMED_TOOL_CALL_SEAL_METADATA_KEY] = {
+      kind: 'single',
+      index: chunk.output_index,
+    };
+    tool_call_chunks.push({
+      type: 'tool_call_chunk',
+      name: chunk.name,
+      args: chunk.arguments,
       index: chunk.output_index,
     });
   } else if (

--- a/src/run.ts
+++ b/src/run.ts
@@ -85,6 +85,7 @@ export class Run<_T extends t.BaseGraphState> {
   private hookRegistry?: HookRegistry;
   private humanInTheLoop?: t.HumanInTheLoopConfig;
   private toolOutputReferences?: t.ToolOutputReferencesConfig;
+  private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
   private toolExecution?: t.ToolExecutionConfig;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
@@ -130,6 +131,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.hookRegistry = config.hooks;
     this.humanInTheLoop = config.humanInTheLoop;
     this.toolOutputReferences = config.toolOutputReferences;
+    this.eagerEventToolExecution = config.eagerEventToolExecution;
     this.toolExecution = config.toolExecution;
 
     if (!config.graphConfig) {
@@ -211,6 +213,7 @@ export class Run<_T extends t.BaseGraphState> {
     standardGraph.hookRegistry = this.hookRegistry;
     standardGraph.humanInTheLoop = this.humanInTheLoop;
     standardGraph.toolOutputReferences = this.toolOutputReferences;
+    standardGraph.eagerEventToolExecution = this.eagerEventToolExecution;
     standardGraph.toolExecution = this.toolExecution;
     this.Graph = standardGraph;
     return standardGraph.createWorkflow();
@@ -236,6 +239,7 @@ export class Run<_T extends t.BaseGraphState> {
     multiAgentGraph.hookRegistry = this.hookRegistry;
     multiAgentGraph.humanInTheLoop = this.humanInTheLoop;
     multiAgentGraph.toolOutputReferences = this.toolOutputReferences;
+    multiAgentGraph.eagerEventToolExecution = this.eagerEventToolExecution;
     multiAgentGraph.toolExecution = this.toolExecution;
     this.Graph = multiAgentGraph;
     return multiAgentGraph.createWorkflow();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -23,6 +23,8 @@ import { getMessageId } from '@/messages';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { coerceRecordArgs, normalizeError } from '@/tools/eagerEventExecution';
 
+const processedChatModelStreamChunks = new WeakSet<object>();
+
 /**
  * Parses content to extract thinking sections enclosed in <think> tags using string operations
  * @param content The content to parse
@@ -291,6 +293,22 @@ function parseCompleteRecordArgs(
   }
 }
 
+function mergeToolCallArgsText(existing: string, incoming: string): string {
+  if (incoming === '') {
+    return existing;
+  }
+  if (existing === '') {
+    return incoming;
+  }
+  if (incoming.startsWith(existing)) {
+    return incoming;
+  }
+  if (existing.startsWith(incoming)) {
+    return existing;
+  }
+  return `${existing}${incoming}`;
+}
+
 function startEagerToolExecutionsFromChunks(args: {
   graph: StandardGraph;
   metadata?: Record<string, unknown>;
@@ -333,7 +351,10 @@ function startEagerToolExecutionsFromChunks(args: {
       incomingId ?? existing.id;
     const name =
       incomingName ?? existing.name;
-    const argsText = `${existing.argsText}${toolCallChunk.args ?? ''}`;
+    const argsText = mergeToolCallArgsText(
+      existing.argsText,
+      toolCallChunk.args ?? ''
+    );
     const next = {
       id,
       name,
@@ -445,6 +466,11 @@ export class ChatModelStreamHandler implements t.EventHandler {
     const agentContext = graph.getAgentContext(metadata);
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
+    if (processedChatModelStreamChunks.has(chunk)) {
+      return;
+    }
+    processedChatModelStreamChunks.add(chunk);
+
     const content = getChunkContent({
       chunk,
       reasoningKey: agentContext.reasoningKey,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -24,6 +24,7 @@ import { getMessageId } from '@/messages';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import {
   buildToolExecutionRequestPlan,
+  coerceRecordArgs,
   normalizeError,
 } from '@/tools/eagerEventExecution';
 
@@ -218,6 +219,24 @@ function hasDirectToolCallInBatch(args: {
   );
 }
 
+function hasPotentialDirectToolInStreamContext(args: {
+  graph: StandardGraph;
+  agentContext?: AgentContext;
+}): boolean {
+  const { graph, agentContext } = args;
+  if (graph.toolExecution?.engine === 'local') {
+    return true;
+  }
+  if ((agentContext?.graphTools?.length ?? 0) > 0) {
+    return true;
+  }
+  return (
+    agentContext?.toolDefinitions?.some((toolDefinition) =>
+      toolDefinition.name.startsWith(Constants.LC_TRANSFER_TO_)
+    ) === true
+  );
+}
+
 type EagerToolExecutionEntry = {
   id: string;
   toolName: string;
@@ -230,8 +249,9 @@ function createEagerToolExecutionPlan(args: {
   metadata?: Record<string, unknown>;
   agentContext?: AgentContext;
   toolCalls: ToolCall[];
+  skipExisting?: boolean;
 }): EagerToolExecutionEntry[] | undefined {
-  const { graph, metadata, agentContext, toolCalls } = args;
+  const { graph, metadata, agentContext, toolCalls, skipExisting = false } = args;
   if (
     !isEagerToolExecutionEnabledForBatch({
       graph,
@@ -246,22 +266,35 @@ function createEagerToolExecutionPlan(args: {
     return undefined;
   }
 
-  // Eager execution must preserve ToolNode batch semantics exactly. If any
-  // call in the final batch cannot be planned, fall back for the whole batch.
+  const candidateToolCalls = skipExisting
+    ? toolCalls.filter((toolCall) => {
+      if (toolCall.id == null || toolCall.id === '') {
+        return true;
+      }
+      return !graph.eagerEventToolExecutions.has(toolCall.id);
+    })
+    : toolCalls;
+  if (candidateToolCalls.length === 0) {
+    return [];
+  }
+
+  // Eager execution must preserve ToolNode batch semantics exactly for every
+  // unstarted call. If any candidate cannot be planned, fall back for that
+  // candidate set.
   if (
-    toolCalls.some(
+    candidateToolCalls.some(
       (toolCall) =>
         toolCall.id == null ||
         toolCall.id === '' ||
         toolCall.name === '' ||
-        graph.eagerEventToolExecutions.has(toolCall.id)
+        (!skipExisting && graph.eagerEventToolExecutions.has(toolCall.id))
     )
   ) {
     return undefined;
   }
 
   const plan = buildToolExecutionRequestPlan({
-    toolCalls: toolCalls.map((toolCall) => ({
+    toolCalls: candidateToolCalls.map((toolCall) => ({
       id: toolCall.id,
       name: toolCall.name,
       args: toolCall.args,
@@ -287,13 +320,15 @@ function startEagerToolExecutions(args: {
   metadata?: Record<string, unknown>;
   agentContext?: AgentContext;
   toolCalls: ToolCall[];
+  skipExisting?: boolean;
 }): void {
-  const { graph, metadata, agentContext, toolCalls } = args;
+  const { graph, metadata, agentContext, toolCalls, skipExisting } = args;
   const entries = createEagerToolExecutionPlan({
     graph,
     metadata,
     agentContext,
     toolCalls,
+    skipExisting,
   });
   if (entries == null || entries.length === 0) {
     return;
@@ -353,6 +388,22 @@ function getEagerToolChunkKey(
   return `${stepKey}\u0000${chunkKey}`;
 }
 
+function getEagerToolChunkIndex(toolCallChunk: ToolCallChunk): number | undefined {
+  return typeof toolCallChunk.index === 'number' ? toolCallChunk.index : undefined;
+}
+
+function isEagerToolChunkStateComplete(
+  state: t.EagerEventToolCallChunkState
+): boolean {
+  return (
+    state.id != null &&
+    state.id !== '' &&
+    state.name != null &&
+    state.name !== '' &&
+    coerceRecordArgs(state.argsText) != null
+  );
+}
+
 function mergeToolCallArgsText(existing: string, incoming: string): string {
   if (incoming === '') {
     return existing;
@@ -381,6 +432,15 @@ function mergeToolCallArgsText(existing: string, incoming: string): string {
   } catch {
     // Fall through to delta concatenation.
   }
+  for (
+    let overlap = Math.min(existing.length, incoming.length);
+    overlap >= 8;
+    overlap -= 1
+  ) {
+    if (existing.endsWith(incoming.slice(0, overlap))) {
+      return `${existing}${incoming.slice(overlap)}`;
+    }
+  }
   return `${existing}${incoming}`;
 }
 
@@ -395,7 +455,8 @@ function recordEagerToolCallChunks(args: {
   }
 
   // Streamed args can be cumulative and parseable before the provider has
-  // emitted the final call; dispatch only happens from complete tool_calls.
+  // sealed the call. Recording stays separate from dispatch so the boundary
+  // logic can wait for either a later tool index or the final tool-call signal.
   for (const toolCallChunk of toolCallChunks) {
     const key = getEagerToolChunkKey(stepKey, toolCallChunk);
     if (key == null) {
@@ -427,17 +488,110 @@ function recordEagerToolCallChunks(args: {
       incomingId ?? existing.id;
     const name =
       incomingName ?? existing.name;
-    const argsText = mergeToolCallArgsText(
-      existing.argsText,
-      toolCallChunk.args ?? ''
-    );
+    const incomingArgs = toolCallChunk.args ?? '';
+    const isRepeatedObservedFragment =
+      incomingArgs !== '' &&
+      incomingArgs.length > 1 &&
+      incomingArgs === existing.lastArgsFragment;
+    const argsText = isRepeatedObservedFragment
+      ? existing.argsText
+      : mergeToolCallArgsText(existing.argsText, incomingArgs);
     const next = {
       id,
       name,
       argsText,
+      index: getEagerToolChunkIndex(toolCallChunk) ?? existing.index,
+      lastArgsFragment:
+        incomingArgs !== '' ? incomingArgs : existing.lastArgsFragment,
     };
     graph.eagerEventToolCallChunks.set(key, next);
   }
+}
+
+function getStreamedReadyToolCalls(args: {
+  graph: StandardGraph;
+  stepKey: string;
+  toolCallChunks?: ToolCallChunk[];
+  sealAll?: boolean;
+}): ToolCall[] {
+  const { graph, stepKey, toolCallChunks, sealAll = false } = args;
+  const currentIndices = new Set<number>();
+  for (const toolCallChunk of toolCallChunks ?? []) {
+    const index = getEagerToolChunkIndex(toolCallChunk);
+    if (index != null) {
+      currentIndices.add(index);
+    }
+  }
+  const highestCurrentIndex =
+    currentIndices.size > 0 ? Math.max(...currentIndices) : undefined;
+  const prefix = `${stepKey}\u0000`;
+  const readyStates: t.EagerEventToolCallChunkState[] = [];
+
+  for (const [key, state] of graph.eagerEventToolCallChunks) {
+    if (!key.startsWith(prefix) || !isEagerToolChunkStateComplete(state)) {
+      continue;
+    }
+    if (state.id != null && graph.eagerEventToolExecutions.has(state.id)) {
+      continue;
+    }
+    const isSealedByLaterChunk =
+      highestCurrentIndex != null &&
+      state.index != null &&
+      state.index < highestCurrentIndex &&
+      !currentIndices.has(state.index);
+    if (sealAll || isSealedByLaterChunk) {
+      readyStates.push(state);
+    }
+  }
+
+  return readyStates
+    .sort((left, right) => (left.index ?? 0) - (right.index ?? 0))
+    .flatMap((state) => {
+      const args = coerceRecordArgs(state.argsText);
+      if (args == null) {
+        return [];
+      }
+      return [
+        {
+          id: state.id,
+          name: state.name ?? '',
+          args,
+        },
+      ];
+    });
+}
+
+function startReadyStreamedEagerToolExecutions(args: {
+  graph: StandardGraph;
+  metadata?: Record<string, unknown>;
+  agentContext?: AgentContext;
+  stepKey: string;
+  toolCallChunks?: ToolCallChunk[];
+  sealAll?: boolean;
+}): void {
+  const { graph, metadata, agentContext, stepKey, toolCallChunks, sealAll } = args;
+  if (
+    hasPotentialDirectToolInStreamContext({ graph, agentContext }) ||
+    !isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext })
+  ) {
+    return;
+  }
+  const toolCalls = getStreamedReadyToolCalls({
+    graph,
+    stepKey,
+    toolCallChunks,
+    sealAll,
+  });
+  if (toolCalls.length === 0) {
+    return;
+  }
+  startEagerToolExecutions({
+    graph,
+    metadata,
+    agentContext,
+    toolCalls,
+    skipExisting: true,
+  });
 }
 
 export function getChunkContent({
@@ -556,6 +710,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
           metadata,
           agentContext,
           toolCalls: chunk.tool_calls,
+          skipExisting: true,
         });
       }
     }
@@ -586,16 +741,24 @@ export class ChatModelStreamHandler implements t.EventHandler {
       chunk.tool_call_chunks.length &&
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
+      recordEagerToolCallChunks({
+        graph,
+        stepKey,
+        toolCallChunks: chunk.tool_call_chunks,
+      });
       await handleToolCallChunks({
         graph,
         stepKey,
         toolCallChunks: chunk.tool_call_chunks,
         metadata,
       });
-      recordEagerToolCallChunks({
+      startReadyStreamedEagerToolExecutions({
         graph,
+        metadata,
+        agentContext,
         stepKey,
         toolCallChunks: chunk.tool_call_chunks,
+        sealAll: hasFinalToolCallSignal(chunk),
       });
     }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -24,10 +24,6 @@ import { getMessageId } from '@/messages';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { coerceRecordArgs, normalizeError } from '@/tools/eagerEventExecution';
 
-const processedChatModelStreamChunks = new WeakMap<
-  StandardGraph,
-  WeakMap<object, string>
->();
 const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
 );
@@ -98,50 +94,6 @@ function isBatchSensitiveToolExecution(graph: StandardGraph): boolean {
     graph.humanInTheLoop?.enabled === true ||
     graph.toolOutputReferences?.enabled === true
   );
-}
-
-function stringifyChunkDedupePart(value: unknown): string {
-  if (value == null) {
-    return '';
-  }
-  if (typeof value === 'string') {
-    return value;
-  }
-  try {
-    return String(JSON.stringify(value));
-  } catch {
-    return String(value);
-  }
-}
-
-function getChunkDedupeSignature(chunk: Partial<AIMessageChunk>): string {
-  return [
-    stringifyChunkDedupePart(chunk.id),
-    stringifyChunkDedupePart(chunk.content),
-    stringifyChunkDedupePart(chunk.additional_kwargs),
-    stringifyChunkDedupePart(chunk.tool_calls),
-    stringifyChunkDedupePart(chunk.tool_call_chunks),
-  ].join('\u0000');
-}
-
-function shouldSkipProcessedChunk(args: {
-  graph: StandardGraph;
-  chunk: Partial<AIMessageChunk>;
-}): boolean {
-  const { graph, chunk } = args;
-  let graphChunks = processedChatModelStreamChunks.get(graph);
-  if (graphChunks == null) {
-    graphChunks = new WeakMap<object, string>();
-    processedChatModelStreamChunks.set(graph, graphChunks);
-  }
-
-  const signature = getChunkDedupeSignature(chunk);
-  if (graphChunks.get(chunk) === signature) {
-    return true;
-  }
-
-  graphChunks.set(chunk, signature);
-  return false;
 }
 
 function isDirectGraphTool(
@@ -542,9 +494,6 @@ export class ChatModelStreamHandler implements t.EventHandler {
     const agentContext = graph.getAgentContext(metadata);
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
-    if (shouldSkipProcessedChunk({ graph, chunk })) {
-      return;
-    }
 
     const content = getChunkContent({
       chunk,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -268,7 +268,7 @@ function createEagerToolExecutionPlan(args: {
       stepId: graph.toolCallStepIds.get(toolCall.id!) ?? '',
       codeSessionContext: getCodeSessionContext(graph, toolCall.name),
     })),
-    usageCount: graph.eagerEventToolUsageCount,
+    usageCount: graph.getEagerEventToolUsageCount(agentContext?.agentId),
   });
   if (plan == null) {
     return undefined;
@@ -550,7 +550,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     ) {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
-      if (!hasToolCallChunks && hasFinalToolCallSignal(chunk)) {
+      if (hasFinalToolCallSignal(chunk)) {
         startEagerToolExecutions({
           graph,
           metadata,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,7 +1,7 @@
 // src/stream.ts
 import type { ChatOpenAIReasoningSummary } from '@langchain/openai';
 import type { AIMessageChunk } from '@langchain/core/messages';
-import type { ToolCall } from '@langchain/core/messages/tool';
+import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs';
 import type * as t from '@/types';
@@ -266,6 +266,110 @@ function startEagerToolExecution(args: {
   });
 }
 
+function getEagerToolChunkKey(toolCallChunk: ToolCallChunk): string | undefined {
+  if (typeof toolCallChunk.index === 'number') {
+    return String(toolCallChunk.index);
+  }
+  if (toolCallChunk.id != null && toolCallChunk.id !== '') {
+    return toolCallChunk.id;
+  }
+  return undefined;
+}
+
+function parseCompleteRecordArgs(
+  argsText: string
+): Record<string, unknown> | undefined {
+  if (argsText.trim() === '') {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(argsText) as unknown;
+    return coerceRecordArgs(parsed) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function startEagerToolExecutionsFromChunks(args: {
+  graph: StandardGraph;
+  metadata?: Record<string, unknown>;
+  agentContext?: AgentContext;
+  toolCallChunks?: ToolCallChunk[];
+}): void {
+  const { graph, metadata, agentContext, toolCallChunks } = args;
+  if (toolCallChunks == null || toolCallChunks.length === 0) {
+    return;
+  }
+
+  for (const toolCallChunk of toolCallChunks) {
+    const key = getEagerToolChunkKey(toolCallChunk);
+    if (key == null) {
+      continue;
+    }
+
+    const existing = graph.eagerEventToolCallChunks.get(key) ?? {
+      argsText: '',
+    };
+    const id =
+      toolCallChunk.id != null && toolCallChunk.id !== ''
+        ? toolCallChunk.id
+        : existing.id;
+    const name =
+      toolCallChunk.name != null && toolCallChunk.name !== ''
+        ? toolCallChunk.name
+        : existing.name;
+    const argsDelta = toolCallChunk.args ?? '';
+    // Some live stream paths surface the same raw tool-call delta twice.
+    // Skipping exact consecutive duplicates keeps assembly conservative; if
+    // this ever drops a legitimate repeated token, final ToolNode arg matching
+    // will reject the stale eager result and fall back to normal dispatch.
+    const isDuplicateDelta =
+      argsDelta !== '' && existing.lastArgsDelta === argsDelta;
+    const argsText = isDuplicateDelta
+      ? existing.argsText
+      : `${existing.argsText}${argsDelta}`;
+    const next = {
+      id,
+      name,
+      argsText,
+      lastArgsDelta:
+        argsDelta !== '' && !isDuplicateDelta
+          ? argsDelta
+          : existing.lastArgsDelta,
+    };
+    graph.eagerEventToolCallChunks.set(key, next);
+
+    if (isDuplicateDelta) {
+      continue;
+    }
+
+    if (id == null || id === '' || name == null || name === '') {
+      continue;
+    }
+    if (graph.eagerEventToolExecutions.has(id)) {
+      continue;
+    }
+
+    const recordArgs = parseCompleteRecordArgs(argsText);
+    if (recordArgs == null) {
+      continue;
+    }
+
+    startEagerToolExecution({
+      graph,
+      metadata,
+      agentContext,
+      toolCall: {
+        id,
+        name,
+        args: recordArgs,
+        type: ToolCallTypes.TOOL_CALL,
+      },
+    });
+  }
+}
+
 export function getChunkContent({
   chunk,
   provider,
@@ -360,6 +464,8 @@ export class ChatModelStreamHandler implements t.EventHandler {
     }
     this.handleReasoning(chunk, agentContext);
     let hasToolCalls = false;
+    const hasToolCallChunks =
+      (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;
     if (
       chunk.tool_calls &&
       chunk.tool_calls.length > 0 &&
@@ -373,18 +479,18 @@ export class ChatModelStreamHandler implements t.EventHandler {
     ) {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
-      for (const toolCall of chunk.tool_calls) {
-        startEagerToolExecution({
-          graph,
-          metadata,
-          agentContext,
-          toolCall,
-        });
+      if (!hasToolCallChunks) {
+        for (const toolCall of chunk.tool_calls) {
+          startEagerToolExecution({
+            graph,
+            metadata,
+            agentContext,
+            toolCall,
+          });
+        }
       }
     }
 
-    const hasToolCallChunks =
-      (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;
     const isEmptyContent =
       typeof content === 'undefined' ||
       !content.length ||
@@ -411,6 +517,12 @@ export class ChatModelStreamHandler implements t.EventHandler {
       chunk.tool_call_chunks.length &&
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
+      startEagerToolExecutionsFromChunks({
+        graph,
+        metadata,
+        agentContext,
+        toolCallChunks: chunk.tool_call_chunks,
+      });
       await handleToolCallChunks({
         graph,
         stepKey,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -201,6 +201,16 @@ function shouldAttemptEagerToolExecution(args: {
   return coerceRecordArgs(toolCall.args) != null;
 }
 
+function hasFinalToolCallSignal(chunk: Partial<AIMessageChunk>): boolean {
+  const metadata = chunk.response_metadata as Record<string, unknown> | undefined;
+  const finishReason =
+    metadata?.finish_reason ??
+    metadata?.finishReason ??
+    metadata?.stop_reason ??
+    metadata?.stopReason;
+  return finishReason === 'tool_calls' || finishReason === 'tool_use';
+}
+
 type EagerToolExecutionEntry = {
   id: string;
   toolName: string;
@@ -526,7 +536,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     ) {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
-      if (!hasToolCallChunks) {
+      if (!hasToolCallChunks && hasFinalToolCallSignal(chunk)) {
         startEagerToolExecutions({
           graph,
           metadata,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -308,17 +308,31 @@ function startEagerToolExecutionsFromChunks(args: {
       continue;
     }
 
-    const existing = graph.eagerEventToolCallChunks.get(key) ?? {
-      argsText: '',
-    };
-    const id =
+    const incomingId =
       toolCallChunk.id != null && toolCallChunk.id !== ''
         ? toolCallChunk.id
-        : existing.id;
-    const name =
+        : undefined;
+    const incomingName =
       toolCallChunk.name != null && toolCallChunk.name !== ''
         ? toolCallChunk.name
-        : existing.name;
+        : undefined;
+    const previous = graph.eagerEventToolCallChunks.get(key);
+    const shouldReset =
+      previous != null &&
+      ((incomingId != null && previous.id != null && incomingId !== previous.id) ||
+        (incomingName != null &&
+          previous.name != null &&
+          incomingName !== previous.name));
+    const existing =
+      previous == null || shouldReset
+        ? {
+          argsText: '',
+        }
+        : previous;
+    const id =
+      incomingId ?? existing.id;
+    const name =
+      incomingName ?? existing.name;
     const argsDelta = toolCallChunk.args ?? '';
     // Some live stream paths surface the same raw tool-call delta twice.
     // Skipping exact consecutive duplicates keeps assembly conservative; if

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -11,6 +11,8 @@ import {
   GraphEvents,
   StepTypes,
   Providers,
+  Constants,
+  CODE_EXECUTION_TOOLS,
 } from '@/common';
 import {
   handleServerToolResult,
@@ -18,6 +20,8 @@ import {
   handleToolCalls,
 } from '@/tools/handlers';
 import { getMessageId } from '@/messages';
+import { safeDispatchCustomEvent } from '@/utils/events';
+import { coerceRecordArgs, normalizeError } from '@/tools/eagerEventExecution';
 
 /**
  * Parses content to extract thinking sections enclosed in <think> tags using string operations
@@ -77,6 +81,189 @@ function getNonEmptyValue(possibleValues: string[]): string | undefined {
     }
   }
   return undefined;
+}
+
+function isBatchSensitiveToolExecution(graph: StandardGraph): boolean {
+  return (
+    graph.hookRegistry != null ||
+    graph.humanInTheLoop?.enabled === true ||
+    graph.toolOutputReferences?.enabled === true
+  );
+}
+
+function isDirectGraphTool(
+  name: string,
+  agentContext: AgentContext | undefined
+): boolean {
+  if (name.startsWith(Constants.LC_TRANSFER_TO_)) {
+    return true;
+  }
+  return (
+    (agentContext?.graphTools as t.GenericTool[] | undefined)?.some(
+      (tool) => 'name' in tool && tool.name === name
+    ) === true
+  );
+}
+
+function toCodeEnvFile(file: t.FileRef, execSessionId: string): t.CodeEnvFile {
+  const base = {
+    id: file.id,
+    resource_id: file.resource_id ?? file.id,
+    name: file.name,
+    storage_session_id: file.storage_session_id ?? execSessionId,
+  };
+  const kind = file.kind ?? 'user';
+  if (kind === 'skill' && file.version != null) {
+    return { ...base, kind: 'skill', version: file.version };
+  }
+  if (kind === 'agent') {
+    return { ...base, kind: 'agent' };
+  }
+  return { ...base, kind: 'user' };
+}
+
+function getCodeSessionContext(
+  graph: StandardGraph,
+  name: string
+): t.ToolCallRequest['codeSessionContext'] | undefined {
+  if (
+    !CODE_EXECUTION_TOOLS.has(name) &&
+    name !== Constants.SKILL_TOOL &&
+    name !== Constants.READ_FILE
+  ) {
+    return undefined;
+  }
+
+  const codeSession = graph.sessions.get(Constants.EXECUTE_CODE) as
+    | t.CodeSessionContext
+    | undefined;
+  if (codeSession?.session_id == null || codeSession.session_id === '') {
+    return undefined;
+  }
+
+  return {
+    session_id: codeSession.session_id,
+    files: codeSession.files?.map((file) =>
+      toCodeEnvFile(file, codeSession.session_id)
+    ),
+  };
+}
+
+function shouldAttemptEagerToolExecution(args: {
+  graph: StandardGraph;
+  metadata?: Record<string, unknown>;
+  agentContext?: AgentContext;
+  toolCall: ToolCall;
+}): boolean {
+  const { graph, metadata, agentContext, toolCall } = args;
+  if (graph.eagerEventToolExecution?.enabled !== true) {
+    return false;
+  }
+  if ((agentContext?.toolDefinitions?.length ?? 0) === 0) {
+    return false;
+  }
+  if (isBatchSensitiveToolExecution(graph)) {
+    return false;
+  }
+  if (
+    metadata?.[Constants.PROGRAMMATIC_TOOL_CALLING] === true ||
+    metadata?.[Constants.BASH_PROGRAMMATIC_TOOL_CALLING] === true
+  ) {
+    return false;
+  }
+  if (graph.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) == null) {
+    return false;
+  }
+  if (
+    toolCall.id == null ||
+    toolCall.id === '' ||
+    toolCall.name === '' ||
+    isDirectGraphTool(toolCall.name, agentContext)
+  ) {
+    return false;
+  }
+  return coerceRecordArgs(toolCall.args) != null;
+}
+
+function startEagerToolExecution(args: {
+  graph: StandardGraph;
+  metadata?: Record<string, unknown>;
+  agentContext?: AgentContext;
+  toolCall: ToolCall;
+}): void {
+  const { graph, metadata, agentContext, toolCall } = args;
+  if (
+    !shouldAttemptEagerToolExecution({
+      graph,
+      metadata,
+      agentContext,
+      toolCall,
+    })
+  ) {
+    return;
+  }
+
+  const id = toolCall.id!;
+  if (graph.eagerEventToolExecutions.has(id)) {
+    return;
+  }
+
+  const toolName = toolCall.name;
+  const coercedArgs = coerceRecordArgs(toolCall.args);
+  if (coercedArgs == null) {
+    return;
+  }
+
+  const turn = graph.eagerEventToolUsageCount.get(toolName) ?? 0;
+  graph.eagerEventToolUsageCount.set(toolName, turn + 1);
+
+  const request: t.ToolCallRequest = {
+    id,
+    name: toolName,
+    args: coercedArgs,
+    stepId: graph.toolCallStepIds.get(id) ?? '',
+    turn,
+  };
+
+  const codeSessionContext = getCodeSessionContext(graph, toolName);
+  if (codeSessionContext != null) {
+    request.codeSessionContext = codeSessionContext;
+  }
+
+  const promise: Promise<t.EagerEventToolExecutionOutcome> = new Promise<
+    t.ToolExecuteResult[]
+  >((resolve, reject) => {
+    const batchRequest: t.ToolExecuteBatchRequest = {
+      toolCalls: [request],
+      userId: graph.config?.configurable?.user_id as string | undefined,
+      agentId: agentContext?.agentId,
+      configurable: graph.config?.configurable as
+        | Record<string, unknown>
+        | undefined,
+      metadata,
+      resolve,
+      reject,
+    };
+
+    safeDispatchCustomEvent(
+      GraphEvents.ON_TOOL_EXECUTE,
+      batchRequest,
+      graph.config
+    );
+  }).then(
+    (results): t.EagerEventToolExecutionOutcome => ({ results }),
+    (error): t.EagerEventToolExecutionOutcome => ({
+      error: normalizeError(error),
+    })
+  );
+
+  graph.eagerEventToolExecutions.set(id, {
+    toolCallId: id,
+    toolName,
+    args: coercedArgs,
+    request,
+    promise,
+  });
 }
 
 export function getChunkContent({
@@ -186,6 +373,14 @@ export class ChatModelStreamHandler implements t.EventHandler {
     ) {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
+      for (const toolCall of chunk.tool_calls) {
+        startEagerToolExecution({
+          graph,
+          metadata,
+          agentContext,
+          toolCall,
+        });
+      }
     }
 
     const hasToolCallChunks =

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -372,6 +372,14 @@ function mergeToolCallArgsText(existing: string, incoming: string): string {
   if (existing === '') {
     return incoming;
   }
+  if (incoming === existing) {
+    try {
+      JSON.parse(incoming);
+      return incoming;
+    } catch {
+      return `${existing}${incoming}`;
+    }
+  }
   if (incoming.startsWith(existing)) {
     return incoming;
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -333,30 +333,13 @@ function startEagerToolExecutionsFromChunks(args: {
       incomingId ?? existing.id;
     const name =
       incomingName ?? existing.name;
-    const argsDelta = toolCallChunk.args ?? '';
-    // Some live stream paths surface the same raw tool-call delta twice.
-    // Skipping exact consecutive duplicates keeps assembly conservative; if
-    // this ever drops a legitimate repeated token, final ToolNode arg matching
-    // will reject the stale eager result and fall back to normal dispatch.
-    const isDuplicateDelta =
-      argsDelta !== '' && existing.lastArgsDelta === argsDelta;
-    const argsText = isDuplicateDelta
-      ? existing.argsText
-      : `${existing.argsText}${argsDelta}`;
+    const argsText = `${existing.argsText}${toolCallChunk.args ?? ''}`;
     const next = {
       id,
       name,
       argsText,
-      lastArgsDelta:
-        argsDelta !== '' && !isDuplicateDelta
-          ? argsDelta
-          : existing.lastArgsDelta,
     };
     graph.eagerEventToolCallChunks.set(key, next);
-
-    if (isDuplicateDelta) {
-      continue;
-    }
 
     if (id == null || id === '' || name == null || name === '') {
       continue;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -268,14 +268,20 @@ function startEagerToolExecution(args: {
   });
 }
 
-function getEagerToolChunkKey(toolCallChunk: ToolCallChunk): string | undefined {
+function getEagerToolChunkKey(
+  stepKey: string,
+  toolCallChunk: ToolCallChunk
+): string | undefined {
+  let chunkKey: string | undefined;
   if (typeof toolCallChunk.index === 'number') {
-    return String(toolCallChunk.index);
+    chunkKey = String(toolCallChunk.index);
+  } else if (toolCallChunk.id != null && toolCallChunk.id !== '') {
+    chunkKey = toolCallChunk.id;
   }
-  if (toolCallChunk.id != null && toolCallChunk.id !== '') {
-    return toolCallChunk.id;
+  if (chunkKey == null) {
+    return undefined;
   }
-  return undefined;
+  return `${stepKey}\u0000${chunkKey}`;
 }
 
 function parseCompleteRecordArgs(
@@ -311,17 +317,18 @@ function mergeToolCallArgsText(existing: string, incoming: string): string {
 
 function startEagerToolExecutionsFromChunks(args: {
   graph: StandardGraph;
+  stepKey: string;
   metadata?: Record<string, unknown>;
   agentContext?: AgentContext;
   toolCallChunks?: ToolCallChunk[];
 }): void {
-  const { graph, metadata, agentContext, toolCallChunks } = args;
+  const { graph, stepKey, metadata, agentContext, toolCallChunks } = args;
   if (toolCallChunks == null || toolCallChunks.length === 0) {
     return;
   }
 
   for (const toolCallChunk of toolCallChunks) {
-    const key = getEagerToolChunkKey(toolCallChunk);
+    const key = getEagerToolChunkKey(stepKey, toolCallChunk);
     if (key == null) {
       continue;
     }
@@ -548,6 +555,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
       });
       startEagerToolExecutionsFromChunks({
         graph,
+        stepKey,
         metadata,
         agentContext,
         toolCallChunks: chunk.tool_call_chunks,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -392,6 +392,24 @@ function getEagerToolChunkIndex(toolCallChunk: ToolCallChunk): number | undefine
   return typeof toolCallChunk.index === 'number' ? toolCallChunk.index : undefined;
 }
 
+function pruneEagerToolCallChunkStates(args: {
+  graph: StandardGraph;
+  stepKey: string;
+  toolCallIds?: ReadonlySet<string>;
+  clearStep?: boolean;
+}): void {
+  const { graph, stepKey, toolCallIds, clearStep = false } = args;
+  const prefix = `${stepKey}\u0000`;
+  for (const [key, state] of graph.eagerEventToolCallChunks) {
+    if (!key.startsWith(prefix)) {
+      continue;
+    }
+    if (clearStep || (state.id != null && toolCallIds?.has(state.id) === true)) {
+      graph.eagerEventToolCallChunks.delete(key);
+    }
+  }
+}
+
 function isEagerToolChunkStateComplete(
   state: t.EagerEventToolCallChunkState
 ): boolean {
@@ -525,13 +543,20 @@ function getStreamedReadyToolCalls(args: {
   const highestCurrentIndex =
     currentIndices.size > 0 ? Math.max(...currentIndices) : undefined;
   const prefix = `${stepKey}\u0000`;
-  const readyStates: t.EagerEventToolCallChunkState[] = [];
+  const readyEntries: Array<{
+    key: string;
+    state: t.EagerEventToolCallChunkState;
+  }> = [];
 
   for (const [key, state] of graph.eagerEventToolCallChunks) {
-    if (!key.startsWith(prefix) || !isEagerToolChunkStateComplete(state)) {
+    if (!key.startsWith(prefix)) {
       continue;
     }
     if (state.id != null && graph.eagerEventToolExecutions.has(state.id)) {
+      graph.eagerEventToolCallChunks.delete(key);
+      continue;
+    }
+    if (!isEagerToolChunkStateComplete(state)) {
       continue;
     }
     const isSealedByLaterChunk =
@@ -540,13 +565,28 @@ function getStreamedReadyToolCalls(args: {
       state.index < highestCurrentIndex &&
       !currentIndices.has(state.index);
     if (sealAll || isSealedByLaterChunk) {
-      readyStates.push(state);
+      readyEntries.push({ key, state });
     }
   }
 
-  return readyStates
-    .sort((left, right) => (left.index ?? 0) - (right.index ?? 0))
-    .flatMap((state) => {
+  pruneEagerToolCallChunkStates({
+    graph,
+    stepKey,
+    toolCallIds: new Set(
+      readyEntries
+        .map(({ state }) => state.id)
+        .filter((id): id is string => id != null && id !== '')
+    ),
+  });
+  if (sealAll) {
+    pruneEagerToolCallChunkStates({ graph, stepKey, clearStep: true });
+  }
+
+  return readyEntries
+    .sort(
+      (left, right) => (left.state.index ?? 0) - (right.state.index ?? 0)
+    )
+    .flatMap(({ state }) => {
       const args = coerceRecordArgs(state.argsText);
       if (args == null) {
         return [];
@@ -688,6 +728,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
       return;
     }
     this.handleReasoning(chunk, agentContext);
+    const stepKey = graph.getStepKey(metadata);
     let hasToolCalls = false;
     const hasToolCallChunks =
       (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;
@@ -712,6 +753,9 @@ export class ChatModelStreamHandler implements t.EventHandler {
           toolCalls: chunk.tool_calls,
           skipExisting: true,
         });
+        if (!hasToolCallChunks) {
+          pruneEagerToolCallChunkStates({ graph, stepKey, clearStep: true });
+        }
       }
     }
 
@@ -727,13 +771,10 @@ export class ChatModelStreamHandler implements t.EventHandler {
       (chunk.id ?? '') !== '' &&
       !graph.prelimMessageIdsByStepKey.has(chunk.id ?? '')
     ) {
-      const stepKey = graph.getStepKey(metadata);
       graph.prelimMessageIdsByStepKey.set(stepKey, chunk.id ?? '');
     } else if (isEmptyChunk) {
       return;
     }
-
-    const stepKey = graph.getStepKey(metadata);
 
     if (
       hasToolCallChunks &&

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -202,12 +202,19 @@ function shouldAttemptEagerToolExecution(args: {
   return coerceRecordArgs(toolCall.args) != null;
 }
 
-function startEagerToolExecution(args: {
+type EagerToolExecutionEntry = {
+  id: string;
+  toolName: string;
+  coercedArgs: Record<string, unknown>;
+  request: t.ToolCallRequest;
+};
+
+function createEagerToolExecutionEntry(args: {
   graph: StandardGraph;
   metadata?: Record<string, unknown>;
   agentContext?: AgentContext;
   toolCall: ToolCall;
-}): void {
+}): EagerToolExecutionEntry | undefined {
   const { graph, metadata, agentContext, toolCall } = args;
   if (
     !shouldAttemptEagerToolExecution({
@@ -217,18 +224,18 @@ function startEagerToolExecution(args: {
       toolCall,
     })
   ) {
-    return;
+    return undefined;
   }
 
   const id = toolCall.id!;
   if (graph.eagerEventToolExecutions.has(id)) {
-    return;
+    return undefined;
   }
 
   const toolName = toolCall.name;
   const coercedArgs = coerceRecordArgs(toolCall.args);
   if (coercedArgs == null) {
-    return;
+    return undefined;
   }
 
   const turn = graph.eagerEventToolUsageCount.get(toolName) ?? 0;
@@ -247,11 +254,41 @@ function startEagerToolExecution(args: {
     request.codeSessionContext = codeSessionContext;
   }
 
+  return {
+    id,
+    toolName,
+    coercedArgs,
+    request,
+  };
+}
+
+function startEagerToolExecutions(args: {
+  graph: StandardGraph;
+  metadata?: Record<string, unknown>;
+  agentContext?: AgentContext;
+  toolCalls: ToolCall[];
+}): void {
+  const { graph, metadata, agentContext, toolCalls } = args;
+  const entries = toolCalls
+    .map((toolCall) =>
+      createEagerToolExecutionEntry({
+        graph,
+        metadata,
+        agentContext,
+        toolCall,
+      })
+    )
+    .filter((entry): entry is EagerToolExecutionEntry => entry != null);
+
+  if (entries.length === 0) {
+    return;
+  }
+
   const promise: Promise<t.EagerEventToolExecutionOutcome> = new Promise<
     t.ToolExecuteResult[]
   >((resolve, reject) => {
     const batchRequest: t.ToolExecuteBatchRequest = {
-      toolCalls: [request],
+      toolCalls: entries.map((entry) => entry.request),
       userId: graph.config?.configurable?.user_id as string | undefined,
       agentId: agentContext?.agentId,
       configurable: graph.config?.configurable as
@@ -274,13 +311,15 @@ function startEagerToolExecution(args: {
     })
   );
 
-  graph.eagerEventToolExecutions.set(id, {
-    toolCallId: id,
-    toolName,
-    args: coercedArgs,
-    request,
-    promise,
-  });
+  for (const entry of entries) {
+    graph.eagerEventToolExecutions.set(entry.id, {
+      toolCallId: entry.id,
+      toolName: entry.toolName,
+      args: entry.coercedArgs,
+      request: entry.request,
+      promise,
+    });
+  }
 }
 
 function getEagerToolChunkKey(
@@ -493,14 +532,12 @@ export class ChatModelStreamHandler implements t.EventHandler {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
       if (!hasToolCallChunks) {
-        for (const toolCall of chunk.tool_calls) {
-          startEagerToolExecution({
-            graph,
-            metadata,
-            agentContext,
-            toolCall,
-          });
-        }
+        startEagerToolExecutions({
+          graph,
+          metadata,
+          agentContext,
+          toolCalls: chunk.tool_calls,
+        });
       }
     }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -22,7 +22,10 @@ import {
 } from '@/tools/handlers';
 import { getMessageId } from '@/messages';
 import { safeDispatchCustomEvent } from '@/utils/events';
-import { coerceRecordArgs, normalizeError } from '@/tools/eagerEventExecution';
+import {
+  buildToolExecutionRequestPlan,
+  normalizeError,
+} from '@/tools/eagerEventExecution';
 
 const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
@@ -164,13 +167,12 @@ function getCodeSessionContext(
   };
 }
 
-function shouldAttemptEagerToolExecution(args: {
+function isEagerToolExecutionEnabledForBatch(args: {
   graph: StandardGraph;
   metadata?: Record<string, unknown>;
   agentContext?: AgentContext;
-  toolCall: ToolCall;
 }): boolean {
-  const { graph, metadata, agentContext, toolCall } = args;
+  const { graph, metadata, agentContext } = args;
   if (graph.eagerEventToolExecution?.enabled !== true) {
     return false;
   }
@@ -189,16 +191,7 @@ function shouldAttemptEagerToolExecution(args: {
   if (graph.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) == null) {
     return false;
   }
-  if (
-    toolCall.id == null ||
-    toolCall.id === '' ||
-    toolCall.name === '' ||
-    isDirectGraphTool(toolCall.name, agentContext) ||
-    isDirectLocalTool(toolCall.name, graph)
-  ) {
-    return false;
-  }
-  return coerceRecordArgs(toolCall.args) != null;
+  return true;
 }
 
 function hasFinalToolCallSignal(chunk: Partial<AIMessageChunk>): boolean {
@@ -232,57 +225,61 @@ type EagerToolExecutionEntry = {
   request: t.ToolCallRequest;
 };
 
-function createEagerToolExecutionEntry(args: {
+function createEagerToolExecutionPlan(args: {
   graph: StandardGraph;
   metadata?: Record<string, unknown>;
   agentContext?: AgentContext;
-  toolCall: ToolCall;
-}): EagerToolExecutionEntry | undefined {
-  const { graph, metadata, agentContext, toolCall } = args;
+  toolCalls: ToolCall[];
+}): EagerToolExecutionEntry[] | undefined {
+  const { graph, metadata, agentContext, toolCalls } = args;
   if (
-    !shouldAttemptEagerToolExecution({
+    !isEagerToolExecutionEnabledForBatch({
       graph,
       metadata,
       agentContext,
-      toolCall,
     })
   ) {
     return undefined;
   }
 
-  const id = toolCall.id!;
-  if (graph.eagerEventToolExecutions.has(id)) {
+  if (hasDirectToolCallInBatch({ graph, agentContext, toolCalls })) {
     return undefined;
   }
 
-  const toolName = toolCall.name;
-  const coercedArgs = coerceRecordArgs(toolCall.args);
-  if (coercedArgs == null) {
+  // Eager execution must preserve ToolNode batch semantics exactly. If any
+  // call in the final batch cannot be planned, fall back for the whole batch.
+  if (
+    toolCalls.some(
+      (toolCall) =>
+        toolCall.id == null ||
+        toolCall.id === '' ||
+        toolCall.name === '' ||
+        graph.eagerEventToolExecutions.has(toolCall.id)
+    )
+  ) {
     return undefined;
   }
 
-  const turn = graph.eagerEventToolUsageCount.get(toolName) ?? 0;
-  graph.eagerEventToolUsageCount.set(toolName, turn + 1);
-
-  const request: t.ToolCallRequest = {
-    id,
-    name: toolName,
-    args: coercedArgs,
-    stepId: graph.toolCallStepIds.get(id) ?? '',
-    turn,
-  };
-
-  const codeSessionContext = getCodeSessionContext(graph, toolName);
-  if (codeSessionContext != null) {
-    request.codeSessionContext = codeSessionContext;
+  const plan = buildToolExecutionRequestPlan({
+    toolCalls: toolCalls.map((toolCall) => ({
+      id: toolCall.id,
+      name: toolCall.name,
+      args: toolCall.args,
+      stepId: graph.toolCallStepIds.get(toolCall.id!) ?? '',
+      codeSessionContext: getCodeSessionContext(graph, toolCall.name),
+    })),
+    usageCount: graph.eagerEventToolUsageCount,
+  });
+  if (plan == null) {
+    return undefined;
   }
 
-  return {
-    id,
-    toolName,
-    coercedArgs,
+  return plan.requests.map((request): EagerToolExecutionEntry => ({
+    id: request.id,
+    toolName: request.name,
+    coercedArgs: request.args,
     request,
-  };
+  }));
 }
 
 function startEagerToolExecutions(args: {
@@ -292,22 +289,13 @@ function startEagerToolExecutions(args: {
   toolCalls: ToolCall[];
 }): void {
   const { graph, metadata, agentContext, toolCalls } = args;
-  if (hasDirectToolCallInBatch({ graph, agentContext, toolCalls })) {
-    return;
-  }
-
-  const entries = toolCalls
-    .map((toolCall) =>
-      createEagerToolExecutionEntry({
-        graph,
-        metadata,
-        agentContext,
-        toolCall,
-      })
-    )
-    .filter((entry): entry is EagerToolExecutionEntry => entry != null);
-
-  if (entries.length === 0) {
+  const entries = createEagerToolExecutionPlan({
+    graph,
+    metadata,
+    agentContext,
+    toolCalls,
+  });
+  if (entries == null || entries.length === 0) {
     return;
   }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -13,6 +13,7 @@ import {
   Providers,
   Constants,
   CODE_EXECUTION_TOOLS,
+  LOCAL_CODING_BUNDLE_NAMES,
 } from '@/common';
 import {
   handleServerToolResult,
@@ -24,6 +25,9 @@ import { safeDispatchCustomEvent } from '@/utils/events';
 import { coerceRecordArgs, normalizeError } from '@/tools/eagerEventExecution';
 
 const processedChatModelStreamChunks = new WeakSet<object>();
+const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
+  LOCAL_CODING_BUNDLE_NAMES
+);
 
 /**
  * Parses content to extract thinking sections enclosed in <think> tags using string operations
@@ -107,6 +111,16 @@ function isDirectGraphTool(
   );
 }
 
+function isDirectLocalTool(name: string, graph: StandardGraph): boolean {
+  if (graph.toolExecution?.engine !== 'local') {
+    return false;
+  }
+  if (graph.toolExecution.local?.includeCodingTools === false) {
+    return CODE_EXECUTION_TOOLS.has(name);
+  }
+  return LOCAL_CODING_BUNDLE_NAME_SET.has(name);
+}
+
 function toCodeEnvFile(file: t.FileRef, execSessionId: string): t.CodeEnvFile {
   const base = {
     id: file.id,
@@ -180,7 +194,8 @@ function shouldAttemptEagerToolExecution(args: {
     toolCall.id == null ||
     toolCall.id === '' ||
     toolCall.name === '' ||
-    isDirectGraphTool(toolCall.name, agentContext)
+    isDirectGraphTool(toolCall.name, agentContext) ||
+    isDirectLocalTool(toolCall.name, graph)
   ) {
     return false;
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -782,25 +782,32 @@ export class ChatModelStreamHandler implements t.EventHandler {
       chunk.tool_call_chunks.length &&
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
-      recordEagerToolCallChunks({
-        graph,
-        stepKey,
-        toolCallChunks: chunk.tool_call_chunks,
-      });
+      const canStreamEager =
+        !hasPotentialDirectToolInStreamContext({ graph, agentContext }) &&
+        isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext });
+      if (canStreamEager) {
+        recordEagerToolCallChunks({
+          graph,
+          stepKey,
+          toolCallChunks: chunk.tool_call_chunks,
+        });
+      }
       await handleToolCallChunks({
         graph,
         stepKey,
         toolCallChunks: chunk.tool_call_chunks,
         metadata,
       });
-      startReadyStreamedEagerToolExecutions({
-        graph,
-        metadata,
-        agentContext,
-        stepKey,
-        toolCallChunks: chunk.tool_call_chunks,
-        sealAll: hasFinalToolCallSignal(chunk),
-      });
+      if (canStreamEager) {
+        startReadyStreamedEagerToolExecutions({
+          graph,
+          metadata,
+          agentContext,
+          stepKey,
+          toolCallChunks: chunk.tool_call_chunks,
+          sealAll: hasFinalToolCallSignal(chunk),
+        });
+      }
     }
 
     if (isEmptyContent) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -24,7 +24,10 @@ import { getMessageId } from '@/messages';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { coerceRecordArgs, normalizeError } from '@/tools/eagerEventExecution';
 
-const processedChatModelStreamChunks = new WeakSet<object>();
+const processedChatModelStreamChunks = new WeakMap<
+  StandardGraph,
+  WeakMap<object, Map<string, string>>
+>();
 const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
 );
@@ -95,6 +98,56 @@ function isBatchSensitiveToolExecution(graph: StandardGraph): boolean {
     graph.humanInTheLoop?.enabled === true ||
     graph.toolOutputReferences?.enabled === true
   );
+}
+
+function stringifyChunkDedupePart(value: unknown): string {
+  if (value == null) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return String(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+function getChunkDedupeSignature(chunk: Partial<AIMessageChunk>): string {
+  return [
+    stringifyChunkDedupePart(chunk.id),
+    stringifyChunkDedupePart(chunk.content),
+    stringifyChunkDedupePart(chunk.additional_kwargs),
+    stringifyChunkDedupePart(chunk.tool_calls),
+    stringifyChunkDedupePart(chunk.tool_call_chunks),
+  ].join('\u0000');
+}
+
+function shouldSkipProcessedChunk(args: {
+  graph: StandardGraph;
+  stepKey: string;
+  chunk: Partial<AIMessageChunk>;
+}): boolean {
+  const { graph, stepKey, chunk } = args;
+  let graphChunks = processedChatModelStreamChunks.get(graph);
+  if (graphChunks == null) {
+    graphChunks = new WeakMap<object, Map<string, string>>();
+    processedChatModelStreamChunks.set(graph, graphChunks);
+  }
+
+  let signaturesByStep = graphChunks.get(chunk);
+  const signature = getChunkDedupeSignature(chunk);
+  if (signaturesByStep?.get(stepKey) === signature) {
+    return true;
+  }
+
+  if (signaturesByStep == null) {
+    signaturesByStep = new Map<string, string>();
+    graphChunks.set(chunk, signaturesByStep);
+  }
+  signaturesByStep.set(stepKey, signature);
+  return false;
 }
 
 function isDirectGraphTool(
@@ -495,10 +548,10 @@ export class ChatModelStreamHandler implements t.EventHandler {
     const agentContext = graph.getAgentContext(metadata);
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
-    if (processedChatModelStreamChunks.has(chunk)) {
+    const stepKey = graph.getStepKey(metadata);
+    if (shouldSkipProcessedChunk({ graph, stepKey, chunk })) {
       return;
     }
-    processedChatModelStreamChunks.add(chunk);
 
     const content = getChunkContent({
       chunk,
@@ -558,8 +611,6 @@ export class ChatModelStreamHandler implements t.EventHandler {
     } else if (isEmptyChunk) {
       return;
     }
-
-    const stepKey = graph.getStepKey(metadata);
 
     if (
       hasToolCallChunks &&

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -211,6 +211,20 @@ function hasFinalToolCallSignal(chunk: Partial<AIMessageChunk>): boolean {
   return finishReason === 'tool_calls' || finishReason === 'tool_use';
 }
 
+function hasDirectToolCallInBatch(args: {
+  graph: StandardGraph;
+  agentContext?: AgentContext;
+  toolCalls: ToolCall[];
+}): boolean {
+  const { graph, agentContext, toolCalls } = args;
+  return toolCalls.some(
+    (toolCall) =>
+      toolCall.name !== '' &&
+      (isDirectGraphTool(toolCall.name, agentContext) ||
+        isDirectLocalTool(toolCall.name, graph))
+  );
+}
+
 type EagerToolExecutionEntry = {
   id: string;
   toolName: string;
@@ -278,6 +292,10 @@ function startEagerToolExecutions(args: {
   toolCalls: ToolCall[];
 }): void {
   const { graph, metadata, agentContext, toolCalls } = args;
+  if (hasDirectToolCallInBatch({ graph, agentContext, toolCalls })) {
+    return;
+  }
+
   const entries = toolCalls
     .map((toolCall) =>
       createEagerToolExecutionEntry({

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -26,7 +26,7 @@ import { coerceRecordArgs, normalizeError } from '@/tools/eagerEventExecution';
 
 const processedChatModelStreamChunks = new WeakMap<
   StandardGraph,
-  WeakMap<object, Map<string, string>>
+  WeakMap<object, string>
 >();
 const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
@@ -126,27 +126,21 @@ function getChunkDedupeSignature(chunk: Partial<AIMessageChunk>): string {
 
 function shouldSkipProcessedChunk(args: {
   graph: StandardGraph;
-  stepKey: string;
   chunk: Partial<AIMessageChunk>;
 }): boolean {
-  const { graph, stepKey, chunk } = args;
+  const { graph, chunk } = args;
   let graphChunks = processedChatModelStreamChunks.get(graph);
   if (graphChunks == null) {
-    graphChunks = new WeakMap<object, Map<string, string>>();
+    graphChunks = new WeakMap<object, string>();
     processedChatModelStreamChunks.set(graph, graphChunks);
   }
 
-  let signaturesByStep = graphChunks.get(chunk);
   const signature = getChunkDedupeSignature(chunk);
-  if (signaturesByStep?.get(stepKey) === signature) {
+  if (graphChunks.get(chunk) === signature) {
     return true;
   }
 
-  if (signaturesByStep == null) {
-    signaturesByStep = new Map<string, string>();
-    graphChunks.set(chunk, signaturesByStep);
-  }
-  signaturesByStep.set(stepKey, signature);
+  graphChunks.set(chunk, signature);
   return false;
 }
 
@@ -548,8 +542,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     const agentContext = graph.getAgentContext(metadata);
 
     const chunk = data.chunk as Partial<AIMessageChunk>;
-    const stepKey = graph.getStepKey(metadata);
-    if (shouldSkipProcessedChunk({ graph, stepKey, chunk })) {
+    if (shouldSkipProcessedChunk({ graph, chunk })) {
       return;
     }
 
@@ -611,6 +604,8 @@ export class ChatModelStreamHandler implements t.EventHandler {
     } else if (isEmptyChunk) {
       return;
     }
+
+    const stepKey = graph.getStepKey(metadata);
 
     if (
       hasToolCallChunks &&

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -205,6 +205,19 @@ function hasFinalToolCallSignal(chunk: Partial<AIMessageChunk>): boolean {
   return finishReason === 'tool_calls' || finishReason === 'tool_use';
 }
 
+function canPrestartSealedStreamedToolChunks(
+  agentContext: AgentContext | undefined
+): boolean {
+  // Starting a streamed tool before the final model message is only safe for
+  // providers whose streaming protocol seals one tool-use block before moving
+  // to the next. OpenAI-compatible routes can emit cumulative/ambiguous tool
+  // payloads and are handled by the final `tool_calls` path instead.
+  return (
+    agentContext?.provider === Providers.ANTHROPIC ||
+    agentContext?.provider === Providers.MOONSHOT
+  );
+}
+
 function hasDirectToolCallInBatch(args: {
   graph: StandardGraph;
   agentContext?: AgentContext;
@@ -783,6 +796,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
       const canStreamEager =
+        canPrestartSealedStreamedToolChunks(agentContext) &&
         !hasPotentialDirectToolInStreamContext({ graph, agentContext }) &&
         isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext });
       if (canStreamEager) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -27,6 +27,11 @@ import {
   coerceRecordArgs,
   normalizeError,
 } from '@/tools/eagerEventExecution';
+import {
+  getStreamedToolCallSeal,
+  getStreamedToolCallAdapter,
+  type StreamedToolCallSeal,
+} from '@/tools/streamedToolCallSeals';
 
 const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
@@ -205,17 +210,21 @@ function hasFinalToolCallSignal(chunk: Partial<AIMessageChunk>): boolean {
   return finishReason === 'tool_calls' || finishReason === 'tool_use';
 }
 
-function canPrestartSealedStreamedToolChunks(
+function canPrestartSequentialStreamedToolChunks(
   agentContext: AgentContext | undefined
 ): boolean {
-  // Starting a streamed tool before the final model message is only safe for
-  // providers whose streaming protocol seals one tool-use block before moving
-  // to the next. OpenAI-compatible routes can emit cumulative/ambiguous tool
-  // payloads and are handled by the final `tool_calls` path instead.
   return (
     agentContext?.provider === Providers.ANTHROPIC ||
     agentContext?.provider === Providers.MOONSHOT
   );
+}
+
+function hasExplicitStreamedToolCallSeals(
+  chunk: Partial<AIMessageChunk>
+): boolean {
+  return getStreamedToolCallAdapter(
+    chunk.response_metadata as Record<string, unknown> | undefined
+  ) != null;
 }
 
 function hasDirectToolCallInBatch(args: {
@@ -543,9 +552,18 @@ function getStreamedReadyToolCalls(args: {
   graph: StandardGraph;
   stepKey: string;
   toolCallChunks?: ToolCallChunk[];
+  seal?: StreamedToolCallSeal;
+  allowSequentialSeal?: boolean;
   sealAll?: boolean;
 }): ToolCall[] {
-  const { graph, stepKey, toolCallChunks, sealAll = false } = args;
+  const {
+    graph,
+    stepKey,
+    toolCallChunks,
+    seal,
+    allowSequentialSeal = false,
+    sealAll = false,
+  } = args;
   const currentIndices = new Set<number>();
   for (const toolCallChunk of toolCallChunks ?? []) {
     const index = getEagerToolChunkIndex(toolCallChunk);
@@ -573,11 +591,21 @@ function getStreamedReadyToolCalls(args: {
       continue;
     }
     const isSealedByLaterChunk =
+      allowSequentialSeal &&
       highestCurrentIndex != null &&
       state.index != null &&
       state.index < highestCurrentIndex &&
       !currentIndices.has(state.index);
-    if (sealAll || isSealedByLaterChunk) {
+    const isSealedExplicitly =
+      seal?.kind === 'single' &&
+      ((seal.id != null && state.id === seal.id) ||
+        (seal.index != null && state.index === seal.index));
+    if (
+      sealAll ||
+      seal?.kind === 'all' ||
+      isSealedByLaterChunk ||
+      isSealedExplicitly
+    ) {
       readyEntries.push({ key, state });
     }
   }
@@ -620,9 +648,20 @@ function startReadyStreamedEagerToolExecutions(args: {
   agentContext?: AgentContext;
   stepKey: string;
   toolCallChunks?: ToolCallChunk[];
+  seal?: StreamedToolCallSeal;
+  allowSequentialSeal?: boolean;
   sealAll?: boolean;
 }): void {
-  const { graph, metadata, agentContext, stepKey, toolCallChunks, sealAll } = args;
+  const {
+    graph,
+    metadata,
+    agentContext,
+    stepKey,
+    toolCallChunks,
+    seal,
+    allowSequentialSeal,
+    sealAll,
+  } = args;
   if (
     hasPotentialDirectToolInStreamContext({ graph, agentContext }) ||
     !isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext })
@@ -633,6 +672,8 @@ function startReadyStreamedEagerToolExecutions(args: {
     graph,
     stepKey,
     toolCallChunks,
+    seal,
+    allowSequentialSeal,
     sealAll,
   });
   if (toolCalls.length === 0) {
@@ -795,8 +836,13 @@ export class ChatModelStreamHandler implements t.EventHandler {
       chunk.tool_call_chunks.length &&
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
+      const streamedToolCallSeal = getStreamedToolCallSeal(
+        chunk.response_metadata as Record<string, unknown> | undefined
+      );
+      const allowSequentialSeal =
+        canPrestartSequentialStreamedToolChunks(agentContext);
       const canStreamEager =
-        canPrestartSealedStreamedToolChunks(agentContext) &&
+        (allowSequentialSeal || hasExplicitStreamedToolCallSeals(chunk)) &&
         !hasPotentialDirectToolInStreamContext({ graph, agentContext }) &&
         isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext });
       if (canStreamEager) {
@@ -819,6 +865,8 @@ export class ChatModelStreamHandler implements t.EventHandler {
           agentContext,
           stepKey,
           toolCallChunks: chunk.tool_call_chunks,
+          seal: streamedToolCallSeal,
+          allowSequentialSeal,
           sealAll: hasFinalToolCallSignal(chunk),
         });
       }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -514,17 +514,17 @@ export class ChatModelStreamHandler implements t.EventHandler {
       chunk.tool_call_chunks.length &&
       typeof chunk.tool_call_chunks[0]?.index === 'number'
     ) {
-      startEagerToolExecutionsFromChunks({
-        graph,
-        metadata,
-        agentContext,
-        toolCallChunks: chunk.tool_call_chunks,
-      });
       await handleToolCallChunks({
         graph,
         stepKey,
         toolCallChunks: chunk.tool_call_chunks,
         metadata,
+      });
+      startEagerToolExecutionsFromChunks({
+        graph,
+        metadata,
+        agentContext,
+        toolCallChunks: chunk.tool_call_chunks,
       });
     }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -284,21 +284,6 @@ function getEagerToolChunkKey(
   return `${stepKey}\u0000${chunkKey}`;
 }
 
-function parseCompleteRecordArgs(
-  argsText: string
-): Record<string, unknown> | undefined {
-  if (argsText.trim() === '') {
-    return undefined;
-  }
-
-  try {
-    const parsed = JSON.parse(argsText) as unknown;
-    return coerceRecordArgs(parsed) ?? undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function mergeToolCallArgsText(existing: string, incoming: string): string {
   if (incoming === '') {
     return existing;
@@ -312,21 +297,28 @@ function mergeToolCallArgsText(existing: string, incoming: string): string {
   if (existing.startsWith(incoming)) {
     return existing;
   }
+  try {
+    JSON.parse(existing);
+    JSON.parse(incoming);
+    return incoming;
+  } catch {
+    // Fall through to delta concatenation.
+  }
   return `${existing}${incoming}`;
 }
 
-function startEagerToolExecutionsFromChunks(args: {
+function recordEagerToolCallChunks(args: {
   graph: StandardGraph;
   stepKey: string;
-  metadata?: Record<string, unknown>;
-  agentContext?: AgentContext;
   toolCallChunks?: ToolCallChunk[];
 }): void {
-  const { graph, stepKey, metadata, agentContext, toolCallChunks } = args;
+  const { graph, stepKey, toolCallChunks } = args;
   if (toolCallChunks == null || toolCallChunks.length === 0) {
     return;
   }
 
+  // Streamed args can be cumulative and parseable before the provider has
+  // emitted the final call; dispatch only happens from complete tool_calls.
   for (const toolCallChunk of toolCallChunks) {
     const key = getEagerToolChunkKey(stepKey, toolCallChunk);
     if (key == null) {
@@ -368,30 +360,6 @@ function startEagerToolExecutionsFromChunks(args: {
       argsText,
     };
     graph.eagerEventToolCallChunks.set(key, next);
-
-    if (id == null || id === '' || name == null || name === '') {
-      continue;
-    }
-    if (graph.eagerEventToolExecutions.has(id)) {
-      continue;
-    }
-
-    const recordArgs = parseCompleteRecordArgs(argsText);
-    if (recordArgs == null) {
-      continue;
-    }
-
-    startEagerToolExecution({
-      graph,
-      metadata,
-      agentContext,
-      toolCall: {
-        id,
-        name,
-        args: recordArgs,
-        type: ToolCallTypes.TOOL_CALL,
-      },
-    });
   }
 }
 
@@ -553,11 +521,9 @@ export class ChatModelStreamHandler implements t.EventHandler {
         toolCallChunks: chunk.tool_call_chunks,
         metadata,
       });
-      startEagerToolExecutionsFromChunks({
+      recordEagerToolCallChunks({
         graph,
         stepKey,
-        metadata,
-        agentContext,
         toolCallChunks: chunk.tool_call_chunks,
       });
     }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2672,7 +2672,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       execution.toolName !== request.name ||
       !recordArgsEqual(execution.args, request.args)
     ) {
-      return undefined;
+      return {
+        toolCallId: request.id,
+        toolName: request.name,
+        args: request.args,
+        request,
+        promise: Promise.resolve({
+          results: [
+            {
+              toolCallId: request.id,
+              status: 'error',
+              content: '',
+              errorMessage:
+                'Tool call arguments changed after eager execution started; refusing to re-run the tool to avoid duplicate side effects.',
+            },
+          ],
+        }),
+      };
     }
 
     return execution;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -50,6 +50,7 @@ import {
   resolveLocalToolRegistry,
   resolveLocalExecutionTools,
 } from '@/tools/local';
+import { recordArgsEqual } from '@/tools/eagerEventExecution';
 
 /**
  * Per-call batch context for `runTool`. Bundles every optional
@@ -413,6 +414,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private sessions?: t.ToolSessionMap;
   /** When true, dispatches ON_TOOL_EXECUTE events instead of invoking tools directly */
   private eventDrivenMode: boolean = false;
+  /** Opt-in stream-layer prestart config for event-driven tools. */
+  private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
+  /** Shared per-run prestarted tool registry populated by ChatModelStreamHandler. */
+  private eagerEventToolExecutions?: Map<string, t.EagerEventToolExecution>;
   /** Agent ID for event-driven mode */
   private agentId?: string;
   /** Tool names that bypass event dispatch and execute directly (e.g., graph-managed handoff tools) */
@@ -469,6 +474,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolRegistry,
     sessions,
     eventDrivenMode,
+    eagerEventToolExecution,
+    eagerEventToolExecutions,
     agentId,
     directToolNames,
     maxContextTokens,
@@ -493,6 +500,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     });
     this.sessions = sessions;
     this.eventDrivenMode = eventDrivenMode ?? false;
+    this.eagerEventToolExecution = eagerEventToolExecution;
+    this.eagerEventToolExecutions = eagerEventToolExecutions;
     this.agentId = agentId;
     this.directToolNames = directToolNames;
     this.maxToolResultChars =
@@ -2370,28 +2379,57 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       });
 
       const requestMap = new Map(requests.map((r) => [r.id, r]));
+      const eagerExecutions: Array<{
+        request: t.ToolCallRequest;
+        execution: t.EagerEventToolExecution;
+      }> = [];
+      const dispatchRequests: t.ToolCallRequest[] = [];
 
-      const results = await new Promise<t.ToolExecuteResult[]>(
-        (resolve, reject) => {
-          const batchRequest: t.ToolExecuteBatchRequest = {
-            toolCalls: requests,
-            userId: config.configurable?.user_id as string | undefined,
-            agentId: this.agentId,
-            configurable: config.configurable as
-              | Record<string, unknown>
-              | undefined,
-            metadata: config.metadata as Record<string, unknown> | undefined,
-            resolve,
-            reject,
-          };
-
-          safeDispatchCustomEvent(
-            GraphEvents.ON_TOOL_EXECUTE,
-            batchRequest,
-            config
-          );
+      for (const request of requests) {
+        const eagerExecution = this.takeMatchingEagerEventExecution(request);
+        if (eagerExecution != null) {
+          eagerExecutions.push({ request, execution: eagerExecution });
+        } else {
+          dispatchRequests.push(request);
         }
-      );
+      }
+
+      const dispatchPromise =
+        dispatchRequests.length === 0
+          ? Promise.resolve([] as t.ToolExecuteResult[])
+          : new Promise<t.ToolExecuteResult[]>((resolve, reject) => {
+            const batchRequest: t.ToolExecuteBatchRequest = {
+              toolCalls: dispatchRequests,
+              userId: config.configurable?.user_id as string | undefined,
+              agentId: this.agentId,
+              configurable: config.configurable as
+                  | Record<string, unknown>
+                  | undefined,
+              metadata: config.metadata as
+                  | Record<string, unknown>
+                  | undefined,
+              resolve,
+              reject,
+            };
+
+            safeDispatchCustomEvent(
+              GraphEvents.ON_TOOL_EXECUTE,
+              batchRequest,
+              config
+            );
+          });
+
+      const eagerResultsPromise = Promise.all(
+        eagerExecutions.map(({ request, execution }) =>
+          this.resolveEagerEventExecution(request, execution)
+        )
+      ).then((results) => results.flat());
+
+      const [eagerResults, dispatchedResults] = await Promise.all([
+        eagerResultsPromise,
+        dispatchPromise,
+      ]);
+      const results = [...eagerResults, ...dispatchedResults];
 
       this.storeCodeSessionFromResults(results, requestMap);
 
@@ -2604,6 +2642,67 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     });
 
     return { toolMessages, injected };
+  }
+
+  private canConsumeEagerEventExecution(): boolean {
+    return (
+      this.eventDrivenMode &&
+      this.eagerEventToolExecution?.enabled === true &&
+      this.hookRegistry == null &&
+      this.humanInTheLoop?.enabled !== true &&
+      this.toolOutputRegistry == null
+    );
+  }
+
+  private takeMatchingEagerEventExecution(
+    request: t.ToolCallRequest
+  ): t.EagerEventToolExecution | undefined {
+    if (!this.canConsumeEagerEventExecution()) {
+      return undefined;
+    }
+
+    const execution = this.eagerEventToolExecutions?.get(request.id);
+    if (execution == null) {
+      return undefined;
+    }
+
+    this.eagerEventToolExecutions?.delete(request.id);
+
+    if (
+      execution.toolName !== request.name ||
+      !recordArgsEqual(execution.args, request.args)
+    ) {
+      return undefined;
+    }
+
+    return execution;
+  }
+
+  private async resolveEagerEventExecution(
+    request: t.ToolCallRequest,
+    execution: t.EagerEventToolExecution
+  ): Promise<t.ToolExecuteResult[]> {
+    const outcome = await execution.promise;
+    if (outcome.error != null) {
+      throw outcome.error;
+    }
+
+    const results = outcome.results.filter(
+      (result) => result.toolCallId === request.id
+    );
+    if (results.length > 0) {
+      return results;
+    }
+
+    return [
+      {
+        toolCallId: request.id,
+        status: 'error',
+        content: '',
+        errorMessage:
+          'Tool execution completed without a result for this tool call',
+      },
+    ];
   }
 
   /**

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -418,6 +418,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
   /** Shared per-run prestarted tool registry populated by ChatModelStreamHandler. */
   private eagerEventToolExecutions?: Map<string, t.EagerEventToolExecution>;
+  /** Shared per-run per-tool turn counter used by eager and normal event dispatch. */
+  private eagerEventToolUsageCount?: Map<string, number>;
   /** Agent ID for event-driven mode */
   private agentId?: string;
   /** Tool names that bypass event dispatch and execute directly (e.g., graph-managed handoff tools) */
@@ -476,6 +478,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     eventDrivenMode,
     eagerEventToolExecution,
     eagerEventToolExecutions,
+    eagerEventToolUsageCount,
     agentId,
     directToolNames,
     maxContextTokens,
@@ -502,6 +505,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.eventDrivenMode = eventDrivenMode ?? false;
     this.eagerEventToolExecution = eagerEventToolExecution;
     this.eagerEventToolExecutions = eagerEventToolExecutions;
+    this.eagerEventToolUsageCount = eagerEventToolUsageCount;
     this.agentId = agentId;
     this.directToolNames = directToolNames;
     this.maxToolResultChars =
@@ -705,6 +709,31 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   public getToolUsageCounts(): ReadonlyMap<string, number> {
     return new Map(this.toolUsageCount); // Return a copy
+  }
+
+  private recordToolUsageTurn(
+    toolName: string,
+    turn: number,
+    callId?: string
+  ): void {
+    this.toolUsageCount.set(
+      toolName,
+      Math.max(this.toolUsageCount.get(toolName) ?? 0, turn + 1)
+    );
+    if (callId != null && callId !== '') {
+      this.toolCallTurns.set(callId, turn);
+    }
+  }
+
+  private claimEventToolUsageTurn(
+    toolName: string,
+    callId?: string
+  ): number {
+    const counter = this.eagerEventToolUsageCount ?? this.toolUsageCount;
+    const turn = counter.get(toolName) ?? 0;
+    counter.set(toolName, turn + 1);
+    this.recordToolUsageTurn(toolName, turn, callId);
+    return turn;
   }
 
   /**
@@ -2341,8 +2370,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     if (approvedEntries.length > 0) {
       const requests: t.ToolCallRequest[] = approvedEntries.map((entry) => {
-        const turn = this.toolUsageCount.get(entry.call.name) ?? 0;
-        this.toolUsageCount.set(entry.call.name, turn + 1);
+        const prestartedExecution =
+          this.canConsumeEagerEventExecution() && entry.call.id != null
+            ? this.eagerEventToolExecutions?.get(entry.call.id)
+            : undefined;
+        const turn =
+          prestartedExecution?.request.turn ??
+          this.claimEventToolUsageTurn(entry.call.name, entry.call.id);
+        if (prestartedExecution?.request.turn != null) {
+          this.recordToolUsageTurn(
+            entry.call.name,
+            prestartedExecution.request.turn,
+            entry.call.id
+          );
+        }
 
         if (entry.batchIndex != null && entry.call.id != null) {
           batchIndexByCallId.set(entry.call.id, entry.batchIndex);

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -729,7 +729,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolName: string,
     callId?: string
   ): number {
-    const counter = this.eagerEventToolUsageCount ?? this.toolUsageCount;
+    const counter =
+      this.canConsumeEagerEventExecution() &&
+      this.eagerEventToolUsageCount != null
+        ? this.eagerEventToolUsageCount
+        : this.toolUsageCount;
     const turn = counter.get(toolName) ?? 0;
     counter.set(toolName, turn + 1);
     this.recordToolUsageTurn(toolName, turn, callId);

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2392,6 +2392,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           };
         }),
         usageCount: this.toolUsageCount,
+        invalidArgsBehavior: 'error-result',
         recordTurn: (toolName, reservedTurn, callId) => {
           this.recordEventToolPlanningTurn(toolName, reservedTurn, callId);
         },
@@ -2407,7 +2408,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
       }
 
-      const requestMap = new Map(requests.map((r) => [r.id, r]));
+      for (const result of plan.rejectedResults) {
+        this.eagerEventToolExecutions?.delete(result.toolCallId);
+      }
+
+      const requestMap = new Map(plan.allRequests.map((r) => [r.id, r]));
       const eagerExecutions: Array<{
         request: t.ToolCallRequest;
         execution: t.EagerEventToolExecution;
@@ -2458,7 +2463,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         eagerResultsPromise,
         dispatchPromise,
       ]);
-      const results = [...eagerResults, ...dispatchedResults];
+      const results = [
+        ...plan.rejectedResults,
+        ...eagerResults,
+        ...dispatchedResults,
+      ];
 
       this.storeCodeSessionFromResults(results, requestMap);
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -50,7 +50,10 @@ import {
   resolveLocalToolRegistry,
   resolveLocalExecutionTools,
 } from '@/tools/local';
-import { recordArgsEqual } from '@/tools/eagerEventExecution';
+import {
+  buildToolExecutionRequestPlan,
+  recordArgsEqual,
+} from '@/tools/eagerEventExecution';
 
 /**
  * Per-call batch context for `runTool`. Bundles every optional
@@ -725,19 +728,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
   }
 
-  private claimEventToolUsageTurn(
+  private recordEventToolPlanningTurn(
     toolName: string,
+    turn: number,
     callId?: string
-  ): number {
-    const counter =
-      this.canConsumeEagerEventExecution() &&
-      this.eagerEventToolUsageCount != null
-        ? this.eagerEventToolUsageCount
-        : this.toolUsageCount;
-    const turn = counter.get(toolName) ?? 0;
-    counter.set(toolName, turn + 1);
+  ): void {
     this.recordToolUsageTurn(toolName, turn, callId);
-    return turn;
+    if (this.canConsumeEagerEventExecution()) {
+      this.eagerEventToolUsageCount?.set(
+        toolName,
+        Math.max(this.eagerEventToolUsageCount.get(toolName) ?? 0, turn + 1)
+      );
+    }
   }
 
   /**
@@ -2373,55 +2375,37 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const batchIndexByCallId = new Map<string, number>();
 
     if (approvedEntries.length > 0) {
-      const requests: t.ToolCallRequest[] = approvedEntries.map((entry) => {
-        const prestartedExecution =
-          this.canConsumeEagerEventExecution() && entry.call.id != null
-            ? this.eagerEventToolExecutions?.get(entry.call.id)
-            : undefined;
-        const turn =
-          prestartedExecution?.request.turn ??
-          this.claimEventToolUsageTurn(entry.call.name, entry.call.id);
-        if (prestartedExecution?.request.turn != null) {
-          this.recordToolUsageTurn(
-            entry.call.name,
-            prestartedExecution.request.turn,
-            entry.call.id
-          );
-        }
+      const plan = buildToolExecutionRequestPlan({
+        toolCalls: approvedEntries.map((entry) => {
+          const codeSessionContext =
+            CODE_EXECUTION_TOOLS.has(entry.call.name) ||
+            entry.call.name === Constants.SKILL_TOOL ||
+            entry.call.name === Constants.READ_FILE
+              ? this.getCodeSessionContext()
+              : undefined;
+          return {
+            id: entry.call.id,
+            name: entry.call.name,
+            args: entry.args,
+            stepId: entry.stepId,
+            codeSessionContext,
+          };
+        }),
+        usageCount: this.toolUsageCount,
+        recordTurn: (toolName, reservedTurn, callId) => {
+          this.recordEventToolPlanningTurn(toolName, reservedTurn, callId);
+        },
+      });
+      if (plan == null) {
+        throw new Error('Unable to build event tool execution request plan');
+      }
+      const requests = plan.requests;
 
+      for (const entry of approvedEntries) {
         if (entry.batchIndex != null && entry.call.id != null) {
           batchIndexByCallId.set(entry.call.id, entry.batchIndex);
         }
-
-        const request: t.ToolCallRequest = {
-          id: entry.call.id!,
-          name: entry.call.name,
-          args: entry.args,
-          stepId: entry.stepId,
-          turn,
-        };
-
-        /**
-         * Emit `codeSessionContext` for any tool whose host handler may need
-         * to reach into the code-execution sandbox:
-         *   - `CODE_EXECUTION_TOOLS` — direct executors that POST to /exec.
-         *   - `SKILL_TOOL` — skill files live alongside code-env state.
-         *   - `READ_FILE` — when the requested path is a code-env artifact
-         *     (e.g. `/mnt/data/...`) the host falls back to reading via the
-         *     same sandbox session; without the seeded `session_id` /
-         *     `_injected_files` here, that fallback can't see prior-turn
-         *     artifacts on the very first call of a turn.
-         */
-        if (
-          CODE_EXECUTION_TOOLS.has(entry.call.name) ||
-          entry.call.name === Constants.SKILL_TOOL ||
-          entry.call.name === Constants.READ_FILE
-        ) {
-          request.codeSessionContext = this.getCodeSessionContext();
-        }
-
-        return request;
-      });
+      }
 
       const requestMap = new Map(requests.map((r) => [r.id, r]));
       const eagerExecutions: Array<{
@@ -2715,7 +2699,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     if (
       execution.toolName !== request.name ||
-      !recordArgsEqual(execution.args, request.args)
+      !recordArgsEqual(execution.args, request.args) ||
+      execution.request.turn !== request.turn
     ) {
       return {
         toolCallId: request.id,
@@ -2729,7 +2714,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               status: 'error',
               content: '',
               errorMessage:
-                'Tool call arguments changed after eager execution started; refusing to re-run the tool to avoid duplicate side effects.',
+                'Tool call changed after eager execution started; refusing to re-run the tool to avoid duplicate side effects.',
             },
           ],
         }),

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -58,6 +58,7 @@ describe('ToolNode eager event tool execution', () => {
   it('uses a matching prestarted event result without redispatching the tool', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const eagerUsageCount = new Map<string, number>([['weather', 1]]);
     const request: t.ToolCallRequest = {
       id: 'call_weather',
       name: 'weather',
@@ -86,6 +87,7 @@ describe('ToolNode eager event tool execution', () => {
       eventDrivenMode: true,
       eagerEventToolExecution: { enabled: true },
       eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: eagerUsageCount,
       toolCallStepIds: new Map([['call_weather', 'step_weather']]),
     });
 
@@ -94,6 +96,7 @@ describe('ToolNode eager event tool execution', () => {
     })) as { messages: ToolMessage[] };
 
     expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerUsageCount.get('weather')).toBe(1);
     expect(eagerExecutions.has('call_weather')).toBe(false);
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0].content).toBe('eager result');
@@ -144,5 +147,33 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0].status).toBe('error');
     expect(result.messages[0].content).toContain('refusing to re-run');
+  });
+
+  it('increments the shared eager turn counter for normal event dispatch', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('normal result');
+    const eagerUsageCount = new Map<string, number>();
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: new Map(),
+      eagerEventToolUsageCount: eagerUsageCount,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      turn: 0,
+    });
+    expect(eagerUsageCount.get('weather')).toBe(1);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toBe('normal result');
   });
 });

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -99,7 +99,7 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages[0].content).toBe('eager result');
   });
 
-  it('falls back to normal dispatch when final args differ from the prestarted call', async () => {
+  it('fails closed without redispatching when final args differ from the prestarted call', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('fresh result');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
     const request: t.ToolCallRequest = {
@@ -139,10 +139,10 @@ describe('ToolNode eager event tool execution', () => {
       ],
     })) as { messages: ToolMessage[] };
 
-    expect(toolExecuteCalls).toHaveLength(1);
-    expect(toolExecuteCalls[0].toolCalls[0].args).toEqual({ city: 'Boston' });
+    expect(toolExecuteCalls).toHaveLength(0);
     expect(eagerExecutions.has('call_weather')).toBe(false);
     expect(result.messages).toHaveLength(1);
-    expect(result.messages[0].content).toBe('fresh result');
+    expect(result.messages[0].status).toBe('error');
+    expect(result.messages[0].content).toContain('refusing to re-run');
   });
 });

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import { GraphEvents } from '@/common';
+import * as events from '@/utils/events';
+import { ToolNode } from '../ToolNode';
+
+function createDummyTool(name: string): StructuredToolInterface {
+  return tool(async () => 'direct should not run', {
+    name,
+    description: 'dummy',
+    schema: z.object({ city: z.string() }),
+  }) as unknown as StructuredToolInterface;
+}
+
+function createAIMessage(
+  id: string,
+  name: string,
+  args: Record<string, unknown>
+): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: [{ id, name, args }],
+  });
+}
+
+function installToolExecuteResponder(content: string): {
+  toolExecuteCalls: t.ToolExecuteBatchRequest[];
+} {
+  const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+  jest
+    .spyOn(events, 'safeDispatchCustomEvent')
+    .mockImplementation(async (event, data): Promise<void> => {
+      if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+        return;
+      }
+      const batch = data as t.ToolExecuteBatchRequest;
+      toolExecuteCalls.push(batch);
+      batch.resolve(
+        batch.toolCalls.map((request) => ({
+          toolCallId: request.id,
+          status: 'success' as const,
+          content,
+        }))
+      );
+    });
+  return { toolExecuteCalls };
+}
+
+describe('ToolNode eager event tool execution', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses a matching prestarted event result without redispatching the tool', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toBe('eager result');
+  });
+
+  it('falls back to normal dispatch when final args differ from the prestarted call', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('fresh result');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'stale eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [
+        createAIMessage('call_weather', 'weather', { city: 'Boston' }),
+      ],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0].args).toEqual({ city: 'Boston' });
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toBe('fresh result');
+  });
+});

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -33,12 +33,12 @@ function createAIMessageWithToolCalls(
   toolCalls: Array<{
     id: string;
     name: string;
-    args: Record<string, unknown>;
+    args: unknown;
   }>
 ): AIMessage {
   return new AIMessage({
     content: '',
-    tool_calls: toolCalls,
+    tool_calls: toolCalls as AIMessage['tool_calls'],
   });
 }
 
@@ -265,6 +265,60 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages[0].status).toBe('success');
     expect(result.messages[1].status).toBe('error');
     expect(result.messages[1].content).toContain('refusing to re-run');
+  });
+
+  it('returns a per-call error for malformed event tool args without aborting the batch', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('normal result');
+    const eagerUsageCount = new Map<string, number>();
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: new Map(),
+      eagerEventToolUsageCount: eagerUsageCount,
+      toolCallStepIds: new Map([
+        ['call_weather_bad', 'step_weather_bad'],
+        ['call_weather_good', 'step_weather_good'],
+      ]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          {
+            id: 'call_weather_bad',
+            name: 'weather',
+            args: ['not', 'an', 'object'],
+          },
+          {
+            id: 'call_weather_good',
+            name: 'weather',
+            args: { city: 'Boston' },
+          },
+        ]),
+      ],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'call_weather_good',
+        name: 'weather',
+        turn: 1,
+      }),
+    ]);
+    expect(eagerUsageCount.get('weather')).toBe(2);
+    expect(result.messages.map((message) => message.tool_call_id)).toEqual([
+      'call_weather_bad',
+      'call_weather_good',
+    ]);
+    expect(result.messages[0].status).toBe('error');
+    expect(result.messages[0].content).toContain(
+      'Invalid tool call arguments'
+    );
+    expect(result.messages[1].status).toBe('success');
+    expect(result.messages[1].content).toBe('normal result');
   });
 
   it('uses the legacy turn counter when eager mode cannot be consumed', async () => {

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -29,6 +29,19 @@ function createAIMessage(
   });
 }
 
+function createAIMessageWithToolCalls(
+  toolCalls: Array<{
+    id: string;
+    name: string;
+    args: Record<string, unknown>;
+  }>
+): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: toolCalls,
+  });
+}
+
 function installToolExecuteResponder(content: string): {
   toolExecuteCalls: t.ToolExecuteBatchRequest[];
 } {
@@ -177,6 +190,81 @@ describe('ToolNode eager event tool execution', () => {
     expect(eagerUsageCount.get('weather')).toBe(1);
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0].content).toBe('normal result');
+  });
+
+  it('preserves final turn order when only part of a batch was prestarted', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('normal result');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const eagerUsageCount = new Map<string, number>([['weather', 1]]);
+    const staleRequest: t.ToolCallRequest = {
+      id: 'call_weather_2',
+      name: 'weather',
+      args: { city: 'Boston' },
+      stepId: 'step_weather_2',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather_2', {
+      toolCallId: 'call_weather_2',
+      toolName: 'weather',
+      args: { city: 'Boston' },
+      request: staleRequest,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather_2',
+            status: 'success',
+            content: 'stale eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: eagerUsageCount,
+      toolCallStepIds: new Map([
+        ['call_weather_1', 'step_weather_1'],
+        ['call_weather_2', 'step_weather_2'],
+      ]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          {
+            id: 'call_weather_1',
+            name: 'weather',
+            args: { city: 'NYC' },
+          },
+          {
+            id: 'call_weather_2',
+            name: 'weather',
+            args: { city: 'Boston' },
+          },
+        ]),
+      ],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'call_weather_1',
+        name: 'weather',
+        turn: 0,
+      }),
+    ]);
+    expect(eagerExecutions.has('call_weather_2')).toBe(false);
+    expect(eagerUsageCount.get('weather')).toBe(2);
+    expect(result.messages.map((message) => message.tool_call_id)).toEqual([
+      'call_weather_1',
+      'call_weather_2',
+    ]);
+    expect(result.messages[0].status).toBe('success');
+    expect(result.messages[1].status).toBe('error');
+    expect(result.messages[1].content).toContain('refusing to re-run');
   });
 
   it('uses the legacy turn counter when eager mode cannot be consumed', async () => {

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -3,8 +3,10 @@ import { tool } from '@langchain/core/tools';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
 import type { StructuredToolInterface } from '@langchain/core/tools';
+import type { PreToolUseHookInput, PreToolUseHookOutput } from '@/hooks';
 import type * as t from '@/types';
 import { GraphEvents } from '@/common';
+import { HookRegistry } from '@/hooks';
 import * as events from '@/utils/events';
 import { ToolNode } from '../ToolNode';
 
@@ -175,5 +177,55 @@ describe('ToolNode eager event tool execution', () => {
     expect(eagerUsageCount.get('weather')).toBe(1);
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0].content).toBe('normal result');
+  });
+
+  it('uses the legacy turn counter when eager mode cannot be consumed', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('normal result');
+    const eagerUsageCount = new Map<string, number>();
+    const preToolTurns: Array<number | undefined> = [];
+    const hookRegistry = new HookRegistry();
+    hookRegistry.register('PreToolUse', {
+      hooks: [
+        async (
+          input: PreToolUseHookInput
+        ): Promise<PreToolUseHookOutput> => {
+          preToolTurns.push(input.turn);
+          return { decision: 'allow' };
+        },
+      ],
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: new Map(),
+      eagerEventToolUsageCount: eagerUsageCount,
+      hookRegistry,
+      toolCallStepIds: new Map([
+        ['call_weather_1', 'step_weather_1'],
+        ['call_weather_2', 'step_weather_2'],
+      ]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessage('call_weather_1', 'weather', { city: 'NYC' }),
+      ],
+    });
+
+    eagerUsageCount.clear();
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessage('call_weather_2', 'weather', { city: 'Boston' }),
+      ],
+    });
+
+    expect(preToolTurns).toEqual([0, 1]);
+    expect(toolExecuteCalls.map((call) => call.toolCalls[0].turn)).toEqual([
+      0, 1,
+    ]);
+    expect(eagerUsageCount.size).toBe(0);
   });
 });

--- a/src/tools/eagerEventExecution.ts
+++ b/src/tools/eagerEventExecution.ts
@@ -1,0 +1,45 @@
+export function coerceRecordArgs(
+  args: unknown
+): Record<string, unknown> | undefined {
+  if (typeof args === 'string') {
+    try {
+      const parsed = JSON.parse(args) as unknown;
+      return coerceRecordArgs(parsed);
+    } catch {
+      return undefined;
+    }
+  }
+
+  if (args === null || typeof args !== 'object' || Array.isArray(args)) {
+    return undefined;
+  }
+
+  return args as Record<string, unknown>;
+}
+
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+    return `{${keys
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+export function recordArgsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>
+): boolean {
+  return stableStringify(left) === stableStringify(right);
+}
+
+export function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/src/tools/eagerEventExecution.ts
+++ b/src/tools/eagerEventExecution.ts
@@ -1,3 +1,5 @@
+import type * as t from '@/types';
+
 export function coerceRecordArgs(
   args: unknown
 ): Record<string, unknown> | undefined {
@@ -42,4 +44,77 @@ export function recordArgsEqual(
 
 export function normalizeError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+export type ToolExecutionPlanCall = {
+  id?: string;
+  name: string;
+  args: unknown;
+  stepId?: string;
+  codeSessionContext?: t.ToolCallRequest['codeSessionContext'];
+};
+
+export type ToolExecutionRequestPlan = {
+  requests: t.ToolCallRequest[];
+};
+
+export function buildToolExecutionRequestPlan(args: {
+  toolCalls: ToolExecutionPlanCall[];
+  usageCount: Map<string, number>;
+  recordTurn?: (toolName: string, turn: number, callId: string) => void;
+}): ToolExecutionRequestPlan | undefined {
+  const prepared: Array<{
+    id: string;
+    name: string;
+    args: Record<string, unknown>;
+    stepId?: string;
+    codeSessionContext?: t.ToolCallRequest['codeSessionContext'];
+  }> = [];
+
+  for (const toolCall of args.toolCalls) {
+    if (
+      toolCall.id == null ||
+      toolCall.id === '' ||
+      toolCall.name === ''
+    ) {
+      return undefined;
+    }
+    const coercedArgs = coerceRecordArgs(toolCall.args);
+    if (coercedArgs == null) {
+      return undefined;
+    }
+    prepared.push({
+      id: toolCall.id,
+      name: toolCall.name,
+      args: coercedArgs,
+      stepId: toolCall.stepId,
+      codeSessionContext: toolCall.codeSessionContext,
+    });
+  }
+
+  const nextUsageCount = new Map(args.usageCount);
+  const requests = prepared.map((toolCall): t.ToolCallRequest => {
+    const turn = nextUsageCount.get(toolCall.name) ?? 0;
+    nextUsageCount.set(toolCall.name, turn + 1);
+    const request: t.ToolCallRequest = {
+      id: toolCall.id,
+      name: toolCall.name,
+      args: toolCall.args,
+      stepId: toolCall.stepId,
+      turn,
+    };
+    if (toolCall.codeSessionContext != null) {
+      request.codeSessionContext = toolCall.codeSessionContext;
+    }
+    return request;
+  });
+
+  for (const [toolName, count] of nextUsageCount) {
+    args.usageCount.set(toolName, count);
+  }
+  for (const request of requests) {
+    args.recordTurn?.(request.name, request.turn ?? 0, request.id);
+  }
+
+  return { requests };
 }

--- a/src/tools/eagerEventExecution.ts
+++ b/src/tools/eagerEventExecution.ts
@@ -55,20 +55,25 @@ export type ToolExecutionPlanCall = {
 };
 
 export type ToolExecutionRequestPlan = {
+  allRequests: t.ToolCallRequest[];
   requests: t.ToolCallRequest[];
+  rejectedResults: t.ToolExecuteResult[];
 };
 
 export function buildToolExecutionRequestPlan(args: {
   toolCalls: ToolExecutionPlanCall[];
   usageCount: Map<string, number>;
+  invalidArgsBehavior?: 'abort' | 'error-result';
   recordTurn?: (toolName: string, turn: number, callId: string) => void;
 }): ToolExecutionRequestPlan | undefined {
+  const invalidArgsBehavior = args.invalidArgsBehavior ?? 'abort';
   const prepared: Array<{
     id: string;
     name: string;
     args: Record<string, unknown>;
     stepId?: string;
     codeSessionContext?: t.ToolCallRequest['codeSessionContext'];
+    rejectedErrorMessage?: string;
   }> = [];
 
   for (const toolCall of args.toolCalls) {
@@ -81,7 +86,19 @@ export function buildToolExecutionRequestPlan(args: {
     }
     const coercedArgs = coerceRecordArgs(toolCall.args);
     if (coercedArgs == null) {
-      return undefined;
+      if (invalidArgsBehavior === 'abort') {
+        return undefined;
+      }
+      prepared.push({
+        id: toolCall.id,
+        name: toolCall.name,
+        args: {},
+        stepId: toolCall.stepId,
+        codeSessionContext: toolCall.codeSessionContext,
+        rejectedErrorMessage:
+          'Invalid tool call arguments: expected a JSON object.',
+      });
+      continue;
     }
     prepared.push({
       id: toolCall.id,
@@ -93,7 +110,7 @@ export function buildToolExecutionRequestPlan(args: {
   }
 
   const nextUsageCount = new Map(args.usageCount);
-  const requests = prepared.map((toolCall): t.ToolCallRequest => {
+  const allRequests = prepared.map((toolCall): t.ToolCallRequest => {
     const turn = nextUsageCount.get(toolCall.name) ?? 0;
     nextUsageCount.set(toolCall.name, turn + 1);
     const request: t.ToolCallRequest = {
@@ -108,13 +125,29 @@ export function buildToolExecutionRequestPlan(args: {
     }
     return request;
   });
+  const requests = allRequests.filter(
+    (_, index) => prepared[index].rejectedErrorMessage == null
+  );
+  const rejectedResults = prepared.flatMap((toolCall) => {
+    if (toolCall.rejectedErrorMessage == null) {
+      return [];
+    }
+    return [
+      {
+        toolCallId: toolCall.id,
+        status: 'error' as const,
+        content: '',
+        errorMessage: toolCall.rejectedErrorMessage,
+      },
+    ];
+  });
 
   for (const [toolName, count] of nextUsageCount) {
     args.usageCount.set(toolName, count);
   }
-  for (const request of requests) {
+  for (const request of allRequests) {
     args.recordTurn?.(request.name, request.turn ?? 0, request.id);
   }
 
-  return { requests };
+  return { allRequests, requests, rejectedResults };
 }

--- a/src/tools/streamedToolCallSeals.ts
+++ b/src/tools/streamedToolCallSeals.ts
@@ -1,0 +1,57 @@
+export const STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY =
+  'lc_streamed_tool_call_adapter';
+export const STREAMED_TOOL_CALL_SEAL_METADATA_KEY =
+  'lc_streamed_tool_call_seal';
+export const OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER = 'openai_responses';
+
+export type StreamedToolCallAdapter =
+  typeof OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER;
+
+export type StreamedToolCallSeal =
+  | {
+      kind: 'single';
+      id?: string;
+      index?: number;
+    }
+  | {
+      kind: 'all';
+    };
+
+export function getStreamedToolCallAdapter(
+  metadata: Record<string, unknown> | undefined
+): StreamedToolCallAdapter | undefined {
+  if (
+    metadata?.[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY] ===
+    OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER
+  ) {
+    return OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER;
+  }
+  return undefined;
+}
+
+export function getStreamedToolCallSeal(
+  metadata: Record<string, unknown> | undefined
+): StreamedToolCallSeal | undefined {
+  const seal = metadata?.[STREAMED_TOOL_CALL_SEAL_METADATA_KEY];
+  if (seal == null || typeof seal !== 'object') {
+    return undefined;
+  }
+  if (!('kind' in seal)) {
+    return undefined;
+  }
+  if (seal.kind === 'all') {
+    return { kind: 'all' };
+  }
+  if (seal.kind !== 'single') {
+    return undefined;
+  }
+  const id = 'id' in seal && typeof seal.id === 'string' ? seal.id : undefined;
+  const index =
+    'index' in seal && typeof seal.index === 'number'
+      ? seal.index
+      : undefined;
+  if (id == null && index == null) {
+    return undefined;
+  }
+  return { kind: 'single', id, index };
+}

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -15,6 +15,7 @@ import type {
   ToolSessionMap,
   ToolExecutionConfig,
   ToolOutputReferencesConfig,
+  EagerEventToolExecutionConfig,
 } from '@/types/tools';
 import type { HumanInTheLoopConfig } from '@/types/hitl';
 import type { HookRegistry } from '@/hooks';
@@ -161,6 +162,16 @@ export type RunConfig = {
    * placeholders. Disabled by default so existing runs are unaffected.
    */
   toolOutputReferences?: ToolOutputReferencesConfig;
+  /**
+   * Opt-in latency optimization for event-driven tools. When enabled,
+   * the streaming layer may start a tool call as soon as it sees a
+   * complete, parseable tool call; ToolNode still waits for the final
+   * assistant message before appending ToolMessages, preserving provider
+   * ordering. The SDK automatically falls back to normal batch dispatch
+   * when hooks, HITL, output references, or ambiguous stream shapes make
+   * eager dispatch unsafe.
+   */
+  eagerEventToolExecution?: EagerEventToolExecutionConfig;
   /**
    * Selects the execution backend for built-in code tools. Omit this to keep
    * the remote LibreChat Code API sandbox. Set `{ engine: 'local' }` to run

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -51,6 +51,13 @@ export type EagerEventToolExecution = {
   promise: Promise<EagerEventToolExecutionOutcome>;
 };
 
+export type EagerEventToolCallChunkState = {
+  id?: string;
+  name?: string;
+  argsText: string;
+  lastArgsDelta?: string;
+};
+
 export type ToolNodeOptions = {
   name?: string;
   tags?: string[];

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -29,6 +29,28 @@ export type ToolRefs = {
 
 export type ToolRefGenerator = (tool_calls: ToolCall[]) => ToolRefs;
 
+export type EagerEventToolExecutionConfig = {
+  /**
+   * When enabled, event-driven tool calls may be started from the
+   * streaming layer as soon as the SDK observes a complete tool call.
+   * Results are still held until ToolNode materializes the final
+   * ToolMessages so provider message ordering is preserved.
+   */
+  enabled?: boolean;
+};
+
+export type EagerEventToolExecutionOutcome =
+  | { results: ToolExecuteResult[]; error?: undefined }
+  | { results?: undefined; error: Error };
+
+export type EagerEventToolExecution = {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  request: ToolCallRequest;
+  promise: Promise<EagerEventToolExecutionOutcome>;
+};
+
 export type ToolNodeOptions = {
   name?: string;
   tags?: string[];
@@ -51,6 +73,10 @@ export type ToolNodeOptions = {
   agentId?: string;
   /** Tool names that must be executed directly (via runTool) even in event-driven mode (e.g., graph-managed handoff tools) */
   directToolNames?: Set<string>;
+  /** Opt-in eager execution for event-driven tool calls. */
+  eagerEventToolExecution?: EagerEventToolExecutionConfig;
+  /** Shared per-run eager execution registry populated by the stream handler. */
+  eagerEventToolExecutions?: Map<string, EagerEventToolExecution>;
   /**
    * Hook registry for PreToolUse/PostToolUse/PostToolUseFailure/
    * PermissionDenied lifecycle hooks. Fires for **every** tool the

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -83,6 +83,8 @@ export type ToolNodeOptions = {
   eagerEventToolExecution?: EagerEventToolExecutionConfig;
   /** Shared per-run eager execution registry populated by the stream handler. */
   eagerEventToolExecutions?: Map<string, EagerEventToolExecution>;
+  /** Shared per-run per-tool turn counter used by eager and normal event dispatch. */
+  eagerEventToolUsageCount?: Map<string, number>;
   /**
    * Hook registry for PreToolUse/PostToolUse/PostToolUseFailure/
    * PermissionDenied lifecycle hooks. Fires for **every** tool the

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -55,6 +55,8 @@ export type EagerEventToolCallChunkState = {
   id?: string;
   name?: string;
   argsText: string;
+  index?: number;
+  lastArgsFragment?: string;
 };
 
 export type ToolNodeOptions = {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -55,7 +55,6 @@ export type EagerEventToolCallChunkState = {
   id?: string;
   name?: string;
   argsText: string;
-  lastArgsDelta?: string;
 };
 
 export type ToolNodeOptions = {


### PR DESCRIPTION
## Summary
- add opt-in `eagerEventToolExecution` run config for event-driven tools
- prestart complete, parseable stream tool calls through `ON_TOOL_EXECUTE` while preserving final ToolMessage ordering in ToolNode
- fall back to normal batch dispatch when hooks, HITL, tool-output refs, PTC metadata, direct graph tools, or final arg mismatches make eager execution unsafe
- add stream and ToolNode coverage for prestart, consume, and fallback behavior

## Verification
- `npx eslint src/__tests__/stream.eagerEventExecution.test.ts src/stream.ts src/tools/ToolNode.ts src/tools/eagerEventExecution.ts src/tools/__tests__/ToolNode.eagerEventExecution.test.ts src/types/tools.ts src/types/run.ts src/run.ts src/graphs/Graph.ts`
- `npx tsc --noEmit --pretty false`
- `NODE_OPTIONS='--experimental-vm-modules' npx jest src/__tests__/stream.eagerEventExecution.test.ts src/tools/__tests__/ToolNode.eagerEventExecution.test.ts src/tools/__tests__/ToolNode.session.test.ts --runInBand`\n- CI: install, lint, typecheck, test all passed