### PR TITLE
feat: surface eager tool completions

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1971,6 +1971,82 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(staleRecord?.completionDispatched).toBeUndefined();
   });
 
+  it('does not mark eager completion dispatched when event delivery is swallowed', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<boolean | void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          return false;
+        }
+        if (event === GraphEvents.ON_TOOL_EXECUTE) {
+          const batch = data as t.ToolExecuteBatchRequest;
+          batch.resolve([
+            {
+              toolCallId: 'call_weather',
+              status: 'success',
+              content: 'weather result',
+            },
+          ]);
+        }
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"C',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    const record = graph.eagerEventToolExecutions.get('call_weather');
+    await record?.promise;
+
+    expect(record?.completionDispatched).toBeUndefined();
+  });
+
   it('does not overwrite a completed tool output with later streamed deltas', () => {
     const { contentParts, aggregateContent } = createContentAggregator();
 

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@/common';
 import { HandlerRegistry } from '@/events';
 import * as events from '@/utils/events';
-import { ChatModelStreamHandler } from '@/stream';
+import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
 import {
   STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
@@ -1791,6 +1791,168 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       turn: 0,
     });
     expect(graph.eagerEventToolCallChunks.size).toBe(0);
+  });
+
+  it('emits a completed event when an eager streamed tool result settles', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const completedEvents: Array<{ result: t.ToolEndEvent }> = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completedEvents.push(data as { result: t.ToolEndEvent });
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"C',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await graph.eagerEventToolExecutions.get('call_weather')?.promise;
+
+    expect(completedEvents).toHaveLength(1);
+    expect(completedEvents[0].result).toMatchObject({
+      id: expect.stringMatching(/^step_/),
+      type: 'tool_call',
+      eager: true,
+      tool_call: {
+        id: 'call_weather',
+        name: 'weather',
+        args: '{"city":"NYC"}',
+        output: 'ok weather',
+        progress: 1,
+      },
+    });
+    expect(
+      graph.eagerEventToolExecutions.get('call_weather')?.completionDispatched
+    ).toBe(true);
+  });
+
+  it('does not overwrite a completed tool output with later streamed deltas', () => {
+    const { contentParts, aggregateContent } = createContentAggregator();
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP,
+      data: {
+        id: 'step_weather',
+        type: StepTypes.TOOL_CALLS,
+        index: 0,
+        stepDetails: {
+          type: StepTypes.TOOL_CALLS,
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: {},
+            },
+          ],
+        },
+        usage: null,
+      } as t.RunStep,
+    });
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP_COMPLETED,
+      data: {
+        result: {
+          id: 'step_weather',
+          index: 0,
+          type: 'tool_call',
+          tool_call: {
+            id: 'call_weather',
+            name: 'weather',
+            args: '{"city":"NYC"}',
+            output: 'sunny',
+            progress: 1,
+          } as t.ProcessedToolCall,
+        },
+      } as { result: t.ToolEndEvent },
+    });
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP_DELTA,
+      data: {
+        id: 'step_weather',
+        delta: {
+          type: StepTypes.TOOL_CALLS,
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC revised"}',
+            },
+          ],
+        },
+      } as t.RunStepDeltaEvent,
+    });
+
+    expect(contentParts[0]).toMatchObject({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: {
+        id: 'call_weather',
+        name: 'weather',
+        args: '{"city":"NYC"}',
+        output: 'sunny',
+        progress: 1,
+      },
+    });
   });
 
   it('does not use next-index sealing for Moonshot streamed tool chunks', async () => {

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1887,6 +1887,90 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     ).toBe(true);
   });
 
+  it('does not emit a stale eager completion after the active execution is invalidated', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const completedEvents: Array<{ result: t.ToolEndEvent }> = [];
+    let pendingBatch: t.ToolExecuteBatchRequest | undefined;
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
+      async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completedEvents.push(data as { result: t.ToolEndEvent });
+          return;
+        }
+        if (event === GraphEvents.ON_TOOL_EXECUTE) {
+          pendingBatch = data as t.ToolExecuteBatchRequest;
+        }
+      }
+    );
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"C',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    const staleRecord = graph.eagerEventToolExecutions.get('call_weather');
+    expect(staleRecord).toBeDefined();
+    expect(pendingBatch?.toolCalls).toHaveLength(1);
+
+    graph.eagerEventToolExecutions.delete('call_weather');
+    pendingBatch?.resolve([
+      {
+        toolCallId: 'call_weather',
+        status: 'success',
+        content: 'stale weather',
+      },
+    ]);
+    await staleRecord?.promise;
+
+    expect(completedEvents).toHaveLength(0);
+    expect(staleRecord?.completionDispatched).toBeUndefined();
+  });
+
   it('does not overwrite a completed tool output with later streamed deltas', () => {
     const { contentParts, aggregateContent } = createContentAggregator();
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -28,6 +28,10 @@ import {
   normalizeError,
 } from '@/tools/eagerEventExecution';
 import {
+  calculateMaxToolResultChars,
+  truncateToolResultContent,
+} from '@/utils/truncation';
+import {
   getStreamedToolCallSeal,
   getStreamedToolCallAdapter,
   type StreamedToolCallSeal,
@@ -369,6 +373,7 @@ function startEagerToolExecutions(args: {
     return;
   }
 
+  const records: t.EagerEventToolExecution[] = [];
   const promise: Promise<t.EagerEventToolExecutionOutcome> = new Promise<
     t.ToolExecuteResult[]
   >((resolve, reject) => {
@@ -407,20 +412,98 @@ function startEagerToolExecutions(args: {
       })
       .catch(reject);
   }).then(
-    (results): t.EagerEventToolExecutionOutcome => ({ results }),
+    async (results): Promise<t.EagerEventToolExecutionOutcome> => {
+      await dispatchEagerToolCompletions({
+        graph,
+        agentContext,
+        records,
+        results,
+      });
+      return { results };
+    },
     (error): t.EagerEventToolExecutionOutcome => ({
       error: normalizeError(error),
     })
   );
 
   for (const entry of entries) {
-    graph.eagerEventToolExecutions.set(entry.id, {
+    const record: t.EagerEventToolExecution = {
       toolCallId: entry.id,
       toolName: entry.toolName,
       args: entry.coercedArgs,
       request: entry.request,
       promise,
-    });
+    };
+    records.push(record);
+    graph.eagerEventToolExecutions.set(entry.id, record);
+  }
+}
+
+async function dispatchEagerToolCompletions(args: {
+  graph: StandardGraph;
+  agentContext?: AgentContext;
+  records: t.EagerEventToolExecution[];
+  results: t.ToolExecuteResult[];
+}): Promise<void> {
+  const { graph, agentContext, records, results } = args;
+  const recordById = new Map(
+    records.map((record) => [record.toolCallId, record])
+  );
+  const maxToolResultChars =
+    agentContext?.maxToolResultChars ??
+    calculateMaxToolResultChars(agentContext?.maxContextTokens);
+
+  for (const result of results) {
+    const record = recordById.get(result.toolCallId);
+    if (record == null) {
+      continue;
+    }
+    const stepId =
+      record.request.stepId ??
+      graph.toolCallStepIds.get(result.toolCallId) ??
+      '';
+    if (stepId === '') {
+      continue;
+    }
+    const output =
+      result.status === 'error'
+        ? `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`
+        : truncateToolResultContent(
+          typeof result.content === 'string'
+            ? result.content
+            : JSON.stringify(result.content),
+          maxToolResultChars
+        );
+
+    try {
+      await safeDispatchCustomEvent(
+        GraphEvents.ON_RUN_STEP_COMPLETED,
+        {
+          result: {
+            id: stepId,
+            index: record.request.turn ?? 0,
+            type: 'tool_call' as const,
+            eager: true,
+            tool_call: {
+              args: JSON.stringify(record.request.args),
+              name: record.toolName,
+              id: result.toolCallId,
+              output,
+              progress: 1,
+            } as t.ProcessedToolCall,
+          },
+        },
+        graph.config
+      );
+      record.completionDispatched = true;
+    } catch (error) {
+      // Let ToolNode dispatch the completion through the normal path later.
+
+      console.warn(
+        `[stream] eager completion dispatch failed for toolCallId=${result.toolCallId}:`,
+        error instanceof Error ? error.message : error
+      );
+    }
   }
 }
 
@@ -1265,9 +1348,12 @@ export function createContentAggregator(): t.ContentAggregatorResult {
 
       const existingContent = contentParts[index] as
         | (Omit<t.ToolCallContent, 'tool_call'> & {
-            tool_call?: t.ToolCallPart;
+            tool_call?: t.ToolCallPart & t.PartMetadata;
           })
         | undefined;
+      if (!finalUpdate && existingContent?.tool_call?.progress === 1) {
+        return;
+      }
 
       /** When args are a valid object, they are likely already invoked */
       let args =

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -479,7 +479,7 @@ async function dispatchEagerToolCompletions(args: {
         );
 
     try {
-      await safeDispatchCustomEvent(
+      const dispatched = await safeDispatchCustomEvent(
         GraphEvents.ON_RUN_STEP_COMPLETED,
         {
           result: {
@@ -498,6 +498,9 @@ async function dispatchEagerToolCompletions(args: {
         },
         graph.config
       );
+      if (dispatched === false) {
+        continue;
+      }
       record.completionDispatched = true;
     } catch (error) {
       // Let ToolNode dispatch the completion through the normal path later.

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -458,6 +458,9 @@ async function dispatchEagerToolCompletions(args: {
     if (record == null) {
       continue;
     }
+    if (graph.eagerEventToolExecutions.get(result.toolCallId) !== record) {
+      continue;
+    }
     const stepId =
       record.request.stepId ??
       graph.toolCallStepIds.get(result.toolCallId) ??

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1062,13 +1062,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             handlerError:
               handlerError instanceof Error
                 ? {
-                    message: handlerError.message,
-                    stack: handlerError.stack ?? undefined,
-                  }
+                  message: handlerError.message,
+                  stack: handlerError.stack ?? undefined,
+                }
                 : {
-                    message: String(handlerError),
-                    stack: undefined,
-                  },
+                  message: String(handlerError),
+                  stack: undefined,
+                },
           });
         }
       }
@@ -1076,11 +1076,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const refMeta =
         unresolvedRefs.length > 0
           ? this.recordOutputReference(
-              runId,
-              errorContent,
-              undefined,
-              unresolvedRefs
-            )
+            runId,
+            errorContent,
+            undefined,
+            unresolvedRefs
+          )
           : undefined;
       return new ToolMessage({
         status: 'error',
@@ -2432,59 +2432,75 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         dispatchRequests.length === 0
           ? Promise.resolve([] as t.ToolExecuteResult[])
           : new Promise<t.ToolExecuteResult[]>((resolve, reject) => {
-              let dispatchSettled = false;
-              let resultSettled = false;
-              let settledResults: t.ToolExecuteResult[] | undefined;
+            let dispatchSettled = false;
+            let resultSettled = false;
+            let settledResults: t.ToolExecuteResult[] | undefined;
 
-              const maybeResolve = (): void => {
-                if (dispatchSettled && resultSettled) {
-                  resolve(settledResults ?? []);
-                }
-              };
+            const maybeResolve = (): void => {
+              if (dispatchSettled && resultSettled) {
+                resolve(settledResults ?? []);
+              }
+            };
 
-              const batchRequest: t.ToolExecuteBatchRequest = {
-                toolCalls: dispatchRequests,
-                userId: config.configurable?.user_id as string | undefined,
-                agentId: this.agentId,
-                configurable: config.configurable as
+            const batchRequest: t.ToolExecuteBatchRequest = {
+              toolCalls: dispatchRequests,
+              userId: config.configurable?.user_id as string | undefined,
+              agentId: this.agentId,
+              configurable: config.configurable as
                   | Record<string, unknown>
                   | undefined,
-                metadata: config.metadata as
+              metadata: config.metadata as
                   | Record<string, unknown>
                   | undefined,
-                resolve: (results): void => {
-                  resultSettled = true;
-                  settledResults = results;
-                  maybeResolve();
-                },
-                reject,
-              };
+              resolve: (results): void => {
+                resultSettled = true;
+                settledResults = results;
+                maybeResolve();
+              },
+              reject,
+            };
 
-              void safeDispatchCustomEvent(
-                GraphEvents.ON_TOOL_EXECUTE,
-                batchRequest,
-                config
-              )
-                .then(() => {
-                  dispatchSettled = true;
-                  maybeResolve();
-                })
-                .catch(reject);
-            });
+            void safeDispatchCustomEvent(
+              GraphEvents.ON_TOOL_EXECUTE,
+              batchRequest,
+              config
+            )
+              .then(() => {
+                dispatchSettled = true;
+                maybeResolve();
+              })
+              .catch(reject);
+          });
 
       const eagerResultsPromise = Promise.all(
-        eagerExecutions.map(({ request, execution }) =>
-          this.resolveEagerEventExecution(request, execution)
-        )
-      ).then((results) => results.flat());
+        eagerExecutions.map(async ({ request, execution }) => {
+          const results = await this.resolveEagerEventExecution(
+            request,
+            execution
+          );
+          return {
+            results,
+            completionDispatched: execution.completionDispatched === true,
+            toolCallId: request.id,
+          };
+        })
+      );
 
       const [eagerResults, dispatchedResults] = await Promise.all([
         eagerResultsPromise,
         dispatchPromise,
       ]);
+      const eagerCompletionDispatchedIds = new Set(
+        eagerResults
+          .filter((result) => result.completionDispatched)
+          .map((result) => result.toolCallId)
+      );
+      const flattenedEagerResults = eagerResults.flatMap(
+        (result) => result.results
+      );
       const results = [
         ...plan.rejectedResults,
-        ...eagerResults,
+        ...flattenedEagerResults,
         ...dispatchedResults,
       ];
 
@@ -2537,11 +2553,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           const errorRefMeta =
             unresolved.length > 0
               ? this.recordOutputReference(
-                  registryRunId,
-                  contentString,
-                  undefined,
-                  unresolved
-                )
+                registryRunId,
+                contentString,
+                undefined,
+                unresolved
+              )
               : undefined;
           toolMessage = new ToolMessage({
             status: 'error',
@@ -2660,14 +2676,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           });
         }
 
-        await this.dispatchStepCompleted(
-          result.toolCallId,
-          toolName,
-          request?.args ?? {},
-          contentString,
-          config,
-          request?.turn
-        );
+        if (!eagerCompletionDispatchedIds.has(result.toolCallId)) {
+          await this.dispatchStepCompleted(
+            result.toolCallId,
+            toolName,
+            request?.args ?? {},
+            contentString,
+            config,
+            request?.turn
+          );
+        }
 
         postToolBatchEntryByCallId.set(result.toolCallId, {
           toolName,
@@ -3015,15 +3033,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       outputs =
         directAdditionalContexts.length > 0
           ? [
-              sendOutput,
-              new HumanMessage({
-                content: directAdditionalContexts.join('\n\n'),
-                // Match the event-driven path's marker so hosts /
-                // model-side annotators treat this as system intent
-                // rather than ordinary user text. Codex P2 [46].
-                additional_kwargs: { role: 'system', source: 'hook' },
-              }),
-            ]
+            sendOutput,
+            new HumanMessage({
+              content: directAdditionalContexts.join('\n\n'),
+              // Match the event-driven path's marker so hosts /
+              // model-side annotators treat this as system intent
+              // rather than ordinary user text. Codex P2 [46].
+              additional_kwargs: { role: 'system', source: 'hook' },
+            }),
+          ]
           : [sendOutput];
       await this.handleRunToolCompletions(
         [input.lg_tool_call],
@@ -3174,17 +3192,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const directOutputs: (BaseMessage | Command)[] =
           directCalls.length > 0
             ? await Promise.all(
-                directCalls.map((call, i) =>
-                  this.runDirectToolWithLifecycleHooks(call, config, {
-                    batchIndex: directIndices[i],
-                    turn,
-                    batchScopeId,
-                    resolvedArgsByCallId,
-                    preBatchSnapshot,
-                    additionalContextsSink: directAdditionalContexts,
-                  })
-                )
+              directCalls.map((call, i) =>
+                this.runDirectToolWithLifecycleHooks(call, config, {
+                  batchIndex: directIndices[i],
+                  turn,
+                  batchScopeId,
+                  resolvedArgsByCallId,
+                  preBatchSnapshot,
+                  additionalContextsSink: directAdditionalContexts,
+                })
               )
+            )
             : [];
 
         if (directCalls.length > 0 && directOutputs.length > 0) {
@@ -3199,29 +3217,29 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const eventResult =
           eventCalls.length > 0
             ? await this.dispatchToolEvents(eventCalls, config, {
-                batchIndices: eventIndices,
-                turn,
-                batchScopeId,
-                preResolvedArgs: preResolvedEventArgs,
-                preBatchSnapshot,
-              })
+              batchIndices: eventIndices,
+              turn,
+              batchScopeId,
+              preResolvedArgs: preResolvedEventArgs,
+              preBatchSnapshot,
+            })
             : {
-                toolMessages: [] as ToolMessage[],
-                injected: [] as BaseMessage[],
-              };
+              toolMessages: [] as ToolMessage[],
+              injected: [] as BaseMessage[],
+            };
 
         const directInjected: BaseMessage[] =
           directAdditionalContexts.length > 0
             ? [
-                new HumanMessage({
-                  content: directAdditionalContexts.join('\n\n'),
-                  // System-role metadata to match the event-driven
-                  // path so policy/recovery guidance is treated
-                  // consistently regardless of whether the tool ran
-                  // direct or dispatched. Codex P2 [46].
-                  additional_kwargs: { role: 'system', source: 'hook' },
-                }),
-              ]
+              new HumanMessage({
+                content: directAdditionalContexts.join('\n\n'),
+                // System-role metadata to match the event-driven
+                // path so policy/recovery guidance is treated
+                // consistently regardless of whether the tool ran
+                // direct or dispatched. Codex P2 [46].
+                additional_kwargs: { role: 'system', source: 'hook' },
+              }),
+            ]
             : [];
         outputs = [
           ...directOutputs,
@@ -3260,15 +3278,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         outputs =
           directAdditionalContexts.length > 0
             ? [
-                ...toolOutputs,
-                new HumanMessage({
-                  content: directAdditionalContexts.join('\n\n'),
-                  // Same system-role marker the event-driven path
-                  // uses so direct vs dispatched is invisible to
-                  // downstream consumers. Codex P2 [46].
-                  additional_kwargs: { role: 'system', source: 'hook' },
-                }),
-              ]
+              ...toolOutputs,
+              new HumanMessage({
+                content: directAdditionalContexts.join('\n\n'),
+                // Same system-role marker the event-driven path
+                // uses so direct vs dispatched is invisible to
+                // downstream consumers. Codex P2 [46].
+                additional_kwargs: { role: 'system', source: 'hook' },
+              }),
+            ]
             : toolOutputs;
       }
     }

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -117,6 +117,65 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages[0].content).toBe('eager result');
   });
 
+  it('does not redispatch completion when eager path already emitted it', async () => {
+    const completedEvents: Array<{ result: t.ToolEndEvent }> = [];
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completedEvents.push(data as { result: t.ToolEndEvent });
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        toolExecuteCalls.push(data as t.ToolExecuteBatchRequest);
+      });
+
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      completionDispatched: true,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: new Map([['weather', 1]]),
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(completedEvents).toHaveLength(0);
+    expect(result.messages[0].content).toBe('eager result');
+  });
+
   it('fails closed without redispatching when final args differ from the prestarted call', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('fresh result');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -49,6 +49,13 @@ export type EagerEventToolExecution = {
   args: Record<string, unknown>;
   request: ToolCallRequest;
   promise: Promise<EagerEventToolExecutionOutcome>;
+  /**
+   * True when the streaming eager path already emitted the user-visible
+   * ON_RUN_STEP_COMPLETED event for this call. ToolNode still consumes the
+   * result later to mutate graph state in provider-safe order, but skips
+   * duplicate completion emission.
+   */
+  completionDispatched?: boolean;
 };
 
 export type EagerEventToolCallChunkState = {
@@ -172,6 +179,8 @@ export type ToolEndEvent = {
   /** The content index of the tool call */
   index: number;
   type?: 'tool_call';
+  /** True when the stream eager path surfaced this completion before ToolNode finalized graph state. */
+  eager?: boolean;
 };
 
 /**

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -13,9 +13,10 @@ export async function safeDispatchCustomEvent(
   event: string,
   payload: unknown,
   config?: RunnableConfig
-): Promise<void> {
+): Promise<boolean | void> {
   try {
     await dispatchCustomEvent(event, payload, config);
+    return true;
   } catch (e) {
     // Check if this is the known EventStreamCallbackHandler error
     if (
@@ -26,10 +27,11 @@ export async function safeDispatchCustomEvent(
       // Suppress this specific error - it's expected during parallel execution
       // when EventStreamCallbackHandler loses track of run IDs
       // console.debug('Suppressed error dispatching custom event:', e);
-      return;
+      return false;
     }
     // Log other errors
     console.error('Error dispatching custom event:', e);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
- emits ON_RUN_STEP_COMPLETED as soon as an eager event-driven tool result settles
- marks those completions with eager=true so hosts can observe the eager path directly
- keeps ToolNode graph-state finalization unchanged and skips duplicate completion events
- prevents late streamed tool-call deltas from overwriting completed tool output in aggregation

## Validation
- npx eslint src/stream.ts src/types/tools.ts src/__tests__/stream.eagerEventExecution.test.ts src/tools/ToolNode.ts src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
- NODE_OPTIONS="--experimental-vm-modules" npx jest src/__tests__/stream.eagerEventExecution.test.ts src/tools/__tests__/ToolNode.eagerEventExecution.test.ts --runInBand
- npx tsc --noEmit --pretty false
- npm run build
- Live probes: Anthropic claude-opus-4-7, Anthropic claude-sonnet-4-5, OpenRouter Anthropic, OpenRouter Gemini