### PR TITLE
fix: allow eager code tools with output refs

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -163,6 +163,59 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
   });
 
+  it('prestarts when subagent callback forwarding can execute tools without a handler registry', async () => {
+    const graph = createGraph({
+      handlerRegistry: undefined,
+      eventToolExecutionAvailable: true,
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+    expect(graph.eagerEventToolExecutions.has('call_weather')).toBe(true);
+  });
+
   it('does not prestart parseable tool calls before a final tool-call signal', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -71,7 +71,8 @@ function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
         (details as t.StepDetails).type === StepTypes.TOOL_CALLS &&
         Array.isArray((details as t.ToolCallsDetails).tool_calls)
       ) {
-        for (const toolCall of (details as t.ToolCallsDetails).tool_calls ?? []) {
+        for (const toolCall of (details as t.ToolCallsDetails).tool_calls ??
+          []) {
           if (toolCall.id != null && toolCall.id !== '') {
             graph.toolCallStepIds.set(toolCall.id, id);
           }
@@ -110,8 +111,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('prestarts a complete event-driven tool call from the stream', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -124,8 +126,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     await new ChatModelStreamHandler().handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -165,8 +166,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('does not prestart parseable tool calls before a final tool-call signal', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -179,8 +181,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -248,8 +249,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ) as unknown as StandardGraph['getAgentContext'],
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -262,8 +264,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `${request.name} result`,
           }))
         );
-      }
-    );
+      });
 
     await new ChatModelStreamHandler().handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -308,7 +309,8 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       }),
     ]);
     const weatherExecution = graph.eagerEventToolExecutions.get('call_weather');
-    const calendarExecution = graph.eagerEventToolExecutions.get('call_calendar');
+    const calendarExecution =
+      graph.eagerEventToolExecutions.get('call_calendar');
     expect(weatherExecution).toMatchObject({
       toolCallId: 'call_weather',
       toolName: 'weather',
@@ -325,8 +327,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('assigns same-tool eager turns in model emission order', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -339,8 +342,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `${request.args.city} weather`,
           }))
         );
-      }
-    );
+      });
 
     await new ChatModelStreamHandler().handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -371,10 +373,12 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       0, 1,
     ]);
     expect(graph.eagerEventToolUsageCount.get('weather')).toBe(2);
-    expect(graph.eagerEventToolExecutions.get('call_weather_1')?.request.turn)
-      .toBe(0);
-    expect(graph.eagerEventToolExecutions.get('call_weather_2')?.request.turn)
-      .toBe(1);
+    expect(
+      graph.eagerEventToolExecutions.get('call_weather_1')?.request.turn
+    ).toBe(0);
+    expect(
+      graph.eagerEventToolExecutions.get('call_weather_2')?.request.turn
+    ).toBe(1);
   });
 
   it('scopes eager turn reservation by agent', async () => {
@@ -391,19 +395,21 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     const graph = createGraph({
       getEagerEventToolUsageCount: jest.fn(getUsageCount),
       getAgentContext: jest.fn(
-        (metadata?: Record<string, unknown>): AgentContext => ({
-          provider: Providers.ANTHROPIC,
-          reasoningKey: 'reasoning',
-          toolDefinitions: [{ name: 'weather' }],
-          graphTools: [],
-          agentId:
-            metadata?.langgraph_node === 'agent_2' ? 'agent_2' : 'agent_1',
-        }) as unknown as AgentContext
+        (metadata?: Record<string, unknown>): AgentContext =>
+          ({
+            provider: Providers.ANTHROPIC,
+            reasoningKey: 'reasoning',
+            toolDefinitions: [{ name: 'weather' }],
+            graphTools: [],
+            agentId:
+              metadata?.langgraph_node === 'agent_2' ? 'agent_2' : 'agent_1',
+          }) as unknown as AgentContext
       ),
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -416,8 +422,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'ok',
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     await handler.handle(
@@ -463,25 +468,27 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     ]);
     expect(usageByAgent.get('agent_1')?.get('weather')).toBe(1);
     expect(usageByAgent.get('agent_2')?.get('weather')).toBe(1);
-    expect(graph.eagerEventToolExecutions.get('call_agent_1_weather')?.request.turn)
-      .toBe(0);
-    expect(graph.eagerEventToolExecutions.get('call_agent_2_weather')?.request.turn)
-      .toBe(0);
+    expect(
+      graph.eagerEventToolExecutions.get('call_agent_1_weather')?.request.turn
+    ).toBe(0);
+    expect(
+      graph.eagerEventToolExecutions.get('call_agent_2_weather')?.request.turn
+    ).toBe(0);
   });
 
   it('skips eager for the whole batch if any call is not request-plannable', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
         const batch = data as t.ToolExecuteBatchRequest;
         toolExecuteCalls.push(batch);
         batch.resolve([]);
-      }
-    );
+      });
 
     await new ChatModelStreamHandler().handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -515,8 +522,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('records complete chunk-only tool calls after creating a tool step', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -529,8 +537,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     await new ChatModelStreamHandler().handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -554,8 +561,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(toolExecuteCalls).toHaveLength(0);
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('{"city":"NYC"}');
   });
 
@@ -572,8 +578,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ) as unknown as StandardGraph['getAgentContext'],
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -586,8 +593,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -666,9 +672,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       stepId: expect.stringMatching(/^step_/),
       turn: 0,
     });
-    expect(graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 0))).toBe(
-      false
-    );
+    expect(
+      graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 0))
+    ).toBe(false);
   });
 
   it('keeps OpenAI Chat Completions streamed chunks on the final tool_calls path', async () => {
@@ -684,8 +690,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ) as unknown as StandardGraph['getAgentContext'],
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -698,8 +705,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `ok ${call.name}`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -786,8 +792,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('prestarts final tool calls even when the final chunk also has tool-call chunks', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -800,8 +807,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     await new ChatModelStreamHandler().handle(
       GraphEvents.CHAT_MODEL_STREAM,
@@ -843,8 +849,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('waits for final tool calls before prestarting streamed chunk calls', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -857,8 +864,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
 
@@ -1033,8 +1039,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('preserves repeated adjacent argument deltas', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -1047,8 +1054,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'ok',
           },
         ]);
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -1127,8 +1133,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
 
     expect(toolExecuteCalls).toHaveLength(0);
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('{"word":"book"}');
 
     await handler.handle(
@@ -1202,8 +1207,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     );
 
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('oo');
   });
 
@@ -1249,16 +1253,16 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     );
 
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('{"titl');
   });
 
   it('does not prestart from cumulative streamed args before final tool calls', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -1271,8 +1275,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -1353,8 +1356,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
 
     expect(toolExecuteCalls).toHaveLength(0);
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('{"city":"NYC","unit":"C"}');
 
     await handler.handle(
@@ -1445,8 +1447,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     );
 
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('{"title":"alpha","city":"NYC"}');
   });
 
@@ -1504,8 +1505,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     );
 
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('{"word":"book"}');
   });
 
@@ -1590,8 +1590,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     );
 
     expect(
-      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))
-        ?.argsText
+      graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 0))?.argsText
     ).toBe('{"city":"NYC"}');
   });
 
@@ -1599,8 +1598,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     const graphA = createGraph();
     const graphB = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -1613,8 +1613,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `${request.id} result`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const sharedChunk = {
@@ -1660,8 +1659,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ) as unknown as StandardGraph['getAgentContext'],
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -1674,8 +1674,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `ok ${call.name}`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -1732,9 +1731,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     ]);
     expect(graph.eagerEventToolExecutions.has('call_weather')).toBe(true);
     expect(graph.eagerEventToolExecutions.has('call_stock')).toBe(false);
-    expect(graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 0))).toBe(
-      false
-    );
+    expect(
+      graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 0))
+    ).toBe(false);
     expect(
       graph.eagerEventToolCallChunks.get(chunkStateKey('step-key', 1))?.argsText
     ).toBe('{"ticker":"C');
@@ -1806,8 +1805,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ) as unknown as StandardGraph['getAgentContext'],
     });
     const completedEvents: Array<{ result: t.ToolEndEvent }> = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
           completedEvents.push(data as { result: t.ToolEndEvent });
           return;
@@ -1823,8 +1823,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `ok ${call.name}`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -1901,8 +1900,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     });
     const completedEvents: Array<{ result: t.ToolEndEvent }> = [];
     let pendingBatch: t.ToolExecuteBatchRequest | undefined;
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
           completedEvents.push(data as { result: t.ToolEndEvent });
           return;
@@ -1910,8 +1910,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
         if (event === GraphEvents.ON_TOOL_EXECUTE) {
           pendingBatch = data as t.ToolExecuteBatchRequest;
         }
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -1983,8 +1982,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
         })
       ) as unknown as StandardGraph['getAgentContext'],
     });
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<boolean | void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<boolean | void> => {
         if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
           return false;
         }
@@ -1998,8 +1998,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             },
           ]);
         }
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -2128,8 +2127,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ) as unknown as StandardGraph['getAgentContext'],
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -2142,8 +2142,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `ok ${call.name}`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -2241,8 +2240,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ) as unknown as StandardGraph['getAgentContext'],
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -2255,8 +2255,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `ok ${call.name}`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -2333,8 +2332,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   it('preserves same-tool turns across per-call streamed eager starts', async () => {
     const graph = createGraph();
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -2347,8 +2347,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `ok ${call.args.city}`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
     const metadata = { langgraph_node: 'agent' };
@@ -2457,8 +2456,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       ),
     });
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -2471,8 +2471,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: `ok ${call.name}`,
           }))
         );
-      }
-    );
+      });
 
     const handler = new ChatModelStreamHandler();
 
@@ -2577,9 +2576,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
-    expect(graph.eagerEventToolCallChunks.has(chunkStateKey('agent_b', 0))).toBe(
-      false
-    );
+    expect(
+      graph.eagerEventToolCallChunks.has(chunkStateKey('agent_b', 0))
+    ).toBe(false);
     expect(
       graph.eagerEventToolCallChunks.get(chunkStateKey('agent_a', 0))?.argsText
     ).toBe('{"city":"NYC"}');
@@ -2618,7 +2617,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
   });
 
   it('does not prestart when batch-sensitive hooks are configured', async () => {
-    const graph = createGraph({ hookRegistry: {} as StandardGraph['hookRegistry'] });
+    const graph = createGraph({
+      hookRegistry: {} as StandardGraph['hookRegistry'],
+    });
     const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
 
     await new ChatModelStreamHandler().handle(
@@ -2734,7 +2735,10 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
         (): Partial<AgentContext> => ({
           provider: Providers.OPENAI,
           reasoningKey: 'reasoning_content',
-          toolDefinitions: [{ name: Constants.EXECUTE_CODE }, { name: 'weather' }],
+          toolDefinitions: [
+            { name: Constants.EXECUTE_CODE },
+            { name: 'weather' },
+          ],
           graphTools: [],
           agentId: 'agent_1',
         })
@@ -2788,6 +2792,484 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     );
     expect(graph.eagerEventToolExecutions.size).toBe(0);
     expect(graph.eagerEventToolCallChunks.size).toBe(0);
+  });
+
+  it('prestarts streamed remote bash tools when the next Anthropic tool call begins', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [
+            { name: Constants.BASH_TOOL },
+            { name: Constants.READ_FILE },
+          ],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_env',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo env"}',
+              index: 2,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_net',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo net"}',
+              index: 3,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'toolu_env',
+        name: Constants.BASH_TOOL,
+        args: { command: 'echo env' },
+        stepId: expect.stringMatching(/^step_/),
+        turn: 0,
+      }),
+    ]);
+    expect(graph.eagerEventToolExecutions.has('toolu_env')).toBe(true);
+    expect(graph.eagerEventToolExecutions.has('toolu_net')).toBe(false);
+  });
+
+  it('prestarts streamed remote bash tools when unrelated graph tools are present', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [
+            { name: Constants.BASH_TOOL },
+            { name: Constants.READ_FILE },
+          ],
+          graphTools: [
+            { name: 'transfer_to_researcher' } as unknown as t.GenericTool,
+          ],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_env',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo env"}',
+              index: 2,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_net',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo net"}',
+              index: 3,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'toolu_env',
+        name: Constants.BASH_TOOL,
+        args: { command: 'echo env' },
+      }),
+    ]);
+  });
+
+  it('prestarts streamed remote bash tools when code output references are enabled', async () => {
+    const graph = createGraph({
+      toolOutputReferences: { enabled: true },
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [
+            { name: Constants.BASH_TOOL },
+            { name: Constants.READ_FILE },
+          ],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    for (const args of ['{"command":"echo ', 'env && ', 'pwd"}']) {
+      await handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        {
+          chunk: {
+            content: '',
+            tool_call_chunks: [
+              {
+                id: 'toolu_env',
+                name: Constants.BASH_TOOL,
+                args,
+                index: 2,
+              },
+            ],
+          } as unknown as t.StreamChunk,
+        },
+        metadata,
+        graph
+      );
+    }
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_net',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo net"}',
+              index: 3,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'toolu_env',
+        name: Constants.BASH_TOOL,
+        args: { command: 'echo env && pwd' },
+      }),
+    ]);
+  });
+
+  it('does not prestart streamed code tools whose args contain output references', async () => {
+    const graph = createGraph({
+      toolOutputReferences: { enabled: true },
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [
+            { name: Constants.BASH_TOOL },
+            { name: Constants.READ_FILE },
+          ],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_ref',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"cat <<EOF\\n{{tool0turn0}}\\nEOF"}',
+              index: 2,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_next',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo next"}',
+              index: 3,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('does not prestart streamed tools when the next Anthropic tool call is a graph tool', async () => {
+    const handoffToolName = `${Constants.LC_TRANSFER_TO_}researcher`;
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [
+            { name: Constants.BASH_TOOL },
+            { name: handoffToolName },
+          ],
+          graphTools: [{ name: handoffToolName } as unknown as t.GenericTool],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_env',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo env"}',
+              index: 2,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_handoff',
+              name: handoffToolName,
+              args: '{"message":"check this"}',
+              index: 3,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('does not prestart streamed tools after a graph tool appeared earlier in the same step', async () => {
+    const handoffToolName = `${Constants.LC_TRANSFER_TO_}researcher`;
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [
+            { name: Constants.BASH_TOOL },
+            { name: handoffToolName },
+          ],
+          graphTools: [{ name: handoffToolName } as unknown as t.GenericTool],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_env',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo env"}',
+              index: 2,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_handoff',
+              name: handoffToolName,
+              args: '{"message":"partial',
+              index: 3,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_next',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo next"}',
+              index: 4,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
   });
 
   it('does not prestart event tools in a mixed direct-tool batch', async () => {
@@ -2846,8 +3328,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     const graph = createGraph();
     graph.eagerEventToolUsageCount.set('weather', 1);
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(
-      async (event, data): Promise<void> => {
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
         if (event !== GraphEvents.ON_TOOL_EXECUTE) {
           return;
         }
@@ -2860,8 +3343,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
             content: 'sunny',
           },
         ]);
-      }
-    );
+      });
 
     await new ChatModelStreamHandler().handle(
       GraphEvents.CHAT_MODEL_STREAM,

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -2937,7 +2937,7 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolExecutions.has('toolu_net')).toBe(false);
   });
 
-  it('prestarts streamed remote bash tools when unrelated graph tools are present', async () => {
+  it('does not prestart streamed remote tools when graph tools may appear later', async () => {
     const graph = createGraph({
       getAgentContext: jest.fn(
         (): Partial<AgentContext> => ({
@@ -3013,14 +3013,9 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       graph
     );
 
-    expect(toolExecuteCalls).toHaveLength(1);
-    expect(toolExecuteCalls[0].toolCalls).toEqual([
-      expect.objectContaining({
-        id: 'toolu_env',
-        name: Constants.BASH_TOOL,
-        args: { command: 'echo env' },
-      }),
-    ]);
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 
   it('prestarts streamed remote bash tools when code output references are enabled', async () => {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -145,6 +145,14 @@ export abstract class Graph<
   /** Set of invoked tool call IDs from non-message run steps completed mid-run, if any */
   invokedToolIds?: Set<string>;
   handlerRegistry: HandlerRegistry | undefined;
+  /**
+   * True when event-driven tool execution can be routed through callbacks even
+   * though this graph intentionally does not own the full handler registry.
+   * Self-spawned subagent graphs use this shape: their callback forwarder sends
+   * `ON_TOOL_EXECUTE` to the parent's handler, while child run-step events stay
+   * wrapped as `ON_SUBAGENT_UPDATE` instead of leaking as parent events.
+   */
+  eventToolExecutionAvailable: boolean = false;
   hookRegistry: HookRegistry | undefined;
   /**
    * Run-scoped HITL configuration. When `humanInTheLoop?.enabled` is
@@ -167,10 +175,8 @@ export abstract class Graph<
   eagerEventToolExecution: t.EagerEventToolExecutionConfig | undefined;
   eagerEventToolExecutions: Map<string, t.EagerEventToolExecution> = new Map();
   eagerEventToolUsageCount: Map<string, number> = new Map();
-  private eagerEventToolUsageCountsByAgentId: Map<
-    string,
-    Map<string, number>
-  > = new Map();
+  private eagerEventToolUsageCountsByAgentId: Map<string, Map<string, number>> =
+    new Map();
   eagerEventToolCallChunks: Map<string, t.EagerEventToolCallChunkState> =
     new Map();
   /**
@@ -1554,7 +1560,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           parentAgentId: agentContext.agentId,
           tokenCounter: agentContext.tokenCounter,
           maxDepth: effectiveSubagentDepth,
-          createChildGraph: (input): StandardGraph => new StandardGraph(input),
+          createChildGraph: (input): StandardGraph => {
+            const childGraph = new StandardGraph(input);
+            childGraph.toolOutputReferences = this.toolOutputReferences;
+            childGraph.eagerEventToolExecution = this.eagerEventToolExecution;
+            childGraph.toolExecution = this.toolExecution;
+            childGraph.eventToolExecutionAvailable =
+              this.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) !=
+              null;
+            return childGraph;
+          },
         });
 
         const subagentTool = tool(async (rawInput, config) => {

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -1,4 +1,4 @@
-import { HumanMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { RunnableConfig } from '@langchain/core/runnables';
@@ -218,6 +218,92 @@ describe('Subagent Integration', () => {
       (t) => 'name' in t && t.name === Constants.SUBAGENT
     );
     expect(subagentTool).toBeDefined();
+  });
+
+  it('inherits eager event-tool settings into self-spawn child graphs', async () => {
+    const originalCreateWorkflow = StandardGraph.prototype.createWorkflow;
+    const observedChildGraphs: Array<{
+      eagerEventToolExecution: StandardGraph['eagerEventToolExecution'];
+      toolOutputReferences: StandardGraph['toolOutputReferences'];
+      eventToolExecutionAvailable: boolean;
+    }> = [];
+    const createWorkflowSpy = jest
+      .spyOn(StandardGraph.prototype, 'createWorkflow')
+      .mockImplementation(function (this: StandardGraph) {
+        if (this.runId?.includes('_sub_') === true) {
+          observedChildGraphs.push({
+            eagerEventToolExecution: this.eagerEventToolExecution,
+            toolOutputReferences: this.toolOutputReferences,
+            eventToolExecutionAvailable: this.eventToolExecutionAvailable,
+          });
+          return {
+            invoke: jest.fn(async () => ({
+              messages: [new AIMessage('child done')],
+            })),
+          } as unknown as ReturnType<StandardGraph['createWorkflow']>;
+        }
+        return originalCreateWorkflow.call(this);
+      });
+
+    const agentWithSelfSpawn: t.AgentInputs = {
+      agentId: 'self-parent',
+      provider: Providers.OPENAI,
+      clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+      instructions: 'Agent with self-spawn for context isolation.',
+      maxContextTokens: 8000,
+      toolDefinitions: [{ name: 'mcp_lookup' }],
+      subagentConfigs: [
+        {
+          type: 'isolated',
+          name: 'Isolated Worker',
+          description: 'Runs a task with isolated context',
+          self: true,
+        },
+      ],
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `self-spawn-eager-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [agentWithSelfSpawn],
+      },
+      customHandlers: {
+        [GraphEvents.ON_TOOL_EXECUTE]: {
+          handle: async () => undefined,
+        },
+      },
+      eagerEventToolExecution: { enabled: true },
+      toolOutputReferences: { enabled: true },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    const context = (run.Graph as StandardGraph).agentContexts.get(
+      'self-parent'
+    );
+    const subagentTool = (context?.graphTools as t.GenericTool[]).find(
+      (tool) => 'name' in tool && tool.name === Constants.SUBAGENT
+    );
+    expect(subagentTool).toBeDefined();
+
+    await subagentTool!.invoke(
+      {
+        description: 'Use your MCP tool.',
+        subagent_type: 'isolated',
+      },
+      callerConfig
+    );
+
+    expect(observedChildGraphs).toEqual([
+      {
+        eagerEventToolExecution: { enabled: true },
+        toolOutputReferences: { enabled: true },
+        eventToolExecutionAvailable: true,
+      },
+    ]);
+
+    createWorkflowSpy.mockRestore();
   });
 
   it('should not create subagent tool when maxSubagentDepth is 0', async () => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -265,11 +265,15 @@ function hasDirectToolCallInBatch(args: {
   );
 }
 
-function hasPotentialLocalDirectToolInStreamContext(args: {
+function hasPotentialDirectToolInStreamContext(args: {
   graph: StandardGraph;
+  agentContext?: AgentContext;
 }): boolean {
-  const { graph } = args;
+  const { graph, agentContext } = args;
   if (graph.toolExecution?.engine === 'local') {
+    return true;
+  }
+  if ((agentContext?.graphTools?.length ?? 0) > 0) {
     return true;
   }
   return false;
@@ -840,7 +844,7 @@ function startReadyStreamedEagerToolExecutions(args: {
     sealAll,
   } = args;
   if (
-    hasPotentialLocalDirectToolInStreamContext({ graph }) ||
+    hasPotentialDirectToolInStreamContext({ graph, agentContext }) ||
     hasDirectToolCallChunkInBatch({ graph, agentContext, toolCallChunks }) ||
     hasDirectToolCallChunkStateInStep({ graph, agentContext, stepKey }) ||
     !isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext })
@@ -1022,7 +1026,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
         canPrestartSequentialStreamedToolChunks(agentContext);
       const canStreamEager =
         (allowSequentialSeal || hasExplicitStreamedToolCallSeals(chunk)) &&
-        !hasPotentialLocalDirectToolInStreamContext({ graph }) &&
+        !hasPotentialDirectToolInStreamContext({ graph, agentContext }) &&
         isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext });
       if (canStreamEager) {
         recordEagerToolCallChunks({

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -210,7 +210,10 @@ function isEagerToolExecutionEnabledForBatch(args: {
   ) {
     return false;
   }
-  if (graph.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) == null) {
+  if (
+    graph.handlerRegistry?.getHandler(GraphEvents.ON_TOOL_EXECUTE) == null &&
+    graph.eventToolExecutionAvailable !== true
+  ) {
     return false;
   }
   return true;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -36,6 +36,7 @@ import {
   getStreamedToolCallAdapter,
   type StreamedToolCallSeal,
 } from '@/tools/streamedToolCallSeals';
+import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
 
 const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
@@ -102,11 +103,22 @@ function getNonEmptyValue(possibleValues: string[]): string | undefined {
 }
 
 function isBatchSensitiveToolExecution(graph: StandardGraph): boolean {
-  return (
-    graph.hookRegistry != null ||
-    graph.humanInTheLoop?.enabled === true ||
-    graph.toolOutputReferences?.enabled === true
-  );
+  return graph.hookRegistry != null || graph.humanInTheLoop?.enabled === true;
+}
+
+function hasToolOutputReference(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return TOOL_OUTPUT_REF_PATTERN.test(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some((item) => hasToolOutputReference(item));
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some((item) =>
+      hasToolOutputReference(item)
+    );
+  }
+  return false;
 }
 
 function isDirectGraphTool(
@@ -250,22 +262,54 @@ function hasDirectToolCallInBatch(args: {
   );
 }
 
-function hasPotentialDirectToolInStreamContext(args: {
+function hasPotentialLocalDirectToolInStreamContext(args: {
   graph: StandardGraph;
-  agentContext?: AgentContext;
 }): boolean {
-  const { graph, agentContext } = args;
+  const { graph } = args;
   if (graph.toolExecution?.engine === 'local') {
     return true;
   }
-  if ((agentContext?.graphTools?.length ?? 0) > 0) {
-    return true;
-  }
+  return false;
+}
+
+function hasDirectToolCallChunkInBatch(args: {
+  graph: StandardGraph;
+  agentContext?: AgentContext;
+  toolCallChunks?: ToolCallChunk[];
+}): boolean {
+  const { graph, agentContext, toolCallChunks } = args;
   return (
-    agentContext?.toolDefinitions?.some((toolDefinition) =>
-      toolDefinition.name.startsWith(Constants.LC_TRANSFER_TO_)
+    toolCallChunks?.some(
+      (toolCallChunk) =>
+        toolCallChunk.name != null &&
+        toolCallChunk.name !== '' &&
+        (isDirectGraphTool(toolCallChunk.name, agentContext) ||
+          isDirectLocalTool(toolCallChunk.name, graph))
     ) === true
   );
+}
+
+function hasDirectToolCallChunkStateInStep(args: {
+  graph: StandardGraph;
+  agentContext?: AgentContext;
+  stepKey: string;
+}): boolean {
+  const { graph, agentContext, stepKey } = args;
+  const prefix = `${stepKey}\u0000`;
+  for (const [key, state] of graph.eagerEventToolCallChunks) {
+    if (!key.startsWith(prefix)) {
+      continue;
+    }
+    const name = state.name;
+    if (
+      name != null &&
+      name !== '' &&
+      (isDirectGraphTool(name, agentContext) || isDirectLocalTool(name, graph))
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 type EagerToolExecutionEntry = {
@@ -300,6 +344,12 @@ function createEagerToolExecutionPlan(args: {
   }
 
   if (hasDirectToolCallInBatch({ graph, agentContext, toolCalls })) {
+    return undefined;
+  }
+  if (
+    graph.toolOutputReferences?.enabled === true &&
+    toolCalls.some((toolCall) => hasToolOutputReference(toolCall.args))
+  ) {
     return undefined;
   }
 
@@ -787,7 +837,9 @@ function startReadyStreamedEagerToolExecutions(args: {
     sealAll,
   } = args;
   if (
-    hasPotentialDirectToolInStreamContext({ graph, agentContext }) ||
+    hasPotentialLocalDirectToolInStreamContext({ graph }) ||
+    hasDirectToolCallChunkInBatch({ graph, agentContext, toolCallChunks }) ||
+    hasDirectToolCallChunkStateInStep({ graph, agentContext, stepKey }) ||
     !isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext })
   ) {
     return;
@@ -967,7 +1019,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
         canPrestartSequentialStreamedToolChunks(agentContext);
       const canStreamEager =
         (allowSequentialSeal || hasExplicitStreamedToolCallSeals(chunk)) &&
-        !hasPotentialDirectToolInStreamContext({ graph, agentContext }) &&
+        !hasPotentialLocalDirectToolInStreamContext({ graph }) &&
         isEagerToolExecutionEnabledForBatch({ graph, metadata, agentContext });
       if (canStreamEager) {
         recordEagerToolCallChunks({

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2724,8 +2724,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       this.eventDrivenMode &&
       this.eagerEventToolExecution?.enabled === true &&
       this.hookRegistry == null &&
-      this.humanInTheLoop?.enabled !== true &&
-      this.toolOutputRegistry == null
+      this.humanInTheLoop?.enabled !== true
     );
   }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2480,7 +2480,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           );
           return {
             results,
-            completionDispatched: execution.completionDispatched === true,
+            completionDispatched:
+              execution.completionDispatched === true &&
+              execution.request.turn === request.turn,
             toolCallId: request.id,
           };
         })

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2742,10 +2742,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     this.eagerEventToolExecutions?.delete(request.id);
 
+    // Only tool identity + canonical args define side-effect identity here.
+    // `request.turn` is final-planning metadata; if it drifts between the
+    // streamed eager reservation and model-end materialization, consume the
+    // same-name/same-args eager result and let the final request drive refs,
+    // completion metadata, and PostToolBatch state.
     if (
       execution.toolName !== request.name ||
-      !recordArgsEqual(execution.args, request.args) ||
-      execution.request.turn !== request.turn
+      !recordArgsEqual(execution.args, request.args)
     ) {
       return {
         toolCallId: request.id,

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -117,6 +117,103 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages[0].content).toBe('eager result');
   });
 
+  it('uses a prestarted event result when final args are canonically equivalent', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC', units: 'metric' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC', units: 'metric' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [
+        createAIMessage('call_weather', 'weather', {
+          units: 'metric',
+          city: 'NYC',
+        }),
+      ],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toBe('eager result');
+  });
+
+  it('uses a prestarted event result when only final planning turn differs', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const eagerUsageCount = new Map<string, number>([['weather', 1]]);
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 7,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: eagerUsageCount,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    expect(eagerUsageCount.get('weather')).toBe(1);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].status).toBe('success');
+    expect(result.messages[0].content).toBe('eager result');
+  });
+
   it('uses a matching prestarted event result when output references are enabled', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
@@ -307,7 +404,7 @@ describe('ToolNode eager event tool execution', () => {
     const { toolExecuteCalls } = installToolExecuteResponder('normal result');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
     const eagerUsageCount = new Map<string, number>([['weather', 1]]);
-    const staleRequest: t.ToolCallRequest = {
+    const prestartedRequest: t.ToolCallRequest = {
       id: 'call_weather_2',
       name: 'weather',
       args: { city: 'Boston' },
@@ -318,13 +415,13 @@ describe('ToolNode eager event tool execution', () => {
       toolCallId: 'call_weather_2',
       toolName: 'weather',
       args: { city: 'Boston' },
-      request: staleRequest,
+      request: prestartedRequest,
       promise: Promise.resolve({
         results: [
           {
             toolCallId: 'call_weather_2',
             status: 'success',
-            content: 'stale eager result',
+            content: 'prestarted eager result',
           },
         ],
       }),
@@ -374,8 +471,8 @@ describe('ToolNode eager event tool execution', () => {
       'call_weather_2',
     ]);
     expect(result.messages[0].status).toBe('success');
-    expect(result.messages[1].status).toBe('error');
-    expect(result.messages[1].content).toContain('refusing to re-run');
+    expect(result.messages[1].status).toBe('success');
+    expect(result.messages[1].content).toBe('prestarted eager result');
   });
 
   it('returns a per-call error for malformed event tool args without aborting the batch', async () => {

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -117,6 +117,58 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages[0].content).toBe('eager result');
   });
 
+  it('uses a matching prestarted event result when output references are enabled', async () => {
+    const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const eagerUsageCount = new Map<string, number>([['weather', 1]]);
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 0,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: eagerUsageCount,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+      toolOutputReferences: { enabled: true },
+    });
+
+    const result = (await toolNode.invoke(
+      {
+        messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+      },
+      { configurable: { run_id: 'run_1' } }
+    )) as { messages: ToolMessage[] };
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(eagerExecutions.has('call_weather')).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toBe('eager result');
+    expect(result.messages[0].additional_kwargs._refKey).toBe('tool0turn0');
+    expect(result.messages[0].additional_kwargs._refScope).toBe('run_1');
+  });
+
   it('does not redispatch completion when eager path already emitted it', async () => {
     const completedEvents: Array<{ result: t.ToolEndEvent }> = [];
     const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
@@ -373,9 +425,7 @@ describe('ToolNode eager event tool execution', () => {
       'call_weather_good',
     ]);
     expect(result.messages[0].status).toBe('error');
-    expect(result.messages[0].content).toContain(
-      'Invalid tool call arguments'
-    );
+    expect(result.messages[0].content).toContain('Invalid tool call arguments');
     expect(result.messages[1].status).toBe('success');
     expect(result.messages[1].content).toBe('normal result');
   });
@@ -387,9 +437,7 @@ describe('ToolNode eager event tool execution', () => {
     const hookRegistry = new HookRegistry();
     hookRegistry.register('PreToolUse', {
       hooks: [
-        async (
-          input: PreToolUseHookInput
-        ): Promise<PreToolUseHookOutput> => {
+        async (input: PreToolUseHookInput): Promise<PreToolUseHookOutput> => {
           preToolTurns.push(input.turn);
           return { decision: 'allow' };
         },
@@ -410,9 +458,7 @@ describe('ToolNode eager event tool execution', () => {
     });
 
     await toolNode.invoke({
-      messages: [
-        createAIMessage('call_weather_1', 'weather', { city: 'NYC' }),
-      ],
+      messages: [createAIMessage('call_weather_1', 'weather', { city: 'NYC' })],
     });
 
     eagerUsageCount.clear();

--- a/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
+++ b/src/tools/__tests__/ToolNode.eagerEventExecution.test.ts
@@ -214,6 +214,68 @@ describe('ToolNode eager event tool execution', () => {
     expect(result.messages[0].content).toBe('eager result');
   });
 
+  it('redispatches completion when a prestarted event result used a stale turn', async () => {
+    const stepCompletions: Array<{
+      result?: { index?: number; tool_call?: { output?: string } };
+    }> = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<boolean | void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          stepCompletions.push(data as (typeof stepCompletions)[number]);
+          return true;
+        }
+        if (event === GraphEvents.ON_TOOL_EXECUTE) {
+          throw new Error('tool should not redispatch');
+        }
+      });
+
+    const eagerExecutions = new Map<string, t.EagerEventToolExecution>();
+    const eagerUsageCount = new Map<string, number>([['weather', 1]]);
+    const request: t.ToolCallRequest = {
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: 'step_weather',
+      turn: 7,
+    };
+    eagerExecutions.set('call_weather', {
+      toolCallId: 'call_weather',
+      toolName: 'weather',
+      args: { city: 'NYC' },
+      request,
+      completionDispatched: true,
+      promise: Promise.resolve({
+        results: [
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'eager result',
+          },
+        ],
+      }),
+    });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      eagerEventToolExecution: { enabled: true },
+      eagerEventToolExecutions: eagerExecutions,
+      eagerEventToolUsageCount: eagerUsageCount,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [createAIMessage('call_weather', 'weather', { city: 'NYC' })],
+    })) as { messages: ToolMessage[] };
+
+    expect(stepCompletions).toHaveLength(1);
+    expect(stepCompletions[0].result?.index).toBe(0);
+    expect(stepCompletions[0].result?.tool_call?.output).toBe('eager result');
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content).toBe('eager result');
+  });
+
   it('uses a matching prestarted event result when output references are enabled', async () => {
     const { toolExecuteCalls } = installToolExecuteResponder('redispatched');
     const eagerExecutions = new Map<string, t.EagerEventToolExecution>();


### PR DESCRIPTION
## Summary
- allow eager event execution when CodeAPI output references are enabled
- skip eager only for tool args that contain `{{tool...}}` placeholders
- keep direct graph/local tool batches on the safe non-eager path

## Tests
- `NODE_OPTIONS='--experimental-vm-modules' npx jest src/__tests__/stream.eagerEventExecution.test.ts src/tools/__tests__/ToolNode.eagerEventExecution.test.ts --runInBand`
- `npx eslint src/stream.ts src/__tests__/stream.eagerEventExecution.test.ts src/tools/ToolNode.ts src/tools/__tests__/ToolNode.eagerEventExecution.test.ts`
- `npx tsc --noEmit --pretty false`