### PR TITLE
fix: stabilize HITL checkpoint resume

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -78,6 +78,29 @@ function getStepScopedEventId(data: unknown): string | undefined {
   return typeof candidate.id === 'string' ? candidate.id : undefined;
 }
 
+function isLangGraphResumeMapForInterrupt(
+  value: unknown,
+  interruptId: string
+): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(value, interruptId);
+}
+
+type InterruptStateSnapshot = {
+  config?: RunnableConfig;
+  tasks?: Array<{
+    interrupts?: Array<{ id?: string }>;
+  }>;
+};
+
+type WorkflowWithStateHistory = {
+  getStateHistory?(
+    config: RunnableConfig
+  ): AsyncIterableIterator<InterruptStateSnapshot>;
+};
+
 export class Run<_T extends t.BaseGraphState> {
   id: string;
   private tokenCounter?: t.TokenCounter;
@@ -734,6 +757,10 @@ export class Run<_T extends t.BaseGraphState> {
         }
       }
 
+      if (this._interrupt != null) {
+        await this.resolveInterruptResumeConfig(config);
+      }
+
       /**
        * Skip the Stop hook when the run paused on a HITL interrupt
        * (still pending human input) or was halted by a hook (the host
@@ -974,11 +1001,97 @@ export class Run<_T extends t.BaseGraphState> {
     },
     streamOptions?: t.EventStreamOptions
   ): Promise<MessageContentComplex[] | undefined> {
+    const interruptId = this._interrupt?.interruptId;
+    const scopedResume =
+      typeof interruptId === 'string' &&
+      interruptId.length > 0 &&
+      !isLangGraphResumeMapForInterrupt(resumeValue, interruptId)
+        ? { [interruptId]: resumeValue }
+        : resumeValue;
+    const resumeConfig = await this.resolveInterruptResumeConfig(callerConfig);
     return this.processStream(
-      new Command({ resume: resumeValue }),
-      callerConfig,
+      new Command({ resume: scopedResume }),
+      resumeConfig,
       streamOptions
     );
+  }
+
+  private async resolveInterruptResumeConfig(
+    callerConfig: Partial<RunnableConfig> & {
+      version: 'v1' | 'v2';
+      run_id?: string;
+    }
+  ): Promise<
+    Partial<RunnableConfig> & {
+      version: 'v1' | 'v2';
+      run_id?: string;
+    }
+  > {
+    const interrupt = this._interrupt;
+    const interruptId = interrupt?.interruptId;
+    const workflow = this.graphRunnable as
+      | (t.CompiledStateWorkflow & WorkflowWithStateHistory)
+      | undefined;
+    const stateHistory = workflow?.getStateHistory;
+    if (interrupt?.checkpointId != null && interrupt.checkpointId.length > 0) {
+      return {
+        ...callerConfig,
+        configurable: {
+          ...callerConfig.configurable,
+          checkpoint_id: interrupt.checkpointId,
+          ...(typeof interrupt.checkpointNs === 'string'
+            ? { checkpoint_ns: interrupt.checkpointNs }
+            : {}),
+        },
+      };
+    }
+    if (
+      interrupt == null ||
+      typeof interruptId !== 'string' ||
+      interruptId.length === 0 ||
+      typeof stateHistory !== 'function'
+    ) {
+      return callerConfig;
+    }
+
+    for await (const snapshot of stateHistory.call(
+      this.graphRunnable,
+      callerConfig as RunnableConfig
+    )) {
+      const hasMatchingInterrupt =
+        snapshot.tasks?.some(
+          (task) =>
+            task.interrupts?.some(
+              (interrupt) => interrupt.id === interruptId
+            ) === true
+        ) === true;
+      const checkpointConfigurable = snapshot.config?.configurable;
+      if (!hasMatchingInterrupt || checkpointConfigurable == null) {
+        continue;
+      }
+
+      const checkpointId = checkpointConfigurable.checkpoint_id;
+      const checkpointNs = checkpointConfigurable.checkpoint_ns;
+      if (typeof checkpointId === 'string' && checkpointId.length > 0) {
+        this._interrupt = {
+          ...interrupt,
+          checkpointId,
+          ...(typeof checkpointNs === 'string' ? { checkpointNs } : {}),
+        };
+        return {
+          ...callerConfig,
+          configurable: {
+            ...callerConfig.configurable,
+            checkpoint_id: checkpointId,
+            ...(typeof checkpointNs === 'string'
+              ? { checkpoint_ns: checkpointNs }
+              : {}),
+          },
+        };
+      }
+    }
+
+    return callerConfig;
   }
 
   private createSystemCallback<K extends keyof t.ClientCallbacks>(

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -17,6 +17,7 @@ import type {
   AgentSessionStream,
   AgentSessionStreamEvent,
   SessionBranchOptions,
+  SessionCheckpointEntry,
   SessionCompactOptions,
   SessionEntry,
   SessionForkOptions,
@@ -332,6 +333,23 @@ function getConfigString(
   return typeof value === 'string' && value !== '' ? value : undefined;
 }
 
+function getConfigOptionalString(
+  config: RunnableConfig | undefined,
+  key: string
+): string | undefined {
+  const configurable = config?.configurable as
+    | Partial<Record<string, unknown>>
+    | undefined;
+  if (
+    configurable == null ||
+    !Object.prototype.hasOwnProperty.call(configurable, key)
+  ) {
+    return undefined;
+  }
+  const value = configurable[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
 function createCallerConfig(
   threadId: string,
   options: AgentSessionRunOptions
@@ -362,6 +380,61 @@ function createCheckpointLookupConfig(config: RunnableConfig): RunnableConfig {
       ...(checkpointId != null ? { checkpoint_id: checkpointId } : {}),
     },
   };
+}
+
+function applyCheckpointReferenceToConfig<
+  TConfig extends RunnableConfig & { version?: 'v1' | 'v2' },
+>(
+  config: TConfig,
+  checkpoint:
+    | {
+        checkpointId?: string;
+        checkpointNs?: string;
+      }
+    | undefined,
+  options?: { overwrite?: boolean }
+): TConfig {
+  if (
+    checkpoint?.checkpointId == null ||
+    checkpoint.checkpointId === '' ||
+    (options?.overwrite !== true &&
+      getConfigString(config, 'checkpoint_id') != null)
+  ) {
+    return config;
+  }
+  return {
+    ...config,
+    configurable: {
+      ...config.configurable,
+      checkpoint_id: checkpoint.checkpointId,
+      checkpoint_ns: checkpoint.checkpointNs ?? '',
+    },
+  };
+}
+
+function getStoredCheckpointForConfig(
+  store: JsonlSessionStore | undefined,
+  threadId: string,
+  config: RunnableConfig
+): SessionCheckpointEntry | undefined {
+  const requestedCheckpointNs = getConfigOptionalString(
+    config,
+    'checkpoint_ns'
+  );
+  if (requestedCheckpointNs == null) {
+    return store?.getLatestCheckpoint(threadId);
+  }
+  const checkpoints = store?.getCheckpoints(threadId) ?? [];
+  for (let i = checkpoints.length - 1; i >= 0; i--) {
+    const checkpoint = checkpoints[i];
+    if (checkpoint.data.source === 'reset') {
+      return undefined;
+    }
+    if ((checkpoint.data.checkpointNs ?? '') === requestedCheckpointNs) {
+      return checkpoint;
+    }
+  }
+  return undefined;
 }
 
 function createLatestCheckpointLookupConfig(
@@ -816,14 +889,30 @@ export class AgentSession {
     runId: string;
     threadId: string;
     config: RunnableConfig;
+    checkpointId?: string;
+    checkpointNs?: string;
   }): Promise<void> {
     if (!this.checkpointing.enabled) {
       return;
     }
-    const tuple = await getLatestCheckpointTuple(
-      this.checkpointing.checkpointer,
-      params.config
+    const checkpointConfig = applyCheckpointReferenceToConfig(
+      params.config,
+      {
+        checkpointId: params.checkpointId,
+        checkpointNs: params.checkpointNs,
+      },
+      { overwrite: true }
     );
+    const tuple =
+      params.checkpointId != null && params.checkpointId !== ''
+        ? await getSelectedCheckpointTuple(
+          this.checkpointing.checkpointer,
+          checkpointConfig
+        )
+        : await getLatestCheckpointTuple(
+          this.checkpointing.checkpointer,
+          params.config
+        );
     if (!tuple) {
       return;
     }
@@ -974,6 +1063,8 @@ export class AgentSession {
         runId,
         threadId,
         config: callerConfig,
+        checkpointId: interrupt?.checkpointId,
+        checkpointNs: interrupt?.checkpointNs,
       });
       const contentParts = (content ?? handlerResult.contentParts).filter(
         (part): part is t.MessageContentComplex => part != null
@@ -1235,7 +1326,11 @@ export class AgentSession {
     const runId = options.runId ?? createRunId();
     const threadId = options.threadId ?? this.threadId;
     const isSessionThread = threadId === this.threadId;
-    const callerConfig = createCallerConfig(threadId, options);
+    const baseCallerConfig = createCallerConfig(threadId, options);
+    const callerConfig = applyCheckpointReferenceToConfig(
+      baseCallerConfig,
+      getStoredCheckpointForConfig(this.store, threadId, baseCallerConfig)?.data
+    );
     await this.store?.appendRunEvent('run.started', undefined, {
       runId,
       threadId,
@@ -1297,6 +1392,8 @@ export class AgentSession {
         runId,
         threadId,
         config: callerConfig,
+        checkpointId: interrupt?.checkpointId,
+        checkpointNs: interrupt?.checkpointNs,
       });
       const contentParts = (content ?? handlerResult.contentParts).filter(
         (part): part is t.MessageContentComplex => part != null

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -768,6 +768,217 @@ describe('JsonlSessionStore', () => {
     ).toEqual(['history']);
   });
 
+  it('resumes isolated Run instances from the stored interrupted checkpoint', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('resumed');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_interrupted',
+    });
+    await session.getSessionStore()?.appendCheckpoint({
+      source: 'run',
+      threadId: session.threadId,
+      runId: 'run_interrupted',
+      checkpointId: 'checkpoint_interrupted',
+      checkpointNs: '',
+    });
+
+    await session.resumeInterrupt([{ type: 'approve' }]);
+
+    expect(mockRun.resume).toHaveBeenCalledWith(
+      [{ type: 'approve' }],
+      expect.objectContaining({
+        configurable: expect.objectContaining({
+          thread_id: session.threadId,
+          checkpoint_id: 'checkpoint_interrupted',
+          checkpoint_ns: '',
+        }),
+      })
+    );
+  });
+
+  it('records a new interrupt checkpoint after resuming from an older checkpoint', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('interrupted again');
+    mockRun.getInterrupt.mockReturnValue({
+      interruptId: 'interrupt_again',
+      threadId: 'thread_new_interrupt',
+      checkpointId: 'checkpoint_new_interrupt',
+      checkpointNs: '',
+      payload: {
+        type: 'tool_approval',
+        action_requests: [],
+        review_configs: [],
+      },
+    });
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_resume_source',
+    });
+    await putCheckpoint({
+      checkpointer,
+      threadId: session.threadId,
+      id: 'checkpoint_new_interrupt',
+    });
+    await session.getSessionStore()?.appendCheckpoint({
+      source: 'run',
+      threadId: session.threadId,
+      runId: 'run_interrupted',
+      checkpointId: 'checkpoint_resume_source',
+      checkpointNs: '',
+    });
+
+    await session.resumeInterrupt([{ type: 'approve' }]);
+
+    expect(
+      session.getSessionStore()?.getLatestCheckpoint(session.threadId)?.data
+    ).toMatchObject({
+      source: 'resume',
+      checkpointId: 'checkpoint_new_interrupt',
+    });
+  });
+
+  it('resumes isolated Run instances from the requested checkpoint namespace', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('resumed requested namespace');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendCheckpoint({
+      source: 'run',
+      threadId: session.threadId,
+      runId: 'run_default',
+      checkpointId: 'checkpoint_default_latest',
+      checkpointNs: '',
+    });
+    await session.getSessionStore()?.appendCheckpoint({
+      source: 'run',
+      threadId: session.threadId,
+      runId: 'run_requested',
+      checkpointId: 'checkpoint_requested_latest',
+      checkpointNs: 'requested',
+    });
+    await session.getSessionStore()?.appendCheckpoint({
+      source: 'run',
+      threadId: session.threadId,
+      runId: 'run_default_again',
+      checkpointId: 'checkpoint_default_newer',
+      checkpointNs: '',
+    });
+
+    await session.resumeInterrupt([{ type: 'approve' }], {
+      config: {
+        configurable: {
+          checkpoint_ns: 'requested',
+        },
+      },
+    });
+
+    expect(mockRun.resume).toHaveBeenCalledWith(
+      [{ type: 'approve' }],
+      expect.objectContaining({
+        configurable: expect.objectContaining({
+          thread_id: session.threadId,
+          checkpoint_id: 'checkpoint_requested_latest',
+          checkpoint_ns: 'requested',
+        }),
+      })
+    );
+  });
+
+  it('resumes isolated Run instances from the explicitly requested default namespace', async () => {
+    const checkpointer = new MemorySaver();
+    const mockRun = createMockRun('resumed default namespace');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      checkpointing: { checkpointer },
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    await session.getSessionStore()?.appendCheckpoint({
+      source: 'run',
+      threadId: session.threadId,
+      runId: 'run_default',
+      checkpointId: 'checkpoint_default_latest',
+      checkpointNs: '',
+    });
+    await session.getSessionStore()?.appendCheckpoint({
+      source: 'run',
+      threadId: session.threadId,
+      runId: 'run_requested_newer',
+      checkpointId: 'checkpoint_requested_newer',
+      checkpointNs: 'requested',
+    });
+
+    await session.resumeInterrupt([{ type: 'approve' }], {
+      config: {
+        configurable: {
+          checkpoint_ns: '',
+        },
+      },
+    });
+
+    expect(mockRun.resume).toHaveBeenCalledWith(
+      [{ type: 'approve' }],
+      expect.objectContaining({
+        configurable: expect.objectContaining({
+          thread_id: session.threadId,
+          checkpoint_id: 'checkpoint_default_latest',
+          checkpoint_ns: '',
+        }),
+      })
+    );
+  });
+
   it('uses only new input when LangGraph checkpoint state already exists', async () => {
     const checkpointer = new MemorySaver();
     const mockRun = createMockRun('checkpointed output');

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -201,7 +201,9 @@ function isEagerToolExecutionEnabledForBatch(args: {
 }
 
 function hasFinalToolCallSignal(chunk: Partial<AIMessageChunk>): boolean {
-  const metadata = chunk.response_metadata as Record<string, unknown> | undefined;
+  const metadata = chunk.response_metadata as
+    | Record<string, unknown>
+    | undefined;
   const finishReason =
     metadata?.finish_reason ??
     metadata?.finishReason ??
@@ -222,9 +224,11 @@ function canPrestartSequentialStreamedToolChunks(
 function hasExplicitStreamedToolCallSeals(
   chunk: Partial<AIMessageChunk>
 ): boolean {
-  return getStreamedToolCallAdapter(
-    chunk.response_metadata as Record<string, unknown> | undefined
-  ) != null;
+  return (
+    getStreamedToolCallAdapter(
+      chunk.response_metadata as Record<string, unknown> | undefined
+    ) != null
+  );
 }
 
 function hasDirectToolCallInBatch(args: {
@@ -273,7 +277,13 @@ function createEagerToolExecutionPlan(args: {
   toolCalls: ToolCall[];
   skipExisting?: boolean;
 }): EagerToolExecutionEntry[] | undefined {
-  const { graph, metadata, agentContext, toolCalls, skipExisting = false } = args;
+  const {
+    graph,
+    metadata,
+    agentContext,
+    toolCalls,
+    skipExisting = false,
+  } = args;
   if (
     !isEagerToolExecutionEnabledForBatch({
       graph,
@@ -329,12 +339,14 @@ function createEagerToolExecutionPlan(args: {
     return undefined;
   }
 
-  return plan.requests.map((request): EagerToolExecutionEntry => ({
-    id: request.id,
-    toolName: request.name,
-    coercedArgs: request.args,
-    request,
-  }));
+  return plan.requests.map(
+    (request): EagerToolExecutionEntry => ({
+      id: request.id,
+      toolName: request.name,
+      coercedArgs: request.args,
+      request,
+    })
+  );
 }
 
 function startEagerToolExecutions(args: {
@@ -359,6 +371,14 @@ function startEagerToolExecutions(args: {
   const promise: Promise<t.EagerEventToolExecutionOutcome> = new Promise<
     t.ToolExecuteResult[]
   >((resolve, reject) => {
+    let dispatchSettled = false;
+    let resultSettled = false;
+    let settledResults: t.ToolExecuteResult[] | undefined;
+    const maybeResolve = (): void => {
+      if (dispatchSettled && resultSettled) {
+        resolve(settledResults ?? []);
+      }
+    };
     const batchRequest: t.ToolExecuteBatchRequest = {
       toolCalls: entries.map((entry) => entry.request),
       userId: graph.config?.configurable?.user_id as string | undefined,
@@ -367,15 +387,24 @@ function startEagerToolExecutions(args: {
         | Record<string, unknown>
         | undefined,
       metadata,
-      resolve,
+      resolve: (results): void => {
+        resultSettled = true;
+        settledResults = results;
+        maybeResolve();
+      },
       reject,
     };
 
-    safeDispatchCustomEvent(
+    void safeDispatchCustomEvent(
       GraphEvents.ON_TOOL_EXECUTE,
       batchRequest,
       graph.config
-    );
+    )
+      .then(() => {
+        dispatchSettled = true;
+        maybeResolve();
+      })
+      .catch(reject);
   }).then(
     (results): t.EagerEventToolExecutionOutcome => ({ results }),
     (error): t.EagerEventToolExecutionOutcome => ({
@@ -410,8 +439,12 @@ function getEagerToolChunkKey(
   return `${stepKey}\u0000${chunkKey}`;
 }
 
-function getEagerToolChunkIndex(toolCallChunk: ToolCallChunk): number | undefined {
-  return typeof toolCallChunk.index === 'number' ? toolCallChunk.index : undefined;
+function getEagerToolChunkIndex(
+  toolCallChunk: ToolCallChunk
+): number | undefined {
+  return typeof toolCallChunk.index === 'number'
+    ? toolCallChunk.index
+    : undefined;
 }
 
 function pruneEagerToolCallChunkStates(args: {
@@ -426,7 +459,10 @@ function pruneEagerToolCallChunkStates(args: {
     if (!key.startsWith(prefix)) {
       continue;
     }
-    if (clearStep || (state.id != null && toolCallIds?.has(state.id) === true)) {
+    if (
+      clearStep ||
+      (state.id != null && toolCallIds?.has(state.id) === true)
+    ) {
       graph.eagerEventToolCallChunks.delete(key);
     }
   }
@@ -514,7 +550,9 @@ function recordEagerToolCallChunks(args: {
     const previous = graph.eagerEventToolCallChunks.get(key);
     const shouldReset =
       previous != null &&
-      ((incomingId != null && previous.id != null && incomingId !== previous.id) ||
+      ((incomingId != null &&
+        previous.id != null &&
+        incomingId !== previous.id) ||
         (incomingName != null &&
           previous.name != null &&
           incomingName !== previous.name));
@@ -524,10 +562,8 @@ function recordEagerToolCallChunks(args: {
           argsText: '',
         }
         : previous;
-    const id =
-      incomingId ?? existing.id;
-    const name =
-      incomingName ?? existing.name;
+    const id = incomingId ?? existing.id;
+    const name = incomingName ?? existing.name;
     const incomingArgs = toolCallChunk.args ?? '';
     const isRepeatedObservedFragment =
       incomingArgs !== '' &&
@@ -624,9 +660,7 @@ function getStreamedReadyToolCalls(args: {
   }
 
   return readyEntries
-    .sort(
-      (left, right) => (left.state.index ?? 0) - (right.state.index ?? 0)
-    )
+    .sort((left, right) => (left.state.index ?? 0) - (right.state.index ?? 0))
     .flatMap(({ state }) => {
       const args = coerceRecordArgs(state.argsText);
       if (args == null) {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1137,7 +1137,7 @@ function createSummarizationChunkHandler({
         ? [{ type: ContentTypes.TEXT, text: raw } as t.MessageContentComplex]
         : raw;
 
-    safeDispatchCustomEvent(
+    void safeDispatchCustomEvent(
       GraphEvents.ON_SUMMARIZE_DELTA,
       {
         id: stepId,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1062,13 +1062,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             handlerError:
               handlerError instanceof Error
                 ? {
-                  message: handlerError.message,
-                  stack: handlerError.stack ?? undefined,
-                }
+                    message: handlerError.message,
+                    stack: handlerError.stack ?? undefined,
+                  }
                 : {
-                  message: String(handlerError),
-                  stack: undefined,
-                },
+                    message: String(handlerError),
+                    stack: undefined,
+                  },
           });
         }
       }
@@ -1076,11 +1076,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const refMeta =
         unresolvedRefs.length > 0
           ? this.recordOutputReference(
-            runId,
-            errorContent,
-            undefined,
-            unresolvedRefs
-          )
+              runId,
+              errorContent,
+              undefined,
+              unresolvedRefs
+            )
           : undefined;
       return new ToolMessage({
         status: 'error',
@@ -1722,12 +1722,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    *   by `runTool`. Threaded as a local map (instead of instance state)
    *   so concurrent batches cannot read each other's entries.
    */
-  private handleRunToolCompletions(
+  private async handleRunToolCompletions(
     calls: ToolCall[],
     outputs: (BaseMessage | Command)[],
     config: RunnableConfig,
     resolvedArgsByCallId?: ResolvedArgsByCallId
-  ): void {
+  ): Promise<void> {
     for (let i = 0; i < calls.length; i++) {
       const call = calls[i];
       const output = outputs[i];
@@ -1785,7 +1785,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         progress: 1,
       };
 
-      safeDispatchCustomEvent(
+      await safeDispatchCustomEvent(
         GraphEvents.ON_RUN_STEP_COMPLETED,
         {
           result: {
@@ -1993,9 +1993,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         });
       };
 
-      const flushDeferredBlockedSideEffects = (): void => {
+      const flushDeferredBlockedSideEffects = async (): Promise<void> => {
         for (const item of deferredBlockedSideEffects) {
-          this.dispatchStepCompleted(
+          await this.dispatchStepCompleted(
             item.callId,
             item.toolName,
             item.args,
@@ -2280,7 +2280,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
              * no risk of being rolled back by a subsequent throw, so
              * no risk of a duplicate `ON_RUN_STEP_COMPLETED` event.
              */
-            this.dispatchStepCompleted(
+            await this.dispatchStepCompleted(
               entry.call.id!,
               entry.call.name,
               entry.args,
@@ -2365,7 +2365,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * dispatches in the same relative position as the pre-deferral
        * code did (after hook processing, before tool execution).
        */
-      flushDeferredBlockedSideEffects();
+      await flushDeferredBlockedSideEffects();
     } else {
       approvedEntries.push(...preToolCalls);
     }
@@ -2432,26 +2432,45 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         dispatchRequests.length === 0
           ? Promise.resolve([] as t.ToolExecuteResult[])
           : new Promise<t.ToolExecuteResult[]>((resolve, reject) => {
-            const batchRequest: t.ToolExecuteBatchRequest = {
-              toolCalls: dispatchRequests,
-              userId: config.configurable?.user_id as string | undefined,
-              agentId: this.agentId,
-              configurable: config.configurable as
-                  | Record<string, unknown>
-                  | undefined,
-              metadata: config.metadata as
-                  | Record<string, unknown>
-                  | undefined,
-              resolve,
-              reject,
-            };
+              let dispatchSettled = false;
+              let resultSettled = false;
+              let settledResults: t.ToolExecuteResult[] | undefined;
 
-            safeDispatchCustomEvent(
-              GraphEvents.ON_TOOL_EXECUTE,
-              batchRequest,
-              config
-            );
-          });
+              const maybeResolve = (): void => {
+                if (dispatchSettled && resultSettled) {
+                  resolve(settledResults ?? []);
+                }
+              };
+
+              const batchRequest: t.ToolExecuteBatchRequest = {
+                toolCalls: dispatchRequests,
+                userId: config.configurable?.user_id as string | undefined,
+                agentId: this.agentId,
+                configurable: config.configurable as
+                  | Record<string, unknown>
+                  | undefined,
+                metadata: config.metadata as
+                  | Record<string, unknown>
+                  | undefined,
+                resolve: (results): void => {
+                  resultSettled = true;
+                  settledResults = results;
+                  maybeResolve();
+                },
+                reject,
+              };
+
+              void safeDispatchCustomEvent(
+                GraphEvents.ON_TOOL_EXECUTE,
+                batchRequest,
+                config
+              )
+                .then(() => {
+                  dispatchSettled = true;
+                  maybeResolve();
+                })
+                .catch(reject);
+            });
 
       const eagerResultsPromise = Promise.all(
         eagerExecutions.map(({ request, execution }) =>
@@ -2518,11 +2537,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           const errorRefMeta =
             unresolved.length > 0
               ? this.recordOutputReference(
-                registryRunId,
-                contentString,
-                undefined,
-                unresolved
-              )
+                  registryRunId,
+                  contentString,
+                  undefined,
+                  unresolved
+                )
               : undefined;
           toolMessage = new ToolMessage({
             status: 'error',
@@ -2641,7 +2660,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           });
         }
 
-        this.dispatchStepCompleted(
+        await this.dispatchStepCompleted(
           result.toolCallId,
           toolName,
           request?.args ?? {},
@@ -2846,14 +2865,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
   }
 
-  private dispatchStepCompleted(
+  private async dispatchStepCompleted(
     toolCallId: string,
     toolName: string,
     args: Record<string, unknown>,
     output: string,
     config: RunnableConfig,
     turn?: number
-  ): void {
+  ): Promise<void> {
     const stepId = this.toolCallStepIds?.get(toolCallId) ?? '';
     if (!stepId) {
       // eslint-disable-next-line no-console
@@ -2864,7 +2883,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       );
     }
 
-    safeDispatchCustomEvent(
+    await safeDispatchCustomEvent(
       GraphEvents.ON_RUN_STEP_COMPLETED,
       {
         result: {
@@ -2996,17 +3015,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       outputs =
         directAdditionalContexts.length > 0
           ? [
-            sendOutput,
-            new HumanMessage({
-              content: directAdditionalContexts.join('\n\n'),
-              // Match the event-driven path's marker so hosts /
-              // model-side annotators treat this as system intent
-              // rather than ordinary user text. Codex P2 [46].
-              additional_kwargs: { role: 'system', source: 'hook' },
-            }),
-          ]
+              sendOutput,
+              new HumanMessage({
+                content: directAdditionalContexts.join('\n\n'),
+                // Match the event-driven path's marker so hosts /
+                // model-side annotators treat this as system intent
+                // rather than ordinary user text. Codex P2 [46].
+                additional_kwargs: { role: 'system', source: 'hook' },
+              }),
+            ]
           : [sendOutput];
-      this.handleRunToolCompletions(
+      await this.handleRunToolCompletions(
         [input.lg_tool_call],
         // Pass only the tool output to completion handling; the
         // HumanMessage isn't a tool result.
@@ -3155,21 +3174,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const directOutputs: (BaseMessage | Command)[] =
           directCalls.length > 0
             ? await Promise.all(
-              directCalls.map((call, i) =>
-                this.runDirectToolWithLifecycleHooks(call, config, {
-                  batchIndex: directIndices[i],
-                  turn,
-                  batchScopeId,
-                  resolvedArgsByCallId,
-                  preBatchSnapshot,
-                  additionalContextsSink: directAdditionalContexts,
-                })
+                directCalls.map((call, i) =>
+                  this.runDirectToolWithLifecycleHooks(call, config, {
+                    batchIndex: directIndices[i],
+                    turn,
+                    batchScopeId,
+                    resolvedArgsByCallId,
+                    preBatchSnapshot,
+                    additionalContextsSink: directAdditionalContexts,
+                  })
+                )
               )
-            )
             : [];
 
         if (directCalls.length > 0 && directOutputs.length > 0) {
-          this.handleRunToolCompletions(
+          await this.handleRunToolCompletions(
             directCalls,
             directOutputs,
             config,
@@ -3180,29 +3199,29 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const eventResult =
           eventCalls.length > 0
             ? await this.dispatchToolEvents(eventCalls, config, {
-              batchIndices: eventIndices,
-              turn,
-              batchScopeId,
-              preResolvedArgs: preResolvedEventArgs,
-              preBatchSnapshot,
-            })
+                batchIndices: eventIndices,
+                turn,
+                batchScopeId,
+                preResolvedArgs: preResolvedEventArgs,
+                preBatchSnapshot,
+              })
             : {
-              toolMessages: [] as ToolMessage[],
-              injected: [] as BaseMessage[],
-            };
+                toolMessages: [] as ToolMessage[],
+                injected: [] as BaseMessage[],
+              };
 
         const directInjected: BaseMessage[] =
           directAdditionalContexts.length > 0
             ? [
-              new HumanMessage({
-                content: directAdditionalContexts.join('\n\n'),
-                // System-role metadata to match the event-driven
-                // path so policy/recovery guidance is treated
-                // consistently regardless of whether the tool ran
-                // direct or dispatched. Codex P2 [46].
-                additional_kwargs: { role: 'system', source: 'hook' },
-              }),
-            ]
+                new HumanMessage({
+                  content: directAdditionalContexts.join('\n\n'),
+                  // System-role metadata to match the event-driven
+                  // path so policy/recovery guidance is treated
+                  // consistently regardless of whether the tool ran
+                  // direct or dispatched. Codex P2 [46].
+                  additional_kwargs: { role: 'system', source: 'hook' },
+                }),
+              ]
             : [];
         outputs = [
           ...directOutputs,
@@ -3230,7 +3249,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             })
           )
         );
-        this.handleRunToolCompletions(
+        await this.handleRunToolCompletions(
           filteredCalls,
           toolOutputs,
           config,
@@ -3241,15 +3260,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         outputs =
           directAdditionalContexts.length > 0
             ? [
-              ...toolOutputs,
-              new HumanMessage({
-                content: directAdditionalContexts.join('\n\n'),
-                // Same system-role marker the event-driven path
-                // uses so direct vs dispatched is invisible to
-                // downstream consumers. Codex P2 [46].
-                additional_kwargs: { role: 'system', source: 'hook' },
-              }),
-            ]
+                ...toolOutputs,
+                new HumanMessage({
+                  content: directAdditionalContexts.join('\n\n'),
+                  // Same system-role marker the event-driven path
+                  // uses so direct vs dispatched is invisible to
+                  // downstream consumers. Codex P2 [46].
+                  additional_kwargs: { role: 'system', source: 'hook' },
+                }),
+              ]
             : toolOutputs;
       }
     }

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -37,6 +37,20 @@ import { HookRegistry } from '@/hooks';
 import { Providers as providers, GraphEvents } from '@/common';
 import { ToolNode } from '../ToolNode';
 
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  await Promise.resolve();
+}
+
+afterEach(async () => {
+  await flushAsyncWork();
+  jest.restoreAllMocks();
+  await flushAsyncWork();
+});
+
 /**
  * Schema-only tool stub. ToolNode in event-driven mode uses the schema
  * for binding/discovery but routes execution through the host via
@@ -71,8 +85,20 @@ function mockEventDispatch(mockResults: t.ToolExecuteResult[]): void {
 }
 
 type MessagesUpdate = { messages: BaseMessage[] };
+type InterruptStateSnapshot = {
+  config?: RunnableConfig;
+  tasks?: Array<{
+    interrupts?: Array<{ id?: string }>;
+  }>;
+};
 type CompiledMessagesGraph = Runnable<unknown, { messages: BaseMessage[] }> & {
   invoke(input: unknown, config?: RunnableConfig): Promise<unknown>;
+  getState?(
+    config: RunnableConfig
+  ): Promise<{ config?: RunnableConfig } | undefined>;
+  getStateHistory?(
+    config: RunnableConfig
+  ): AsyncIterableIterator<InterruptStateSnapshot>;
 };
 
 /** Factory for a minimal `agent → tools → END` graph wrapping the ToolNode. */
@@ -80,18 +106,26 @@ function buildHITLGraph(
   toolNode: ToolNode,
   toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>
 ): CompiledMessagesGraph {
-  let agentInvocations = 0;
+  const toolCallIds = new Set(toolCalls.map((call) => call.id));
   const builder = new StateGraph(MessagesAnnotation)
-    .addNode('agent', (): MessagesUpdate => {
-      agentInvocations += 1;
+    .addNode('agent', (state: { messages?: BaseMessage[] }): MessagesUpdate => {
       /**
-       * First entry → emit the AIMessage carrying tool_calls so the
-       * ToolNode actually has work. After resume the agent re-enters
-       * once more (a normal LangGraph loop), but at that point any
-       * approved tool already has a ToolMessage in state, so we emit
-       * an empty AIMessage to satisfy the loop and end the run.
+       * Emit the AIMessage carrying tool_calls until this test graph
+       * actually has a matching ToolMessage in state. LangGraph usually
+       * resumes at the interrupted `tools` node, but under full-suite
+       * async callback pressure it can re-enter this tiny test graph from
+       * START while still carrying the resume value. A call-count based
+       * fake agent then returned "done" too early and made HITL resume
+       * assertions order-dependent. State is the stable contract here:
+       * no tool result means the tool node still needs work.
        */
-      if (agentInvocations === 1) {
+      const hasMatchingToolResult =
+        state.messages?.some(
+          (message): boolean =>
+            message._getType() === 'tool' &&
+            toolCallIds.has((message as ToolMessage).tool_call_id)
+        ) === true;
+      if (!hasMatchingToolResult) {
         return {
           messages: [new AIMessage({ content: '', tool_calls: toolCalls })],
         };
@@ -121,6 +155,52 @@ function makeHookRegistry(
     ],
   });
   return registry;
+}
+
+function resumeFromInterrupt<TResume>(
+  interrupted: unknown,
+  resume: TResume
+): Command {
+  if (isInterrupted<unknown>(interrupted)) {
+    const interruptId = interrupted.__interrupt__[0]?.id;
+    if (typeof interruptId === 'string' && interruptId.length > 0) {
+      return new Command({ resume: { [interruptId]: resume } });
+    }
+  }
+  return new Command({ resume });
+}
+
+async function resumeGraph<TResume>(
+  graph: CompiledMessagesGraph,
+  interrupted: unknown,
+  resume: TResume,
+  config: RunnableConfig
+): Promise<unknown> {
+  const interruptId = isInterrupted<unknown>(interrupted)
+    ? interrupted.__interrupt__[0]?.id
+    : undefined;
+  let checkpointConfig = config;
+  if (typeof interruptId === 'string' && graph.getStateHistory != null) {
+    for await (const snapshot of graph.getStateHistory(config)) {
+      const hasMatchingInterrupt =
+        snapshot.tasks?.some(
+          (task) =>
+            task.interrupts?.some(
+              (interrupt) => interrupt.id === interruptId
+            ) === true
+        ) === true;
+      if (hasMatchingInterrupt && snapshot.config != null) {
+        checkpointConfig = snapshot.config;
+        break;
+      }
+    }
+  } else {
+    checkpointConfig = (await graph.getState?.(config))?.config ?? config;
+  }
+  return graph.invoke(
+    resumeFromInterrupt(interrupted, resume),
+    checkpointConfig
+  );
 }
 
 describe('ToolNode HITL — `ask` decision raises interrupt() when humanInTheLoop is enabled', () => {
@@ -196,10 +276,14 @@ describe('ToolNode HITL — `ask` decision raises interrupt() when humanInTheLoo
     const interrupted = await graph.invoke({ messages: [] }, config);
     expect(isInterrupted(interrupted)).toBe(true);
 
-    const resumed = (await graph.invoke(
-      new Command({ resume: [{ type: 'approve' }] }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'approve' }],
       config
-    )) as { messages: BaseMessage[] };
+    )) as {
+      messages: BaseMessage[];
+    };
 
     const toolMessages = resumed.messages.filter(
       (m): m is ToolMessage => m._getType() === 'tool'
@@ -226,12 +310,12 @@ describe('ToolNode HITL — `ask` decision raises interrupt() when humanInTheLoo
     ]);
     const config = { configurable: { thread_id: 'thread-hitl-reject' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'reject', reason: 'destructive command' }],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'reject', reason: 'destructive command' }],
       config
     )) as { messages: BaseMessage[] };
 
@@ -279,12 +363,12 @@ describe('ToolNode HITL — `ask` decision raises interrupt() when humanInTheLoo
     ]);
     const config = { configurable: { thread_id: 'thread-hitl-edit' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
-    await graph.invoke(
-      new Command({
-        resume: [{ type: 'edit', updatedInput: { command: 'patched' } }],
-      }),
+    await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'edit', updatedInput: { command: 'patched' } }],
       config
     );
 
@@ -320,16 +404,16 @@ describe('ToolNode HITL — `ask` decision raises interrupt() when humanInTheLoo
     ]);
     const config = { configurable: { thread_id: 'thread-hitl-respond' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     const dispatchCallsBefore = dispatchSpy.mock.calls.filter(
       ([event]) => event === 'on_tool_execute'
     ).length;
 
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'respond', responseText: 'no relevant results' }],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'respond', responseText: 'no relevant results' }],
       config
     )) as { messages: BaseMessage[] };
 
@@ -399,10 +483,12 @@ describe('ToolNode HITL — `ask` decision raises interrupt() when humanInTheLoo
     ]);
     const config = { configurable: { thread_id: 'thread-hitl-map' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
-    const resumed = (await graph.invoke(
-      new Command({ resume: { call_1: { type: 'approve' } } }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      { call_1: { type: 'approve' } },
       config
     )) as { messages: BaseMessage[] };
 
@@ -561,10 +647,10 @@ describe('ToolNode HITL — multi-tool batches', () => {
       'call_2',
     ]);
 
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'approve' }, { type: 'reject', reason: 'too risky' }],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'approve' }, { type: 'reject', reason: 'too risky' }],
       config
     )) as { messages: BaseMessage[] };
 
@@ -745,11 +831,12 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
       ],
     });
 
+    const hexToolCallId = '0123456789abcdef0123456789abcdef';
     const node = new ToolNode({
       tools: [createSchemaStub('echo')],
       eventDrivenMode: true,
       agentId: 'agent-x',
-      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      toolCallStepIds: new Map([[hexToolCallId, 'step_1']]),
       hookRegistry: registry,
       humanInTheLoop: { enabled: true },
     });
@@ -762,7 +849,7 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
             new AIMessage({
               content: '',
               tool_calls: [
-                { id: 'call_1', name: 'echo', args: { command: 'x' } },
+                { id: hexToolCallId, name: 'echo', args: { command: 'x' } },
               ],
             }),
           ],
@@ -804,8 +891,10 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
     expect(dispatchCount).toBe(0);
 
     /** This is the API contract under test: Run.resume() with a
-     * decision array (not graph.invoke + Command). */
-    await run.resume([{ type: 'approve' }], callerConfig);
+     * tool_call_id-keyed decision map (not graph.invoke + Command).
+     * The tool_call_id intentionally looks like a LangGraph interrupt
+     * id; Run.resume must still wrap it under the real interrupt id. */
+    await run.resume({ [hexToolCallId]: { type: 'approve' } }, callerConfig);
 
     expect(dispatchCount).toBe(1);
     /** Resume completed naturally: interrupt cleared, no halt
@@ -1732,13 +1821,13 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'dedup-thread' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
     /** First pass: interrupt() threw, so the deferred denial side
      * effects were not flushed. Zero step-completed events for the
      * denied tool yet. */
     expect(stepCompletedDispatches.filter((id) => id === 'call_a')).toEqual([]);
 
-    await graph.invoke(new Command({ resume: [{ type: 'approve' }] }), config);
+    await resumeGraph(graph, interrupted, [{ type: 'approve' }], config);
 
     /** After resume: the denied tool dispatches exactly once (deferred
      * flush on the resume re-execution); the approved tool dispatches
@@ -1803,13 +1892,13 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'allowed-enforce' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** Submit `edit` — outside the advertised allowlist. */
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'edit', updatedInput: { command: 'malicious' } }],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'edit', updatedInput: { command: 'malicious' } }],
       config
     )) as { messages: BaseMessage[] };
 
@@ -1875,10 +1964,10 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'allowed-pass' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** Submit `approve` — explicitly in the allowlist. */
-    await graph.invoke(new Command({ resume: [{ type: 'approve' }] }), config);
+    await resumeGraph(graph, interrupted, [{ type: 'approve' }], config);
 
     expect(dispatchedArgs).toEqual([{ command: 'original' }]);
   });
@@ -2048,7 +2137,7 @@ describe('Codex review fixes', () => {
       command: 'redacted-command',
     });
 
-    await graph.invoke(new Command({ resume: [{ type: 'approve' }] }), config);
+    await resumeGraph(graph, interrupted, [{ type: 'approve' }], config);
 
     /** And the host execution dispatches the rewritten args, not
      * the original. Without the fix, the policy redaction would be
@@ -2307,15 +2396,15 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'edit-malformed' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** `{ type: 'edit' }` with no updatedInput — same trust-boundary
      * issue as malformed respond. Must fail closed, NOT pass undefined
      * into applyInputOverride and approve a tool with garbage args. */
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'edit' } as unknown as t.ToolApprovalDecision],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'edit' } as unknown as t.ToolApprovalDecision],
       config
     )) as { messages: BaseMessage[] };
 
@@ -2361,19 +2450,19 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'edit-nonobject' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** `updatedInput: 'string'` — wire deserializer didn't enforce
      * object shape; SDK must reject. */
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [
-          {
-            type: 'edit',
-            updatedInput: 'not-an-object' as unknown as Record<string, unknown>,
-          },
-        ],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [
+        {
+          type: 'edit',
+          updatedInput: 'not-an-object' as unknown as Record<string, unknown>,
+        },
+      ],
       config
     )) as { messages: BaseMessage[] };
 
@@ -2410,17 +2499,17 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'edit-array' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [
-          {
-            type: 'edit',
-            updatedInput: [1, 2, 3] as unknown as Record<string, unknown>,
-          },
-        ],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [
+        {
+          type: 'edit',
+          updatedInput: [1, 2, 3] as unknown as Record<string, unknown>,
+        },
+      ],
       config
     )) as { messages: BaseMessage[] };
 
@@ -2462,15 +2551,15 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'respond-malformed' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** Submit a `respond` decision with NO responseText — wire shape
      * the SDK can't honor. Must fail closed (blockEntry path), NOT
      * crash truncateToolResultContent on `undefined.length`. */
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'respond' } as unknown as t.ToolApprovalDecision],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'respond' } as unknown as t.ToolApprovalDecision],
       config
     )) as { messages: BaseMessage[] };
 
@@ -2508,19 +2597,19 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'respond-nonstring' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** `responseText: 42` — wire deserializer didn't enforce string;
      * SDK must reject without crashing. */
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [
-          {
-            type: 'respond',
-            responseText: 42 as unknown as string,
-          },
-        ],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [
+        {
+          type: 'respond',
+          responseText: 42 as unknown as string,
+        },
+      ],
       config
     )) as { messages: BaseMessage[] };
 
@@ -2571,14 +2660,14 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'respond-truncate' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** 200-char response — well over the 50-char cap. */
     const oversized = 'A'.repeat(200);
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'respond', responseText: oversized }],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'respond', responseText: oversized }],
       config
     )) as { messages: BaseMessage[] };
 
@@ -3091,8 +3180,10 @@ describe('Codex review fixes', () => {
     expect(payload.action_requests[0].tool_call_id).toBe('call_b');
     expect(dispatchedToolNames).toEqual([]);
 
-    const resumed = (await graph.invoke(
-      new Command({ resume: [{ type: 'approve' }] }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'approve' }],
       config
     )) as { messages: BaseMessage[] };
 
@@ -3222,17 +3313,17 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'mixed-respond-reject' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
     /** First pass: interrupt fires before either dispatch path runs. */
     expect(stepCompletedDispatches).toEqual([]);
 
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [
-          { type: 'respond', responseText: 'fake answer' },
-          { type: 'reject', reason: 'no thanks' },
-        ],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [
+        { type: 'respond', responseText: 'fake answer' },
+        { type: 'reject', reason: 'no thanks' },
+      ],
       config
     )) as { messages: BaseMessage[] };
 
@@ -3394,13 +3485,13 @@ describe('Codex review fixes', () => {
     ]);
     const config = { configurable: { thread_id: 'unknown-decision' } };
 
-    await graph.invoke({ messages: [] }, config);
+    const interrupted = await graph.invoke({ messages: [] }, config);
 
     /** Host sends a typo'd / malformed decision. Must NOT silently approve. */
-    const resumed = (await graph.invoke(
-      new Command({
-        resume: [{ type: 'aproved' as 'approve' }],
-      }),
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'aproved' as 'approve' }],
       config
     )) as { messages: BaseMessage[] };
 
@@ -3555,7 +3646,7 @@ describe('AskUserQuestion — interrupt + resume', () => {
     const config = { configurable: { thread_id: 'ask-q-thread' } };
 
     const interrupted = (await graph.invoke({ messages: [] }, config)) as {
-      __interrupt__?: Array<{ value?: t.HumanInterruptPayload }>;
+      __interrupt__?: Array<{ id?: string; value?: t.HumanInterruptPayload }>;
     };
     expect(interrupted.__interrupt__).toBeDefined();
     const payload = interrupted.__interrupt__![0].value!;
@@ -3566,7 +3657,12 @@ describe('AskUserQuestion — interrupt + resume', () => {
     expect(payload.question.options).toHaveLength(2);
 
     const resolution: t.AskUserQuestionResolution = { answer: 'production' };
-    await graph.invoke(new Command({ resume: resolution }), config);
+    await resumeGraph(
+      graph as unknown as CompiledMessagesGraph,
+      interrupted,
+      resolution,
+      config
+    );
 
     expect(resumedAnswer).toBe('production');
   });

--- a/src/types/hitl.ts
+++ b/src/types/hitl.ts
@@ -327,6 +327,10 @@ export interface RunInterruptResult<TPayload = HumanInterruptPayload> {
   interruptId: string;
   /** `thread_id` the run was bound to — required to resume. */
   threadId?: string;
+  /** LangGraph checkpoint id that contains the paused interrupt task. */
+  checkpointId?: string;
+  /** LangGraph checkpoint namespace for the paused interrupt task. */
+  checkpointNs?: string;
   /** Structured payload describing what needs human input. */
   payload: TPayload;
 }


### PR DESCRIPTION
## Summary
- resume HITL runs against the checkpoint snapshot that actually contains the captured interrupt
- scope resume payloads by LangGraph interrupt id when available
- await tool lifecycle custom-event dispatches so mocks/callbacks cannot bleed between HITL tests

## Verification
- `for i in 1 2 3; do NODE_OPTIONS='--experimental-vm-modules' npx jest src/tools/__tests__/hitl.test.ts --runInBand || exit $?; done`\n- `NODE_OPTIONS='--experimental-vm-modules' npx jest src/tools/__tests__/directToolHITLResumeScope.test.ts --runInBand`\n- `npm run build`