### PR TITLE
feat: Anthropic eager input streaming for Code API tools

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -2937,6 +2937,88 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolExecutions.has('toolu_net')).toBe(false);
   });
 
+  it('prestarts a single streamed remote bash tool on Anthropic final stop_reason', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [{ name: Constants.BASH_TOOL }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'toolu_env',
+            status: 'success',
+            content: 'ok bash_tool',
+          },
+        ]);
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'toolu_env',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo env"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: [],
+          additional_kwargs: { stop_reason: 'tool_use' },
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls).toEqual([
+      expect.objectContaining({
+        id: 'toolu_env',
+        name: Constants.BASH_TOOL,
+        args: { command: 'echo env' },
+        stepId: expect.stringMatching(/^step_/),
+        turn: 0,
+      }),
+    ]);
+    expect(graph.eagerEventToolExecutions.has('toolu_env')).toBe(true);
+    expect(
+      graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 0))
+    ).toBe(false);
+  });
+
   it('does not prestart streamed remote tools when graph tools may appear later', async () => {
     const graph = createGraph({
       getAgentContext: jest.fn(

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -9,6 +9,7 @@ import type {
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { AnthropicInput } from '@langchain/anthropic';
 import type { Anthropic } from '@anthropic-ai/sdk';
+import { CODE_EXECUTION_TOOLS, Constants } from '@/common';
 import type {
   AnthropicMessageCreateParams,
   AnthropicStreamingMessageCreateParams,
@@ -27,8 +28,14 @@ const MAX_STREAM_QUEUE_CHUNKS = 256;
 const MAX_STREAM_QUEUE_TEXT_CHARS = 8192;
 const STREAM_CHUNK_MIN_SIZE = 4;
 const STREAM_BOUNDARIES = new Set([' ', '.', ',', '!', '?', ';', ':']);
+const ANTHROPIC_EAGER_CODEAPI_TOOL_NAMES = new Set<string>([
+  ...CODE_EXECUTION_TOOLS,
+  Constants.READ_FILE,
+]);
 
 type StreamTokenType = 'string' | 'input' | 'content';
+type FormattedAnthropicTool = Anthropic.Messages.ToolUnion &
+  Record<string, unknown>;
 
 const ANTHROPIC_TOOL_BETAS: Partial<Record<string, AnthropicBeta>> = {
   tool_search_tool_regex_20251119: 'advanced-tool-use-2025-11-20',
@@ -159,6 +166,45 @@ function isSetSamplingValue(value?: number | null): value is number {
 
 function isNonDefaultTemperature(value?: number): boolean {
   return isSetSamplingValue(value) && value !== 1;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Anthropic's fine-grained tool streaming is currently enabled per tool with
+ * `eager_input_streaming`. LangChain's generic `extras` schema does not pass
+ * that field through yet, so add it at the final Anthropic tool-shape boundary.
+ */
+function enableEagerInputStreamingForCodeApiTools(
+  tool: Anthropic.Messages.ToolUnion
+): Anthropic.Messages.ToolUnion {
+  if (!isRecord(tool)) {
+    return tool;
+  }
+
+  const name = tool.name;
+  if (
+    typeof name !== 'string' ||
+    !ANTHROPIC_EAGER_CODEAPI_TOOL_NAMES.has(name)
+  ) {
+    return tool;
+  }
+
+  const formattedTool = tool as FormattedAnthropicTool;
+  if (formattedTool.eager_input_streaming === false) {
+    return tool;
+  }
+
+  if (formattedTool.eager_input_streaming === true) {
+    return tool;
+  }
+
+  return {
+    ...formattedTool,
+    eager_input_streaming: true,
+  } as Anthropic.Messages.ToolUnion;
 }
 
 function validateInvocationParamCompatibility({
@@ -468,6 +514,13 @@ export class CustomAnthropic extends ChatAnthropicMessages {
     return 'LibreChatAnthropic';
   }
 
+  override formatStructuredToolToAnthropic(
+    tools?: ChatAnthropicToolType[]
+  ): Anthropic.Messages.ToolUnion[] | undefined {
+    const formatted = super.formatStructuredToolToAnthropic(tools);
+    return formatted?.map(enableEagerInputStreamingForCodeApiTools);
+  }
+
   /**
    * Get the parameters used to invoke the model
    */
@@ -759,12 +812,12 @@ export class CustomAnthropic extends ChatAnthropicMessages {
       return tokenChunks.reduce(async (previous, currentToken) => {
         await previous;
         const newChunk = cloneChunk(currentToken, tokenType, chunk);
-        const chunkForToken =
-          emittedUsage && newChunk.usage_metadata != null
-            ? new AIMessageChunk(
-              Object.assign({}, newChunk, { usage_metadata: undefined })
-            )
-            : newChunk;
+        let chunkForToken = newChunk;
+        if (emittedUsage && newChunk.usage_metadata != null) {
+          chunkForToken = new AIMessageChunk(
+            Object.assign({}, newChunk, { usage_metadata: undefined })
+          );
+        }
 
         await enqueueChunk({
           token: currentToken,

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -34,8 +34,6 @@ const ANTHROPIC_EAGER_CODEAPI_TOOL_NAMES = new Set<string>([
 ]);
 
 type StreamTokenType = 'string' | 'input' | 'content';
-type FormattedAnthropicTool = Anthropic.Messages.ToolUnion &
-  Record<string, unknown>;
 
 const ANTHROPIC_TOOL_BETAS: Partial<Record<string, AnthropicBeta>> = {
   tool_search_tool_regex_20251119: 'advanced-tool-use-2025-11-20',
@@ -168,8 +166,10 @@ function isNonDefaultTemperature(value?: number): boolean {
   return isSetSamplingValue(value) && value !== 1;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+function isAnthropicCustomTool(
+  tool: Anthropic.Messages.ToolUnion
+): tool is Anthropic.Messages.Tool {
+  return 'input_schema' in tool;
 }
 
 /**
@@ -180,31 +180,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function enableEagerInputStreamingForCodeApiTools(
   tool: Anthropic.Messages.ToolUnion
 ): Anthropic.Messages.ToolUnion {
-  if (!isRecord(tool)) {
-    return tool;
-  }
-
-  const name = tool.name;
   if (
-    typeof name !== 'string' ||
-    !ANTHROPIC_EAGER_CODEAPI_TOOL_NAMES.has(name)
+    !isAnthropicCustomTool(tool) ||
+    !ANTHROPIC_EAGER_CODEAPI_TOOL_NAMES.has(tool.name)
   ) {
     return tool;
   }
 
-  const formattedTool = tool as FormattedAnthropicTool;
-  if (formattedTool.eager_input_streaming === false) {
-    return tool;
-  }
-
-  if (formattedTool.eager_input_streaming === true) {
+  if (tool.eager_input_streaming != null) {
     return tool;
   }
 
   return {
-    ...formattedTool,
+    ...tool,
     eager_input_streaming: true,
-  } as Anthropic.Messages.ToolUnion;
+  };
 }
 
 function validateInvocationParamCompatibility({

--- a/src/llm/anthropic/llm.spec.ts
+++ b/src/llm/anthropic/llm.spec.ts
@@ -34,6 +34,7 @@ import { toLangChainContent } from '@/messages/langchain';
 import { formatAgentMessages } from '@/messages/format';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
 import { _documentsInParams, CustomAnthropic as ChatAnthropic } from './index';
+import { createSchemaOnlyTool } from '@/tools/schema';
 import { partitionAndMarkAnthropicToolCache } from '@/messages/anthropicToolCache';
 import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
 import { ModelEndHandler, ToolEndHandler } from '@/events';
@@ -723,6 +724,87 @@ test('Test ChatAnthropic headers passed through', async () => {
   const message = new HumanMessage('Hello!');
   const res = await chat.invoke([message]);
   // console.log({ res });
+});
+
+test.each([
+  Constants.EXECUTE_CODE,
+  Constants.BASH_TOOL,
+  Constants.PROGRAMMATIC_TOOL_CALLING,
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+  Constants.READ_FILE,
+])(
+  'Anthropic CodeAPI tool %s enables fine-grained tool input streaming',
+  (toolName) => {
+    const model = new ChatAnthropic({ modelName });
+    const codeApiTool = createSchemaOnlyTool({
+      name: toolName,
+      description: 'Run a CodeAPI-adjacent tool',
+      parameters: {
+        type: 'object',
+        properties: {
+          input: { type: 'string' },
+        },
+        required: ['input'],
+      },
+    });
+
+    const params = model.invocationParams({
+      tools: [codeApiTool],
+    } as never);
+
+    expect(params.tools?.[0]).toMatchObject({
+      name: toolName,
+      eager_input_streaming: true,
+    });
+  }
+);
+
+test('Anthropic fine-grained tool input streaming preserves explicit opt-out', () => {
+  const model = new ChatAnthropic({ modelName });
+
+  const params = model.invocationParams({
+    tools: [
+      {
+        name: Constants.BASH_TOOL,
+        description: 'Run bash',
+        eager_input_streaming: false,
+        input_schema: {
+          type: 'object',
+          properties: {
+            command: { type: 'string' },
+          },
+          required: ['command'],
+        },
+      },
+    ],
+  } as never);
+
+  expect(params.tools?.[0]).toMatchObject({
+    name: Constants.BASH_TOOL,
+    eager_input_streaming: false,
+  });
+});
+
+test('Anthropic fine-grained tool input streaming is scoped to CodeAPI tools', () => {
+  const model = new ChatAnthropic({ modelName });
+  const weatherTool = createSchemaOnlyTool({
+    name: 'get_weather',
+    description: 'Get weather',
+    parameters: {
+      type: 'object',
+      properties: {
+        location: { type: 'string' },
+      },
+      required: ['location'],
+    },
+  });
+
+  const params = model.invocationParams({
+    tools: [weatherTool],
+  } as never);
+
+  expect(params.tools?.[0]).toMatchObject({ name: 'get_weather' });
+  expect(params.tools?.[0]).not.toHaveProperty('eager_input_streaming');
 });
 
 describe('ChatAnthropic image inputs', () => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -42,6 +42,13 @@ const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
 );
 
+type ToolCallFinishSignalMetadata = {
+  finish_reason?: string | null;
+  finishReason?: string | null;
+  stop_reason?: string | null;
+  stopReason?: string | null;
+};
+
 /**
  * Parses content to extract thinking sections enclosed in <think> tags using string operations
  * @param content The content to parse
@@ -221,13 +228,20 @@ function isEagerToolExecutionEnabledForBatch(args: {
 
 function hasFinalToolCallSignal(chunk: Partial<AIMessageChunk>): boolean {
   const metadata = chunk.response_metadata as
-    | Record<string, unknown>
+    | ToolCallFinishSignalMetadata
+    | undefined;
+  const additionalKwargs = chunk.additional_kwargs as
+    | ToolCallFinishSignalMetadata
     | undefined;
   const finishReason =
     metadata?.finish_reason ??
     metadata?.finishReason ??
     metadata?.stop_reason ??
-    metadata?.stopReason;
+    metadata?.stopReason ??
+    additionalKwargs?.finish_reason ??
+    additionalKwargs?.finishReason ??
+    additionalKwargs?.stop_reason ??
+    additionalKwargs?.stopReason;
   return finishReason === 'tool_calls' || finishReason === 'tool_use';
 }
 
@@ -360,14 +374,15 @@ function createEagerToolExecutionPlan(args: {
     return undefined;
   }
 
-  const candidateToolCalls = skipExisting
-    ? toolCalls.filter((toolCall) => {
+  let candidateToolCalls = toolCalls;
+  if (skipExisting) {
+    candidateToolCalls = toolCalls.filter((toolCall) => {
       if (toolCall.id == null || toolCall.id === '') {
         return true;
       }
       return !graph.eagerEventToolExecutions.has(toolCall.id);
-    })
-    : toolCalls;
+    });
+  }
   if (candidateToolCalls.length === 0) {
     return [];
   }
@@ -525,15 +540,14 @@ async function dispatchEagerToolCompletions(args: {
     if (stepId === '') {
       continue;
     }
+    const resultContent =
+      typeof result.content === 'string'
+        ? result.content
+        : JSON.stringify(result.content);
     const output =
       result.status === 'error'
         ? `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`
-        : truncateToolResultContent(
-          typeof result.content === 'string'
-            ? result.content
-            : JSON.stringify(result.content),
-          maxToolResultChars
-        );
+        : truncateToolResultContent(resultContent, maxToolResultChars);
 
     try {
       const dispatched = await safeDispatchCustomEvent(
@@ -704,11 +718,7 @@ function recordEagerToolCallChunks(args: {
           previous.name != null &&
           incomingName !== previous.name));
     const existing =
-      previous == null || shouldReset
-        ? {
-          argsText: '',
-        }
-        : previous;
+      previous == null || shouldReset ? { argsText: '' } : previous;
     const id = incomingId ?? existing.id;
     const name = incomingName ?? existing.name;
     const incomingArgs = toolCallChunk.args ?? '';
@@ -967,6 +977,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     this.handleReasoning(chunk, agentContext);
     const stepKey = graph.getStepKey(metadata);
     let hasToolCalls = false;
+    const hasFinalToolSignal = hasFinalToolCallSignal(chunk);
     const hasToolCallChunks =
       (chunk.tool_call_chunks && chunk.tool_call_chunks.length > 0) ?? false;
     if (
@@ -982,7 +993,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     ) {
       hasToolCalls = true;
       await handleToolCalls(chunk.tool_calls, metadata, graph);
-      if (hasFinalToolCallSignal(chunk)) {
+      if (hasFinalToolSignal) {
         startEagerToolExecutions({
           graph,
           metadata,
@@ -1003,6 +1014,23 @@ export class ChatModelStreamHandler implements t.EventHandler {
 
     /** Set a preliminary message ID if found in empty chunk */
     const isEmptyChunk = isEmptyContent && !hasToolCallChunks;
+    if (isEmptyChunk) {
+      const allowSequentialSeal =
+        canPrestartSequentialStreamedToolChunks(agentContext);
+      if (
+        hasFinalToolSignal &&
+        (allowSequentialSeal || hasExplicitStreamedToolCallSeals(chunk))
+      ) {
+        startReadyStreamedEagerToolExecutions({
+          graph,
+          metadata,
+          agentContext,
+          stepKey,
+          allowSequentialSeal,
+          sealAll: true,
+        });
+      }
+    }
     if (
       isEmptyChunk &&
       (chunk.id ?? '') !== '' &&
@@ -1050,7 +1078,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
           toolCallChunks: chunk.tool_call_chunks,
           seal: streamedToolCallSeal,
           allowSequentialSeal,
-          sealAll: hasFinalToolCallSignal(chunk),
+          sealAll: hasFinalToolSignal,
         });
       }
     }
@@ -1314,7 +1342,7 @@ export function createContentAggregator(): t.ContentAggregatorResult {
     finalUpdate = false
   ): void => {
     if (!contentPart) {
-      console.warn('No content part found in \'updateContent\'');
+      console.warn('No content part found in updateContent');
       return;
     }
     const partType = contentPart.type ?? '';


### PR DESCRIPTION
## Summary

Adds Anthropic's current per-tool `eager_input_streaming: true` flag to the final Anthropic tool definition for CodeAPI/event-driven execution tools:

- `execute_code`
- `bash_tool`
- `run_tools_with_code`
- `run_tools_with_bash`
- `read_file`

The flag is applied only in the Anthropic adapter after LangChain formats tools for Anthropic, because LangChain's generic tool `extras` schema does not currently pass this field through. Explicit `eager_input_streaming: false` is preserved, and non-CodeAPI tools are left unchanged.

## Research Notes

Anthropic's current docs describe fine-grained tool input streaming as a per-tool `eager_input_streaming` setting rather than relying solely on the old beta header. Live testing showed `input_json_delta` events still occur without the field on the tested model, but the field changed chunk/timing behavior and gave earlier tool-input deltas in samples.

## Live Validation

Model: `claude-haiku-4-5-20251001`

Raw Anthropic stream comparison:

| Case | First input delta | Delta count | Result |
| --- | ---: | ---: | --- |
| no eager field | 1407ms | 225 | streamed `input_json_delta` |
| old beta header only | 874ms | 83 | streamed `input_json_delta` |
| per-tool `eager_input_streaming` | 452ms | 50 | streamed `input_json_delta`, earliest in sample |

Run/eager event pipeline comparison with mocked host execution:

| Case | First `ON_TOOL_EXECUTE` | First model end | Eager before model end |
| --- | ---: | ---: | --- |
| field stripped | 2264ms | 2290ms | yes |
| new field | 1868ms | 2031ms | yes |

Validity check at the streamed-tool seal point:

| Case | bash first delta | read_file first delta / bash seal | Eager bash args parseable | Eager args == final args |
| --- | ---: | ---: | --- | --- |
| field stripped | 838ms | 1049ms | yes | yes |
| `eager_input_streaming: true` | 764ms | 964ms | yes | yes |

## Tests

- `ANTHROPIC_API_KEY=test NODE_OPTIONS='--experimental-vm-modules' npx jest src/llm/anthropic/llm.spec.ts --runInBand -t 'Anthropic (CodeAPI tool|fine-grained tool input streaming)'`
- `ANTHROPIC_API_KEY=test NODE_OPTIONS='--experimental-vm-modules' npx jest src/__tests__/stream.eagerEventExecution.test.ts --runInBand -t 'CodeAPI|eager|stale|redispatch|changed'`
- `ANTHROPIC_API_KEY=test npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/llm/anthropic/index.ts`
- `npx prettier --check src/llm/anthropic/index.ts src/llm/anthropic/llm.spec.ts`
- `git diff --check`