### PR TITLE
👥 fix: Sanitize Subagent Update Events

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1563,7 +1563,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);
             childGraph.hookRegistry = this.hookRegistry;
-            childGraph.humanInTheLoop = this.humanInTheLoop;
+            /**
+             * Do not propagate `humanInTheLoop` into the child graph yet:
+             * nested subagent interrupts need a stable child checkpoint and
+             * resume bridge. Child hooks still fire; `ask` decisions fail
+             * closed inside the subagent until that flow is implemented.
+             */
             childGraph.toolOutputReferences = this.toolOutputReferences;
             childGraph.eagerEventToolExecution = this.eagerEventToolExecution;
             childGraph.toolExecution = this.toolExecution;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1562,6 +1562,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);
+            childGraph.hookRegistry = this.hookRegistry;
+            childGraph.humanInTheLoop = this.humanInTheLoop;
             childGraph.toolOutputReferences = this.toolOutputReferences;
             childGraph.eagerEventToolExecution = this.eagerEventToolExecution;
             childGraph.toolExecution = this.toolExecution;

--- a/src/hooks/__tests__/executeHooks.test.ts
+++ b/src/hooks/__tests__/executeHooks.test.ts
@@ -109,6 +109,44 @@ describe('executeHooks', () => {
     consoleWarnSpy.mockRestore();
   });
 
+  describe('abort listener management', () => {
+    it('uses one abort listener for many hooks on one matcher', async () => {
+      const registry = new HookRegistry();
+      const listenerCounts = new Map<AbortSignal, number>();
+      let maxAbortListeners = 0;
+      const addEventListenerSpy = jest
+        .spyOn(AbortSignal.prototype, 'addEventListener')
+        .mockImplementation(function (
+          this: AbortSignal,
+          type: string,
+          _listener: EventListenerOrEventListenerObject | null
+        ): void {
+          if (type !== 'abort') {
+            return;
+          }
+          const count = (listenerCounts.get(this) ?? 0) + 1;
+          listenerCounts.set(this, count);
+          maxAbortListeners = Math.max(maxAbortListeners, count);
+        });
+      const hooks = Array.from({ length: 12 }, () =>
+        runStartHook(async (): Promise<RunStartHookOutput> => ({}))
+      );
+
+      try {
+        registry.register('RunStart', { hooks });
+
+        await executeHooks({
+          registry,
+          input: runStartInput(),
+          timeoutMs: 1000,
+        });
+        expect(maxAbortListeners).toBe(1);
+      } finally {
+        addEventListenerSpy.mockRestore();
+      }
+    });
+  });
+
   describe('empty matcher set', () => {
     it('returns an empty aggregated result when no matchers are registered', async () => {
       const registry = new HookRegistry();

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -46,6 +46,11 @@ interface HookOutcome {
   timedOut: boolean;
 }
 
+interface AbortRace {
+  promise: Promise<never>;
+  cleanup: () => void;
+}
+
 function freshResult(): AggregatedHookResult {
   return {
     additionalContexts: [],
@@ -110,10 +115,10 @@ async function runHook(
   hook: WideCallback,
   input: HookInput,
   signal: AbortSignal,
+  abortPromise: Promise<never>,
   matcher: WideMatcher
 ): Promise<HookOutcome> {
   const hookPromise = Promise.resolve().then(() => hook(input, signal));
-  const { promise: abortPromise, cleanup } = makeAbortPromise(signal);
   try {
     const output = await Promise.race([hookPromise, abortPromise]);
     return { matcher, output, error: null, timedOut: false };
@@ -124,8 +129,22 @@ async function runHook(
       error: describeError(err),
       timedOut: isTimeout(err),
     };
+  }
+}
+
+async function runMatcherHooks(
+  matcher: WideMatcher,
+  input: HookInput,
+  signal: AbortSignal
+): Promise<HookOutcome[]> {
+  const abortRace: AbortRace = makeAbortPromise(signal);
+  const tasks = matcher.hooks.map((hook) =>
+    runHook(hook, input, signal, abortRace.promise, matcher)
+  );
+  try {
+    return await Promise.all(tasks);
   } finally {
-    cleanup();
+    abortRace.cleanup();
   }
 }
 
@@ -373,7 +392,7 @@ export async function executeHooks(
   }
 
   // --- SYNC CRITICAL SECTION: once-matcher removal must complete before any await ---
-  const tasks: Promise<HookOutcome>[] = [];
+  const tasks: Promise<HookOutcome[]>[] = [];
   for (const matcher of matchers) {
     if (!matchesQuery(matcher.pattern, matchQuery)) {
       continue;
@@ -381,18 +400,19 @@ export async function executeHooks(
     if (matcher.once === true) {
       registry.removeMatcher(event, matcher, sessionId);
     }
+    if (matcher.hooks.length === 0) {
+      continue;
+    }
     const perHookTimeout = matcher.timeout ?? timeoutMs;
     const matcherSignal = combineSignals(signal, perHookTimeout);
-    for (const hook of matcher.hooks) {
-      tasks.push(runHook(hook, input, matcherSignal, matcher));
-    }
+    tasks.push(runMatcherHooks(matcher, input, matcherSignal));
   }
   // --- END SYNC CRITICAL SECTION ---
   if (tasks.length === 0) {
     return freshResult();
   }
 
-  const outcomes = await Promise.all(tasks);
+  const outcomes = (await Promise.all(tasks)).flat();
   reportErrors(outcomes, event, logger);
   const aggregated = fold(outcomes);
   /**

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1419,6 +1419,73 @@ describe('SubagentExecutor', () => {
       expect(serialized).not.toContain('nested-completed-secret');
     });
 
+    it('does not drop non-droppable updates when the forwarding queue overflows', async () => {
+      const completedIds: string[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: async (_event, rawData): Promise<void> => {
+          const update = rawData as SubagentUpdateEvent;
+          if (update.phase === 'run_step_completed') {
+            const data = update.data as { result?: { id?: string } };
+            if (data.result?.id != null) {
+              completedIds.push(data.result.id);
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          }
+        },
+      });
+
+      const factory: () => StandardGraph = (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(async (_state, options) => {
+              const opts = options as { callbacks?: unknown[] };
+              const forwarder = (opts.callbacks ?? [])[0] as {
+                handleCustomEvent?: (
+                  eventName: string,
+                  data: unknown
+                ) => Promise<void> | void;
+              };
+              for (let index = 0; index < 80; index++) {
+                await forwarder.handleCustomEvent?.(
+                  GraphEvents.ON_RUN_STEP_COMPLETED,
+                  {
+                    result: {
+                      id: `step_${index}`,
+                      index,
+                      type: 'tool_call',
+                      tool_call: {
+                        id: `call_${index}`,
+                        name: 'calculator',
+                        args: '{}',
+                        output: `${index}`,
+                        progress: 1,
+                      },
+                    },
+                  }
+                );
+              }
+              return { messages: [new AIMessage('ok')] };
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+      });
+
+      expect(completedIds).toHaveLength(80);
+      expect(completedIds[0]).toBe('step_0');
+      expect(completedIds[completedIds.length - 1]).toBe('step_79');
+    });
+
     it('does NOT forward ON_TOOL_EXECUTE when the parent registry has no handler (safe fallback)', async () => {
       /**
        * The executor strips `toolDefinitions` when the parent registry has

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from '@jest/globals';
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import { HookRegistry } from '@/hooks/HookRegistry';
-import { Providers, GraphEvents } from '@/common';
+import { Providers, GraphEvents, StepTypes } from '@/common';
 import { HandlerRegistry } from '@/events';
 import { AgentContext } from '@/agents/AgentContext';
 import type {
@@ -1489,6 +1489,57 @@ describe('summarizeEvent', () => {
 });
 
 describe('sanitizeForwardedSubagentUpdateData', () => {
+  it('uses an allowlist for run step payloads', () => {
+    const sanitized = sanitizeForwardedSubagentUpdateData(
+      GraphEvents.ON_RUN_STEP,
+      {
+        id: 'step_1',
+        type: StepTypes.TOOL_CALLS,
+        agentId: 'researcher',
+        index: 0,
+        stepDetails: {
+          type: StepTypes.TOOL_CALLS,
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '21 * 2' },
+              futureSecret: 'nested-secret',
+            },
+          ],
+          futureSecret: 'details-secret',
+        },
+        configurable: { access_token: 'access-secret' },
+        metadata: { refresh_token: 'refresh-secret' },
+        futureSecret: 'top-level-secret',
+      }
+    );
+
+    expect(sanitized).toEqual({
+      id: 'step_1',
+      type: StepTypes.TOOL_CALLS,
+      agentId: 'researcher',
+      index: 0,
+      stepDetails: {
+        type: StepTypes.TOOL_CALLS,
+        tool_calls: [
+          {
+            id: 'call_1',
+            name: 'calculator',
+            args: { expression: '21 * 2' },
+          },
+        ],
+      },
+    });
+    const serialized = JSON.stringify(sanitized);
+    expect(serialized).not.toContain('futureSecret');
+    expect(serialized).not.toContain('top-level-secret');
+    expect(serialized).not.toContain('details-secret');
+    expect(serialized).not.toContain('nested-secret');
+    expect(serialized).not.toContain('access-secret');
+    expect(serialized).not.toContain('refresh-secret');
+  });
+
   it('keeps completed tool output while stripping operational fields', () => {
     const output = 'x'.repeat(10_000);
     const sanitized = sanitizeForwardedSubagentUpdateData(
@@ -1504,7 +1555,9 @@ describe('sanitizeForwardedSubagentUpdateData', () => {
             args: '{}',
             output,
             progress: 1,
+            futureSecret: 'nested-secret',
           },
+          futureSecret: 'result-secret',
         },
         configurable: {
           user: {
@@ -1516,6 +1569,7 @@ describe('sanitizeForwardedSubagentUpdateData', () => {
         metadata: {
           refresh_token: 'refresh-secret',
         },
+        futureSecret: 'top-level-secret',
       }
     );
 
@@ -1535,6 +1589,10 @@ describe('sanitizeForwardedSubagentUpdateData', () => {
     });
     const serialized = JSON.stringify(sanitized);
     expect(serialized).toContain(output);
+    expect(serialized).not.toContain('futureSecret');
+    expect(serialized).not.toContain('top-level-secret');
+    expect(serialized).not.toContain('result-secret');
+    expect(serialized).not.toContain('nested-secret');
     expect(serialized).not.toContain('configurable');
     expect(serialized).not.toContain('metadata');
     expect(serialized).not.toContain('access-secret');

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -5,7 +5,13 @@ import { HookRegistry } from '@/hooks/HookRegistry';
 import { Providers, GraphEvents } from '@/common';
 import { HandlerRegistry } from '@/events';
 import { AgentContext } from '@/agents/AgentContext';
-import type { AgentInputs, ResolvedSubagentConfig } from '@/types';
+import type {
+  AgentInputs,
+  ResolvedSubagentConfig,
+  SubagentUpdateEvent,
+  ToolExecuteBatchRequest,
+  ToolExecuteResult,
+} from '@/types';
 import {
   SubagentExecutor,
   filterSubagentResult,
@@ -13,6 +19,7 @@ import {
   buildChildInputs,
   summarizeEvent,
 } from '../subagent';
+import { sanitizeForwardedSubagentUpdateData } from '../subagent/SubagentExecutor';
 import type { StandardGraph } from '@/graphs/Graph';
 
 jest.setTimeout(15000);
@@ -547,15 +554,17 @@ describe('SubagentExecutor', () => {
   });
 
   describe('parentConfigurable inheritance', () => {
+    type CapturingGraphFactory = {
+      factory: () => StandardGraph;
+      getInvokeConfig: () => Record<string, unknown> | undefined;
+    };
+
     /**
      * Build a stub factory that captures the second argument to
      * `workflow.invoke()` (the runnable config) so tests can assert on
      * the `configurable` we forwarded to the child graph.
      */
-    function makeCapturingGraphFactory(): {
-      factory: () => StandardGraph;
-      getInvokeConfig: () => Record<string, unknown> | undefined;
-    } {
+    function makeCapturingGraphFactory(): CapturingGraphFactory {
       let capturedConfig: Record<string, unknown> | undefined;
       const factory = (): StandardGraph =>
         ({
@@ -1099,6 +1108,124 @@ describe('SubagentExecutor', () => {
       ]);
     });
 
+    it('sanitizes ON_TOOL_EXECUTE before wrapping it in ON_SUBAGENT_UPDATE', async () => {
+      const toolRequests: ToolExecuteBatchRequest[] = [];
+      const subagentUpdates: SubagentUpdateEvent[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_TOOL_EXECUTE, {
+        handle: (_event, rawData): void => {
+          const request = rawData as ToolExecuteBatchRequest;
+          toolRequests.push(request);
+          const results: ToolExecuteResult[] = request.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ran ${call.name}`,
+          }));
+          request.resolve(results);
+        },
+      });
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, rawData): void => {
+          subagentUpdates.push(rawData as SubagentUpdateEvent);
+        },
+      });
+
+      let capturedInvokeOptions: unknown;
+      const factory: () => StandardGraph = (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(async (_state, options) => {
+              capturedInvokeOptions = options;
+              return { messages: [new AIMessage('ok')] };
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_parent_123',
+      });
+
+      const opts = capturedInvokeOptions as { callbacks?: unknown[] };
+      const forwarder = (opts.callbacks ?? [])[0] as {
+        handleCustomEvent?: (
+          eventName: string,
+          data: unknown
+        ) => Promise<void> | void;
+      };
+
+      const batchRequest: ToolExecuteBatchRequest = {
+        toolCalls: [
+          {
+            id: 'call_child_xyz',
+            name: 'calculator',
+            args: { expression: '21 * 2' },
+            stepId: 'step_secret',
+            turn: 7,
+          },
+        ],
+        agentId: 'researcher',
+        userId: 'user_secret',
+        configurable: {
+          user: {
+            federatedTokens: {
+              access_token: 'access-secret',
+              id_token: 'id-secret',
+              refresh_token: 'refresh-secret',
+            },
+          },
+          requestBody: { currentTaskInput: 'sensitive task input' },
+        },
+        metadata: {
+          access_token: 'metadata-secret',
+        },
+        resolve: jest.fn(),
+        reject: jest.fn(),
+      };
+
+      await forwarder.handleCustomEvent?.(
+        GraphEvents.ON_TOOL_EXECUTE,
+        batchRequest
+      );
+
+      expect(toolRequests).toHaveLength(1);
+      expect(toolRequests[0].configurable).toBe(batchRequest.configurable);
+      expect(toolRequests[0].metadata).toBe(batchRequest.metadata);
+
+      const toolUpdate = subagentUpdates.find(
+        (update) =>
+          update.phase === 'run_step' &&
+          update.label === 'Calling calculator'
+      );
+      expect(toolUpdate?.data).toEqual({
+        agentId: 'researcher',
+        toolCalls: [
+          {
+            id: 'call_child_xyz',
+            name: 'calculator',
+            args: { expression: '21 * 2' },
+          },
+        ],
+      });
+      const serializedUpdate = JSON.stringify(toolUpdate);
+      expect(serializedUpdate).not.toContain('configurable');
+      expect(serializedUpdate).not.toContain('metadata');
+      expect(serializedUpdate).not.toContain('access-secret');
+      expect(serializedUpdate).not.toContain('id-secret');
+      expect(serializedUpdate).not.toContain('refresh-secret');
+      expect(serializedUpdate).not.toContain('metadata-secret');
+      expect(serializedUpdate).not.toContain('sensitive task input');
+      expect(serializedUpdate).not.toContain('step_secret');
+      expect(serializedUpdate).not.toContain('user_secret');
+    });
+
     it('does NOT forward ON_TOOL_EXECUTE when the parent registry has no handler (safe fallback)', async () => {
       /**
        * The executor strips `toolDefinitions` when the parent registry has
@@ -1292,5 +1419,59 @@ describe('summarizeEvent', () => {
 
   it('returns the event name for unknown events', () => {
     expect(summarizeEvent('on_unknown_event', {})).toBe('on_unknown_event');
+  });
+});
+
+describe('sanitizeForwardedSubagentUpdateData', () => {
+  it('keeps completed tool output while stripping operational fields', () => {
+    const output = 'x'.repeat(10_000);
+    const sanitized = sanitizeForwardedSubagentUpdateData(
+      GraphEvents.ON_RUN_STEP_COMPLETED,
+      {
+        result: {
+          id: 'step_1',
+          index: 0,
+          type: 'tool_call',
+          tool_call: {
+            id: 'call_1',
+            name: 'list_tables_mcp_ClickHouse',
+            args: '{}',
+            output,
+            progress: 1,
+          },
+        },
+        configurable: {
+          user: {
+            federatedTokens: {
+              access_token: 'access-secret',
+            },
+          },
+        },
+        metadata: {
+          refresh_token: 'refresh-secret',
+        },
+      }
+    );
+
+    expect(sanitized).toEqual({
+      result: {
+        id: 'step_1',
+        index: 0,
+        type: 'tool_call',
+        tool_call: {
+          id: 'call_1',
+          name: 'list_tables_mcp_ClickHouse',
+          args: '{}',
+          output,
+          progress: 1,
+        },
+      },
+    });
+    const serialized = JSON.stringify(sanitized);
+    expect(serialized).toContain(output);
+    expect(serialized).not.toContain('configurable');
+    expect(serialized).not.toContain('metadata');
+    expect(serialized).not.toContain('access-secret');
+    expect(serialized).not.toContain('refresh-secret');
   });
 });

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1292,6 +1292,133 @@ describe('SubagentExecutor', () => {
       expect(phases[phases.length - 1]).toBe('stop');
     });
 
+    it('allowlists forwarded run step payloads before wrapping them in ON_SUBAGENT_UPDATE', async () => {
+      const subagentUpdates: SubagentUpdateEvent[] = [];
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: (_event, rawData): void => {
+          subagentUpdates.push(rawData as SubagentUpdateEvent);
+        },
+      });
+
+      const output = 'tool output that should stay visible';
+      const factory: () => StandardGraph = (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(async (_state, options) => {
+              const opts = options as { callbacks?: unknown[] };
+              const forwarder = (opts.callbacks ?? [])[0] as {
+                handleCustomEvent?: (
+                  eventName: string,
+                  data: unknown
+                ) => Promise<void> | void;
+              };
+              await forwarder.handleCustomEvent?.(GraphEvents.ON_RUN_STEP, {
+                id: 'step_1',
+                type: StepTypes.TOOL_CALLS,
+                agentId: 'researcher',
+                index: 0,
+                stepDetails: {
+                  type: StepTypes.TOOL_CALLS,
+                  tool_calls: [
+                    {
+                      id: 'call_1',
+                      name: 'calculator',
+                      args: { expression: '21 * 2' },
+                      futureSecret: 'nested-step-secret',
+                    },
+                  ],
+                  futureSecret: 'step-details-secret',
+                },
+                configurable: { access_token: 'access-secret' },
+                metadata: { refresh_token: 'refresh-secret' },
+                futureSecret: 'top-level-step-secret',
+              });
+              await forwarder.handleCustomEvent?.(
+                GraphEvents.ON_RUN_STEP_COMPLETED,
+                {
+                  result: {
+                    id: 'step_1',
+                    index: 0,
+                    type: 'tool_call',
+                    tool_call: {
+                      id: 'call_1',
+                      name: 'calculator',
+                      args: '{}',
+                      output,
+                      progress: 1,
+                      futureSecret: 'nested-completed-secret',
+                    },
+                    futureSecret: 'completed-result-secret',
+                  },
+                  configurable: { access_token: 'access-secret' },
+                  metadata: { refresh_token: 'refresh-secret' },
+                  futureSecret: 'top-level-completed-secret',
+                }
+              );
+              return { messages: [new AIMessage('ok')] };
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+      });
+
+      const runStep = subagentUpdates.find(
+        (update) => update.phase === 'run_step'
+      );
+      const completedStep = subagentUpdates.find(
+        (update) => update.phase === 'run_step_completed'
+      );
+      expect(runStep?.data).toEqual({
+        id: 'step_1',
+        type: StepTypes.TOOL_CALLS,
+        agentId: 'researcher',
+        index: 0,
+        stepDetails: {
+          type: StepTypes.TOOL_CALLS,
+          tool_calls: [
+            {
+              id: 'call_1',
+              name: 'calculator',
+              args: { expression: '21 * 2' },
+            },
+          ],
+        },
+      });
+      expect(completedStep?.data).toEqual({
+        result: {
+          id: 'step_1',
+          index: 0,
+          type: 'tool_call',
+          tool_call: {
+            id: 'call_1',
+            name: 'calculator',
+            args: '{}',
+            output,
+            progress: 1,
+          },
+        },
+      });
+      const serialized = JSON.stringify([runStep, completedStep]);
+      expect(serialized).toContain(output);
+      expect(serialized).not.toContain('futureSecret');
+      expect(serialized).not.toContain('access-secret');
+      expect(serialized).not.toContain('refresh-secret');
+      expect(serialized).not.toContain('top-level-step-secret');
+      expect(serialized).not.toContain('nested-step-secret');
+      expect(serialized).not.toContain('top-level-completed-secret');
+      expect(serialized).not.toContain('nested-completed-secret');
+    });
+
     it('does NOT forward ON_TOOL_EXECUTE when the parent registry has no handler (safe fallback)', async () => {
       /**
        * The executor strips `toolDefinitions` when the parent registry has

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -685,6 +685,41 @@ describe('SubagentExecutor', () => {
       expect(configurable.requestBody).toEqual({ messageId: 'msg-1' });
     });
 
+    it('strips LangGraph runtime fields from child workflow.invoke configurable', async () => {
+      const { factory, getInvokeConfig } = makeCapturingGraphFactory();
+      const executor = createExecutor({ createChildGraph: factory });
+
+      await executor.execute({
+        description: 'task',
+        subagentType: 'researcher',
+        parentConfigurable: {
+          __pregel_abort_signals: { externalAbortSignal: 'parent-signal' },
+          __pregel_call: (): void => undefined,
+          __pregel_scratchpad: { currentTaskInput: 'large-payload' },
+          checkpoint_id: 'parent-checkpoint-id',
+          checkpoint_map: { parent: 'checkpoint' },
+          checkpoint_ns: 'parent-checkpoint-ns',
+          requestBody: { messageId: 'msg-1' },
+          thread_id: 'parent-thread',
+          user: { id: 'user_abc' },
+        },
+      });
+
+      const configurable = getInvokeConfig()!.configurable as Record<
+        string,
+        unknown
+      >;
+      expect(configurable.__pregel_abort_signals).toBeUndefined();
+      expect(configurable.__pregel_call).toBeUndefined();
+      expect(configurable.__pregel_scratchpad).toBeUndefined();
+      expect(configurable.checkpoint_id).toBeUndefined();
+      expect(configurable.checkpoint_map).toBeUndefined();
+      expect(configurable.checkpoint_ns).toBeUndefined();
+      expect(configurable.requestBody).toEqual({ messageId: 'msg-1' });
+      expect(configurable.thread_id).toBe('parent-thread');
+      expect(configurable.user).toEqual({ id: 'user_abc' });
+    });
+
     it('does not require parentConfigurable (back-compat with hosts that omit it)', async () => {
       const { factory, getInvokeConfig } = makeCapturingGraphFactory();
       const executor = createExecutor({ createChildGraph: factory });

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -1226,6 +1226,72 @@ describe('SubagentExecutor', () => {
       expect(serializedUpdate).not.toContain('user_secret');
     });
 
+    it('drains observational updates before stop without parallel handler publishes', async () => {
+      const phases: SubagentUpdateEvent['phase'][] = [];
+      let activePublishes = 0;
+      let maxActivePublishes = 0;
+      const registry = new HandlerRegistry();
+      registry.register(GraphEvents.ON_SUBAGENT_UPDATE, {
+        handle: async (_event, rawData): Promise<void> => {
+          const update = rawData as SubagentUpdateEvent;
+          activePublishes += 1;
+          maxActivePublishes = Math.max(maxActivePublishes, activePublishes);
+          if (update.phase === 'message_delta') {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          }
+          phases.push(update.phase);
+          activePublishes -= 1;
+        },
+      });
+
+      const factory: () => StandardGraph = (): StandardGraph =>
+        ({
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockImplementation(async (_state, options) => {
+              const opts = options as { callbacks?: unknown[] };
+              const forwarder = (opts.callbacks ?? [])[0] as {
+                handleCustomEvent?: (
+                  eventName: string,
+                  data: unknown
+                ) => Promise<void> | void;
+              };
+              for (let index = 0; index < 5; index++) {
+                await forwarder.handleCustomEvent?.(
+                  GraphEvents.ON_MESSAGE_DELTA,
+                  {
+                    id: `msg_${index}`,
+                    delta: { content: [{ type: 'text', text: `${index}` }] },
+                  }
+                );
+              }
+              return { messages: [new AIMessage('ok')] };
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph;
+
+      const executor = createExecutor({
+        createChildGraph: factory,
+        parentHandlerRegistry: registry,
+      });
+
+      await executor.execute({
+        description: 'Task',
+        subagentType: 'researcher',
+      });
+
+      expect(maxActivePublishes).toBe(1);
+      expect(phases[0]).toBe('start');
+      expect(phases.slice(1, 6)).toEqual([
+        'message_delta',
+        'message_delta',
+        'message_delta',
+        'message_delta',
+        'message_delta',
+      ]);
+      expect(phases[phases.length - 1]).toBe('stop');
+    });
+
     it('does NOT forward ON_TOOL_EXECUTE when the parent registry has no handler (safe fallback)', async () => {
       /**
        * The executor strips `toolDefinitions` when the parent registry has

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -4,6 +4,7 @@ import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import type {
   HookCallback,
+  PermissionDeniedHookOutput,
   PostToolUseHookOutput,
   PreToolUseHookOutput,
   SubagentStartHookInput,
@@ -350,5 +351,102 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(preToolEvents).toContain('researcher-child:calculator');
     expect(postToolEvents).toContain('-:subagent');
     expect(postToolEvents).toContain('researcher-child:calculator');
+  });
+
+  it('child subagent tool ask hooks fail closed instead of starting unsupported nested HITL', async () => {
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return class extends FakeChatModel {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          constructor(_options: any) {
+            super({
+              responses: ['Using calculator.', CHILD_RESPONSE],
+              sleep: 1,
+              toolCalls: [createCalculatorToolCall()],
+            });
+          }
+          bindTools(
+            tools: unknown
+          ): ReturnType<FakeChatModel['withConfig']> {
+            const config = {
+              tools,
+            } as Parameters<FakeChatModel['withConfig']>[0];
+            return this.withConfig(config);
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const registry = new HookRegistry();
+    const deniedTools: string[] = [];
+    const executedTools: string[] = [];
+
+    const preHook: HookCallback<'PreToolUse'> = async (
+      input
+    ): Promise<PreToolUseHookOutput> => {
+      if (input.toolName === 'calculator') {
+        return { decision: 'ask', reason: 'review calculator' };
+      }
+      return { decision: 'allow' };
+    };
+    registry.register('PreToolUse', { hooks: [preHook] });
+
+    const deniedHook: HookCallback<'PermissionDenied'> = async (
+      input
+    ): Promise<PermissionDeniedHookOutput> => {
+      deniedTools.push(
+        `${input.agentId ?? '-'}:${input.toolName}:${input.reason}`
+      );
+      return {};
+    };
+    registry.register('PermissionDenied', { hooks: [deniedHook] });
+
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+      [GraphEvents.ON_TOOL_EXECUTE]: {
+        handle: (_event, rawData): void => {
+          const request = rawData as t.ToolExecuteBatchRequest;
+          executedTools.push(...request.toolCalls.map((call) => call.name));
+          const results: t.ToolExecuteResult[] = request.toolCalls.map(
+            (call) => ({
+              toolCallId: call.id,
+              status: 'success',
+              content: '42',
+            })
+          );
+          request.resolve(results);
+        },
+      },
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `subagent-tool-ask-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createParentAgentWithChildTool()],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers,
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+    });
+
+    const tc = makeSubagentToolCall();
+    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('calculate something')] },
+      callerConfig
+    );
+
+    expect(run.getInterrupt()).toBeUndefined();
+    expect(deniedTools).toContain(
+      'researcher-child:calculator:review calculator'
+    );
+    expect(executedTools).not.toContain('calculator');
   });
 });

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -4,6 +4,8 @@ import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import type {
   HookCallback,
+  PostToolUseHookOutput,
+  PreToolUseHookOutput,
   SubagentStartHookInput,
   SubagentStartHookOutput,
   SubagentStopHookInput,
@@ -11,6 +13,7 @@ import type {
 } from '@/hooks/types';
 import { HookRegistry } from '@/hooks/HookRegistry';
 import { Run } from '@/run';
+import { FakeChatModel } from '@/llm/fake';
 import {
   Constants,
   GraphEvents,
@@ -21,6 +24,18 @@ import {
 import * as providers from '@/llm/providers';
 
 const CHILD_RESPONSE = 'Hook test child response.';
+
+const calculatorDef: t.LCTool = {
+  name: 'calculator',
+  description: 'Evaluate a math expression.',
+  parameters: {
+    type: 'object',
+    properties: {
+      expression: { type: 'string' },
+    },
+    required: ['expression'],
+  },
+};
 
 const callerConfig = {
   configurable: { thread_id: 'hook-test-thread' },
@@ -63,6 +78,40 @@ function createParentAgent(): t.AgentInputs {
         },
       },
     ],
+  };
+}
+
+function createParentAgentWithChildTool(): t.AgentInputs {
+  return {
+    agentId: 'hook-parent',
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+    instructions: 'Delegate research tasks to subagents.',
+    maxContextTokens: 8000,
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Researcher',
+        description: 'Researches topics',
+        agentInputs: {
+          agentId: 'researcher-child',
+          provider: Providers.OPENAI,
+          clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+          instructions: 'Use calculator for arithmetic, then answer concisely.',
+          maxContextTokens: 8000,
+          toolDefinitions: [calculatorDef],
+        },
+      },
+    ],
+  };
+}
+
+function createCalculatorToolCall(): ToolCall {
+  return {
+    name: 'calculator',
+    args: { expression: '21 * 2' },
+    id: 'call_child_calculator',
+    type: 'tool_call',
   };
 }
 
@@ -211,5 +260,95 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(String(toolMessages[0].content)).toContain(
       'Blocked: policy violation'
     );
+  });
+
+  it('PreToolUse and PostToolUse fire for event-driven tools inside subagents', async () => {
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return class extends FakeChatModel {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          constructor(_options: any) {
+            super({
+              responses: ['Using calculator.', CHILD_RESPONSE],
+              sleep: 1,
+              toolCalls: [createCalculatorToolCall()],
+            });
+          }
+          bindTools(
+            tools: unknown
+          ): ReturnType<FakeChatModel['withConfig']> {
+            const config = {
+              tools,
+            } as Parameters<FakeChatModel['withConfig']>[0];
+            return this.withConfig(config);
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const registry = new HookRegistry();
+    const preToolEvents: string[] = [];
+    const postToolEvents: string[] = [];
+
+    const preHook: HookCallback<'PreToolUse'> = async (
+      input
+    ): Promise<PreToolUseHookOutput> => {
+      preToolEvents.push(`${input.agentId ?? '-'}:${input.toolName}`);
+      return { decision: 'allow' };
+    };
+    registry.register('PreToolUse', { hooks: [preHook] });
+
+    const postHook: HookCallback<'PostToolUse'> = async (
+      input
+    ): Promise<PostToolUseHookOutput> => {
+      postToolEvents.push(`${input.agentId ?? '-'}:${input.toolName}`);
+      return {};
+    };
+    registry.register('PostToolUse', { hooks: [postHook] });
+
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+      [GraphEvents.ON_TOOL_EXECUTE]: {
+        handle: (_event, rawData): void => {
+          const request = rawData as t.ToolExecuteBatchRequest;
+          const results: t.ToolExecuteResult[] = request.toolCalls.map(
+            (call) => ({
+              toolCallId: call.id,
+              status: 'success',
+              content: '42',
+            })
+          );
+          request.resolve(results);
+        },
+      },
+    };
+
+    const run = await Run.create<t.IState>({
+      runId: `subagent-tool-hook-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [createParentAgentWithChildTool()],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers,
+      hooks: registry,
+    });
+
+    const tc = makeSubagentToolCall();
+    run.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [tc]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('calculate something')] },
+      callerConfig
+    );
+
+    expect(preToolEvents).toContain('-:subagent');
+    expect(preToolEvents).toContain('researcher-child:calculator');
+    expect(postToolEvents).toContain('-:subagent');
+    expect(postToolEvents).toContain('researcher-child:calculator');
   });
 });

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -23,11 +23,50 @@ import { executeHooks } from '@/hooks';
 const DEFAULT_MAX_TURNS = 25;
 const RECURSION_MULTIPLIER = 3;
 const ERROR_MESSAGE_MAX_CHARS = 200;
+const SUBAGENT_UPDATE_OMITTED_KEYS = new Set([
+  'Authorization',
+  'access_token',
+  'accessToken',
+  'authorization',
+  'checkpoint',
+  'checkpointMap',
+  'configurable',
+  'currentTaskInput',
+  'federatedTokens',
+  'id_token',
+  'idToken',
+  'metadata',
+  'refreshToken',
+  'refresh_token',
+  'reject',
+  'requestBody',
+  'resolve',
+  'scratchpad',
+  'user',
+  'userId',
+  'userMCPAuthMap',
+  'user_id',
+]);
 
 const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
   additionalContexts: [] as string[],
   errors: [] as string[],
 });
+
+type SanitizedSubagentToolCall = {
+  id: string;
+  name: string;
+  args?: ToolExecuteBatchRequest['toolCalls'][number]['args'];
+};
+
+type SanitizedSubagentToolExecuteData = {
+  toolCalls: SanitizedSubagentToolCall[];
+  agentId?: string;
+};
+
+type ShallowSanitizedUpdateData = {
+  [key: string]: unknown;
+};
 
 export type SubagentExecuteParams = {
   description: string;
@@ -468,7 +507,7 @@ export class SubagentExecutor {
         parentAgentId,
         parentToolCallId,
         phase,
-        data,
+        data: sanitizeForwardedSubagentUpdateData(eventName, data),
         label: summarizeEvent(eventName, data),
         timestamp: new Date().toISOString(),
       };
@@ -498,28 +537,28 @@ export class SubagentExecutor {
            * We also surface a short notice in the subagent-update stream so
            * the UI can show "calling <tool>" for each tool the child spawns.
            */
-          await wrap(eventName, 'run_step', data);
+          void wrap(eventName, 'run_step', data);
           return;
         }
 
         if (eventName === GraphEvents.ON_RUN_STEP) {
-          await wrap(eventName, 'run_step', data);
+          void wrap(eventName, 'run_step', data);
           return;
         }
         if (eventName === GraphEvents.ON_RUN_STEP_DELTA) {
-          await wrap(eventName, 'run_step_delta', data);
+          void wrap(eventName, 'run_step_delta', data);
           return;
         }
         if (eventName === GraphEvents.ON_RUN_STEP_COMPLETED) {
-          await wrap(eventName, 'run_step_completed', data);
+          void wrap(eventName, 'run_step_completed', data);
           return;
         }
         if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
-          await wrap(eventName, 'message_delta', data);
+          void wrap(eventName, 'message_delta', data);
           return;
         }
         if (eventName === GraphEvents.ON_REASONING_DELTA) {
-          await wrap(eventName, 'reasoning_delta', data);
+          void wrap(eventName, 'reasoning_delta', data);
           return;
         }
       },
@@ -527,16 +566,67 @@ export class SubagentExecutor {
     /**
      * `awaitHandlers = true` is required so the child's `ToolNode` actually
      * blocks on the parent's `ON_TOOL_EXECUTE` handler until it resolves
-     * the batch request. The same flag applies to observational events
-     * (message_delta, run_step, …), which means a slow
-     * `ON_SUBAGENT_UPDATE` handler on the host serializes the child
-     * stream. If host-side latency becomes a concern, a future
-     * refinement could split operational and observational events into
-     * separate callback handlers with distinct await semantics.
+     * the batch request. The callback also sees observational events
+     * (message_delta, run_step, …), but `ON_SUBAGENT_UPDATE` calls are
+     * deliberately emitted fire-and-forget so host UI publication cannot
+     * backpressure the child graph. `wrap` swallows handler errors because
+     * these events are observational.
      */
     handler.awaitHandlers = true;
     return handler;
   }
+}
+
+export function sanitizeForwardedSubagentUpdateData(
+  eventName: string,
+  data: unknown
+): unknown {
+  if (eventName === GraphEvents.ON_TOOL_EXECUTE) {
+    return sanitizeToolExecuteUpdateData(data);
+  }
+  if (data == null || typeof data !== 'object' || Array.isArray(data)) {
+    return data;
+  }
+  return omitOperationalUpdateFields(data);
+}
+
+function sanitizeToolExecuteUpdateData(
+  data: unknown
+): SanitizedSubagentToolExecuteData {
+  const request = data as Partial<ToolExecuteBatchRequest>;
+  const toolCalls = Array.isArray(request.toolCalls)
+    ? request.toolCalls.map(sanitizeToolCallForUpdate)
+    : [];
+  const sanitized: SanitizedSubagentToolExecuteData = { toolCalls };
+  if (typeof request.agentId === 'string') {
+    sanitized.agentId = request.agentId;
+  }
+  return sanitized;
+}
+
+function sanitizeToolCallForUpdate(
+  call: ToolExecuteBatchRequest['toolCalls'][number]
+): SanitizedSubagentToolCall {
+  const sanitized: SanitizedSubagentToolCall = {
+    id: call.id,
+    name: call.name,
+    args: call.args,
+  };
+  return sanitized;
+}
+
+function omitOperationalUpdateFields(data: object): ShallowSanitizedUpdateData {
+  const sanitized: ShallowSanitizedUpdateData = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (
+      SUBAGENT_UPDATE_OMITTED_KEYS.has(key) ||
+      typeof value === 'function'
+    ) {
+      continue;
+    }
+    sanitized[key] = value;
+  }
+  return sanitized;
 }
 
 /**

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -5,18 +5,25 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { Callbacks } from '@langchain/core/callbacks/manager';
 import type {
   AgentInputs,
+  MessageDeltaEvent,
+  ProcessedToolCall,
+  ReasoningDeltaEvent,
+  RunStep,
+  RunStepDeltaEvent,
   StandardGraphInput,
   ResolvedSubagentConfig,
+  StepCompleted,
   SubagentConfig,
   SubagentUpdateEvent,
   SubagentUpdatePhase,
   ToolExecuteBatchRequest,
+  ToolCallDelta,
   TokenCounter,
 } from '@/types';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
-import { GraphEvents, Callback } from '@/common';
+import { GraphEvents, Callback, StepTypes } from '@/common';
 import type { HandlerRegistry } from '@/events';
 import { executeHooks } from '@/hooks';
 
@@ -24,30 +31,6 @@ const DEFAULT_MAX_TURNS = 25;
 const RECURSION_MULTIPLIER = 3;
 const ERROR_MESSAGE_MAX_CHARS = 200;
 const MAX_PENDING_SUBAGENT_UPDATES = 64;
-const SUBAGENT_UPDATE_OMITTED_KEYS = new Set([
-  'Authorization',
-  'access_token',
-  'accessToken',
-  'authorization',
-  'checkpoint',
-  'checkpointMap',
-  'configurable',
-  'currentTaskInput',
-  'federatedTokens',
-  'id_token',
-  'idToken',
-  'metadata',
-  'refreshToken',
-  'refresh_token',
-  'reject',
-  'requestBody',
-  'resolve',
-  'scratchpad',
-  'user',
-  'userId',
-  'userMCPAuthMap',
-  'user_id',
-]);
 
 const HOOK_FALLBACK: AggregatedHookResult = Object.freeze({
   additionalContexts: [] as string[],
@@ -65,8 +48,87 @@ type SanitizedSubagentToolExecuteData = {
   agentId?: string;
 };
 
-type ShallowSanitizedUpdateData = {
-  [key: string]: unknown;
+type SanitizedRunStep = Partial<
+  Pick<
+    RunStep,
+    | 'agentId'
+    | 'groupId'
+    | 'id'
+    | 'index'
+    | 'runId'
+    | 'stepIndex'
+    | 'summary'
+    | 'type'
+    | 'usage'
+  >
+> & {
+  stepDetails?: SanitizedStepDetails;
+};
+
+type SanitizedStepDetails =
+  | {
+      type: StepTypes.MESSAGE_CREATION;
+      message_creation?: {
+        message_id?: string;
+      };
+    }
+  | {
+      type: StepTypes.TOOL_CALLS;
+      tool_calls?: SanitizedAgentToolCall[];
+    };
+
+type SanitizedAgentToolCall = {
+  id?: string;
+  name?: string;
+  args?: string | object;
+  type?: string;
+  function?: {
+    name?: string;
+    arguments?: string | object;
+  };
+};
+
+type SanitizedRunStepDelta = Partial<Pick<RunStepDeltaEvent, 'id'>> & {
+  delta?: SanitizedToolCallDelta;
+};
+
+type SanitizedToolCallDelta = Partial<
+  Pick<ToolCallDelta, 'auth' | 'expires_at' | 'summary' | 'type'>
+> & {
+  tool_calls?: SanitizedAgentToolCall[];
+};
+
+type SanitizedStepCompleted =
+  | {
+      id?: string;
+      index?: number;
+      type: 'tool_call';
+      tool_call?: SanitizedProcessedToolCall;
+    }
+  | {
+      type: 'summary';
+      summary?: Extract<StepCompleted, { type: 'summary' }>['summary'];
+    };
+
+type SanitizedProcessedToolCall = Partial<
+  Pick<ProcessedToolCall, 'args' | 'id' | 'name' | 'output' | 'progress'>
+>;
+
+type SanitizedRunStepCompleted = {
+  result?: SanitizedStepCompleted;
+};
+
+type SanitizedMessageDelta = Partial<Pick<MessageDeltaEvent, 'id'>> & {
+  delta?: {
+    content?: MessageDeltaEvent['delta']['content'];
+    tool_call_ids?: MessageDeltaEvent['delta']['tool_call_ids'];
+  };
+};
+
+type SanitizedReasoningDelta = Partial<Pick<ReasoningDeltaEvent, 'id'>> & {
+  delta?: {
+    content?: ReasoningDeltaEvent['delta']['content'];
+  };
 };
 
 type QueuedSubagentUpdate = {
@@ -645,10 +707,22 @@ export function sanitizeForwardedSubagentUpdateData(
   if (eventName === GraphEvents.ON_TOOL_EXECUTE) {
     return sanitizeToolExecuteUpdateData(data);
   }
-  if (data == null || typeof data !== 'object' || Array.isArray(data)) {
-    return data;
+  if (eventName === GraphEvents.ON_RUN_STEP) {
+    return sanitizeRunStepUpdateData(data);
   }
-  return omitOperationalUpdateFields(data);
+  if (eventName === GraphEvents.ON_RUN_STEP_DELTA) {
+    return sanitizeRunStepDeltaUpdateData(data);
+  }
+  if (eventName === GraphEvents.ON_RUN_STEP_COMPLETED) {
+    return sanitizeRunStepCompletedUpdateData(data);
+  }
+  if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
+    return sanitizeMessageDeltaUpdateData(data);
+  }
+  if (eventName === GraphEvents.ON_REASONING_DELTA) {
+    return sanitizeReasoningDeltaUpdateData(data);
+  }
+  return undefined;
 }
 
 function isDroppableSubagentUpdatePhase(phase: SubagentUpdatePhase): boolean {
@@ -684,18 +758,229 @@ function sanitizeToolCallForUpdate(
   return sanitized;
 }
 
-function omitOperationalUpdateFields(data: object): ShallowSanitizedUpdateData {
-  const sanitized: ShallowSanitizedUpdateData = {};
-  for (const [key, value] of Object.entries(data)) {
-    if (
-      SUBAGENT_UPDATE_OMITTED_KEYS.has(key) ||
-      typeof value === 'function'
-    ) {
-      continue;
+function sanitizeRunStepUpdateData(data: unknown): SanitizedRunStep | undefined {
+  if (!isObjectLike(data)) {
+    return undefined;
+  }
+  const step = data as Partial<RunStep>;
+  const sanitized: SanitizedRunStep = {};
+  assignString(sanitized, 'agentId', step.agentId);
+  assignNumber(sanitized, 'groupId', step.groupId);
+  assignString(sanitized, 'id', step.id);
+  assignNumber(sanitized, 'index', step.index);
+  assignString(sanitized, 'runId', step.runId);
+  assignNumber(sanitized, 'stepIndex', step.stepIndex);
+  assignString(sanitized, 'type', step.type);
+  if (step.summary !== undefined) {
+    sanitized.summary = step.summary;
+  }
+  if (step.usage !== undefined) {
+    sanitized.usage = step.usage;
+  }
+  sanitized.stepDetails = sanitizeStepDetails(step.stepDetails);
+  return sanitized;
+}
+
+function sanitizeRunStepDeltaUpdateData(
+  data: unknown
+): SanitizedRunStepDelta | undefined {
+  if (!isObjectLike(data)) {
+    return undefined;
+  }
+  const event = data as Partial<RunStepDeltaEvent>;
+  const sanitized: SanitizedRunStepDelta = {};
+  assignString(sanitized, 'id', event.id);
+  sanitized.delta = sanitizeToolCallDelta(event.delta);
+  return sanitized;
+}
+
+function sanitizeRunStepCompletedUpdateData(
+  data: unknown
+): SanitizedRunStepCompleted | undefined {
+  if (!isObjectLike(data)) {
+    return undefined;
+  }
+  const event = data as { result?: unknown };
+  return { result: sanitizeStepCompleted(event.result) };
+}
+
+function sanitizeMessageDeltaUpdateData(
+  data: unknown
+): SanitizedMessageDelta | undefined {
+  if (!isObjectLike(data)) {
+    return undefined;
+  }
+  const event = data as Partial<MessageDeltaEvent>;
+  const sanitized: SanitizedMessageDelta = {};
+  assignString(sanitized, 'id', event.id);
+  if (event.delta != null) {
+    sanitized.delta = {};
+    if (event.delta.content !== undefined) {
+      sanitized.delta.content = event.delta.content;
     }
-    sanitized[key] = value;
+    if (event.delta.tool_call_ids !== undefined) {
+      sanitized.delta.tool_call_ids = event.delta.tool_call_ids;
+    }
   }
   return sanitized;
+}
+
+function sanitizeReasoningDeltaUpdateData(
+  data: unknown
+): SanitizedReasoningDelta | undefined {
+  if (!isObjectLike(data)) {
+    return undefined;
+  }
+  const event = data as Partial<ReasoningDeltaEvent>;
+  const sanitized: SanitizedReasoningDelta = {};
+  assignString(sanitized, 'id', event.id);
+  if (event.delta?.content !== undefined) {
+    sanitized.delta = { content: event.delta.content };
+  }
+  return sanitized;
+}
+
+function sanitizeStepDetails(stepDetails: unknown): SanitizedStepDetails | undefined {
+  if (!isObjectLike(stepDetails)) {
+    return undefined;
+  }
+  const rawDetails = stepDetails as {
+    message_creation?: { message_id?: unknown };
+    tool_calls?: unknown[];
+    type?: unknown;
+  };
+  if (rawDetails.type === StepTypes.MESSAGE_CREATION) {
+    const sanitized: SanitizedStepDetails = {
+      type: StepTypes.MESSAGE_CREATION,
+    };
+    const messageId = rawDetails.message_creation?.message_id;
+    if (typeof messageId === 'string') {
+      sanitized.message_creation = { message_id: messageId };
+    }
+    return sanitized;
+  }
+  if (rawDetails.type === StepTypes.TOOL_CALLS) {
+    const sanitized: SanitizedStepDetails = {
+      type: StepTypes.TOOL_CALLS,
+    };
+    if (Array.isArray(rawDetails.tool_calls)) {
+      sanitized.tool_calls = rawDetails.tool_calls.map(sanitizeAgentToolCall);
+    }
+    return sanitized;
+  }
+  return undefined;
+}
+
+function sanitizeToolCallDelta(
+  delta: ToolCallDelta | undefined
+): SanitizedToolCallDelta | undefined {
+  if (!isObjectLike(delta)) {
+    return undefined;
+  }
+  const sanitized: SanitizedToolCallDelta = {};
+  assignString(sanitized, 'auth', delta.auth);
+  assignNumber(sanitized, 'expires_at', delta.expires_at);
+  assignString(sanitized, 'type', delta.type);
+  if (delta.summary !== undefined) {
+    sanitized.summary = delta.summary;
+  }
+  if (Array.isArray(delta.tool_calls)) {
+    sanitized.tool_calls = delta.tool_calls.map(sanitizeAgentToolCall);
+  }
+  return sanitized;
+}
+
+function sanitizeStepCompleted(data: unknown): SanitizedStepCompleted | undefined {
+  if (!isObjectLike(data)) {
+    return undefined;
+  }
+  const completed = data as Partial<StepCompleted> & {
+    id?: unknown;
+    index?: unknown;
+    tool_call?: unknown;
+  };
+  if (completed.type === 'summary') {
+    return {
+      type: 'summary',
+      summary: completed.summary,
+    };
+  }
+  if (completed.type !== 'tool_call') {
+    return undefined;
+  }
+  const sanitized: SanitizedStepCompleted = { type: 'tool_call' };
+  assignString(sanitized, 'id', completed.id);
+  assignNumber(sanitized, 'index', completed.index);
+  sanitized.tool_call = sanitizeProcessedToolCall(completed.tool_call);
+  return sanitized;
+}
+
+function sanitizeProcessedToolCall(
+  toolCall: unknown
+): SanitizedProcessedToolCall | undefined {
+  if (!isObjectLike(toolCall)) {
+    return undefined;
+  }
+  const call = toolCall as Partial<ProcessedToolCall>;
+  const sanitized: SanitizedProcessedToolCall = {};
+  assignString(sanitized, 'id', call.id);
+  assignString(sanitized, 'name', call.name);
+  if (call.args !== undefined) {
+    sanitized.args = call.args;
+  }
+  assignString(sanitized, 'output', call.output);
+  assignNumber(sanitized, 'progress', call.progress);
+  return sanitized;
+}
+
+function sanitizeAgentToolCall(toolCall: unknown): SanitizedAgentToolCall {
+  if (!isObjectLike(toolCall)) {
+    return {};
+  }
+  const call = toolCall as SanitizedAgentToolCall;
+  const sanitized: SanitizedAgentToolCall = {};
+  assignString(sanitized, 'id', call.id);
+  assignString(sanitized, 'name', call.name);
+  assignString(sanitized, 'type', call.type);
+  if (call.args !== undefined) {
+    sanitized.args = call.args;
+  }
+  if (isObjectLike(call.function)) {
+    const fn: SanitizedAgentToolCall['function'] = {};
+    assignString(fn, 'name', call.function.name);
+    if (
+      typeof call.function.arguments === 'string' ||
+      isObjectLike(call.function.arguments)
+    ) {
+      fn.arguments = call.function.arguments;
+    }
+    sanitized.function = fn;
+  }
+  return sanitized;
+}
+
+function isObjectLike(value: unknown): value is object {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function assignString<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  value: unknown
+): void {
+  if (typeof value === 'string') {
+    target[key] = value as T[K];
+  }
+}
+
+function assignNumber<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  value: unknown
+): void {
+  if (typeof value === 'number') {
+    target[key] = value as T[K];
+  }
 }
 
 /**

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -142,6 +142,13 @@ type ForwarderCallback = {
   drain: () => Promise<void>;
 };
 
+const LANGGRAPH_RUNTIME_CONFIG_PREFIX = '__pregel_';
+const LANGGRAPH_CHECKPOINT_CONFIG_KEYS = new Set([
+  'checkpoint_id',
+  'checkpoint_map',
+  'checkpoint_ns',
+]);
+
 export type SubagentExecuteParams = {
   description: string;
   subagentType: string;
@@ -154,11 +161,13 @@ export type SubagentExecuteParams = {
    */
   parentToolCallId?: string;
   /**
-   * Snapshot of the parent invocation's `config.configurable` at the
-   * spawn-tool call site. Inherited verbatim into the child workflow's
-   * `configurable` so host-set fields (`requestBody`, `user`,
-   * `userMCPAuthMap`, etc.) propagate — fixing MCP body-placeholder
-   * substitution and per-user lookups for subagent tool calls.
+   * Snapshot of the parent invocation's host `config.configurable` at
+   * the spawn-tool call site. Host-set fields (`requestBody`, `user`,
+   * `userMCPAuthMap`, etc.) propagate into the child workflow's
+   * `configurable` — fixing MCP body-placeholder substitution and
+   * per-user lookups for subagent tool calls. LangGraph runtime keys
+   * (`__pregel_*`, checkpoint bookkeeping) are intentionally not
+   * inherited; the child graph recreates its own runtime config.
    *
    * Inheritance details (verified empirically against LangGraph):
    *   - host-set keys propagate as-is into the child's tool dispatches;
@@ -390,10 +399,11 @@ export class SubagentExecutor {
        */
       const callbacks: Callbacks = forwarder ? [forwarder] : [];
       /**
-       * Inherit the parent's `configurable` verbatim — host-set fields
+       * Inherit the parent's host `configurable` — host-set fields
        * (`requestBody`, `user`, `userMCPAuthMap`, etc.) AND the run-
        * identity fields (`run_id`, `parent_run_id`, `thread_id`) all
-       * propagate.
+       * propagate. LangGraph's own runtime keys are excluded because the
+       * child graph creates its own scratchpad/checkpoint/abort plumbing.
        *
        * Run-identity propagation is intentional and matches the
        * convention this executor itself already uses for `SubagentStart`
@@ -418,7 +428,7 @@ export class SubagentExecutor {
        * case (synchronous subagents within a single user turn).
        */
       const inheritedConfigurable: Record<string, unknown> =
-        params.parentConfigurable ?? {};
+        sanitizeChildConfigurable(params.parentConfigurable);
       result = await workflow.invoke(
         { messages: [new HumanMessage(description)] },
         {
@@ -702,6 +712,26 @@ export class SubagentExecutor {
     handler.awaitHandlers = true;
     return { handler, drain };
   }
+}
+
+function sanitizeChildConfigurable(
+  parentConfigurable: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  if (parentConfigurable == null) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(parentConfigurable).filter(
+      ([key]) => !isLangGraphRuntimeConfigKey(key)
+    )
+  );
+}
+
+function isLangGraphRuntimeConfigKey(key: string): boolean {
+  return (
+    key.startsWith(LANGGRAPH_RUNTIME_CONFIG_PREFIX) ||
+    LANGGRAPH_CHECKPOINT_CONFIG_KEYS.has(key)
+  );
 }
 
 export function sanitizeForwardedSubagentUpdateData(

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -603,7 +603,11 @@ export class SubagentExecutor {
         const dropIndex = queuedUpdates.findIndex((queued) =>
           isDroppableSubagentUpdatePhase(queued.phase)
         );
-        queuedUpdates.splice(dropIndex >= 0 ? dropIndex : 0, 1);
+        if (dropIndex >= 0) {
+          queuedUpdates.splice(dropIndex, 1);
+        } else if (isDroppableSubagentUpdatePhase(update.phase)) {
+          return;
+        }
       }
       queuedUpdates.push(update);
     };

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -23,6 +23,7 @@ import { executeHooks } from '@/hooks';
 const DEFAULT_MAX_TURNS = 25;
 const RECURSION_MULTIPLIER = 3;
 const ERROR_MESSAGE_MAX_CHARS = 200;
+const MAX_PENDING_SUBAGENT_UPDATES = 64;
 const SUBAGENT_UPDATE_OMITTED_KEYS = new Set([
   'Authorization',
   'access_token',
@@ -66,6 +67,17 @@ type SanitizedSubagentToolExecuteData = {
 
 type ShallowSanitizedUpdateData = {
   [key: string]: unknown;
+};
+
+type QueuedSubagentUpdate = {
+  eventName: string;
+  phase: SubagentUpdatePhase;
+  data: unknown;
+};
+
+type ForwarderCallback = {
+  handler: BaseCallbackHandler;
+  drain: () => Promise<void>;
 };
 
 export type SubagentExecuteParams = {
@@ -272,7 +284,7 @@ export class SubagentExecutor {
       tokenCounter: this.tokenCounter,
     });
 
-    const forwarder = forwardingEnabled
+    const forwarding = forwardingEnabled
       ? this.createForwarderCallback({
         parentRegistry: parentRegistry!,
         subagentType,
@@ -281,6 +293,7 @@ export class SubagentExecutor {
         parentToolCallId,
       })
       : undefined;
+    const forwarder = forwarding?.handler;
 
     if (forwarder) {
       await this.emitSubagentUpdate(parentRegistry!, {
@@ -360,6 +373,7 @@ export class SubagentExecutor {
     } catch (error) {
       const errorMessage = truncateErrorMessage(error);
       if (forwarder) {
+        await forwarding.drain();
         await this.emitSubagentUpdate(parentRegistry!, {
           childRunId,
           subagentType,
@@ -406,6 +420,7 @@ export class SubagentExecutor {
     }
 
     if (forwarder) {
+      await forwarding.drain();
       await this.emitSubagentUpdate(parentRegistry!, {
         childRunId,
         subagentType,
@@ -479,7 +494,7 @@ export class SubagentExecutor {
     subagentAgentId: string;
     childRunId: string;
     parentToolCallId?: string;
-  }): BaseCallbackHandler {
+  }): ForwarderCallback {
     const {
       parentRegistry,
       subagentType,
@@ -499,23 +514,69 @@ export class SubagentExecutor {
       if (!handler) {
         return;
       }
-      const event: SubagentUpdateEvent = {
-        runId: parentRunId,
-        subagentRunId: childRunId,
-        subagentType,
-        subagentAgentId,
-        parentAgentId,
-        parentToolCallId,
-        phase,
-        data: sanitizeForwardedSubagentUpdateData(eventName, data),
-        label: summarizeEvent(eventName, data),
-        timestamp: new Date().toISOString(),
-      };
       try {
+        const event: SubagentUpdateEvent = {
+          runId: parentRunId,
+          subagentRunId: childRunId,
+          subagentType,
+          subagentAgentId,
+          parentAgentId,
+          parentToolCallId,
+          phase,
+          data: sanitizeForwardedSubagentUpdateData(eventName, data),
+          label: summarizeEvent(eventName, data),
+          timestamp: new Date().toISOString(),
+        };
         await handler.handle(GraphEvents.ON_SUBAGENT_UPDATE, event);
       } catch {
         /* observational — swallow */
       }
+    };
+
+    const queuedUpdates: QueuedSubagentUpdate[] = [];
+    let drainPromise: Promise<void> | undefined;
+
+    const enqueue = (update: QueuedSubagentUpdate): void => {
+      if (queuedUpdates.length >= MAX_PENDING_SUBAGENT_UPDATES) {
+        const dropIndex = queuedUpdates.findIndex((queued) =>
+          isDroppableSubagentUpdatePhase(queued.phase)
+        );
+        queuedUpdates.splice(dropIndex >= 0 ? dropIndex : 0, 1);
+      }
+      queuedUpdates.push(update);
+    };
+
+    const drain = async (): Promise<void> => {
+      if (drainPromise != null) {
+        await drainPromise;
+        return;
+      }
+      drainPromise = (async (): Promise<void> => {
+        while (queuedUpdates.length > 0) {
+          const update = queuedUpdates.shift();
+          if (update == null) {
+            continue;
+          }
+          await wrap(update.eventName, update.phase, update.data);
+        }
+      })();
+      try {
+        await drainPromise;
+      } finally {
+        drainPromise = undefined;
+        if (queuedUpdates.length > 0) {
+          await drain();
+        }
+      }
+    };
+
+    const scheduleWrap = (
+      eventName: string,
+      phase: SubagentUpdatePhase,
+      data: unknown
+    ): void => {
+      enqueue({ eventName, phase, data });
+      void drain();
     };
 
     const handler = BaseCallbackHandler.fromMethods({
@@ -537,28 +598,28 @@ export class SubagentExecutor {
            * We also surface a short notice in the subagent-update stream so
            * the UI can show "calling <tool>" for each tool the child spawns.
            */
-          void wrap(eventName, 'run_step', data);
+          scheduleWrap(eventName, 'run_step', data);
           return;
         }
 
         if (eventName === GraphEvents.ON_RUN_STEP) {
-          void wrap(eventName, 'run_step', data);
+          scheduleWrap(eventName, 'run_step', data);
           return;
         }
         if (eventName === GraphEvents.ON_RUN_STEP_DELTA) {
-          void wrap(eventName, 'run_step_delta', data);
+          scheduleWrap(eventName, 'run_step_delta', data);
           return;
         }
         if (eventName === GraphEvents.ON_RUN_STEP_COMPLETED) {
-          void wrap(eventName, 'run_step_completed', data);
+          scheduleWrap(eventName, 'run_step_completed', data);
           return;
         }
         if (eventName === GraphEvents.ON_MESSAGE_DELTA) {
-          void wrap(eventName, 'message_delta', data);
+          scheduleWrap(eventName, 'message_delta', data);
           return;
         }
         if (eventName === GraphEvents.ON_REASONING_DELTA) {
-          void wrap(eventName, 'reasoning_delta', data);
+          scheduleWrap(eventName, 'reasoning_delta', data);
           return;
         }
       },
@@ -566,14 +627,14 @@ export class SubagentExecutor {
     /**
      * `awaitHandlers = true` is required so the child's `ToolNode` actually
      * blocks on the parent's `ON_TOOL_EXECUTE` handler until it resolves
-     * the batch request. The callback also sees observational events
-     * (message_delta, run_step, …), but `ON_SUBAGENT_UPDATE` calls are
-     * deliberately emitted fire-and-forget so host UI publication cannot
-     * backpressure the child graph. `wrap` swallows handler errors because
-     * these events are observational.
+     * the batch request. Observational `ON_SUBAGENT_UPDATE` calls are queued
+     * behind a bounded sequential dispatcher so host UI publication cannot
+     * backpressure each child emission or run unbounded concurrent publishes.
+     * The executor drains this queue before terminal stop/error envelopes to
+     * preserve phase ordering.
      */
     handler.awaitHandlers = true;
-    return handler;
+    return { handler, drain };
   }
 }
 
@@ -588,6 +649,14 @@ export function sanitizeForwardedSubagentUpdateData(
     return data;
   }
   return omitOperationalUpdateFields(data);
+}
+
+function isDroppableSubagentUpdatePhase(phase: SubagentUpdatePhase): boolean {
+  return (
+    phase === 'message_delta' ||
+    phase === 'reasoning_delta' ||
+    phase === 'run_step_delta'
+  );
 }
 
 function sanitizeToolExecuteUpdateData(


### PR DESCRIPTION
## Summary

I sanitized subagent update forwarding so observational events no longer publish raw child graph payloads while preserving operational tool execution behavior.

- Sanitized forwarded `ON_TOOL_EXECUTE` subagent updates down to `agentId` and compact `toolCalls` entries with `id`, `name`, and `args`.
- Stripped operational and sensitive top-level fields from forwarded subagent update payloads, including `configurable`, `metadata`, token fields, user context, request body, checkpoint/scratchpad fields, and promise callbacks.
- Preserved the raw parent `ON_TOOL_EXECUTE` path so event-driven subagent tools still receive inherited configurable context for execution.
- Changed observational subagent updates to fire-and-forget inside the awaited forwarder callback so slow UI/SSE publication cannot backpressure child graph execution.
- Added regression coverage proving sensitive metadata is absent from `ON_SUBAGENT_UPDATE` while completed tool output remains intact.
- Confirmed the leak with a live API repro from the main worktree, then confirmed the patched worktree still executes the subagent tool with no token-shaped values in subagent updates.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `npx jest src/tools/__tests__/SubagentExecutor.test.ts --runInBand`
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/tools/subagent/SubagentExecutor.ts src/tools/subagent/index.ts src/tools/__tests__/SubagentExecutor.test.ts`
- [x] Live API repro on unpatched main confirmed `ON_SUBAGENT_UPDATE` leaked inherited `configurable` values.
- [x] Live API repro on patched worktree confirmed the subagent tool still executed and no fake token/request values appeared in `ON_SUBAGENT_UPDATE`.

### **Test Configuration**:

- Node.js via local repository toolchain
- OpenAI live API using the existing main worktree `.env`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes