### PR TITLE
🧵 fix: Strip Unsupported Claude Assistant Prefill

### DIFF
--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -17,9 +17,13 @@ import type {
   ChatAnthropicToolType,
   AnthropicMCPServerURLDefinition,
   AnthropicContextManagementConfigParam,
+  AnthropicRequestOptions,
 } from '@/llm/anthropic/types';
 import { _makeMessageChunkFromAnthropicEvent } from './utils/message_outputs';
-import { _convertMessagesToAnthropicPayload } from './utils/message_inputs';
+import {
+  _convertMessagesToAnthropicPayload,
+  stripUnsupportedAssistantPrefill,
+} from './utils/message_inputs';
 import { handleToolChoice } from './utils/tools';
 
 const DEFAULT_STREAM_DELAY = 25;
@@ -591,6 +595,26 @@ export class CustomAnthropic extends ChatAnthropicMessages {
     });
   }
 
+  protected override async createStreamWithRetry(
+    request: AnthropicStreamingMessageCreateParams,
+    options?: AnthropicRequestOptions
+  ): ReturnType<ChatAnthropicMessages['createStreamWithRetry']> {
+    return super.createStreamWithRetry(
+      stripUnsupportedAssistantPrefill(request),
+      options
+    );
+  }
+
+  protected override async completionWithRetry(
+    request: AnthropicMessageCreateParams,
+    options: AnthropicRequestOptions
+  ): ReturnType<ChatAnthropicMessages['completionWithRetry']> {
+    return super.completionWithRetry(
+      stripUnsupportedAssistantPrefill(request),
+      options
+    );
+  }
+
   async *_streamResponseChunks(
     messages: BaseMessage[],
     options: this['ParsedCallOptions'],
@@ -599,11 +623,11 @@ export class CustomAnthropic extends ChatAnthropicMessages {
     this.resetTokenEvents();
     const params = this.invocationParams(options);
     const formattedMessages = _convertMessagesToAnthropicPayload(messages);
-    const payload = {
+    const payload = stripUnsupportedAssistantPrefill({
       ...params,
       ...formattedMessages,
       stream: true,
-    } as const;
+    } as const);
     const coerceContentToString =
       !_toolsInParams(payload) &&
       !_documentsInParams(payload) &&

--- a/src/llm/anthropic/llm.spec.ts
+++ b/src/llm/anthropic/llm.spec.ts
@@ -64,7 +64,11 @@ import type {
   ToolEndEvent,
   TPayload,
 } from '@/types';
-import { _convertMessagesToAnthropicPayload } from './utils/message_inputs';
+import {
+  _convertMessagesToAnthropicPayload,
+  modelDisallowsAssistantPrefill,
+  stripUnsupportedAssistantPrefill,
+} from './utils/message_inputs';
 import {
   _makeMessageChunkFromAnthropicEvent,
   getAnthropicUsageMetadata,
@@ -2634,6 +2638,58 @@ describe('Anthropic Reasoning with contentBlocks', () => {
     const reasoningBlocks = blocks.filter(isReasoningContentBlock);
     expect(reasoningBlocks.length).toBeGreaterThan(0);
     expect(reasoningBlocks[0].reasoning.length).toBeGreaterThan(10);
+  });
+});
+
+describe('Claude assistant prefill compatibility', () => {
+  test.each([
+    'claude-sonnet-4-6',
+    'claude-opus-4-7',
+    'global.anthropic.claude-opus-4-6-v1:0',
+    'anthropic/claude-sonnet-4.6',
+  ])('detects %s as not supporting assistant prefill', (model) => {
+    expect(modelDisallowsAssistantPrefill(model)).toBe(true);
+  });
+
+  test.each([
+    'claude-sonnet-4-5-20250929',
+    'claude-opus-4-20250514',
+    'claude-opus-4-70',
+    'gpt-5.4',
+  ])('leaves %s prefill support unchanged', (model) => {
+    expect(modelDisallowsAssistantPrefill(model)).toBe(false);
+  });
+
+  test('strips trailing assistant messages for Claude 4.6+ requests', () => {
+    const request = {
+      model: 'claude-opus-4-6',
+      max_tokens: 100,
+      messages: [
+        { role: 'user' as const, content: 'What changed?' },
+        { role: 'assistant' as const, content: 'Draft prefill' },
+        { role: 'assistant' as const, content: 'Another prefill' },
+      ],
+    };
+
+    const sanitized = stripUnsupportedAssistantPrefill(request);
+
+    expect(sanitized).not.toBe(request);
+    expect(sanitized.messages).toEqual([
+      { role: 'user', content: 'What changed?' },
+    ]);
+  });
+
+  test('does not strip assistant messages for older Claude models', () => {
+    const request = {
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 100,
+      messages: [
+        { role: 'user' as const, content: 'Write JSON only.' },
+        { role: 'assistant' as const, content: '{' },
+      ],
+    };
+
+    expect(stripUnsupportedAssistantPrefill(request)).toBe(request);
   });
 });
 

--- a/src/llm/anthropic/llm.spec.ts
+++ b/src/llm/anthropic/llm.spec.ts
@@ -2646,8 +2646,10 @@ describe('Claude assistant prefill compatibility', () => {
     'claude-sonnet-4-6',
     'claude-sonnet-4-6@20260217',
     'claude-opus-4-7',
+    'claude-opus-4-10',
     'global.anthropic.claude-opus-4-6-v1:0',
     'anthropic/claude-sonnet-4.6',
+    'anthropic/claude-sonnet-4.12',
   ])('detects %s as not supporting assistant prefill', (model) => {
     expect(modelDisallowsAssistantPrefill(model)).toBe(true);
   });
@@ -2655,7 +2657,7 @@ describe('Claude assistant prefill compatibility', () => {
   test.each([
     'claude-sonnet-4-5-20250929',
     'claude-opus-4-20250514',
-    'claude-opus-4-70',
+    'anthropic.claude-opus-4-20250514-v1:0',
     'gpt-5.4',
   ])('leaves %s prefill support unchanged', (model) => {
     expect(modelDisallowsAssistantPrefill(model)).toBe(false);

--- a/src/llm/anthropic/llm.spec.ts
+++ b/src/llm/anthropic/llm.spec.ts
@@ -2644,6 +2644,7 @@ describe('Anthropic Reasoning with contentBlocks', () => {
 describe('Claude assistant prefill compatibility', () => {
   test.each([
     'claude-sonnet-4-6',
+    'claude-sonnet-4-6@20260217',
     'claude-opus-4-7',
     'global.anthropic.claude-opus-4-6-v1:0',
     'anthropic/claude-sonnet-4.6',

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -49,8 +49,10 @@ type GoogleFunctionCallBlock = MessageContentComplex & {
 };
 
 const ANTHROPIC_EMPTY_TEXT_PLACEHOLDER = '_';
+const CLAUDE_4_RELEASE_DATE_MODEL_PATTERN =
+  /claude-(?:opus|sonnet|haiku)-4-\d{8}(?:[-.@]|$)/i;
 const CLAUDE_4_MINOR_MODEL_PATTERN =
-  /claude-(?:opus|sonnet|haiku)-4[-.](\d)(?:[-.@]|$)/i;
+  /claude-(?:opus|sonnet|haiku)-4[-.](\d+)(?:[-.@]|$)/i;
 
 function _formatImage(imageUrl: string) {
   const parsed = parseBase64DataUrl({ dataUrl: imageUrl });
@@ -799,7 +801,12 @@ export function _convertMessagesToAnthropicPayload(
 }
 
 export function modelDisallowsAssistantPrefill(model?: string): boolean {
-  const match = CLAUDE_4_MINOR_MODEL_PATTERN.exec(model ?? '');
+  const modelId = model ?? '';
+  if (CLAUDE_4_RELEASE_DATE_MODEL_PATTERN.test(modelId)) {
+    return false;
+  }
+
+  const match = CLAUDE_4_MINOR_MODEL_PATTERN.exec(modelId);
   if (!match) {
     return false;
   }

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -49,6 +49,8 @@ type GoogleFunctionCallBlock = MessageContentComplex & {
 };
 
 const ANTHROPIC_EMPTY_TEXT_PLACEHOLDER = '_';
+const CLAUDE_4_MINOR_MODEL_PATTERN =
+  /claude-(?:opus|sonnet|haiku)-4[-.](\d)(?:[-.]|$)/i;
 
 function _formatImage(imageUrl: string) {
   const parsed = parseBase64DataUrl({ dataUrl: imageUrl });
@@ -794,6 +796,43 @@ export function _convertMessagesToAnthropicPayload(
     messages: mergeMessages(formattedMessages),
     system,
   } as AnthropicMessageCreateParams;
+}
+
+export function modelDisallowsAssistantPrefill(model?: string): boolean {
+  const match = CLAUDE_4_MINOR_MODEL_PATTERN.exec(model ?? '');
+  if (!match) {
+    return false;
+  }
+  return Number(match[1]) >= 6;
+}
+
+export function stripUnsupportedAssistantPrefill<
+  T extends Pick<AnthropicMessageCreateParams, 'messages'> & { model?: string },
+>(request: T): T {
+  if (!modelDisallowsAssistantPrefill(request.model)) {
+    return request;
+  }
+
+  const messages = request.messages;
+  if (
+    messages.length <= 1 ||
+    messages[messages.length - 1]?.role !== 'assistant'
+  ) {
+    return request;
+  }
+
+  const nextMessages = [...messages];
+  while (
+    nextMessages.length > 1 &&
+    nextMessages[nextMessages.length - 1]?.role === 'assistant'
+  ) {
+    nextMessages.pop();
+  }
+
+  return {
+    ...request,
+    messages: nextMessages,
+  };
 }
 
 function mergeMessages(messages: AnthropicMessageCreateParams['messages']) {

--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -50,7 +50,7 @@ type GoogleFunctionCallBlock = MessageContentComplex & {
 
 const ANTHROPIC_EMPTY_TEXT_PLACEHOLDER = '_';
 const CLAUDE_4_MINOR_MODEL_PATTERN =
-  /claude-(?:opus|sonnet|haiku)-4[-.](\d)(?:[-.]|$)/i;
+  /claude-(?:opus|sonnet|haiku)-4[-.](\d)(?:[-.@]|$)/i;
 
 function _formatImage(imageUrl: string) {
   const parsed = parseBase64DataUrl({ dataUrl: imageUrl });


### PR DESCRIPTION
## Summary

I fixed Claude 4.6+ Anthropic dispatch so requests ending with assistant messages no longer fail on models that reject assistant prefill. This addresses the root cause behind danny-avila/LibreChat#13196.

- Detect Claude Opus, Sonnet, and Haiku 4.6+ model IDs across direct and provider-shaped names.
- Strip trailing assistant-role messages immediately before Anthropic streaming and non-streaming dispatch for affected models.
- Preserve existing assistant-prefill behavior for Claude 4.5 and older models.
- Add regression coverage for affected and unaffected Claude model IDs.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I validated the fix with targeted unit coverage, package build, and live Vertex AI checks against `claude-sonnet-4-6`.

### **Test Configuration**:

- Project: `regulated-dev-441020`
- Region: `us-east5`
- Model: `claude-sonnet-4-6`
- Auth: user ADC via `gcloud auth application-default login`

Commands and checks:

- `npm test -- --runTestsByPath src/llm/anthropic/llm.spec.ts --runInBand --modulePathIgnorePatterns='<rootDir>/.claude' -t 'Claude assistant prefill compatibility'`
- `npm run build`
- `git diff --check`
- Live Vertex raw SDK: user-final message succeeded, final assistant prefill failed with `This model does not support assistant message prefill. The conversation must end with a user message.`
- Live Vertex non-streaming: base `ChatAnthropic` failed with the same 400, patched `CustomAnthropic` succeeded with the same final `AIMessage` input.
- Live Vertex streaming: base `ChatAnthropic` failed with the same 400, patched `CustomAnthropic` succeeded with the same final `AIMessage` input.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
