### PR TITLE
☁️ feat: Add Cloudflare Sandbox Execution Backend

### DIFF
--- a/docs/cloudflare-sandbox-tools.md
+++ b/docs/cloudflare-sandbox-tools.md
@@ -1,0 +1,103 @@
+# Cloudflare Sandbox Tool Execution
+
+`@librechat/agents` can run the built-in coding tools against a
+Cloudflare Sandbox by selecting the `cloudflare-sandbox` execution
+engine. The sandbox runtime is structural: any object with the required
+`exec`, `readFile`, `writeFile`, `mkdir`, `listFiles`, and `deleteFile`
+methods can be supplied.
+
+```ts
+import {
+  CLOUDFLARE_BASH_CODING_TOOL_NAMES,
+  createCloudflareBridgeRuntime,
+  Providers,
+} from '@librechat/agents';
+import { getSandbox } from '@cloudflare/sandbox';
+
+const runId = crypto.randomUUID();
+const sandbox = getSandbox(env.Sandbox, runId);
+
+const config = {
+  llmConfig: {
+    provider: Providers.OPENAI,
+    model: env.WORKERS_AI_MODEL,
+    apiKey: env.CLOUDFLARE_API_TOKEN,
+    configuration: {
+      baseURL: `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/ai/v1`,
+    },
+  },
+  toolExecution: {
+    engine: 'cloudflare-sandbox',
+    cloudflare: {
+      sandbox,
+      workspaceRoot: '/workspace',
+      env: {
+        GITHUB_TOKEN: env.GITHUB_TOKEN,
+      },
+      timeoutMs: 120000,
+      maxOutputChars: 200000,
+      includeCodingTools: true,
+      codingToolNames: CLOUDFLARE_BASH_CODING_TOOL_NAMES,
+      fileCheckpointing: true,
+    },
+  },
+} as const;
+```
+
+By default, the Cloudflare backend exposes the same built-in coding
+tool names as the local backend:
+
+- `read_file`
+- `write_file`
+- `edit_file`
+- `grep_search`
+- `glob_search`
+- `list_directory`
+- `compile_check`
+- `bash_tool`
+- `execute_code`
+- `run_tools_with_code`
+- `run_tools_with_bash`
+
+Review workflows that only want a bash-driven sandbox can set
+`codingToolNames` to `CLOUDFLARE_BASH_CODING_TOOL_NAMES`. That exposes
+file/search/list/compile tools plus `bash_tool` and `run_tools_with_bash`,
+while leaving out `execute_code` and `run_tools_with_code`.
+
+Paths are interpreted inside `workspaceRoot` and are clamped to that
+workspace. Command execution uses `sandbox.exec()`; file operations use
+the sandbox file APIs. No Workers AI provider is added by this backend:
+use `Providers.OPENAI` with an OpenAI-compatible `baseURL` and API key.
+
+## Outside Cloudflare
+
+Code running outside a Worker cannot call `getSandbox(env.Sandbox, id)`
+directly because it does not have a Durable Object binding. Deploy a
+Worker that wraps your handler with `bridge()` from
+`@cloudflare/sandbox/bridge`, set a `SANDBOX_API_KEY` secret, and create
+a structural runtime with `createCloudflareBridgeRuntime()`:
+
+```ts
+const sandbox = createCloudflareBridgeRuntime({
+  baseURL: process.env.CF_SANDBOX_BRIDGE_URL!,
+  apiKey: process.env.CF_SANDBOX_API_KEY!,
+  sandboxId: runId,
+});
+
+const config = {
+  toolExecution: {
+    engine: 'cloudflare-sandbox',
+    cloudflare: {
+      sandbox,
+      workspaceRoot: '/workspace',
+      includeCodingTools: true,
+      codingToolNames: CLOUDFLARE_BASH_CODING_TOOL_NAMES,
+    },
+  },
+} as const;
+```
+
+The bridge adapter uses `/v1/sandbox/:id/exec` for command execution
+and the bridge file endpoints for reads/writes. Operations not exposed
+directly by the bridge (`mkdir`, `listFiles`, `deleteFile`) are
+implemented with bash commands inside the same sandbox workspace.

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -2847,6 +2847,72 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolCallChunks.size).toBe(0);
   });
 
+  it('does not prestart streamed Cloudflare sandbox direct coding tools', async () => {
+    const graph = createGraph({
+      toolExecution: {
+        engine: 'cloudflare-sandbox',
+        cloudflare: { sandbox: {} },
+      } as StandardGraph['toolExecution'],
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: Constants.BASH_TOOL }, { name: 'weather' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_bash',
+              name: Constants.BASH_TOOL,
+              args: '{"command":"echo ok"}',
+              index: 1,
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+    expect(graph.eagerEventToolCallChunks.size).toBe(0);
+  });
+
   it('prestarts streamed remote bash tools when the next Anthropic tool call begins', async () => {
     const graph = createGraph({
       getAgentContext: jest.fn(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -58,6 +58,7 @@ import { createFakeStreamingLLM } from '@/llm/fake';
 import { handleToolCalls } from '@/tools/handlers';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
+import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
 import { isThinkingEnabled } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import { HandlerRegistry } from '@/events';
@@ -337,11 +338,12 @@ export abstract class Graph<
   /**
    * Single per-Run file checkpointer shared across every ToolNode the
    * graph compiles. Lazily constructed when
-   * `toolExecution.local.fileCheckpointing === true` so multi-agent
-   * graphs see ONE snapshot store, not one-per-agent. Returns
-   * undefined when checkpointing is disabled or the local engine
-   * isn't selected. Exposed via `Run.getFileCheckpointer()` /
-   * `Run.rewindFiles()`.
+   * `toolExecution.local.fileCheckpointing === true` or
+   * `toolExecution.cloudflare.fileCheckpointing === true` so
+   * multi-agent graphs see ONE snapshot store, not one-per-agent.
+   * Returns undefined when checkpointing is disabled or a supported
+   * coding-tool engine isn't selected. Exposed via
+   * `Run.getFileCheckpointer()` / `Run.rewindFiles()`.
    */
   private _fileCheckpointer?: t.LocalFileCheckpointer;
   /**
@@ -364,20 +366,32 @@ export abstract class Graph<
     if (this._fileCheckpointer != null) {
       return this._fileCheckpointer;
     }
-    if (
-      this.toolExecution?.engine !== 'local' ||
-      this.toolExecution.local?.fileCheckpointing !== true
-    ) {
-      return undefined;
-    }
     // Eagerly create via the bundle factory so the construction path
     // matches the bundle-only callers (and future bundle-internal
     // cleanup hooks fire). The bundle factory itself accepts a pre-
     // supplied checkpointer when present, so re-injecting this one
     // into every ToolNode is idempotent.
-    const bundle = createLocalCodingToolBundle(this.toolExecution.local ?? {});
-    this._fileCheckpointer = bundle.checkpointer;
-    return this._fileCheckpointer;
+    if (
+      this.toolExecution?.engine === 'local' &&
+      this.toolExecution.local?.fileCheckpointing === true
+    ) {
+      const bundle = createLocalCodingToolBundle(
+        this.toolExecution.local ?? {}
+      );
+      this._fileCheckpointer = bundle.checkpointer;
+      return this._fileCheckpointer;
+    }
+    if (
+      this.toolExecution?.engine === 'cloudflare-sandbox' &&
+      this.toolExecution.cloudflare?.fileCheckpointing === true
+    ) {
+      const bundle = createCloudflareCodingToolBundle(
+        this.toolExecution.cloudflare
+      );
+      this._fileCheckpointer = bundle.checkpointer;
+      return this._fileCheckpointer;
+    }
+    return undefined;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export * from './tools/ToolNode';
 export * from './tools/schema';
 export * from './tools/handlers';
 export * from './tools/local';
+export * from './tools/cloudflare';
 export * from './tools/search';
 
 /* Misc. */

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -136,10 +136,19 @@ function isDirectGraphTool(
 }
 
 function isDirectLocalTool(name: string, graph: StandardGraph): boolean {
-  if (graph.toolExecution?.engine !== 'local') {
+  const toolExecution = graph.toolExecution;
+  const engine = toolExecution?.engine;
+  if (
+    toolExecution == null ||
+    (engine !== 'local' && engine !== 'cloudflare-sandbox')
+  ) {
     return false;
   }
-  if (graph.toolExecution.local?.includeCodingTools === false) {
+  const includeCodingTools =
+    engine === 'cloudflare-sandbox'
+      ? toolExecution.cloudflare?.includeCodingTools
+      : toolExecution.local?.includeCodingTools;
+  if (includeCodingTools === false) {
     return CODE_EXECUTION_TOOLS.has(name);
   }
   return LOCAL_CODING_BUNDLE_NAME_SET.has(name);
@@ -270,7 +279,8 @@ function hasPotentialDirectToolInStreamContext(args: {
   agentContext?: AgentContext;
 }): boolean {
   const { graph, agentContext } = args;
-  if (graph.toolExecution?.engine === 'local') {
+  const engine = graph.toolExecution?.engine;
+  if (engine === 'local' || engine === 'cloudflare-sandbox') {
     return true;
   }
   if ((agentContext?.graphTools?.length ?? 0) > 0) {

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -178,6 +178,37 @@ describe('Cloudflare sandbox execution backend', () => {
     expect(result.timedOut).toBe(true);
   });
 
+  it('passes call-specific timeouts to the Cloudflare spawn wrapper', async () => {
+    let execCommand = '';
+    let execTimeout: number | undefined;
+    const sandbox = createRuntime({
+      exec: async (command, options) => {
+        execCommand = command;
+        execTimeout = options?.timeout;
+        return {
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        };
+      },
+    });
+    const config = createCloudflareLocalExecutionConfig({
+      sandbox,
+      workspaceRoot: '/workspace',
+      timeoutMs: 1000,
+    });
+
+    await expect(
+      spawnLocalProcess('bash', ['-lc', 'echo ok'], {
+        ...config,
+        timeoutMs: 120000,
+      })
+    ).resolves.toMatchObject({ exitCode: 0, timedOut: false });
+
+    expect(execCommand).toContain('timeout -k 2s 120s bash -lc');
+    expect(execTimeout).toBe(125000);
+  });
+
   it('marks Cloudflare code execution timeouts', async () => {
     const sandbox = createRuntime({
       exec: async (command) => ({
@@ -239,6 +270,7 @@ describe('Cloudflare sandbox execution backend', () => {
       sandbox,
       workspaceRoot: '/workspace',
       readOnly: true,
+      shell: '/bin/sh',
     });
 
     await programmatic.invoke({
@@ -247,6 +279,8 @@ describe('Cloudflare sandbox execution backend', () => {
     });
 
     expect(source).toContain('READ_ONLY = True');
+    expect(source).toContain('SHELL = "/bin/sh"');
+    expect(source).toContain('[SHELL, "-lc", command, "--"]');
     expect(source).toContain('_assert_writable("write_file")');
     expect(source).toContain('if _is_within_workspace(resolved):');
     expect(source).toContain('_validate_bash_command(command, args=args)');
@@ -294,6 +328,7 @@ describe('Cloudflare sandbox execution backend', () => {
     const programmatic = createCloudflareBashProgrammaticToolCallingTool({
       sandbox,
       workspaceRoot: '/workspace',
+      shell: '/bin/sh',
     });
 
     await programmatic.invoke({
@@ -301,6 +336,8 @@ describe('Cloudflare sandbox execution backend', () => {
     });
 
     expect(execCommand).toContain('const ALLOW_DANGEROUS_COMMANDS = false;');
+    expect(execCommand).toContain('const SHELL = "/bin/sh";');
+    expect(execCommand).toContain('cp.spawn(SHELL, ["-lc", command, "--"');
     expect(execCommand).toContain(
       'function validateBashCommand(command, args)'
     );

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -307,6 +307,63 @@ describe('Cloudflare sandbox execution backend', () => {
     expect(execCommand).toContain('validateBashCommand(command, args);');
   });
 
+  it('uses root-safe path containment in programmatic helpers', async () => {
+    let pythonSource = '';
+    const pythonSandbox = createRuntime({
+      writeFile: async (_path, content) => {
+        pythonSource = String(content);
+        return { ok: true };
+      },
+      exec: async () => ({
+        exitCode: 0,
+        stdout: 'done',
+        stderr: '',
+      }),
+    });
+    const pythonProgrammatic = createCloudflareProgrammaticToolCallingTool({
+      sandbox: pythonSandbox,
+      workspaceRoot: '/',
+    });
+
+    await pythonProgrammatic.invoke({
+      code: 'print("ok")',
+      lang: 'py',
+    });
+
+    expect(pythonSource).toContain('WORKSPACE = "/"');
+    expect(pythonSource).toContain(
+      'return os.path.commonpath([root, resolved]) == root'
+    );
+
+    let bashCommand = '';
+    const bashSandbox = createRuntime({
+      exec: async (command) => {
+        bashCommand = command;
+        return {
+          exitCode: 0,
+          stdout: 'done',
+          stderr: '',
+        };
+      },
+    });
+    const bashProgrammatic = createCloudflareBashProgrammaticToolCallingTool({
+      sandbox: bashSandbox,
+      workspaceRoot: '/',
+    });
+
+    await bashProgrammatic.invoke({
+      code: 'printf "%s\\n" "ok"',
+    });
+
+    expect(bashCommand).toContain('const WORKSPACE = "/";');
+    expect(bashCommand).toContain(
+      'const relative = path.relative(root, resolved);'
+    );
+    expect(bashCommand).toContain(
+      'relative.startsWith("..") || path.isAbsolute(relative)'
+    );
+  });
+
   it('enforces Cloudflare codingToolNames as an allowlist', () => {
     const tools = resolveLocalToolsForBinding({
       tools: [

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -1,0 +1,178 @@
+import type * as t from '@/types';
+import { spawnLocalProcess } from '../local/LocalExecutionEngine';
+import {
+  createCloudflareWorkspaceFS,
+  createCloudflareLocalExecutionConfig,
+} from '../cloudflare/CloudflareSandboxExecutionEngine';
+import { createCloudflareBridgeRuntime } from '../cloudflare/CloudflareBridgeRuntime';
+
+function sseResponse(events: string): Response {
+  return new Response(events, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function sseExit(exitCode = 0): Response {
+  return sseResponse(`event: exit\ndata: {"exit_code":${exitCode}}\n\n`);
+}
+
+function bodyText(body: BodyInit | null | undefined): string {
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (body == null) {
+    return '';
+  }
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body).toString('utf8');
+  }
+  return String(body);
+}
+
+function createRuntime(
+  overrides: Partial<t.CloudflareSandboxRuntime> = {}
+): t.CloudflareSandboxRuntime {
+  return {
+    exec: async () => ({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    }),
+    readFile: async () => '',
+    writeFile: async () => ({ ok: true }),
+    mkdir: async () => ({ ok: true }),
+    listFiles: async () => [],
+    deleteFile: async () => ({ ok: true }),
+    ...overrides,
+  };
+}
+
+describe('Cloudflare sandbox execution backend', () => {
+  it('normalizes trailing workspace slashes before clamping paths', async () => {
+    const readPaths: string[] = [];
+    const fs = createCloudflareWorkspaceFS({
+      workspaceRoot: '/workspace/',
+      sandbox: createRuntime({
+        readFile: async (filePath) => {
+          readPaths.push(filePath);
+          return 'ok';
+        },
+      }),
+    });
+
+    await expect(fs.readFile('file.txt', 'utf8')).resolves.toBe('ok');
+    expect(readPaths).toEqual(['/workspace/file.txt']);
+  });
+
+  it('stats the workspace root without listing its parent directory', async () => {
+    const listPaths: string[] = [];
+    const fs = createCloudflareWorkspaceFS({
+      workspaceRoot: '/workspace/',
+      sandbox: createRuntime({
+        listFiles: async (filePath) => {
+          listPaths.push(filePath);
+          return [{ name: 'src', type: 'directory' }];
+        },
+      }),
+    });
+
+    const stats = await fs.stat('.');
+
+    expect(stats.isDirectory()).toBe(true);
+    expect(listPaths).toEqual(['/workspace']);
+  });
+
+  it('aborts remote exec when the local timeout kills the spawn wrapper', async () => {
+    let signal: AbortSignal | undefined;
+    const sandbox = createRuntime({
+      exec: (_command, options) =>
+        new Promise<t.CloudflareSandboxExecResult>((_resolve, reject) => {
+          signal = options?.signal;
+          signal?.addEventListener('abort', () => reject(new Error('aborted')));
+        }),
+    });
+    const config = createCloudflareLocalExecutionConfig({
+      sandbox,
+      timeoutMs: 10,
+      workspaceRoot: '/workspace',
+    });
+
+    const result = await spawnLocalProcess('bash', ['-lc', 'sleep 10'], config);
+
+    expect(signal?.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBe(143);
+  });
+});
+
+describe('Cloudflare bridge runtime', () => {
+  it('retries sandbox creation after a transient create failure', async () => {
+    let createCalls = 0;
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = input.toString();
+      if (url.endsWith('/sandbox')) {
+        createCalls += 1;
+        if (createCalls === 1) {
+          return new Response('try again', { status: 503 });
+        }
+        return Response.json({ id: 'retryid' });
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+    const runtime = createCloudflareBridgeRuntime({
+      baseURL: 'https://bridge.example',
+      fetch: fetchImpl,
+    });
+
+    await expect(runtime.getSandboxId()).rejects.toThrow('503');
+    await expect(runtime.getSandboxId()).resolves.toBe('retryid');
+    expect(createCalls).toBe(2);
+  });
+
+  it('fails exec when the SSE stream ends before an exit event', async () => {
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = input.toString();
+      if (url.endsWith('/exec')) {
+        const stdout = Buffer.from('partial').toString('base64');
+        return sseResponse(`event: stdout\ndata: ${stdout}\n\n`);
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+    const runtime = createCloudflareBridgeRuntime({
+      baseURL: 'https://bridge.example',
+      sandboxId: 'abc',
+      fetch: fetchImpl,
+    });
+
+    await expect(runtime.exec('echo partial')).rejects.toThrow(
+      'closed before an exit event'
+    );
+  });
+
+  it('prunes hidden directory trees when includeHidden is disabled', async () => {
+    let command = '';
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = input.toString();
+      if (url.endsWith('/exec')) {
+        const body = JSON.parse(bodyText(init?.body)) as { argv?: string[] };
+        command = body.argv?.[2] ?? '';
+        return sseExit();
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+    const runtime = createCloudflareBridgeRuntime({
+      baseURL: 'https://bridge.example',
+      sandboxId: 'abc',
+      fetch: fetchImpl,
+    });
+
+    await runtime.listFiles('/workspace', {
+      recursive: true,
+      includeHidden: false,
+    });
+
+    expect(command).toContain('-prune');
+    expect(command).toContain('\\( -name \'.*\' -prune \\) -o');
+  });
+});

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -6,6 +6,7 @@ import {
   createCloudflareWorkspaceFS,
   createCloudflareLocalExecutionConfig,
   executeCloudflareBash,
+  executeCloudflareCode,
 } from '../cloudflare/CloudflareSandboxExecutionEngine';
 import { createCloudflareBridgeRuntime } from '../cloudflare/CloudflareBridgeRuntime';
 import {
@@ -152,19 +153,21 @@ describe('Cloudflare sandbox execution backend', () => {
   it('wraps direct bash commands with an in-sandbox timeout', async () => {
     let execCommand = '';
     let execTimeout: number | undefined;
+    let calls = 0;
     const sandbox = createRuntime({
       exec: async (command, options) => {
+        calls += 1;
         execCommand = command;
         execTimeout = options?.timeout;
         return {
-          exitCode: 0,
+          exitCode: calls === 1 ? 0 : 124,
           stdout: 'ok',
           stderr: '',
         };
       },
     });
 
-    await executeCloudflareBash('echo ok', {
+    const result = await executeCloudflareBash('echo ok', {
       sandbox,
       workspaceRoot: '/workspace',
       timeoutMs: 1500,
@@ -172,6 +175,28 @@ describe('Cloudflare sandbox execution backend', () => {
 
     expect(execCommand).toContain('timeout -k 2s 2s bash -lc');
     expect(execTimeout).toBe(6500);
+    expect(result.timedOut).toBe(true);
+  });
+
+  it('marks Cloudflare code execution timeouts', async () => {
+    const sandbox = createRuntime({
+      exec: async (command) => ({
+        exitCode: command.startsWith('rm -rf') ? 0 : 124,
+        stdout: '',
+        stderr: '',
+      }),
+    });
+
+    const result = await executeCloudflareCode(
+      { lang: 'py', code: 'print("slow")' },
+      {
+        sandbox,
+        workspaceRoot: '/workspace',
+        timeoutMs: 1000,
+      }
+    );
+
+    expect(result.timedOut).toBe(true);
   });
 
   it('forwards only explicit Cloudflare env vars to sandbox exec', async () => {
@@ -392,5 +417,27 @@ describe('Cloudflare bridge runtime', () => {
 
     expect(command).toContain('-prune');
     expect(command).toContain('\\( -name \'.*\' -prune \\) -o');
+  });
+
+  it('fails bridge listFiles for non-directory targets', async () => {
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = input.toString();
+      if (url.endsWith('/exec')) {
+        const stderr = Buffer.from('not a directory').toString('base64');
+        return sseResponse(
+          `event: stderr\ndata: ${stderr}\n\nevent: exit\ndata: {"exit_code":20}\n\n`
+        );
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    };
+    const runtime = createCloudflareBridgeRuntime({
+      baseURL: 'https://bridge.example',
+      sandboxId: 'abc',
+      fetch: fetchImpl,
+    });
+
+    await expect(runtime.listFiles('/workspace/file.txt')).rejects.toThrow(
+      'not a directory'
+    );
   });
 });

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -192,6 +192,27 @@ describe('Cloudflare sandbox execution backend', () => {
 });
 
 describe('Cloudflare bridge runtime', () => {
+  it('preserves caller-provided sandbox ids', async () => {
+    const urls: string[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      urls.push(input.toString());
+      if (input.toString().endsWith('/exec')) {
+        return sseExit();
+      }
+      throw new Error(`Unexpected URL: ${input.toString()}`);
+    };
+    const runtime = createCloudflareBridgeRuntime({
+      baseURL: 'https://bridge.example',
+      sandboxId: 'user-123',
+      fetch: fetchImpl,
+    });
+
+    await expect(runtime.getSandboxId()).resolves.toBe('user-123');
+    await runtime.exec('true');
+
+    expect(urls).toEqual(['https://bridge.example/v1/sandbox/user-123/exec']);
+  });
+
   it('retries sandbox creation after a transient create failure', async () => {
     let createCalls = 0;
     const fetchImpl: typeof fetch = async (input) => {

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -1,8 +1,11 @@
 import type * as t from '@/types';
+import { Constants } from '@/common';
 import { spawnLocalProcess } from '../local/LocalExecutionEngine';
+import { resolveLocalToolsForBinding } from '../local/resolveLocalExecutionTools';
 import {
   createCloudflareWorkspaceFS,
   createCloudflareLocalExecutionConfig,
+  executeCloudflareBash,
 } from '../cloudflare/CloudflareSandboxExecutionEngine';
 import { createCloudflareBridgeRuntime } from '../cloudflare/CloudflareBridgeRuntime';
 import {
@@ -69,6 +72,22 @@ describe('Cloudflare sandbox execution backend', () => {
     expect(readPaths).toEqual(['/workspace/file.txt']);
   });
 
+  it('allows root workspace paths', async () => {
+    const readPaths: string[] = [];
+    const fs = createCloudflareWorkspaceFS({
+      workspaceRoot: '/',
+      sandbox: createRuntime({
+        readFile: async (filePath) => {
+          readPaths.push(filePath);
+          return 'ok';
+        },
+      }),
+    });
+
+    await expect(fs.readFile('tmp/file.txt', 'utf8')).resolves.toBe('ok');
+    expect(readPaths).toEqual(['/tmp/file.txt']);
+  });
+
   it('stats the workspace root without listing its parent directory', async () => {
     const listPaths: string[] = [];
     const fs = createCloudflareWorkspaceFS({
@@ -107,6 +126,52 @@ describe('Cloudflare sandbox execution backend', () => {
     expect(signal?.aborted).toBe(true);
     expect(result.timedOut).toBe(true);
     expect(result.exitCode).toBe(143);
+  });
+
+  it('memoizes sandbox factory results per config object', async () => {
+    let calls = 0;
+    const runtime = createRuntime({
+      readFile: async () => 'ok',
+      writeFile: async () => ({ ok: true }),
+    });
+    const config = {
+      workspaceRoot: '/workspace',
+      sandbox: async (): Promise<t.CloudflareSandboxRuntime> => {
+        calls += 1;
+        return runtime;
+      },
+    };
+    const fs = createCloudflareWorkspaceFS(config);
+
+    await fs.readFile('a.txt', 'utf8');
+    await fs.writeFile('b.txt', 'ok', 'utf8');
+
+    expect(calls).toBe(1);
+  });
+
+  it('wraps direct bash commands with an in-sandbox timeout', async () => {
+    let execCommand = '';
+    let execTimeout: number | undefined;
+    const sandbox = createRuntime({
+      exec: async (command, options) => {
+        execCommand = command;
+        execTimeout = options?.timeout;
+        return {
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        };
+      },
+    });
+
+    await executeCloudflareBash('echo ok', {
+      sandbox,
+      workspaceRoot: '/workspace',
+      timeoutMs: 1500,
+    });
+
+    expect(execCommand).toContain('timeout -k 2s 2s bash -lc');
+    expect(execTimeout).toBe(6500);
   });
 
   it('forwards only explicit Cloudflare env vars to sandbox exec', async () => {
@@ -162,6 +227,33 @@ describe('Cloudflare sandbox execution backend', () => {
     expect(source).toContain('_validate_bash_command(command, args=args)');
   });
 
+  it('clamps programmatic timeouts before sandbox execution', async () => {
+    const timeouts: Array<number | undefined> = [];
+    const sandbox = createRuntime({
+      writeFile: async () => ({ ok: true }),
+      exec: async (_command, options) => {
+        timeouts.push(options?.timeout);
+        return {
+          exitCode: 0,
+          stdout: 'done',
+          stderr: '',
+        };
+      },
+    });
+    const programmatic = createCloudflareProgrammaticToolCallingTool({
+      sandbox,
+      workspaceRoot: '/workspace',
+    });
+
+    await programmatic.invoke({
+      code: 'print("ok")',
+      lang: 'py',
+      timeout: 300000,
+    });
+
+    expect(timeouts[0]).toBe(305000);
+  });
+
   it('injects bash validation into bash programmatic tools', async () => {
     let execCommand = '';
     const sandbox = createRuntime({
@@ -188,6 +280,26 @@ describe('Cloudflare sandbox execution backend', () => {
       'function validateBashCommand(command, args)'
     );
     expect(execCommand).toContain('validateBashCommand(command, args);');
+  });
+
+  it('enforces Cloudflare codingToolNames as an allowlist', () => {
+    const tools = resolveLocalToolsForBinding({
+      tools: [
+        { name: Constants.EXECUTE_CODE } as t.GenericTool,
+        { name: Constants.BASH_TOOL } as t.GenericTool,
+      ],
+      toolExecution: {
+        engine: 'cloudflare-sandbox',
+        cloudflare: {
+          sandbox: createRuntime(),
+          codingToolNames: [Constants.BASH_TOOL],
+        },
+      },
+    }) as t.GenericTool[];
+    const names = tools.map((toolDef) => toolDef.name);
+
+    expect(names).toContain(Constants.BASH_TOOL);
+    expect(names).not.toContain(Constants.EXECUTE_CODE);
   });
 });
 

--- a/src/tools/__tests__/CloudflareSandboxExecution.test.ts
+++ b/src/tools/__tests__/CloudflareSandboxExecution.test.ts
@@ -5,6 +5,10 @@ import {
   createCloudflareLocalExecutionConfig,
 } from '../cloudflare/CloudflareSandboxExecutionEngine';
 import { createCloudflareBridgeRuntime } from '../cloudflare/CloudflareBridgeRuntime';
+import {
+  createCloudflareBashProgrammaticToolCallingTool,
+  createCloudflareProgrammaticToolCallingTool,
+} from '../cloudflare/CloudflareProgrammaticToolCalling';
 
 function sseResponse(events: string): Response {
   return new Response(events, {
@@ -103,6 +107,87 @@ describe('Cloudflare sandbox execution backend', () => {
     expect(signal?.aborted).toBe(true);
     expect(result.timedOut).toBe(true);
     expect(result.exitCode).toBe(143);
+  });
+
+  it('forwards only explicit Cloudflare env vars to sandbox exec', async () => {
+    let execEnv: Record<string, string | undefined> | undefined;
+    const sandbox = createRuntime({
+      exec: async (_command, options) => {
+        execEnv = options?.env;
+        return {
+          exitCode: 0,
+          stdout: 'ok',
+          stderr: '',
+        };
+      },
+    });
+    const config = createCloudflareLocalExecutionConfig({
+      sandbox,
+      workspaceRoot: '/workspace',
+      env: { SAFE_FOR_SANDBOX: 'yes' },
+    });
+
+    await spawnLocalProcess('bash', ['-lc', 'echo ok'], config);
+
+    expect(execEnv).toEqual({ SAFE_FOR_SANDBOX: 'yes' });
+  });
+
+  it('injects read-only and workspace guards into Python programmatic tools', async () => {
+    let source = '';
+    const sandbox = createRuntime({
+      writeFile: async (_path, content) => {
+        source = String(content);
+        return { ok: true };
+      },
+      exec: async () => ({
+        exitCode: 0,
+        stdout: 'done',
+        stderr: '',
+      }),
+    });
+    const programmatic = createCloudflareProgrammaticToolCallingTool({
+      sandbox,
+      workspaceRoot: '/workspace',
+      readOnly: true,
+    });
+
+    await programmatic.invoke({
+      code: 'await write_file("x.txt", "blocked")',
+      lang: 'py',
+    });
+
+    expect(source).toContain('READ_ONLY = True');
+    expect(source).toContain('_assert_writable("write_file")');
+    expect(source).toContain('if _is_within_workspace(resolved):');
+    expect(source).toContain('_validate_bash_command(command, args=args)');
+  });
+
+  it('injects bash validation into bash programmatic tools', async () => {
+    let execCommand = '';
+    const sandbox = createRuntime({
+      exec: async (command) => {
+        execCommand = command;
+        return {
+          exitCode: 0,
+          stdout: 'done',
+          stderr: '',
+        };
+      },
+    });
+    const programmatic = createCloudflareBashProgrammaticToolCallingTool({
+      sandbox,
+      workspaceRoot: '/workspace',
+    });
+
+    await programmatic.invoke({
+      code: 'printf "%s\\n" "ok"',
+    });
+
+    expect(execCommand).toContain('const ALLOW_DANGEROUS_COMMANDS = false;');
+    expect(execCommand).toContain(
+      'function validateBashCommand(command, args)'
+    );
+    expect(execCommand).toContain('validateBashCommand(command, args);');
   });
 });
 

--- a/src/tools/cloudflare/CloudflareBridgeRuntime.ts
+++ b/src/tools/cloudflare/CloudflareBridgeRuntime.ts
@@ -45,6 +45,11 @@ function normalizePrefix(prefix: string | undefined): string {
   return withLeadingSlash.replace(/\/+$/, '');
 }
 
+function normalizeWorkspaceRoot(workspaceRoot: string): string {
+  const normalized = path.normalize(workspaceRoot);
+  return normalized === '/' ? normalized : normalized.replace(/\/+$/, '');
+}
+
 function base32Encode(bytes: Uint8Array): string {
   let bits = 0;
   let value = 0;
@@ -98,7 +103,7 @@ function encodeBridgePath(filePath: string): string {
 
 function toSandboxPath(filePath: string, workspaceRoot: string): string {
   const raw = filePath === '' ? '.' : filePath;
-  const root = path.normalize(workspaceRoot);
+  const root = normalizeWorkspaceRoot(workspaceRoot);
   const resolved = raw.startsWith('/')
     ? path.normalize(raw)
     : path.resolve(root, raw);
@@ -262,7 +267,7 @@ export function createCloudflareBridgeRuntime(
 ): CloudflareBridgeRuntime {
   const baseURL = normalizeBaseURL(config.baseURL);
   const apiPrefix = normalizePrefix(config.apiRoutePrefix);
-  const workspaceRoot = path.normalize(
+  const workspaceRoot = normalizeWorkspaceRoot(
     config.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT
   );
   const shell = config.shell ?? DEFAULT_SHELL;
@@ -291,7 +296,10 @@ export function createCloudflareBridgeRuntime(
           );
         }
         return payload.id;
-      })();
+      })().catch((error: unknown) => {
+        sandboxIdPromise = undefined;
+        throw error;
+      });
     }
     return sandboxIdPromise;
   }
@@ -325,7 +333,7 @@ export function createCloudflareBridgeRuntime(
     let buffer = '';
     let stdout = '';
     let stderr = '';
-    let exitCode = 0;
+    let exitCode: number | undefined;
 
     try {
       for (;;) {
@@ -350,8 +358,32 @@ export function createCloudflareBridgeRuntime(
           }
         }
       }
+      buffer += decoder.decode();
+      const parsed = parseSSEChunk(buffer);
+      buffer = parsed.remainder;
+      for (const event of parsed.events) {
+        if (event.event === 'stdout') {
+          const decoded = decodeBase64(event.data);
+          stdout += decoded;
+          options.onOutput?.('stdout', decoded);
+        } else if (event.event === 'stderr') {
+          const decoded = decodeBase64(event.data);
+          stderr += decoded;
+          options.onOutput?.('stderr', decoded);
+        } else if (event.event === 'exit') {
+          exitCode = parseExitCode(event.data);
+        } else if (event.event === 'error') {
+          throw new Error(parseBridgeError(event.data));
+        }
+      }
     } finally {
       reader.releaseLock();
+    }
+
+    if (exitCode == null) {
+      throw new Error(
+        'Cloudflare sandbox bridge exec stream closed before an exit event.'
+      );
     }
 
     return {
@@ -417,7 +449,8 @@ export function createCloudflareBridgeRuntime(
   ): Promise<t.CloudflareSandboxFileInfo[]> {
     const resolvedPath = toSandboxPath(filePath, workspaceRoot);
     const maxDepth = options?.recursive === true ? '' : '-maxdepth 1';
-    const hiddenFilter = options?.includeHidden === true ? '' : ' ! -name \'.*\'';
+    const hiddenFilter =
+      options?.includeHidden === true ? '' : ' \\( -name \'.*\' -prune \\) -o';
     const command =
       `find ${quote(resolvedPath)} -mindepth 1 ${maxDepth}${hiddenFilter} ` +
       '-printf \'%y\\t%s\\t%p\\n\'';

--- a/src/tools/cloudflare/CloudflareBridgeRuntime.ts
+++ b/src/tools/cloudflare/CloudflareBridgeRuntime.ts
@@ -77,6 +77,9 @@ function toSandboxPath(filePath: string, workspaceRoot: string): string {
   const resolved = raw.startsWith('/')
     ? path.normalize(raw)
     : path.resolve(root, raw);
+  if (root === '/') {
+    return resolved;
+  }
   if (resolved === root || resolved.startsWith(`${root}/`)) {
     return resolved;
   }

--- a/src/tools/cloudflare/CloudflareBridgeRuntime.ts
+++ b/src/tools/cloudflare/CloudflareBridgeRuntime.ts
@@ -4,8 +4,6 @@ import type * as t from '@/types';
 const DEFAULT_API_PREFIX = '/v1';
 const DEFAULT_WORKSPACE_ROOT = '/workspace';
 const DEFAULT_SHELL = 'bash';
-const BRIDGE_SANDBOX_ID_RE = /^[a-z2-7]{1,128}$/;
-const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
 
 export type CloudflareBridgeRuntimeConfig = {
   /** Base URL of a Worker using `bridge()` from `@cloudflare/sandbox/bridge`. */
@@ -48,34 +46,6 @@ function normalizePrefix(prefix: string | undefined): string {
 function normalizeWorkspaceRoot(workspaceRoot: string): string {
   const normalized = path.normalize(workspaceRoot);
   return normalized === '/' ? normalized : normalized.replace(/\/+$/, '');
-}
-
-function base32Encode(bytes: Uint8Array): string {
-  let bits = 0;
-  let value = 0;
-  let output = '';
-  for (const byte of bytes) {
-    value = (value << 8) | byte;
-    bits += 8;
-    while (bits >= 5) {
-      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
-      bits -= 5;
-    }
-  }
-  if (bits > 0) {
-    output += BASE32_ALPHABET[(value << (5 - bits)) & 31];
-  }
-  return output;
-}
-
-async function normalizeBridgeSandboxId(id: string): Promise<string> {
-  const lower = id.toLowerCase();
-  if (BRIDGE_SANDBOX_ID_RE.test(lower)) {
-    return lower;
-  }
-  const bytes = new TextEncoder().encode(id);
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
-  return `lc${base32Encode(new Uint8Array(digest)).slice(0, 50)}`;
 }
 
 function getFetch(config: CloudflareBridgeRuntimeConfig): typeof fetch {
@@ -273,9 +243,7 @@ export function createCloudflareBridgeRuntime(
   const shell = config.shell ?? DEFAULT_SHELL;
   const fetchImpl = getFetch(config);
   let sandboxIdPromise: Promise<string> | undefined =
-    config.sandboxId != null
-      ? normalizeBridgeSandboxId(config.sandboxId)
-      : undefined;
+    config.sandboxId != null ? Promise.resolve(config.sandboxId) : undefined;
 
   function bridgeURL(suffix: string): string {
     return `${baseURL}${apiPrefix}${suffix}`;
@@ -309,18 +277,22 @@ export function createCloudflareBridgeRuntime(
     options: t.CloudflareSandboxExecOptions = {}
   ): Promise<t.CloudflareSandboxExecResult> {
     const sandboxId = await getSandboxId();
-    const response = await fetchImpl(bridgeURL(`/sandbox/${sandboxId}/exec`), {
-      method: 'POST',
-      headers: createHeaders(config, {
-        'Content-Type': 'application/json',
-      }),
-      body: JSON.stringify({
-        argv: [shell, '-lc', commandWithEnv(command, options.env)],
-        cwd: toSandboxPath(options.cwd ?? workspaceRoot, workspaceRoot),
-        timeout_ms: options.timeout,
-      }),
-      signal: options.signal,
-    });
+    const sandboxPathId = encodeURIComponent(sandboxId);
+    const response = await fetchImpl(
+      bridgeURL(`/sandbox/${sandboxPathId}/exec`),
+      {
+        method: 'POST',
+        headers: createHeaders(config, {
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({
+          argv: [shell, '-lc', commandWithEnv(command, options.env)],
+          cwd: toSandboxPath(options.cwd ?? workspaceRoot, workspaceRoot),
+          timeout_ms: options.timeout,
+        }),
+        signal: options.signal,
+      }
+    );
     await assertOk(response, 'exec');
     if (response.body == null) {
       throw new Error(
@@ -397,9 +369,12 @@ export function createCloudflareBridgeRuntime(
 
   async function readFile(filePath: string): Promise<Buffer> {
     const sandboxId = await getSandboxId();
+    const sandboxPathId = encodeURIComponent(sandboxId);
     const resolvedPath = toSandboxPath(filePath, workspaceRoot);
     const response = await fetchImpl(
-      bridgeURL(`/sandbox/${sandboxId}/file/${encodeBridgePath(resolvedPath)}`),
+      bridgeURL(
+        `/sandbox/${sandboxPathId}/file/${encodeBridgePath(resolvedPath)}`
+      ),
       {
         headers: createHeaders(config),
       }
@@ -414,10 +389,13 @@ export function createCloudflareBridgeRuntime(
     options?: { encoding?: string }
   ): Promise<unknown> {
     const sandboxId = await getSandboxId();
+    const sandboxPathId = encodeURIComponent(sandboxId);
     const resolvedPath = toSandboxPath(filePath, workspaceRoot);
     const body = await normalizeWriteBody(content, options);
     const response = await fetchImpl(
-      bridgeURL(`/sandbox/${sandboxId}/file/${encodeBridgePath(resolvedPath)}`),
+      bridgeURL(
+        `/sandbox/${sandboxPathId}/file/${encodeBridgePath(resolvedPath)}`
+      ),
       {
         method: 'PUT',
         headers: createHeaders(config, {

--- a/src/tools/cloudflare/CloudflareBridgeRuntime.ts
+++ b/src/tools/cloudflare/CloudflareBridgeRuntime.ts
@@ -432,8 +432,10 @@ export function createCloudflareBridgeRuntime(
     const maxDepth = options?.recursive === true ? '' : '-maxdepth 1';
     const hiddenFilter =
       options?.includeHidden === true ? '' : ' \\( -name \'.*\' -prune \\) -o';
+    const quotedPath = quote(resolvedPath);
     const command =
-      `find ${quote(resolvedPath)} -mindepth 1 ${maxDepth}${hiddenFilter} ` +
+      `[ -d ${quotedPath} ] || { printf '%s is not a directory\\n' ${quotedPath} >&2; exit 20; }; ` +
+      `find ${quotedPath} -mindepth 1 ${maxDepth}${hiddenFilter} ` +
       '-printf \'%y\\t%s\\t%p\\n\'';
     const result = await exec(command, { cwd: workspaceRoot });
     if (result.exitCode !== 0) {

--- a/src/tools/cloudflare/CloudflareBridgeRuntime.ts
+++ b/src/tools/cloudflare/CloudflareBridgeRuntime.ts
@@ -1,0 +1,464 @@
+import { posix as path } from 'path';
+import type * as t from '@/types';
+
+const DEFAULT_API_PREFIX = '/v1';
+const DEFAULT_WORKSPACE_ROOT = '/workspace';
+const DEFAULT_SHELL = 'bash';
+const BRIDGE_SANDBOX_ID_RE = /^[a-z2-7]{1,128}$/;
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+export type CloudflareBridgeRuntimeConfig = {
+  /** Base URL of a Worker using `bridge()` from `@cloudflare/sandbox/bridge`. */
+  baseURL: string;
+  /** Bearer token stored in the bridge Worker as `SANDBOX_API_KEY`. */
+  apiKey?: string;
+  /** Existing sandbox id. If omitted, the adapter creates one lazily. */
+  sandboxId?: string;
+  /** Bridge API route prefix. Defaults to `/v1`. */
+  apiRoutePrefix?: string;
+  /** Workspace root used for path clamping. Defaults to `/workspace`. */
+  workspaceRoot?: string;
+  /** Optional bridge session id sent as `Session-Id`. */
+  sessionId?: string;
+  /** Shell used to run command strings over the bridge exec endpoint. */
+  shell?: string;
+  /** Optional fetch implementation. Defaults to global `fetch`. */
+  fetch?: typeof fetch;
+};
+
+export type CloudflareBridgeRuntime = t.CloudflareSandboxRuntime & {
+  getSandboxId(): Promise<string>;
+};
+
+type BridgeSSEEvent = {
+  event: string;
+  data: string;
+};
+
+function normalizeBaseURL(baseURL: string): string {
+  return baseURL.replace(/\/+$/, '');
+}
+
+function normalizePrefix(prefix: string | undefined): string {
+  const raw = prefix ?? DEFAULT_API_PREFIX;
+  const withLeadingSlash = raw.startsWith('/') ? raw : `/${raw}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+}
+
+function base32Encode(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let output = '';
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return output;
+}
+
+async function normalizeBridgeSandboxId(id: string): Promise<string> {
+  const lower = id.toLowerCase();
+  if (BRIDGE_SANDBOX_ID_RE.test(lower)) {
+    return lower;
+  }
+  const bytes = new TextEncoder().encode(id);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return `lc${base32Encode(new Uint8Array(digest)).slice(0, 50)}`;
+}
+
+function getFetch(config: CloudflareBridgeRuntimeConfig): typeof fetch {
+  const fetchImpl = config.fetch ?? globalThis.fetch;
+  return fetchImpl.bind(globalThis) as typeof fetch;
+}
+
+function quote(value: string): string {
+  if (value === '') {
+    return '\'\'';
+  }
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, '\'\\\'\'')}'`;
+}
+
+function encodeBridgePath(filePath: string): string {
+  return filePath
+    .replace(/^\/+/, '')
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+}
+
+function toSandboxPath(filePath: string, workspaceRoot: string): string {
+  const raw = filePath === '' ? '.' : filePath;
+  const root = path.normalize(workspaceRoot);
+  const resolved = raw.startsWith('/')
+    ? path.normalize(raw)
+    : path.resolve(root, raw);
+  if (resolved === root || resolved.startsWith(`${root}/`)) {
+    return resolved;
+  }
+  throw new Error(
+    `Path is outside the Cloudflare sandbox workspace: ${filePath}`
+  );
+}
+
+function typeFromFind(value: string): t.CloudflareSandboxFileInfo['type'] {
+  switch (value) {
+  case 'd':
+    return 'directory';
+  case 'l':
+    return 'symlink';
+  case 'f':
+    return 'file';
+  default:
+    return 'other';
+  }
+}
+
+function decodeBase64(value: string): string {
+  return Buffer.from(value, 'base64').toString('utf8');
+}
+
+async function readResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+async function assertOk(response: Response, operation: string): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+  const text = await readResponseText(response);
+  throw new Error(
+    `Cloudflare sandbox bridge ${operation} failed (${response.status}): ${text}`
+  );
+}
+
+function createHeaders(
+  config: CloudflareBridgeRuntimeConfig,
+  extra?: HeadersInit
+): Headers {
+  const headers = new Headers(extra);
+  if (config.apiKey != null && config.apiKey !== '') {
+    headers.set('Authorization', `Bearer ${config.apiKey}`);
+  }
+  if (config.sessionId != null && config.sessionId !== '') {
+    headers.set('Session-Id', config.sessionId);
+  }
+  return headers;
+}
+
+function envScript(env?: Record<string, string | undefined>): string {
+  if (env == null) {
+    return '';
+  }
+  return Object.entries(env)
+    .filter((entry): entry is [string, string] => entry[1] != null)
+    .map(([key, value]) => `export ${key}=${quote(value)}`)
+    .join('\n');
+}
+
+function commandWithEnv(
+  command: string,
+  env?: Record<string, string | undefined>
+): string {
+  const exports = envScript(env);
+  return exports === '' ? command : `${exports}\n${command}`;
+}
+
+async function collectReadableStream(
+  stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function normalizeWriteBody(
+  content: string | ReadableStream<Uint8Array>,
+  options?: { encoding?: string }
+): Promise<Uint8Array> {
+  if (typeof content !== 'string') {
+    return collectReadableStream(content);
+  }
+  if (options?.encoding === 'base64') {
+    return Buffer.from(content, 'base64');
+  }
+  return Buffer.from(content, options?.encoding === 'utf8' ? 'utf8' : 'utf8');
+}
+
+function parseSSEChunk(buffer: string): {
+  events: BridgeSSEEvent[];
+  remainder: string;
+} {
+  const normalized = buffer.replace(/\r\n/g, '\n');
+  const parts = normalized.split('\n\n');
+  const remainder = parts.pop() ?? '';
+  const events = parts
+    .map((part) => {
+      let event = 'message';
+      const dataLines: string[] = [];
+      for (const line of part.split('\n')) {
+        if (line.startsWith('event:')) {
+          event = line.slice('event:'.length).trim();
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice('data:'.length).trimStart());
+        }
+      }
+      return { event, data: dataLines.join('\n') };
+    })
+    .filter((event) => event.data !== '' || event.event !== 'message');
+  return { events, remainder };
+}
+
+function parseExitCode(data: string): number {
+  try {
+    const parsed = JSON.parse(data) as { exit_code?: number };
+    return typeof parsed.exit_code === 'number' ? parsed.exit_code : 1;
+  } catch {
+    return 1;
+  }
+}
+
+function parseBridgeError(data: string): string {
+  try {
+    const parsed = JSON.parse(data) as { error?: string };
+    return parsed.error ?? data;
+  } catch {
+    return data;
+  }
+}
+
+export function createCloudflareBridgeRuntime(
+  config: CloudflareBridgeRuntimeConfig
+): CloudflareBridgeRuntime {
+  const baseURL = normalizeBaseURL(config.baseURL);
+  const apiPrefix = normalizePrefix(config.apiRoutePrefix);
+  const workspaceRoot = path.normalize(
+    config.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT
+  );
+  const shell = config.shell ?? DEFAULT_SHELL;
+  const fetchImpl = getFetch(config);
+  let sandboxIdPromise: Promise<string> | undefined =
+    config.sandboxId != null
+      ? normalizeBridgeSandboxId(config.sandboxId)
+      : undefined;
+
+  function bridgeURL(suffix: string): string {
+    return `${baseURL}${apiPrefix}${suffix}`;
+  }
+
+  async function getSandboxId(): Promise<string> {
+    if (sandboxIdPromise == null) {
+      sandboxIdPromise = (async (): Promise<string> => {
+        const response = await fetchImpl(bridgeURL('/sandbox'), {
+          method: 'POST',
+          headers: createHeaders(config),
+        });
+        await assertOk(response, 'sandbox create');
+        const payload = (await response.json()) as { id?: string };
+        if (typeof payload.id !== 'string' || payload.id === '') {
+          throw new Error(
+            'Cloudflare sandbox bridge create did not return an id.'
+          );
+        }
+        return payload.id;
+      })();
+    }
+    return sandboxIdPromise;
+  }
+
+  async function exec(
+    command: string,
+    options: t.CloudflareSandboxExecOptions = {}
+  ): Promise<t.CloudflareSandboxExecResult> {
+    const sandboxId = await getSandboxId();
+    const response = await fetchImpl(bridgeURL(`/sandbox/${sandboxId}/exec`), {
+      method: 'POST',
+      headers: createHeaders(config, {
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        argv: [shell, '-lc', commandWithEnv(command, options.env)],
+        cwd: toSandboxPath(options.cwd ?? workspaceRoot, workspaceRoot),
+        timeout_ms: options.timeout,
+      }),
+      signal: options.signal,
+    });
+    await assertOk(response, 'exec');
+    if (response.body == null) {
+      throw new Error(
+        'Cloudflare sandbox bridge exec response did not include a body.'
+      );
+    }
+
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let buffer = '';
+    let stdout = '';
+    let stderr = '';
+    let exitCode = 0;
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const parsed = parseSSEChunk(buffer);
+        buffer = parsed.remainder;
+        for (const event of parsed.events) {
+          if (event.event === 'stdout') {
+            const decoded = decodeBase64(event.data);
+            stdout += decoded;
+            options.onOutput?.('stdout', decoded);
+          } else if (event.event === 'stderr') {
+            const decoded = decodeBase64(event.data);
+            stderr += decoded;
+            options.onOutput?.('stderr', decoded);
+          } else if (event.event === 'exit') {
+            exitCode = parseExitCode(event.data);
+          } else if (event.event === 'error') {
+            throw new Error(parseBridgeError(event.data));
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return {
+      success: exitCode === 0,
+      exitCode,
+      stdout,
+      stderr,
+      command,
+    };
+  }
+
+  async function readFile(filePath: string): Promise<Buffer> {
+    const sandboxId = await getSandboxId();
+    const resolvedPath = toSandboxPath(filePath, workspaceRoot);
+    const response = await fetchImpl(
+      bridgeURL(`/sandbox/${sandboxId}/file/${encodeBridgePath(resolvedPath)}`),
+      {
+        headers: createHeaders(config),
+      }
+    );
+    await assertOk(response, 'readFile');
+    return Buffer.from(await response.arrayBuffer());
+  }
+
+  async function writeFile(
+    filePath: string,
+    content: string | ReadableStream<Uint8Array>,
+    options?: { encoding?: string }
+  ): Promise<unknown> {
+    const sandboxId = await getSandboxId();
+    const resolvedPath = toSandboxPath(filePath, workspaceRoot);
+    const body = await normalizeWriteBody(content, options);
+    const response = await fetchImpl(
+      bridgeURL(`/sandbox/${sandboxId}/file/${encodeBridgePath(resolvedPath)}`),
+      {
+        method: 'PUT',
+        headers: createHeaders(config, {
+          'Content-Type': 'application/octet-stream',
+        }),
+        body,
+      }
+    );
+    await assertOk(response, 'writeFile');
+    return response.json().catch(() => ({ ok: true }));
+  }
+
+  async function mkdir(
+    filePath: string,
+    options?: { recursive?: boolean }
+  ): Promise<unknown> {
+    const resolvedPath = toSandboxPath(filePath, workspaceRoot);
+    const command = `${options?.recursive === true ? 'mkdir -p' : 'mkdir'} -- ${quote(resolvedPath)}`;
+    const result = await exec(command, { cwd: workspaceRoot });
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `mkdir failed for ${resolvedPath}`);
+    }
+    return { ok: true };
+  }
+
+  async function listFiles(
+    filePath: string,
+    options?: t.CloudflareSandboxListFilesOptions
+  ): Promise<t.CloudflareSandboxFileInfo[]> {
+    const resolvedPath = toSandboxPath(filePath, workspaceRoot);
+    const maxDepth = options?.recursive === true ? '' : '-maxdepth 1';
+    const hiddenFilter = options?.includeHidden === true ? '' : ' ! -name \'.*\'';
+    const command =
+      `find ${quote(resolvedPath)} -mindepth 1 ${maxDepth}${hiddenFilter} ` +
+      '-printf \'%y\\t%s\\t%p\\n\'';
+    const result = await exec(command, { cwd: workspaceRoot });
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `listFiles failed for ${resolvedPath}`);
+    }
+    return result.stdout
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const [rawType, rawSize, ...pathParts] = line.split('\t');
+        const absolutePath = pathParts.join('\t');
+        return {
+          name: path.basename(absolutePath),
+          absolutePath,
+          relativePath: path.relative(resolvedPath, absolutePath),
+          type: typeFromFind(rawType),
+          size: Number.parseInt(rawSize, 10) || 0,
+        };
+      });
+  }
+
+  async function deleteFile(filePath: string): Promise<unknown> {
+    const resolvedPath = toSandboxPath(filePath, workspaceRoot);
+    const result = await exec(`rm -rf -- ${quote(resolvedPath)}`, {
+      cwd: workspaceRoot,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `deleteFile failed for ${resolvedPath}`);
+    }
+    return { ok: true };
+  }
+
+  return {
+    getSandboxId,
+    exec,
+    readFile,
+    writeFile,
+    mkdir,
+    listFiles,
+    deleteFile,
+  };
+}

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -1,6 +1,8 @@
 import { tool } from '@langchain/core/tools';
 import type { DynamicStructuredTool } from '@langchain/core/tools';
 import type * as t from '@/types';
+
+/* eslint-disable no-useless-escape -- generated sandbox helper source needs escapes for emitted JS/Python string literals. */
 import {
   formatCompletedResponse,
   normalizeToPythonIdentifier,
@@ -19,6 +21,8 @@ import { Constants } from '@/common';
 import {
   executeCloudflareCode,
   getCloudflareWorkspaceRoot,
+  resolveCloudflareSandbox,
+  validateCloudflareBashCommand,
 } from './CloudflareSandboxExecutionEngine';
 
 type ProgrammaticParams = {
@@ -32,6 +36,7 @@ type ProgrammaticParams = {
 const DEFAULT_TIMEOUT = 60000;
 const MIN_TIMEOUT = 1000;
 const MAX_TIMEOUT = 300000;
+const DEFAULT_MAX_OUTPUT_CHARS = 200000;
 
 type TimeoutSchema = {
   type: 'integer';
@@ -102,6 +107,50 @@ function createTimeoutSchema(timeoutMs?: number): TimeoutSchema {
   };
 }
 
+function quoteShell(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
+    return value;
+  }
+  const escapedQuote = String.raw`'\''`;
+  return `'${value.replace(/'/g, escapedQuote)}'`;
+}
+
+function truncateOutput(
+  value: string,
+  maxChars = DEFAULT_MAX_OUTPUT_CHARS
+): string {
+  if (value.length <= maxChars) {
+    return value;
+  }
+  const head = Math.floor(maxChars * 0.6);
+  const tail = maxChars - head;
+  const omitted = value.length - maxChars;
+  return `${value.slice(0, head)}\n\n[... ${omitted} characters truncated ...]\n\n${value.slice(
+    value.length - tail
+  )}`;
+}
+
+async function executeGeneratedCloudflareBash(
+  command: string,
+  config: t.CloudflareSandboxExecutionConfig
+): ReturnType<typeof executeCloudflareCode> {
+  const sandbox = await resolveCloudflareSandbox(config);
+  const workspaceRoot = getCloudflareWorkspaceRoot(config);
+  const shell = config.shell ?? 'bash';
+  const result = await sandbox.exec(`${shell} -lc ${quoteShell(command)}`, {
+    cwd: workspaceRoot,
+    env: config.env,
+    timeout: config.timeoutMs,
+  });
+  const maxOutputChars = config.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+  return {
+    stdout: truncateOutput(result.stdout, maxOutputChars),
+    stderr: truncateOutput(result.stderr, maxOutputChars),
+    exitCode: result.exitCode,
+    timedOut: false,
+  };
+}
+
 function createCloudflareProgrammaticToolCallingSchema(
   config: t.CloudflareSandboxExecutionConfig
 ): CloudflareProgrammaticToolCallingJsonSchema {
@@ -157,20 +206,122 @@ function indent(code: string, spaces = 4): string {
     .join('\n');
 }
 
-function createPythonNativeToolSource(workspaceRoot: string): string {
+function pythonBoolean(value: boolean | undefined): 'True' | 'False' {
+  return value === true ? 'True' : 'False';
+}
+
+function createPythonNativeToolSource(
+  config: t.CloudflareSandboxExecutionConfig,
+  workspaceRoot: string
+): string {
   return `
 import asyncio, fnmatch, glob, json, os, pathlib, re, shlex, shutil, subprocess, sys, tempfile
 
 WORKSPACE = ${JSON.stringify(workspaceRoot)}
+READ_ONLY = ${pythonBoolean(config.readOnly)}
+ALLOW_DANGEROUS_COMMANDS = ${pythonBoolean(config.allowDangerousCommands)}
+DESTRUCTIVE_TARGET = r"(?:/|~|\\$\\{?HOME\\}?|\\.)(?:/?\\.?\\*|/)?"
+DANGEROUS_COMMAND_PATTERNS = [
+    re.compile(r"\\brm\\s+(?:-[^\\s]*[rf][^\\s]*\\s+|-[^\\s]*[r][^\\s]*\\s+-[^\\s]*[f][^\\s]*\\s+)(?:--\\s+)?" + DESTRUCTIVE_TARGET + r"\\s*(?:$|[;&|])"),
+    re.compile(r"\\b(?:mkfs|mkswap|fdisk|parted|diskutil)\\b"),
+    re.compile(r"\\bdd\\s+[^;&|]*\\bof=/dev/"),
+    re.compile(r"\\bchmod\\s+-R\\s+(?:777|a\\+w)\\s+(?:--\\s+)?" + DESTRUCTIVE_TARGET + r"(?:$|\\s|[;&|])"),
+    re.compile(r"\\bchown\\s+-R\\s+[^;&|]+\\s+(?:--\\s+)?" + DESTRUCTIVE_TARGET + r"(?:$|\\s|[;&|])"),
+    re.compile(r":\\s*\\(\\s*\\)\\s*\\{\\s*:\\s*\\|\\s*:\\s*&\\s*\\}\\s*;\\s*:"),
+]
+QUOTED_DESTRUCTIVE_PATTERNS = [
+    re.compile(r"\\brm\\s+(?:-[^\\s]*[rf][^\\s]*\\s+){1,3}(?:--\\s+)?[\\"']" + DESTRUCTIVE_TARGET + r"[\\"']"),
+    re.compile(r"\\bchmod\\s+-R\\s+(?:777|a\\+w)\\s+(?:--\\s+)?[\\"']" + DESTRUCTIVE_TARGET + r"[\\"']"),
+    re.compile(r"\\bchown\\s+-R\\s+[^;&|]+\\s+(?:--\\s+)?[\\"']" + DESTRUCTIVE_TARGET + r"[\\"']"),
+]
+NESTED_SHELL_PREFIX = r"(?:(?:ba|z|da|k)?sh|eval)\\s+(?:-l?c\\s+)?"
+NESTED_SHELL_DESTRUCTIVE_PATTERNS = [
+    re.compile(NESTED_SHELL_PREFIX + r"[\\"'][^\\"']*\\brm\\s+-[^\\s\\"']*[rf][^\\s\\"']*\\s+(?:--\\s+)?(?:/|~|\\$\\{?HOME\\}?|\\.)"),
+    re.compile(NESTED_SHELL_PREFIX + r"[\\"'][^\\"']*\\bchmod\\s+-R\\s+(?:777|a\\+w)\\s+(?:--\\s+)?(?:/|~|\\$\\{?HOME\\}?|\\.)"),
+    re.compile(NESTED_SHELL_PREFIX + r"[\\"'][^\\"']*\\bchown\\s+-R\\s+[^;&|]+\\s+(?:--\\s+)?(?:/|~|\\$\\{?HOME\\}?|\\.)"),
+]
+MUTATING_COMMAND_PATTERN = re.compile(r"\\b(?:rm|mv|cp|touch|mkdir|rmdir|ln|truncate|tee|sed\\s+-i|perl\\s+-pi|python(?:3)?\\s+-c|node\\s+-e|npm\\s+(?:install|ci|update|publish)|pnpm\\s+(?:install|update|publish)|yarn\\s+(?:install|add|publish)|git\\s+(?:add|commit|checkout|switch|reset|clean|rebase|merge|push|pull|stash|tag|branch)|chmod|chown)\\b|(?:^|[^<])>\\s*[^&]|\\bcat\\s+[^|;&]*>\\s*")
+PROTECTED_TARGET_ARG_RE = re.compile(r"^(?:/|~|\\$\\{?HOME\\}?|\\.)(?:/?\\.?\\*|/)?$")
+DESTRUCTIVE_OP_IN_COMMAND_RE = re.compile(r"\\b(?:rm\\s+-[^\\s]*[rf]|chmod\\s+-R|chown\\s+-R)\\b")
+
+def _is_within_workspace(file_path):
+    resolved = os.path.abspath(file_path)
+    root = os.path.abspath(WORKSPACE)
+    return resolved == root or resolved.startswith(root + os.sep)
 
 def _resolve(file_path="."):
     raw = file_path or "."
     candidate = raw if os.path.isabs(raw) else os.path.join(WORKSPACE, raw)
     resolved = os.path.abspath(candidate)
-    root = os.path.abspath(WORKSPACE)
-    if resolved != root and not resolved.startswith(root + os.sep):
+    if not _is_within_workspace(resolved):
         raise ValueError(f"Path is outside the Cloudflare sandbox workspace: {file_path}")
     return resolved
+
+def _assert_writable(tool_name):
+    if READ_ONLY:
+        raise PermissionError(f"{tool_name} is blocked in read-only Cloudflare sandbox mode.")
+
+def _strip_quoted_content(command):
+    output = []
+    quote = None
+    escaped = False
+    index = 0
+    while index < len(command):
+        char = command[index]
+        if escaped:
+            escaped = False
+            output.append(" ")
+            index += 1
+            continue
+        if char == "\\\\":
+            escaped = True
+            output.append(" ")
+            index += 1
+            continue
+        if quote is not None:
+            if char == quote:
+                quote = None
+            output.append(" ")
+            index += 1
+            continue
+        if char in ("'", '"', "\`"):
+            quote = char
+            output.append(" ")
+            index += 1
+            continue
+        if char == "#":
+            while index < len(command) and command[index] != "\\n":
+                output.append(" ")
+                index += 1
+            output.append("\\n")
+            index += 1
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+def _validate_bash_command(command, args=None):
+    errors = []
+    normalized = _strip_quoted_content(command)
+    if command.strip() == "":
+        errors.append("Command is empty.")
+    if "\\0" in command:
+        errors.append("Command contains a NUL byte.")
+    if not ALLOW_DANGEROUS_COMMANDS:
+        if any(pattern.search(normalized) for pattern in DANGEROUS_COMMAND_PATTERNS):
+            errors.append("Command matches a destructive command pattern.")
+        elif any(pattern.search(command) for pattern in QUOTED_DESTRUCTIVE_PATTERNS):
+            errors.append("Command matches a destructive command pattern (quoted target).")
+        elif any(pattern.search(command) for pattern in NESTED_SHELL_DESTRUCTIVE_PATTERNS):
+            errors.append("Command matches a destructive command pattern (nested shell payload).")
+        elif args and DESTRUCTIVE_OP_IN_COMMAND_RE.search(command):
+            offending = next((str(arg) for arg in args if PROTECTED_TARGET_ARG_RE.search(str(arg))), None)
+            if offending is not None:
+                errors.append(f"Command matches a destructive command pattern (protected target \\"{offending}\\" passed via positional arg).")
+    if READ_ONLY and MUTATING_COMMAND_PATTERN.search(normalized):
+        errors.append("Command appears to mutate files or repository state in read-only Cloudflare sandbox mode.")
+    if errors:
+        raise ValueError("\\n".join(errors))
 
 def _line_window(content, offset=None, limit=None):
     start = max((offset or 1) - 1, 0)
@@ -179,6 +330,7 @@ def _line_window(content, offset=None, limit=None):
     return "\\n".join(f"{start + idx + 1:6d}\\t{line}" for idx, line in enumerate(selected))
 
 def _run(command, timeout=None, args=None):
+    _validate_bash_command(command, args=args)
     completed = subprocess.run(
         ["bash", "-lc", command, "--"] + [str(arg) for arg in (args or [])],
         cwd=WORKSPACE,
@@ -299,6 +451,7 @@ async def read_file(file_path, offset=None, limit=None):
         return _line_window(handle.read(), offset, limit)
 
 async def write_file(file_path, content):
+    _assert_writable("write_file")
     resolved = _resolve(file_path)
     os.makedirs(os.path.dirname(resolved), exist_ok=True)
     existed = os.path.exists(resolved)
@@ -307,6 +460,7 @@ async def write_file(file_path, content):
     return f"{'Overwrote' if existed else 'Created'} {resolved} ({len(content)} chars)."
 
 async def edit_file(file_path, old_text=None, new_text=None, edits=None):
+    _assert_writable("edit_file")
     resolved = _resolve(file_path)
     edits = edits or [{"old_text": old_text, "new_text": new_text}]
     content = open(resolved, encoding="utf-8").read()
@@ -349,7 +503,14 @@ async def grep_search(pattern, path=".", glob=None, max_results=200):
 
 async def glob_search(pattern, path=".", max_results=200):
     root = _resolve(path)
-    matches = glob_module.glob(os.path.join(root, pattern), recursive=True)[:max_results]
+    target = pattern if os.path.isabs(pattern) else os.path.join(root, pattern)
+    matches = []
+    for match in glob_module.glob(target, recursive=True):
+        resolved = os.path.abspath(match)
+        if _is_within_workspace(resolved):
+            matches.append(resolved)
+            if len(matches) >= max_results:
+                break
     return "\\n".join(matches) if matches else "No files found."
 
 async def compile_check(command=None, timeout_ms=None):
@@ -366,7 +527,10 @@ glob_module = glob
 `.trim();
 }
 
-function createNodeNativeToolSource(workspaceRoot: string): string {
+function createNodeNativeToolSource(
+  config: t.CloudflareSandboxExecutionConfig,
+  workspaceRoot: string
+): string {
   return `
 const fs = require("fs");
 const fsp = fs.promises;
@@ -374,6 +538,31 @@ const path = require("path");
 const cp = require("child_process");
 
 const WORKSPACE = ${JSON.stringify(workspaceRoot)};
+const READ_ONLY = ${JSON.stringify(config.readOnly === true)};
+const ALLOW_DANGEROUS_COMMANDS = ${JSON.stringify(config.allowDangerousCommands === true)};
+const DESTRUCTIVE_TARGET = "(?:\\\\/|~|\\\\$\\\\{?HOME\\\\}?|\\\\.)(?:\\\\/?\\\\.?\\\\*|\\\\/)?";
+const DANGEROUS_COMMAND_PATTERNS = [
+  new RegExp("\\\\brm\\\\s+(?:-[^\\\\s]*[rf][^\\\\s]*\\\\s+|-[^\\\\s]*[r][^\\\\s]*\\\\s+-[^\\\\s]*[f][^\\\\s]*\\\\s+)(?:--\\\\s+)?" + DESTRUCTIVE_TARGET + "\\\\s*(?:$|[;&|])"),
+  /\\b(?:mkfs|mkswap|fdisk|parted|diskutil)\\b/,
+  /\\bdd\\s+[^;&|]*\\bof=\\/dev\\//,
+  new RegExp("\\\\bchmod\\\\s+-R\\\\s+(?:777|a\\\\+w)\\\\s+(?:--\\\\s+)?" + DESTRUCTIVE_TARGET + "(?:$|\\\\s|[;&|])"),
+  new RegExp("\\\\bchown\\\\s+-R\\\\s+[^;&|]+\\\\s+(?:--\\\\s+)?" + DESTRUCTIVE_TARGET + "(?:$|\\\\s|[;&|])"),
+  /:\\s*\\(\\s*\\)\\s*\\{\\s*:\\s*\\|\\s*:\\s*&\\s*\\}\\s*;\\s*:/,
+];
+const QUOTED_DESTRUCTIVE_PATTERNS = [
+  new RegExp("\\\\brm\\\\s+(?:-[^\\\\s]*[rf][^\\\\s]*\\\\s+){1,3}(?:--\\\\s+)?[\\\"']" + DESTRUCTIVE_TARGET + "[\\\"']"),
+  new RegExp("\\\\bchmod\\\\s+-R\\\\s+(?:777|a\\\\+w)\\\\s+(?:--\\\\s+)?[\\\"']" + DESTRUCTIVE_TARGET + "[\\\"']"),
+  new RegExp("\\\\bchown\\\\s+-R\\\\s+[^;&|]+\\\\s+(?:--\\\\s+)?[\\\"']" + DESTRUCTIVE_TARGET + "[\\\"']"),
+];
+const NESTED_SHELL_PREFIX = "(?:(?:ba|z|da|k)?sh|eval)\\\\s+(?:-l?c\\\\s+)?";
+const NESTED_SHELL_DESTRUCTIVE_PATTERNS = [
+  new RegExp(NESTED_SHELL_PREFIX + "[\\\"'][^\\\"']*\\\\brm\\\\s+-[^\\\\s\\\"']*[rf][^\\\\s\\\"']*\\\\s+(?:--\\\\s+)?(?:\\\\/|~|\\\\$\\\\{?HOME\\\\}?|\\\\.)"),
+  new RegExp(NESTED_SHELL_PREFIX + "[\\\"'][^\\\"']*\\\\bchmod\\\\s+-R\\\\s+(?:777|a\\\\+w)\\\\s+(?:--\\\\s+)?(?:\\\\/|~|\\\\$\\\\{?HOME\\\\}?|\\\\.)"),
+  new RegExp(NESTED_SHELL_PREFIX + "[\\\"'][^\\\"']*\\\\bchown\\\\s+-R\\\\s+[^;&|]+\\\\s+(?:--\\\\s+)?(?:\\\\/|~|\\\\$\\\\{?HOME\\\\}?|\\\\.)"),
+];
+const MUTATING_COMMAND_PATTERN = /\\b(?:rm|mv|cp|touch|mkdir|rmdir|ln|truncate|tee|sed\\s+-i|perl\\s+-pi|python(?:3)?\\s+-c|node\\s+-e|npm\\s+(?:install|ci|update|publish)|pnpm\\s+(?:install|update|publish)|yarn\\s+(?:install|add|publish)|git\\s+(?:add|commit|checkout|switch|reset|clean|rebase|merge|push|pull|stash|tag|branch)|chmod|chown)\\b|(?:^|[^<])>\\s*[^&]|\\bcat\\s+[^|;&]*>\\s*/;
+const PROTECTED_TARGET_ARG_RE = /^(?:\\/|~|\\$\\{?HOME\\}?|\\.)(?:\\/?\\.?\\*|\\/)?$/;
+const DESTRUCTIVE_OP_IN_COMMAND_RE = /\\b(?:rm\\s+-[^\\s]*[rf]|chmod\\s+-R|chown\\s+-R)\\b/;
 
 function resolvePath(filePath) {
   const raw = filePath || ".";
@@ -384,6 +573,82 @@ function resolvePath(filePath) {
     throw new Error("Path is outside the Cloudflare sandbox workspace: " + filePath);
   }
   return resolved;
+}
+
+function assertWritable(toolName) {
+  if (READ_ONLY) {
+    throw new Error(toolName + " is blocked in read-only Cloudflare sandbox mode.");
+  }
+}
+
+function stripQuotedContent(command) {
+  let output = "";
+  let quote;
+  let escaped = false;
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index];
+    if (escaped) {
+      escaped = false;
+      output += " ";
+      continue;
+    }
+    if (char === "\\\\") {
+      escaped = true;
+      output += " ";
+      continue;
+    }
+    if (quote != null) {
+      if (char === quote) quote = undefined;
+      output += " ";
+      continue;
+    }
+    if (char === "\\\"" || char === "'" || char === "\`") {
+      quote = char;
+      output += " ";
+      continue;
+    }
+    if (char === "#") {
+      while (index < command.length && command[index] !== "\\n") {
+        output += " ";
+        index += 1;
+      }
+      output += "\\n";
+      continue;
+    }
+    output += char;
+  }
+  return output;
+}
+
+function validateBashCommand(command, args) {
+  const errors = [];
+  const normalized = stripQuotedContent(command);
+  if (command.trim() === "") {
+    errors.push("Command is empty.");
+  }
+  if (command.includes("\\0")) {
+    errors.push("Command contains a NUL byte.");
+  }
+  if (!ALLOW_DANGEROUS_COMMANDS) {
+    if (DANGEROUS_COMMAND_PATTERNS.some((pattern) => pattern.test(normalized))) {
+      errors.push("Command matches a destructive command pattern.");
+    } else if (QUOTED_DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(command))) {
+      errors.push("Command matches a destructive command pattern (quoted target).");
+    } else if (NESTED_SHELL_DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(command))) {
+      errors.push("Command matches a destructive command pattern (nested shell payload).");
+    } else if ((args || []).length > 0 && DESTRUCTIVE_OP_IN_COMMAND_RE.test(command)) {
+      const offending = (args || []).map(String).find((arg) => PROTECTED_TARGET_ARG_RE.test(arg));
+      if (offending !== undefined) {
+        errors.push("Command matches a destructive command pattern (protected target \\"" + offending + "\\" passed via positional arg).");
+      }
+    }
+  }
+  if (READ_ONLY && MUTATING_COMMAND_PATTERN.test(normalized)) {
+    errors.push("Command appears to mutate files or repository state in read-only Cloudflare sandbox mode.");
+  }
+  if (errors.length > 0) {
+    throw new Error(errors.join("\\n"));
+  }
 }
 
 function lineWindow(content, offset, limit) {
@@ -401,6 +666,7 @@ function quote(value) {
 }
 
 function run(command, timeoutMs, args) {
+  validateBashCommand(command, args);
   return new Promise((resolve) => {
     const child = cp.spawn("bash", ["-lc", command, "--", ...((args || []).map(String))], {
       cwd: WORKSPACE,
@@ -585,6 +851,7 @@ async function read_file(payload) {
 }
 
 async function write_file(payload) {
+  assertWritable("write_file");
   const resolved = resolvePath(payload.file_path);
   await fsp.mkdir(path.dirname(resolved), { recursive: true });
   const existed = fs.existsSync(resolved);
@@ -593,6 +860,7 @@ async function write_file(payload) {
 }
 
 async function edit_file(payload) {
+  assertWritable("edit_file");
   const resolved = resolvePath(payload.file_path);
   const edits = payload.edits || [{ old_text: payload.old_text, new_text: payload.new_text }];
   let content = await fsp.readFile(resolved, "utf8");
@@ -694,6 +962,7 @@ main().catch((error) => {
 function createPythonProgram(
   userCode: string,
   toolDefs: t.LCTool[],
+  config: t.CloudflareSandboxExecutionConfig,
   workspaceRoot: string
 ): string {
   const aliases = toolDefs
@@ -705,7 +974,7 @@ function createPythonProgram(
     })
     .filter(Boolean)
     .join('\n');
-  return `${createPythonNativeToolSource(workspaceRoot)}
+  return `${createPythonNativeToolSource(config, workspaceRoot)}
 ${aliases}
 
 async def __lc_user_main__():
@@ -718,9 +987,10 @@ asyncio.run(__lc_user_main__())
 function createBashProgram(
   userCode: string,
   toolDefs: t.LCTool[],
+  config: t.CloudflareSandboxExecutionConfig,
   workspaceRoot: string
 ): string {
-  const helper = createNodeNativeToolSource(workspaceRoot);
+  const helper = createNodeNativeToolSource(config, workspaceRoot);
   const functions = toolDefs
     .map((def) => {
       const bashName = normalizeToBashIdentifier(def.name);
@@ -761,30 +1031,36 @@ async function runProgrammatic(args: {
   const timeoutMs =
     args.params.timeout ?? args.cloudflareConfig.timeoutMs ?? DEFAULT_TIMEOUT;
   const workspaceRoot = getCloudflareWorkspaceRoot(args.cloudflareConfig);
-  const result =
-    args.runtime === 'bash'
-      ? await executeCloudflareCode(
-        {
-          lang: 'bash',
-          code: createBashProgram(
-            args.params.code,
-            effectiveTools,
-            workspaceRoot
-          ),
-        },
-        { ...args.cloudflareConfig, timeoutMs }
-      )
-      : await executeCloudflareCode(
-        {
-          lang: 'py',
-          code: createPythonProgram(
-            args.params.code,
-            effectiveTools,
-            workspaceRoot
-          ),
-        },
-        { ...args.cloudflareConfig, timeoutMs }
-      );
+  let result: Awaited<ReturnType<typeof executeCloudflareCode>>;
+
+  if (args.runtime === 'bash') {
+    await validateCloudflareBashCommand(args.params.code, [], {
+      ...args.cloudflareConfig,
+      timeoutMs,
+    });
+    result = await executeGeneratedCloudflareBash(
+      createBashProgram(
+        args.params.code,
+        effectiveTools,
+        args.cloudflareConfig,
+        workspaceRoot
+      ),
+      { ...args.cloudflareConfig, timeoutMs }
+    );
+  } else {
+    result = await executeCloudflareCode(
+      {
+        lang: 'py',
+        code: createPythonProgram(
+          args.params.code,
+          effectiveTools,
+          args.cloudflareConfig,
+          workspaceRoot
+        ),
+      },
+      { ...args.cloudflareConfig, timeoutMs }
+    );
+  }
 
   if (result.exitCode !== 0 || result.timedOut) {
     throw new Error(

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -1,0 +1,849 @@
+import { tool } from '@langchain/core/tools';
+import type { DynamicStructuredTool } from '@langchain/core/tools';
+import type * as t from '@/types';
+import {
+  formatCompletedResponse,
+  normalizeToPythonIdentifier,
+  ProgrammaticToolCallingDescription,
+  ProgrammaticToolCallingName,
+  ProgrammaticToolCallingSchema,
+  filterToolsByUsage,
+} from '@/tools/ProgrammaticToolCalling';
+import {
+  BashProgrammaticToolCallingDescription,
+  BashProgrammaticToolCallingSchema,
+  filterBashToolsByUsage,
+  normalizeToBashIdentifier,
+} from '@/tools/BashProgrammaticToolCalling';
+import { Constants } from '@/common';
+import {
+  executeCloudflareCode,
+  getCloudflareWorkspaceRoot,
+} from './CloudflareSandboxExecutionEngine';
+
+type ProgrammaticParams = {
+  code: string;
+  timeout?: number;
+  lang?: string;
+  runtime?: string;
+  language?: string;
+};
+
+const DEFAULT_TIMEOUT = 60000;
+const MIN_TIMEOUT = 1000;
+const MAX_TIMEOUT = 300000;
+
+type TimeoutSchema = {
+  type: 'integer';
+  minimum: number;
+  maximum: number;
+  default: number;
+  description: string;
+};
+
+type CloudflareProgrammaticToolCallingJsonSchema = {
+  type: 'object';
+  properties: typeof ProgrammaticToolCallingSchema.properties & {
+    timeout: TimeoutSchema;
+    lang: {
+      type: 'string';
+      enum: readonly ['py', 'python', 'bash', 'sh'];
+      default: 'bash';
+      description: string;
+    };
+  };
+  required: readonly ['code'];
+};
+
+type CloudflareBashProgrammaticToolCallingJsonSchema = {
+  type: 'object';
+  properties: typeof BashProgrammaticToolCallingSchema.properties & {
+    timeout: TimeoutSchema;
+  };
+  required: readonly ['code'];
+};
+
+const NATIVE_TOOL_NAMES = new Set<string>([
+  Constants.READ_FILE,
+  Constants.WRITE_FILE,
+  Constants.EDIT_FILE,
+  Constants.GREP_SEARCH,
+  Constants.GLOB_SEARCH,
+  Constants.LIST_DIRECTORY,
+  Constants.COMPILE_CHECK,
+  Constants.BASH_TOOL,
+  Constants.EXECUTE_CODE,
+]);
+
+function normalizeTimeout(timeoutMs: number | undefined): number {
+  if (timeoutMs == null || !Number.isFinite(timeoutMs)) {
+    return DEFAULT_TIMEOUT;
+  }
+  return Math.max(MIN_TIMEOUT, Math.floor(timeoutMs));
+}
+
+function formatTimeout(timeoutMs: number): string {
+  return timeoutMs % 1000 === 0
+    ? `${timeoutMs / 1000} seconds`
+    : `${timeoutMs} milliseconds`;
+}
+
+function createTimeoutSchema(timeoutMs?: number): TimeoutSchema {
+  const defaultTimeout = normalizeTimeout(timeoutMs);
+  const maxTimeout = Math.max(MAX_TIMEOUT, defaultTimeout);
+  return {
+    type: 'integer',
+    minimum: MIN_TIMEOUT,
+    maximum: maxTimeout,
+    default: defaultTimeout,
+    description:
+      'Maximum Cloudflare Sandbox execution time in milliseconds. ' +
+      `Default: ${formatTimeout(defaultTimeout)}. Max: ${formatTimeout(maxTimeout)}.`,
+  };
+}
+
+function createCloudflareProgrammaticToolCallingSchema(
+  config: t.CloudflareSandboxExecutionConfig
+): CloudflareProgrammaticToolCallingJsonSchema {
+  return {
+    ...ProgrammaticToolCallingSchema,
+    properties: {
+      ...ProgrammaticToolCallingSchema.properties,
+      timeout: createTimeoutSchema(config.timeoutMs),
+      lang: {
+        type: 'string',
+        enum: ['py', 'python', 'bash', 'sh'],
+        default: 'bash',
+        description:
+          'Cloudflare Sandbox runtime for orchestration code. Defaults to bash; use py/python for Python orchestration.',
+      },
+    },
+  } as const;
+}
+
+function createCloudflareBashProgrammaticToolCallingSchema(
+  config: t.CloudflareSandboxExecutionConfig
+): CloudflareBashProgrammaticToolCallingJsonSchema {
+  return {
+    ...BashProgrammaticToolCallingSchema,
+    properties: {
+      ...BashProgrammaticToolCallingSchema.properties,
+      timeout: createTimeoutSchema(config.timeoutMs),
+    },
+  } as const;
+}
+
+function resolveRuntime(params: ProgrammaticParams): 'python' | 'bash' {
+  const raw = params.lang ?? params.runtime ?? params.language ?? 'bash';
+  return raw === 'py' || raw === 'python' ? 'python' : 'bash';
+}
+
+function filterNativeTools(
+  toolDefs: t.LCTool[],
+  code: string,
+  runtime: 'python' | 'bash'
+): t.LCTool[] {
+  const nativeDefs = toolDefs.filter((def) => NATIVE_TOOL_NAMES.has(def.name));
+  const filter =
+    runtime === 'bash' ? filterBashToolsByUsage : filterToolsByUsage;
+  return filter(nativeDefs, code);
+}
+
+function indent(code: string, spaces = 4): string {
+  const prefix = ' '.repeat(spaces);
+  return code
+    .split('\n')
+    .map((line) => (line === '' ? line : prefix + line))
+    .join('\n');
+}
+
+function createPythonNativeToolSource(workspaceRoot: string): string {
+  return `
+import asyncio, fnmatch, glob, json, os, pathlib, re, shlex, shutil, subprocess, sys, tempfile
+
+WORKSPACE = ${JSON.stringify(workspaceRoot)}
+
+def _resolve(file_path="."):
+    raw = file_path or "."
+    candidate = raw if os.path.isabs(raw) else os.path.join(WORKSPACE, raw)
+    resolved = os.path.abspath(candidate)
+    root = os.path.abspath(WORKSPACE)
+    if resolved != root and not resolved.startswith(root + os.sep):
+        raise ValueError(f"Path is outside the Cloudflare sandbox workspace: {file_path}")
+    return resolved
+
+def _line_window(content, offset=None, limit=None):
+    start = max((offset or 1) - 1, 0)
+    lines = content.split("\\n")
+    selected = lines[start:] if not limit or limit <= 0 else lines[start:start + limit]
+    return "\\n".join(f"{start + idx + 1:6d}\\t{line}" for idx, line in enumerate(selected))
+
+def _run(command, timeout=None, args=None):
+    completed = subprocess.run(
+        ["bash", "-lc", command, "--"] + [str(arg) for arg in (args or [])],
+        cwd=WORKSPACE,
+        capture_output=True,
+        text=True,
+        timeout=(timeout / 1000 if timeout else None),
+    )
+    return {
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "exit_code": completed.returncode,
+    }
+
+def _format_run(result):
+    text = ""
+    if result.get("stdout"):
+        text += f"stdout:\\n{result['stdout']}\\n"
+    else:
+        text += "stdout: Empty. Ensure you're writing output explicitly.\\n"
+    if result.get("stderr"):
+        text += f"stderr:\\n{result['stderr']}\\n"
+    if result.get("exit_code") not in (None, 0):
+        text += f"exit_code: {result['exit_code']}\\n"
+    text += f"working_directory: {WORKSPACE}"
+    return text.strip()
+
+def _detect_compile_command():
+    if os.path.exists(os.path.join(WORKSPACE, "tsconfig.json")):
+        return "typescript", "npx --no-install tsc --noEmit", "tsconfig.json present"
+    package_json = os.path.join(WORKSPACE, "package.json")
+    if os.path.exists(package_json):
+        try:
+            if '"typescript"' in open(package_json, encoding="utf-8").read():
+                return "typescript", "npx --no-install tsc --noEmit", "package.json declares typescript"
+        except Exception:
+            pass
+    if os.path.exists(os.path.join(WORKSPACE, "Cargo.toml")):
+        return "rust", "cargo check --message-format=short", "Cargo.toml present"
+    if os.path.exists(os.path.join(WORKSPACE, "go.mod")):
+        return "go", "go vet ./...", "go.mod present"
+    if any(os.path.exists(os.path.join(WORKSPACE, name)) for name in ["pyproject.toml", "setup.py", "setup.cfg"]):
+        return "python-compile", "python3 -m py_compile $(find . -name '*.py' -not -path './.venv/*' -not -path './node_modules/*')", "Python project"
+    return "unknown", "", "no recognised project marker"
+
+async def bash_tool(command, args=None):
+    return _format_run(_run(command, args=args))
+
+async def execute_code(lang, code, args=None):
+    args = args or []
+    temp_dir = tempfile.mkdtemp(prefix="lc-ptc-", dir=WORKSPACE)
+    try:
+        def q(value):
+            import shlex
+            return shlex.quote(str(value))
+        arg_text = " ".join(q(arg) for arg in args)
+        if lang in ("py", "python"):
+            file_path = os.path.join(temp_dir, "main.py")
+            open(file_path, "w", encoding="utf-8").write(code)
+            return _format_run(_run(f"python3 {q(file_path)} {arg_text}"))
+        if lang in ("js", "javascript"):
+            file_path = os.path.join(temp_dir, "main.js")
+            open(file_path, "w", encoding="utf-8").write(code)
+            return _format_run(_run(f"node {q(file_path)} {arg_text}"))
+        if lang in ("ts", "typescript"):
+            file_path = os.path.join(temp_dir, "main.ts")
+            open(file_path, "w", encoding="utf-8").write(code)
+            return _format_run(_run(f"npx --no-install tsx {q(file_path)} {arg_text}"))
+        if lang == "php":
+            file_path = os.path.join(temp_dir, "main.php")
+            open(file_path, "w", encoding="utf-8").write(code)
+            return _format_run(_run(f"php {q(file_path)} {arg_text}"))
+        if lang == "go":
+            file_path = os.path.join(temp_dir, "main.go")
+            open(file_path, "w", encoding="utf-8").write(code)
+            return _format_run(_run(f"go run {q(file_path)} {arg_text}"))
+        if lang == "rs":
+            file_path = os.path.join(temp_dir, "main.rs")
+            open(file_path, "w", encoding="utf-8").write(code)
+            binary = os.path.join(temp_dir, "main-rs")
+            return _format_run(_run(f"rustc {q(file_path)} -o {q(binary)} && {q(binary)} {arg_text}"))
+        if lang == "c":
+            file_path = os.path.join(temp_dir, "main.c")
+            open(file_path, "w", encoding="utf-8").write(code)
+            binary = os.path.join(temp_dir, "main-c")
+            return _format_run(_run(f"cc {q(file_path)} -o {q(binary)} && {q(binary)} {arg_text}"))
+        if lang == "cpp":
+            file_path = os.path.join(temp_dir, "main.cpp")
+            open(file_path, "w", encoding="utf-8").write(code)
+            binary = os.path.join(temp_dir, "main-cpp")
+            return _format_run(_run(f"c++ {q(file_path)} -o {q(binary)} && {q(binary)} {arg_text}"))
+        if lang == "java":
+            file_path = os.path.join(temp_dir, "Main.java")
+            open(file_path, "w", encoding="utf-8").write(code)
+            return _format_run(_run(f"javac {q(file_path)} && java -cp {q(temp_dir)} Main {arg_text}"))
+        if lang == "r":
+            file_path = os.path.join(temp_dir, "main.R")
+            open(file_path, "w", encoding="utf-8").write(code)
+            return _format_run(_run(f"Rscript {q(file_path)} {arg_text}"))
+        if lang == "d":
+            file_path = os.path.join(temp_dir, "main.d")
+            open(file_path, "w", encoding="utf-8").write(code)
+            binary = os.path.join(temp_dir, "main-d")
+            return _format_run(_run(f"dmd {q(file_path)} -of={q(binary)} && {q(binary)} {arg_text}"))
+        if lang == "f90":
+            file_path = os.path.join(temp_dir, "main.f90")
+            open(file_path, "w", encoding="utf-8").write(code)
+            binary = os.path.join(temp_dir, "main-f90")
+            return _format_run(_run(f"gfortran {q(file_path)} -o {q(binary)} && {q(binary)} {arg_text}"))
+        if lang in ("bash", "sh"):
+            return _format_run(_run(code, args=args))
+        raise ValueError(f"Unsupported Cloudflare sandbox runtime: {lang}")
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+async def read_file(file_path, offset=None, limit=None):
+    resolved = _resolve(file_path)
+    with open(resolved, encoding="utf-8") as handle:
+        return _line_window(handle.read(), offset, limit)
+
+async def write_file(file_path, content):
+    resolved = _resolve(file_path)
+    os.makedirs(os.path.dirname(resolved), exist_ok=True)
+    existed = os.path.exists(resolved)
+    with open(resolved, "w", encoding="utf-8") as handle:
+        handle.write(content)
+    return f"{'Overwrote' if existed else 'Created'} {resolved} ({len(content)} chars)."
+
+async def edit_file(file_path, old_text=None, new_text=None, edits=None):
+    resolved = _resolve(file_path)
+    edits = edits or [{"old_text": old_text, "new_text": new_text}]
+    content = open(resolved, encoding="utf-8").read()
+    for edit in edits:
+        old = edit.get("old_text") or ""
+        new = edit.get("new_text") or ""
+        if content.count(old) != 1:
+            raise ValueError(f"Could not locate old_text exactly once in {file_path}")
+        content = content.replace(old, new, 1)
+    open(resolved, "w", encoding="utf-8").write(content)
+    return f"Applied {len(edits)} edit(s) to {resolved}."
+
+async def list_directory(path="."):
+    resolved = _resolve(path)
+    entries = []
+    for name in sorted(os.listdir(resolved)):
+        full = os.path.join(resolved, name)
+        entries.append(("dir " if os.path.isdir(full) else "file") + "\\t" + name)
+    return "\\n".join(entries) or "Directory is empty."
+
+async def grep_search(pattern, path=".", glob=None, max_results=200):
+    root = _resolve(path)
+    regex = re.compile(pattern)
+    out = []
+    for current, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in {".git", "node_modules", ".venv", "dist", "build"}]
+        for name in files:
+            rel = os.path.relpath(os.path.join(current, name), root)
+            if glob and not fnmatch.fnmatch(rel, glob):
+                continue
+            try:
+                for line_no, line in enumerate(open(os.path.join(current, name), encoding="utf-8", errors="ignore"), 1):
+                    if regex.search(line):
+                        out.append(f"{os.path.join(current, name)}:{line_no}:{line.rstrip()}")
+                        if len(out) >= max_results:
+                            return "\\n".join(out)
+            except Exception:
+                pass
+    return "\\n".join(out) if out else "No matches found."
+
+async def glob_search(pattern, path=".", max_results=200):
+    root = _resolve(path)
+    matches = glob_module.glob(os.path.join(root, pattern), recursive=True)[:max_results]
+    return "\\n".join(matches) if matches else "No files found."
+
+async def compile_check(command=None, timeout_ms=None):
+    kind, detected, reason = _detect_compile_command()
+    command = command or detected
+    if not command:
+        return f"compile_check: {reason}. Pass an explicit command to override."
+    result = _run(command, timeout_ms)
+    status = "PASSED" if result["exit_code"] == 0 else "FAILED"
+    return f"compile_check ({kind}) {status} via {command}\\n\\nstdout:\\n{result['stdout']}\\nstderr:\\n{result['stderr']}\\nworking_directory: {WORKSPACE}\\nreason: {reason}"
+
+# Avoid shadowing the glob_search function argument named "glob".
+glob_module = glob
+`.trim();
+}
+
+function createNodeNativeToolSource(workspaceRoot: string): string {
+  return `
+const fs = require("fs");
+const fsp = fs.promises;
+const path = require("path");
+const cp = require("child_process");
+
+const WORKSPACE = ${JSON.stringify(workspaceRoot)};
+
+function resolvePath(filePath) {
+  const raw = filePath || ".";
+  const candidate = path.isAbsolute(raw) ? raw : path.join(WORKSPACE, raw);
+  const resolved = path.resolve(candidate);
+  const root = path.resolve(WORKSPACE);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new Error("Path is outside the Cloudflare sandbox workspace: " + filePath);
+  }
+  return resolved;
+}
+
+function lineWindow(content, offset, limit) {
+  const start = Math.max((offset || 1) - 1, 0);
+  const lines = content.split("\\n");
+  const selected = !limit || limit <= 0 ? lines.slice(start) : lines.slice(start, start + limit);
+  return selected.map((line, index) => String(start + index + 1).padStart(6, " ") + "\\t" + line).join("\\n");
+}
+
+function quote(value) {
+  const text = String(value);
+  if (text === "") return "''";
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(text)) return text;
+  return "'" + text.replace(/'/g, "'\\\\''") + "'";
+}
+
+function run(command, timeoutMs, args) {
+  return new Promise((resolve) => {
+    const child = cp.spawn("bash", ["-lc", command, "--", ...((args || []).map(String))], {
+      cwd: WORKSPACE,
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = timeoutMs
+      ? setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+      }, timeoutMs)
+      : null;
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      if (timer) clearTimeout(timer);
+      resolve({ stdout, stderr: stderr + error.message, exit_code: 1, timed_out: timedOut });
+    });
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      resolve({ stdout, stderr, exit_code: timedOut ? null : code, timed_out: timedOut });
+    });
+  });
+}
+
+function formatRun(result) {
+  let text = "";
+  if (result.stdout) {
+    text += "stdout:\\n" + result.stdout + "\\n";
+  } else {
+    text += "stdout: Empty. Ensure you're writing output explicitly.\\n";
+  }
+  if (result.stderr) {
+    text += "stderr:\\n" + result.stderr + "\\n";
+  }
+  if (result.timed_out) {
+    text += "timed_out: true\\n";
+  }
+  if (result.exit_code !== null && result.exit_code !== undefined && result.exit_code !== 0) {
+    text += "exit_code: " + result.exit_code + "\\n";
+  }
+  text += "working_directory: " + WORKSPACE;
+  return text.trim();
+}
+
+async function detectCompileCommand() {
+  async function exists(name) {
+    try {
+      await fsp.access(path.join(WORKSPACE, name));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  if (await exists("tsconfig.json")) {
+    return ["typescript", "npx --no-install tsc --noEmit", "tsconfig.json present"];
+  }
+  if (await exists("package.json")) {
+    try {
+      if ((await fsp.readFile(path.join(WORKSPACE, "package.json"), "utf8")).includes('"typescript"')) {
+        return ["typescript", "npx --no-install tsc --noEmit", "package.json declares typescript"];
+      }
+    } catch {}
+  }
+  if (await exists("Cargo.toml")) return ["rust", "cargo check --message-format=short", "Cargo.toml present"];
+  if (await exists("go.mod")) return ["go", "go vet ./...", "go.mod present"];
+  if (await exists("pyproject.toml") || await exists("setup.py") || await exists("setup.cfg")) {
+    return ["python-compile", "python3 -m py_compile $(find . -name '*.py' -not -path './.venv/*' -not -path './node_modules/*')", "Python project"];
+  }
+  return ["unknown", "", "no recognised project marker"];
+}
+
+function globToRegExp(pattern) {
+  const escaped = pattern.replace(/[|\\\\{}()[\\]^$+*?.]/g, "\\\\$&");
+  return new RegExp("^" + escaped.replace(/\\\\\\*\\\\\\*/g, ".*").replace(/\\\\\\*/g, "[^/]*") + "$");
+}
+
+function globMatch(relativePath, pattern) {
+  const matcher = globToRegExp(pattern);
+  return matcher.test(relativePath) || matcher.test(path.basename(relativePath));
+}
+
+async function walkFiles(root, visit) {
+  const entries = await fsp.readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if ([".git", "node_modules", ".venv", "dist", "build"].includes(entry.name)) continue;
+      await walkFiles(full, visit);
+    } else if (entry.isFile()) {
+      await visit(full);
+    }
+  }
+}
+
+async function bash_tool(payload) {
+  return formatRun(await run(payload.command, undefined, payload.args));
+}
+
+async function execute_code(payload) {
+  const lang = payload.lang;
+  const code = payload.code;
+  const args = payload.args || [];
+  const tempDir = await fsp.mkdtemp(path.join(WORKSPACE, "lc-ptc-"));
+  try {
+    const argText = args.map(quote).join(" ");
+    async function writeAndRun(fileName, command) {
+      const filePath = path.join(tempDir, fileName);
+      await fsp.writeFile(filePath, code, "utf8");
+      return formatRun(await run(command(filePath, argText), undefined, []));
+    }
+    if (lang === "py" || lang === "python") {
+      return writeAndRun("main.py", (filePath, argText) => "python3 " + quote(filePath) + " " + argText);
+    }
+    if (lang === "js" || lang === "javascript") {
+      return writeAndRun("main.js", (filePath, argText) => "node " + quote(filePath) + " " + argText);
+    }
+    if (lang === "ts" || lang === "typescript") {
+      return writeAndRun("main.ts", (filePath, argText) => "npx --no-install tsx " + quote(filePath) + " " + argText);
+    }
+    if (lang === "php") {
+      return writeAndRun("main.php", (filePath, argText) => "php " + quote(filePath) + " " + argText);
+    }
+    if (lang === "go") {
+      return writeAndRun("main.go", (filePath, argText) => "go run " + quote(filePath) + " " + argText);
+    }
+    if (lang === "rs") {
+      return writeAndRun("main.rs", (filePath, argText) => {
+        const binary = path.join(tempDir, "main-rs");
+        return "rustc " + quote(filePath) + " -o " + quote(binary) + " && " + quote(binary) + " " + argText;
+      });
+    }
+    if (lang === "c") {
+      return writeAndRun("main.c", (filePath, argText) => {
+        const binary = path.join(tempDir, "main-c");
+        return "cc " + quote(filePath) + " -o " + quote(binary) + " && " + quote(binary) + " " + argText;
+      });
+    }
+    if (lang === "cpp") {
+      return writeAndRun("main.cpp", (filePath, argText) => {
+        const binary = path.join(tempDir, "main-cpp");
+        return "c++ " + quote(filePath) + " -o " + quote(binary) + " && " + quote(binary) + " " + argText;
+      });
+    }
+    if (lang === "java") {
+      return writeAndRun("Main.java", (filePath, argText) => "javac " + quote(filePath) + " && java -cp " + quote(tempDir) + " Main " + argText);
+    }
+    if (lang === "r") {
+      return writeAndRun("main.R", (filePath, argText) => "Rscript " + quote(filePath) + " " + argText);
+    }
+    if (lang === "d") {
+      return writeAndRun("main.d", (filePath, argText) => {
+        const binary = path.join(tempDir, "main-d");
+        return "dmd " + quote(filePath) + " -of=" + quote(binary) + " && " + quote(binary) + " " + argText;
+      });
+    }
+    if (lang === "f90") {
+      return writeAndRun("main.f90", (filePath, argText) => {
+        const binary = path.join(tempDir, "main-f90");
+        return "gfortran " + quote(filePath) + " -o " + quote(binary) + " && " + quote(binary) + " " + argText;
+      });
+    }
+    if (lang === "bash" || lang === "sh") {
+      return formatRun(await run(code, undefined, args));
+    }
+    throw new Error("Unsupported Cloudflare sandbox runtime: " + lang);
+  } finally {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function read_file(payload) {
+  const resolved = resolvePath(payload.file_path);
+  return lineWindow(await fsp.readFile(resolved, "utf8"), payload.offset, payload.limit);
+}
+
+async function write_file(payload) {
+  const resolved = resolvePath(payload.file_path);
+  await fsp.mkdir(path.dirname(resolved), { recursive: true });
+  const existed = fs.existsSync(resolved);
+  await fsp.writeFile(resolved, payload.content, "utf8");
+  return (existed ? "Overwrote " : "Created ") + resolved + " (" + payload.content.length + " chars).";
+}
+
+async function edit_file(payload) {
+  const resolved = resolvePath(payload.file_path);
+  const edits = payload.edits || [{ old_text: payload.old_text, new_text: payload.new_text }];
+  let content = await fsp.readFile(resolved, "utf8");
+  for (const edit of edits) {
+    const oldText = edit.old_text || "";
+    const newText = edit.new_text || "";
+    if (oldText === "" || content.split(oldText).length - 1 !== 1) {
+      throw new Error("Could not locate old_text exactly once in " + payload.file_path);
+    }
+    content = content.replace(oldText, newText);
+  }
+  await fsp.writeFile(resolved, content, "utf8");
+  return "Applied " + edits.length + " edit(s) to " + resolved + ".";
+}
+
+async function list_directory(payload) {
+  const resolved = resolvePath(payload.path || ".");
+  const entries = await fsp.readdir(resolved, { withFileTypes: true });
+  const lines = entries
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((entry) => (entry.isDirectory() ? "dir" : "file") + "\\t" + entry.name);
+  return lines.join("\\n") || "Directory is empty.";
+}
+
+async function grep_search(payload) {
+  const root = resolvePath(payload.path || ".");
+  const regex = new RegExp(payload.pattern);
+  const maxResults = payload.max_results || 200;
+  const out = [];
+  await walkFiles(root, async (filePath) => {
+    if (out.length >= maxResults) return;
+    const relative = path.relative(root, filePath);
+    if (payload.glob && !globMatch(relative, payload.glob)) return;
+    let text = "";
+    try {
+      text = await fsp.readFile(filePath, "utf8");
+    } catch {
+      return;
+    }
+    text.split("\\n").forEach((line, index) => {
+      if (out.length < maxResults && regex.test(line)) {
+        out.push(filePath + ":" + (index + 1) + ":" + line);
+      }
+    });
+  });
+  return out.join("\\n") || "No matches found.";
+}
+
+async function glob_search(payload) {
+  const root = resolvePath(payload.path || ".");
+  const maxResults = payload.max_results || 200;
+  const out = [];
+  await walkFiles(root, async (filePath) => {
+    if (out.length >= maxResults) return;
+    const relative = path.relative(root, filePath);
+    if (globMatch(relative, payload.pattern)) out.push(filePath);
+  });
+  return out.join("\\n") || "No files found.";
+}
+
+async function compile_check(payload) {
+  const [kind, detected, reason] = await detectCompileCommand();
+  const command = payload.command || detected;
+  if (!command) {
+    return "compile_check: " + reason + ". Pass an explicit command to override.";
+  }
+  const result = await run(command, payload.timeout_ms);
+  const status = result.exit_code === 0 ? "PASSED" : "FAILED";
+  return "compile_check (" + kind + ") " + status + " via " + command + "\\n\\nstdout:\\n" + result.stdout + "\\nstderr:\\n" + result.stderr + "\\nworking_directory: " + WORKSPACE + "\\nreason: " + reason;
+}
+
+const TOOLS = {
+  bash_tool,
+  execute_code,
+  read_file,
+  write_file,
+  edit_file,
+  list_directory,
+  grep_search,
+  glob_search,
+  compile_check,
+};
+
+async function main() {
+  const name = process.argv[2];
+  const payload = JSON.parse(process.argv[3] || "{}");
+  if (!TOOLS[name]) throw new Error("Unknown tool: " + name);
+  const result = await TOOLS[name](payload);
+  process.stdout.write(typeof result === "string" ? result : JSON.stringify(result));
+}
+
+main().catch((error) => {
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exit(1);
+});
+`.trim();
+}
+
+function createPythonProgram(
+  userCode: string,
+  toolDefs: t.LCTool[],
+  workspaceRoot: string
+): string {
+  const aliases = toolDefs
+    .map((def) => {
+      const pythonName = normalizeToPythonIdentifier(def.name);
+      return NATIVE_TOOL_NAMES.has(def.name) && pythonName !== def.name
+        ? `${pythonName} = globals()[${JSON.stringify(def.name)}]`
+        : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+  return `${createPythonNativeToolSource(workspaceRoot)}
+${aliases}
+
+async def __lc_user_main__():
+${indent(userCode)}
+
+asyncio.run(__lc_user_main__())
+`;
+}
+
+function createBashProgram(
+  userCode: string,
+  toolDefs: t.LCTool[],
+  workspaceRoot: string
+): string {
+  const helper = createNodeNativeToolSource(workspaceRoot);
+  const functions = toolDefs
+    .map((def) => {
+      const bashName = normalizeToBashIdentifier(def.name);
+      if (!NATIVE_TOOL_NAMES.has(def.name)) {
+        return '';
+      }
+      return `${bashName}() { node "$__LC_TOOL_HELPER" ${JSON.stringify(def.name)} "$1"; }`;
+    })
+    .filter(Boolean)
+    .join('\n');
+  return `
+set -euo pipefail
+command -v node >/dev/null 2>&1 || { echo "Cloudflare programmatic tool calling requires node in the sandbox image." >&2; exit 127; }
+__LC_TOOL_HELPER="$(mktemp /tmp/lc-tools.XXXXXX.js)"
+cat > "$__LC_TOOL_HELPER" <<'JS'
+${helper}
+JS
+trap 'rm -f "$__LC_TOOL_HELPER"' EXIT
+${functions}
+${userCode}
+`.trim();
+}
+
+async function runProgrammatic(args: {
+  params: ProgrammaticParams;
+  config?: { toolCall?: unknown };
+  cloudflareConfig: t.CloudflareSandboxExecutionConfig;
+  runtime: 'python' | 'bash';
+}): Promise<[string, t.ProgrammaticExecutionArtifact]> {
+  const toolCall = (args.config?.toolCall ??
+    {}) as Partial<t.ProgrammaticCache>;
+  const toolDefs = toolCall.toolDefs ?? [];
+  const effectiveTools = filterNativeTools(
+    toolDefs,
+    args.params.code,
+    args.runtime
+  );
+  const timeoutMs =
+    args.params.timeout ?? args.cloudflareConfig.timeoutMs ?? DEFAULT_TIMEOUT;
+  const workspaceRoot = getCloudflareWorkspaceRoot(args.cloudflareConfig);
+  const result =
+    args.runtime === 'bash'
+      ? await executeCloudflareCode(
+        {
+          lang: 'bash',
+          code: createBashProgram(
+            args.params.code,
+            effectiveTools,
+            workspaceRoot
+          ),
+        },
+        { ...args.cloudflareConfig, timeoutMs }
+      )
+      : await executeCloudflareCode(
+        {
+          lang: 'py',
+          code: createPythonProgram(
+            args.params.code,
+            effectiveTools,
+            workspaceRoot
+          ),
+        },
+        { ...args.cloudflareConfig, timeoutMs }
+      );
+
+  if (result.exitCode !== 0 || result.timedOut) {
+    throw new Error(
+      result.stderr !== ''
+        ? result.stderr
+        : `Cloudflare ${args.runtime} programmatic execution exited with code ${result.exitCode ?? 'unknown'}`
+    );
+  }
+
+  return formatCompletedResponse({
+    status: 'completed',
+    session_id: 'cloudflare-sandbox',
+    stdout: result.stdout,
+    stderr: result.stderr,
+    files: [],
+  });
+}
+
+export function createCloudflareProgrammaticToolCallingTool(
+  cloudflareConfig: t.CloudflareSandboxExecutionConfig
+): DynamicStructuredTool {
+  return tool(
+    async (rawParams, config) => {
+      const params = rawParams as ProgrammaticParams;
+      return runProgrammatic({
+        params,
+        config,
+        cloudflareConfig,
+        runtime: resolveRuntime(params),
+      });
+    },
+    {
+      name: ProgrammaticToolCallingName,
+      description: `${ProgrammaticToolCallingDescription}\n\nCloudflare Sandbox engine: exposes the built-in coding tools inside the sandbox process. Non-coding host tools are not callable from this in-sandbox programmatic runner.`,
+      schema: createCloudflareProgrammaticToolCallingSchema(cloudflareConfig),
+      responseFormat: Constants.CONTENT_AND_ARTIFACT,
+    }
+  );
+}
+
+export function createCloudflareBashProgrammaticToolCallingTool(
+  cloudflareConfig: t.CloudflareSandboxExecutionConfig
+): DynamicStructuredTool {
+  return tool(
+    async (rawParams, config) => {
+      const params = rawParams as ProgrammaticParams;
+      return runProgrammatic({
+        params,
+        config,
+        cloudflareConfig,
+        runtime: 'bash',
+      });
+    },
+    {
+      name: Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+      description: `${BashProgrammaticToolCallingDescription}\n\nCloudflare Sandbox engine: exposes the built-in coding tools as bash functions inside the sandbox process. Non-coding host tools are not callable from this in-sandbox programmatic runner.`,
+      schema:
+        createCloudflareBashProgrammaticToolCallingSchema(cloudflareConfig),
+      responseFormat: Constants.CONTENT_AND_ARTIFACT,
+    }
+  );
+}

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -154,6 +154,10 @@ function outerTimeoutMs(timeoutMs: number): number {
   return timeoutMs + 5000;
 }
 
+function isInSandboxTimeoutExit(exitCode: number | null): boolean {
+  return exitCode === 124 || exitCode === 137;
+}
+
 async function executeGeneratedCloudflareBash(
   command: string,
   config: t.CloudflareSandboxExecutionConfig
@@ -175,7 +179,7 @@ async function executeGeneratedCloudflareBash(
     stdout: truncateOutput(result.stdout, maxOutputChars),
     stderr: truncateOutput(result.stderr, maxOutputChars),
     exitCode: result.exitCode,
-    timedOut: false,
+    timedOut: isInSandboxTimeoutExit(result.exitCode),
   };
 }
 

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -107,6 +107,21 @@ function createTimeoutSchema(timeoutMs?: number): TimeoutSchema {
   };
 }
 
+function clampExecutionTimeout(
+  requestedTimeoutMs: number | undefined,
+  configuredTimeoutMs: number | undefined
+): number {
+  const defaultTimeout = normalizeTimeout(configuredTimeoutMs);
+  const maxTimeout = Math.max(MAX_TIMEOUT, defaultTimeout);
+  if (requestedTimeoutMs == null || !Number.isFinite(requestedTimeoutMs)) {
+    return defaultTimeout;
+  }
+  return Math.min(
+    Math.max(MIN_TIMEOUT, Math.floor(requestedTimeoutMs)),
+    maxTimeout
+  );
+}
+
 function quoteShell(value: string): string {
   if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
     return value;
@@ -130,6 +145,15 @@ function truncateOutput(
   )}`;
 }
 
+function withInSandboxTimeout(command: string, timeoutMs: number): string {
+  const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+  return `timeout -k 2s ${timeoutSeconds}s ${command}`;
+}
+
+function outerTimeoutMs(timeoutMs: number): number {
+  return timeoutMs + 5000;
+}
+
 async function executeGeneratedCloudflareBash(
   command: string,
   config: t.CloudflareSandboxExecutionConfig
@@ -137,11 +161,15 @@ async function executeGeneratedCloudflareBash(
   const sandbox = await resolveCloudflareSandbox(config);
   const workspaceRoot = getCloudflareWorkspaceRoot(config);
   const shell = config.shell ?? 'bash';
-  const result = await sandbox.exec(`${shell} -lc ${quoteShell(command)}`, {
-    cwd: workspaceRoot,
-    env: config.env,
-    timeout: config.timeoutMs,
-  });
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT;
+  const result = await sandbox.exec(
+    withInSandboxTimeout(`${shell} -lc ${quoteShell(command)}`, timeoutMs),
+    {
+      cwd: workspaceRoot,
+      env: config.env,
+      timeout: outerTimeoutMs(timeoutMs),
+    }
+  );
   const maxOutputChars = config.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
   return {
     stdout: truncateOutput(result.stdout, maxOutputChars),
@@ -1028,8 +1056,10 @@ async function runProgrammatic(args: {
     args.params.code,
     args.runtime
   );
-  const timeoutMs =
-    args.params.timeout ?? args.cloudflareConfig.timeoutMs ?? DEFAULT_TIMEOUT;
+  const timeoutMs = clampExecutionTimeout(
+    args.params.timeout,
+    args.cloudflareConfig.timeoutMs
+  );
   const workspaceRoot = getCloudflareWorkspaceRoot(args.cloudflareConfig);
   let result: Awaited<ReturnType<typeof executeCloudflareCode>>;
 

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -250,6 +250,7 @@ function createPythonNativeToolSource(
 import asyncio, fnmatch, glob, json, os, pathlib, re, shlex, shutil, subprocess, sys, tempfile
 
 WORKSPACE = ${JSON.stringify(workspaceRoot)}
+SHELL = ${JSON.stringify(config.shell ?? 'bash')}
 READ_ONLY = ${pythonBoolean(config.readOnly)}
 ALLOW_DANGEROUS_COMMANDS = ${pythonBoolean(config.allowDangerousCommands)}
 DESTRUCTIVE_TARGET = r"(?:/|~|\\$\\{?HOME\\}?|\\.)(?:/?\\.?\\*|/)?"
@@ -364,7 +365,7 @@ def _line_window(content, offset=None, limit=None):
 def _run(command, timeout=None, args=None):
     _validate_bash_command(command, args=args)
     completed = subprocess.run(
-        ["bash", "-lc", command, "--"] + [str(arg) for arg in (args or [])],
+        [SHELL, "-lc", command, "--"] + [str(arg) for arg in (args or [])],
         cwd=WORKSPACE,
         capture_output=True,
         text=True,
@@ -570,6 +571,7 @@ const path = require("path");
 const cp = require("child_process");
 
 const WORKSPACE = ${JSON.stringify(workspaceRoot)};
+const SHELL = ${JSON.stringify(config.shell ?? 'bash')};
 const READ_ONLY = ${JSON.stringify(config.readOnly === true)};
 const ALLOW_DANGEROUS_COMMANDS = ${JSON.stringify(config.allowDangerousCommands === true)};
 const DESTRUCTIVE_TARGET = "(?:\\\\/|~|\\\\$\\\\{?HOME\\\\}?|\\\\.)(?:\\\\/?\\\\.?\\\\*|\\\\/)?";
@@ -701,7 +703,7 @@ function quote(value) {
 function run(command, timeoutMs, args) {
   validateBashCommand(command, args);
   return new Promise((resolve) => {
-    const child = cp.spawn("bash", ["-lc", command, "--", ...((args || []).map(String))], {
+    const child = cp.spawn(SHELL, ["-lc", command, "--", ...((args || []).map(String))], {
       cwd: WORKSPACE,
       env: process.env,
     });

--- a/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
+++ b/src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts
@@ -279,7 +279,7 @@ DESTRUCTIVE_OP_IN_COMMAND_RE = re.compile(r"\\b(?:rm\\s+-[^\\s]*[rf]|chmod\\s+-R
 def _is_within_workspace(file_path):
     resolved = os.path.abspath(file_path)
     root = os.path.abspath(WORKSPACE)
-    return resolved == root or resolved.startswith(root + os.sep)
+    return os.path.commonpath([root, resolved]) == root
 
 def _resolve(file_path="."):
     raw = file_path or "."
@@ -601,7 +601,8 @@ function resolvePath(filePath) {
   const candidate = path.isAbsolute(raw) ? raw : path.join(WORKSPACE, raw);
   const resolved = path.resolve(candidate);
   const root = path.resolve(WORKSPACE);
-  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+  const relative = path.relative(root, resolved);
+  if (relative && (relative.startsWith("..") || path.isAbsolute(relative))) {
     throw new Error("Path is outside the Cloudflare sandbox workspace: " + filePath);
   }
   return resolved;

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -5,7 +5,10 @@ import type { ChildProcessWithoutNullStreams } from 'child_process';
 import type { WriteFileOptions, MakeDirectoryOptions, Stats } from 'fs';
 import type { FileHandle } from 'fs/promises';
 import type * as t from '@/types';
-import { validateBashCommand } from '@/tools/local/LocalExecutionEngine';
+import {
+  LOCAL_SPAWN_TIMEOUT_MS,
+  validateBashCommand,
+} from '@/tools/local/LocalExecutionEngine';
 import type { WorkspaceFS, ReaddirEntry } from '@/tools/local/workspaceFS';
 
 const DEFAULT_WORKSPACE_ROOT = '/workspace';
@@ -436,14 +439,23 @@ function createCloudflareSpawn(
     void (async (): Promise<void> => {
       const ctx = await getRuntimeContext(config);
       const rendered = [command, ...args].map(quote).join(' ');
-      const timedCommand = withInSandboxTimeout(rendered, ctx.timeoutMs);
+      const spawnTimeoutMs = (
+        options as {
+          [LOCAL_SPAWN_TIMEOUT_MS]?: number;
+        }
+      )[LOCAL_SPAWN_TIMEOUT_MS];
+      const timeoutMs =
+        typeof spawnTimeoutMs === 'number' && Number.isFinite(spawnTimeoutMs)
+          ? spawnTimeoutMs
+          : ctx.timeoutMs;
+      const timedCommand = withInSandboxTimeout(rendered, timeoutMs);
       const cwd =
         options.cwd == null ? ctx.workspaceRoot : options.cwd.toString();
       try {
         const result = await ctx.sandbox.exec(timedCommand, {
           cwd,
           env: ctx.env,
-          timeout: outerTimeoutMs(ctx.timeoutMs),
+          timeout: outerTimeoutMs(timeoutMs),
           signal: abortController.signal,
         });
         if (state.closed) {

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -37,10 +37,17 @@ type SandboxRuntimeContext = {
   shell: string;
 };
 
+function normalizeWorkspaceRoot(workspaceRoot: string): string {
+  const normalized = path.normalize(workspaceRoot);
+  return normalized === '/' ? normalized : normalized.replace(/\/+$/, '');
+}
+
 export function getCloudflareWorkspaceRoot(
   config?: t.CloudflareSandboxExecutionConfig
 ): string {
-  return config?.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT;
+  return normalizeWorkspaceRoot(
+    config?.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT
+  );
 }
 
 export async function resolveCloudflareSandbox(
@@ -65,10 +72,11 @@ async function getRuntimeContext(
 
 function toSandboxPath(filePath: string, workspaceRoot: string): string {
   const raw = filePath === '' ? '.' : filePath;
+  const root = normalizeWorkspaceRoot(workspaceRoot);
   const resolved = raw.startsWith('/')
     ? path.normalize(raw)
-    : path.resolve(workspaceRoot, raw);
-  if (resolved === workspaceRoot || resolved.startsWith(`${workspaceRoot}/`)) {
+    : path.resolve(root, raw);
+  if (resolved === root || resolved.startsWith(`${root}/`)) {
     return resolved;
   }
   throw new Error(
@@ -278,6 +286,12 @@ export function createCloudflareWorkspaceFS(
     stat: async (filePath: string) => {
       const sandbox = await resolveCloudflareSandbox(config);
       const resolved = toSandboxPath(filePath, workspaceRoot);
+      if (resolved === workspaceRoot) {
+        const entries = normalizeFileList(
+          await sandbox.listFiles(resolved, { includeHidden: true })
+        );
+        return createStats({ size: entries.length, type: 'directory' });
+      }
       const info = await findChildInfo(sandbox, resolved);
       if (info != null) {
         return createStats({ size: info.size, type: info.type });
@@ -349,7 +363,25 @@ function createCloudflareSpawn(
   return (command, args, options) => {
     const stdout = new PassThrough();
     const stderr = new PassThrough();
+    const abortController = new AbortController();
     const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+    const state = { closed: false };
+    const closeOnce = (
+      exitCode: number | null,
+      signal: NodeJS.Signals | null
+    ): void => {
+      if (state.closed) {
+        return;
+      }
+      state.closed = true;
+      stdout.end();
+      stderr.end();
+      Object.assign(child, {
+        exitCode,
+        signalCode: signal,
+      });
+      child.emit('close', exitCode, signal);
+    };
     Object.assign(child, {
       stdout,
       stderr,
@@ -359,8 +391,10 @@ function createCloudflareSpawn(
       exitCode: null,
       signalCode: null,
       pid: undefined,
-      kill: () => {
-        Object.assign(child, { killed: true });
+      kill: (signal: NodeJS.Signals = 'SIGTERM') => {
+        Object.assign(child, { killed: true, signalCode: signal });
+        abortController.abort();
+        closeOnce(null, signal);
         return true;
       },
     });
@@ -378,19 +412,20 @@ function createCloudflareSpawn(
             ...(options.env as Record<string, string | undefined> | undefined),
           },
           timeout: ctx.timeoutMs,
+          signal: abortController.signal,
         });
+        if (state.closed) {
+          return;
+        }
         if (result.stdout) stdout.write(result.stdout);
         if (result.stderr) stderr.write(result.stderr);
-        stdout.end();
-        stderr.end();
-        Object.assign(child, { exitCode: result.exitCode });
-        child.emit('close', result.exitCode, null);
+        closeOnce(result.exitCode, null);
       } catch (error) {
+        if (state.closed) {
+          return;
+        }
         stderr.write((error as Error).message);
-        stdout.end();
-        stderr.end();
-        Object.assign(child, { exitCode: 1 });
-        child.emit('close', 1, null);
+        closeOnce(1, null);
       }
     })();
 

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -1,0 +1,659 @@
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { posix as path } from 'path';
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+import type { WriteFileOptions, MakeDirectoryOptions, Stats } from 'fs';
+import type { FileHandle } from 'fs/promises';
+import type * as t from '@/types';
+import { validateBashCommand } from '@/tools/local/LocalExecutionEngine';
+import type { WorkspaceFS, ReaddirEntry } from '@/tools/local/workspaceFS';
+
+const DEFAULT_WORKSPACE_ROOT = '/workspace';
+const DEFAULT_TIMEOUT_MS = 60000;
+const DEFAULT_MAX_OUTPUT_CHARS = 200000;
+const PROTECTED_TARGET_ARG_RE = /^(?:\/|~|\$\{?HOME\}?|\.)(?:\/?\.?\*|\/)?$/;
+const DESTRUCTIVE_OP_IN_COMMAND_RE =
+  /\b(?:rm\s+-[^\s]*[rf]|chmod\s+-R|chown\s+-R)\b/;
+
+type SpawnResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  timedOut: boolean;
+};
+
+type RuntimeCommand = {
+  fileName: string;
+  source?: string;
+  command: string;
+};
+
+type SandboxRuntimeContext = {
+  sandbox: t.CloudflareSandboxRuntime;
+  workspaceRoot: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs: number;
+  maxOutputChars: number;
+  shell: string;
+};
+
+export function getCloudflareWorkspaceRoot(
+  config?: t.CloudflareSandboxExecutionConfig
+): string {
+  return config?.workspaceRoot ?? DEFAULT_WORKSPACE_ROOT;
+}
+
+export async function resolveCloudflareSandbox(
+  config: t.CloudflareSandboxExecutionConfig
+): Promise<t.CloudflareSandboxRuntime> {
+  const sandbox = config.sandbox;
+  return typeof sandbox === 'function' ? await sandbox() : sandbox;
+}
+
+async function getRuntimeContext(
+  config: t.CloudflareSandboxExecutionConfig
+): Promise<SandboxRuntimeContext> {
+  return {
+    sandbox: await resolveCloudflareSandbox(config),
+    workspaceRoot: getCloudflareWorkspaceRoot(config),
+    env: config.env,
+    timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxOutputChars: config.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS,
+    shell: config.shell ?? 'bash',
+  };
+}
+
+function toSandboxPath(filePath: string, workspaceRoot: string): string {
+  const raw = filePath === '' ? '.' : filePath;
+  const resolved = raw.startsWith('/')
+    ? path.normalize(raw)
+    : path.resolve(workspaceRoot, raw);
+  if (resolved === workspaceRoot || resolved.startsWith(`${workspaceRoot}/`)) {
+    return resolved;
+  }
+  throw new Error(
+    `Path is outside the Cloudflare sandbox workspace: ${filePath}`
+  );
+}
+
+function quote(value: string): string {
+  if (value === '') {
+    return '\'\'';
+  }
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/g, '\'\\\'\'')}'`;
+}
+
+function truncateOutput(value: string, maxChars: number): string {
+  if (maxChars <= 0 || value.length <= maxChars) {
+    return value;
+  }
+  const head = Math.max(Math.floor(maxChars / 2), 0);
+  const tail = Math.max(maxChars - head, 0);
+  return `${value.slice(0, head)}\n...[truncated ${value.length - maxChars} chars]...\n${value.slice(value.length - tail)}`;
+}
+
+async function readStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+}
+
+async function normalizeReadFileContent(
+  result: t.CloudflareSandboxReadFileResult
+): Promise<Buffer> {
+  if (typeof result === 'string') {
+    return Buffer.from(result, 'utf8');
+  }
+  if (Buffer.isBuffer(result)) {
+    return result;
+  }
+  if (result instanceof Uint8Array) {
+    return Buffer.from(result);
+  }
+  const content = result.content;
+  if (typeof content === 'string') {
+    if (result.encoding === 'base64') {
+      return Buffer.from(content, 'base64');
+    }
+    return Buffer.from(content, 'utf8');
+  }
+  if (Buffer.isBuffer(content)) {
+    return content;
+  }
+  if (content instanceof Uint8Array) {
+    return Buffer.from(content);
+  }
+  return readStream(content);
+}
+
+function bytesToStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller): void {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+}
+
+function normalizeWriteFileContent(content: string | Buffer | Uint8Array): {
+  content: string | ReadableStream<Uint8Array>;
+  options?: { encoding?: string };
+} {
+  if (typeof content === 'string') {
+    return { content, options: { encoding: 'utf8' } };
+  }
+  return { content: bytesToStream(content) };
+}
+
+function createStats(info: {
+  size?: number;
+  type?: t.CloudflareSandboxFileInfo['type'];
+}): Stats {
+  const type = info.type ?? 'file';
+  const now = new Date();
+  return {
+    size: info.size ?? 0,
+    isFile: () => type === 'file',
+    isDirectory: () => type === 'directory',
+    isSymbolicLink: () => type === 'symlink',
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    dev: 0,
+    ino: 0,
+    mode: 0,
+    nlink: 1,
+    uid: 0,
+    gid: 0,
+    rdev: 0,
+    blksize: 0,
+    blocks: 0,
+    atimeMs: now.getTime(),
+    mtimeMs: now.getTime(),
+    ctimeMs: now.getTime(),
+    birthtimeMs: now.getTime(),
+    atime: now,
+    mtime: now,
+    ctime: now,
+    birthtime: now,
+  } as Stats;
+}
+
+function normalizeFileList(
+  result: t.CloudflareSandboxListFilesResult
+): t.CloudflareSandboxFileInfo[] {
+  return Array.isArray(result) ? result : result.files;
+}
+
+function entryNameFor(
+  info: t.CloudflareSandboxFileInfo,
+  parentPath: string
+): string {
+  if (info.name !== '') {
+    return info.name.includes('/') ? path.basename(info.name) : info.name;
+  }
+  if (info.absolutePath != null && info.absolutePath !== '') {
+    return path.basename(info.absolutePath);
+  }
+  if (info.relativePath != null && info.relativePath !== '') {
+    return path.basename(info.relativePath);
+  }
+  return path.basename(parentPath);
+}
+
+function entryAbsolutePath(
+  info: t.CloudflareSandboxFileInfo,
+  parentPath: string
+): string {
+  if (info.absolutePath != null && info.absolutePath !== '') {
+    return path.normalize(info.absolutePath);
+  }
+  if (info.relativePath != null && info.relativePath !== '') {
+    return path.resolve(parentPath, info.relativePath);
+  }
+  return path.resolve(parentPath, info.name);
+}
+
+function createDirent(info: t.CloudflareSandboxFileInfo): ReaddirEntry {
+  return {
+    name: entryNameFor(info, ''),
+    isFile: () => (info.type ?? 'file') === 'file',
+    isDirectory: () => info.type === 'directory',
+    isSymbolicLink: () => info.type === 'symlink',
+  };
+}
+
+async function findChildInfo(
+  sandbox: t.CloudflareSandboxRuntime,
+  filePath: string
+): Promise<t.CloudflareSandboxFileInfo | undefined> {
+  const parent = path.dirname(filePath);
+  const basename = path.basename(filePath);
+  const entries = normalizeFileList(
+    await sandbox.listFiles(parent, { includeHidden: true })
+  );
+  return entries.find((entry) => {
+    const absolute = entryAbsolutePath(entry, parent);
+    return absolute === filePath || entryNameFor(entry, parent) === basename;
+  });
+}
+
+export function createCloudflareWorkspaceFS(
+  config: t.CloudflareSandboxExecutionConfig
+): WorkspaceFS {
+  const workspaceRoot = getCloudflareWorkspaceRoot(config);
+
+  const fs: WorkspaceFS = {
+    readFile: (async (filePath: string, encoding?: 'utf8') => {
+      const sandbox = await resolveCloudflareSandbox(config);
+      const resolved = toSandboxPath(filePath, workspaceRoot);
+      const buffer = await normalizeReadFileContent(
+        await sandbox.readFile(resolved, encoding ? { encoding } : undefined)
+      );
+      return encoding != null ? buffer.toString(encoding) : buffer;
+    }) as WorkspaceFS['readFile'],
+    writeFile: async (
+      filePath: string,
+      content: string | Buffer,
+      _options?: WriteFileOptions
+    ) => {
+      const sandbox = await resolveCloudflareSandbox(config);
+      const resolved = toSandboxPath(filePath, workspaceRoot);
+      const normalized = normalizeWriteFileContent(content);
+      await sandbox.writeFile(resolved, normalized.content, normalized.options);
+    },
+    stat: async (filePath: string) => {
+      const sandbox = await resolveCloudflareSandbox(config);
+      const resolved = toSandboxPath(filePath, workspaceRoot);
+      const info = await findChildInfo(sandbox, resolved);
+      if (info != null) {
+        return createStats({ size: info.size, type: info.type });
+      }
+      try {
+        const entries = normalizeFileList(
+          await sandbox.listFiles(resolved, { includeHidden: true })
+        );
+        return createStats({ size: entries.length, type: 'directory' });
+      } catch {
+        const buffer = await normalizeReadFileContent(
+          await sandbox.readFile(resolved)
+        );
+        return createStats({ size: buffer.length, type: 'file' });
+      }
+    },
+    readdir: (async (filePath: string, options?: { withFileTypes: true }) => {
+      const sandbox = await resolveCloudflareSandbox(config);
+      const resolved = toSandboxPath(filePath, workspaceRoot);
+      const entries = normalizeFileList(
+        await sandbox.listFiles(resolved, { includeHidden: true })
+      );
+      if (options?.withFileTypes === true) {
+        return entries.map(createDirent);
+      }
+      return entries.map((entry) => entryNameFor(entry, resolved));
+    }) as WorkspaceFS['readdir'],
+    mkdir: async (filePath: string, options?: MakeDirectoryOptions) => {
+      const sandbox = await resolveCloudflareSandbox(config);
+      await sandbox.mkdir(toSandboxPath(filePath, workspaceRoot), {
+        recursive: options?.recursive,
+      });
+    },
+    realpath: async (filePath: string) =>
+      toSandboxPath(filePath, workspaceRoot),
+    unlink: async (filePath: string) => {
+      const sandbox = await resolveCloudflareSandbox(config);
+      await sandbox.deleteFile(toSandboxPath(filePath, workspaceRoot));
+    },
+    open: async (filePath: string, _flags: 'r') => {
+      const sandbox = await resolveCloudflareSandbox(config);
+      const resolved = toSandboxPath(filePath, workspaceRoot);
+      const buffer = await normalizeReadFileContent(
+        await sandbox.readFile(resolved)
+      );
+      return {
+        read: async (
+          target: Buffer,
+          offset: number,
+          length: number,
+          position: number
+        ) => {
+          const start = Math.max(position, 0);
+          const slice = buffer.subarray(start, start + length);
+          slice.copy(target, offset);
+          return { bytesRead: slice.length, buffer: target };
+        },
+        close: async () => undefined,
+      } as unknown as FileHandle;
+    },
+  };
+
+  return fs;
+}
+
+function createCloudflareSpawn(
+  config: t.CloudflareSandboxExecutionConfig
+): t.LocalSpawn {
+  return (command, args, options) => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+    Object.assign(child, {
+      stdout,
+      stderr,
+      stdin: new PassThrough(),
+      stdio: [null, stdout, stderr],
+      killed: false,
+      exitCode: null,
+      signalCode: null,
+      pid: undefined,
+      kill: () => {
+        Object.assign(child, { killed: true });
+        return true;
+      },
+    });
+
+    void (async (): Promise<void> => {
+      const ctx = await getRuntimeContext(config);
+      const rendered = [command, ...args].map(quote).join(' ');
+      const cwd =
+        options.cwd == null ? ctx.workspaceRoot : options.cwd.toString();
+      try {
+        const result = await ctx.sandbox.exec(rendered, {
+          cwd,
+          env: {
+            ...ctx.env,
+            ...(options.env as Record<string, string | undefined> | undefined),
+          },
+          timeout: ctx.timeoutMs,
+        });
+        if (result.stdout) stdout.write(result.stdout);
+        if (result.stderr) stderr.write(result.stderr);
+        stdout.end();
+        stderr.end();
+        Object.assign(child, { exitCode: result.exitCode });
+        child.emit('close', result.exitCode, null);
+      } catch (error) {
+        stderr.write((error as Error).message);
+        stdout.end();
+        stderr.end();
+        Object.assign(child, { exitCode: 1 });
+        child.emit('close', 1, null);
+      }
+    })();
+
+    return child;
+  };
+}
+
+export function createCloudflareLocalExecutionConfig(
+  config: t.CloudflareSandboxExecutionConfig
+): t.LocalExecutionConfig {
+  const workspaceRoot = getCloudflareWorkspaceRoot(config);
+  return {
+    cwd: workspaceRoot,
+    workspace: { root: workspaceRoot },
+    exec: {
+      spawn: createCloudflareSpawn(config),
+      fs: createCloudflareWorkspaceFS(config),
+      sandboxed: true,
+    },
+    shell: config.shell ?? 'bash',
+    timeoutMs: config.timeoutMs,
+    maxOutputChars: config.maxOutputChars,
+    env: config.env,
+    includeCodingTools: config.includeCodingTools,
+    compileCheck: config.compileCheck,
+    readOnly: config.readOnly,
+    allowDangerousCommands: config.allowDangerousCommands,
+    bashAst: config.bashAst,
+    fileCheckpointing: config.fileCheckpointing,
+    maxReadBytes: config.maxReadBytes,
+    attachReadAttachments: config.attachReadAttachments,
+    maxAttachmentBytes: config.maxAttachmentBytes,
+    postEditSyntaxCheck: config.postEditSyntaxCheck,
+  };
+}
+
+async function validateCloudflareBashCommand(
+  command: string,
+  args: readonly string[],
+  config: t.CloudflareSandboxExecutionConfig
+): Promise<void> {
+  const localConfig = createCloudflareLocalExecutionConfig(config);
+  const validation = await validateBashCommand(command, localConfig);
+  if (!validation.valid) {
+    throw new Error(validation.errors.join('\n'));
+  }
+
+  if (
+    args.length > 0 &&
+    config.allowDangerousCommands !== true &&
+    DESTRUCTIVE_OP_IN_COMMAND_RE.test(command)
+  ) {
+    const offending = args.find((arg) => PROTECTED_TARGET_ARG_RE.test(arg));
+    if (offending !== undefined) {
+      throw new Error(
+        `Command matches a destructive command pattern (protected target "${offending}" passed via positional arg).`
+      );
+    }
+  }
+}
+
+export async function executeCloudflareBash(
+  command: string,
+  config: t.CloudflareSandboxExecutionConfig,
+  args: readonly string[] = []
+): Promise<SpawnResult> {
+  await validateCloudflareBashCommand(command, args, config);
+  const ctx = await getRuntimeContext(config);
+  const shellCommand =
+    args.length > 0
+      ? `${ctx.shell} -lc ${quote(command)} -- ${args.map(quote).join(' ')}`
+      : `${ctx.shell} -lc ${quote(command)}`;
+  const result = await ctx.sandbox.exec(shellCommand, {
+    cwd: ctx.workspaceRoot,
+    env: ctx.env,
+    timeout: ctx.timeoutMs,
+  });
+  return {
+    stdout: truncateOutput(result.stdout, ctx.maxOutputChars),
+    stderr: truncateOutput(result.stderr, ctx.maxOutputChars),
+    exitCode: result.exitCode,
+    timedOut: false,
+  };
+}
+
+function runtimeForCode(
+  lang: string,
+  tempDir: string,
+  code: string,
+  args: string[] = [],
+  shell = 'bash'
+): RuntimeCommand {
+  const fileFor = (name: string): string => path.join(tempDir, name);
+  const argText = args.map(quote).join(' ');
+  switch (lang) {
+  case 'py':
+  case 'python':
+    return {
+      fileName: 'main.py',
+      source: code,
+      command: `python3 ${quote(fileFor('main.py'))} ${argText}`,
+    };
+  case 'js':
+  case 'javascript':
+    return {
+      fileName: 'main.js',
+      source: code,
+      command: `node ${quote(fileFor('main.js'))} ${argText}`,
+    };
+  case 'ts':
+  case 'typescript':
+    return {
+      fileName: 'main.ts',
+      source: code,
+      command: `npx --no-install tsx ${quote(fileFor('main.ts'))} ${argText}`,
+    };
+  case 'php':
+    return {
+      fileName: 'main.php',
+      source: code,
+      command: `php ${quote(fileFor('main.php'))} ${argText}`,
+    };
+  case 'go':
+    return {
+      fileName: 'main.go',
+      source: code,
+      command: `go run ${quote(fileFor('main.go'))} ${argText}`,
+    };
+  case 'rs':
+    return {
+      fileName: 'main.rs',
+      source: code,
+      command: `${shell} -lc ${quote(
+        `rustc ${quote(fileFor('main.rs'))} -o ${quote(fileFor('main-rs'))} && ${quote(fileFor('main-rs'))} ${argText}`
+      )}`,
+    };
+  case 'c':
+    return {
+      fileName: 'main.c',
+      source: code,
+      command: `${shell} -lc ${quote(
+        `cc ${quote(fileFor('main.c'))} -o ${quote(fileFor('main-c'))} && ${quote(fileFor('main-c'))} ${argText}`
+      )}`,
+    };
+  case 'cpp':
+    return {
+      fileName: 'main.cpp',
+      source: code,
+      command: `${shell} -lc ${quote(
+        `c++ ${quote(fileFor('main.cpp'))} -o ${quote(fileFor('main-cpp'))} && ${quote(fileFor('main-cpp'))} ${argText}`
+      )}`,
+    };
+  case 'java':
+    return {
+      fileName: 'Main.java',
+      source: code,
+      command: `${shell} -lc ${quote(
+        `javac ${quote(fileFor('Main.java'))} && java -cp ${quote(tempDir)} Main ${argText}`
+      )}`,
+    };
+  case 'r':
+    return {
+      fileName: 'main.R',
+      source: code,
+      command: `Rscript ${quote(fileFor('main.R'))} ${argText}`,
+    };
+  case 'd':
+    return {
+      fileName: 'main.d',
+      source: code,
+      command: `${shell} -lc ${quote(
+        `dmd ${quote(fileFor('main.d'))} -of=${quote(fileFor('main-d'))} && ${quote(fileFor('main-d'))} ${argText}`
+      )}`,
+    };
+  case 'f90':
+    return {
+      fileName: 'main.f90',
+      source: code,
+      command: `${shell} -lc ${quote(
+        `gfortran ${quote(fileFor('main.f90'))} -o ${quote(fileFor('main-f90'))} && ${quote(fileFor('main-f90'))} ${argText}`
+      )}`,
+    };
+  case 'bash':
+  case 'sh':
+    return {
+      fileName: 'main.sh',
+      source: code,
+      command: `${shell} -lc ${quote(code)} -- ${argText}`,
+    };
+  default:
+    throw new Error(`Unsupported Cloudflare sandbox runtime: ${lang}`);
+  }
+}
+
+export async function executeCloudflareCode(
+  input: { lang: string; code: string; args?: string[] },
+  config: t.CloudflareSandboxExecutionConfig
+): Promise<SpawnResult> {
+  if (input.lang === 'bash' || input.lang === 'sh') {
+    return executeCloudflareBash(input.code, config, input.args ?? []);
+  }
+  const ctx = await getRuntimeContext(config);
+  const id = globalThis.crypto.randomUUID();
+  const tempDir = path.join(ctx.workspaceRoot, '.lc-exec', id);
+  const runtime = runtimeForCode(
+    input.lang,
+    tempDir,
+    input.code,
+    input.args,
+    ctx.shell
+  );
+  await ctx.sandbox.mkdir(tempDir, { recursive: true });
+  if (runtime.source != null) {
+    await ctx.sandbox.writeFile(
+      path.join(tempDir, runtime.fileName),
+      runtime.source,
+      {
+        encoding: 'utf8',
+      }
+    );
+  }
+  try {
+    const result = await ctx.sandbox.exec(runtime.command, {
+      cwd: ctx.workspaceRoot,
+      env: ctx.env,
+      timeout: ctx.timeoutMs,
+    });
+    return {
+      stdout: truncateOutput(result.stdout, ctx.maxOutputChars),
+      stderr: truncateOutput(result.stderr, ctx.maxOutputChars),
+      exitCode: result.exitCode,
+      timedOut: false,
+    };
+  } finally {
+    await ctx.sandbox
+      .exec(`rm -rf ${quote(tempDir)}`, {
+        cwd: ctx.workspaceRoot,
+        env: ctx.env,
+        timeout: 10000,
+      })
+      .catch(() => undefined);
+  }
+}
+
+export function formatCloudflareOutput(
+  result: SpawnResult,
+  cwd: string
+): string {
+  let formatted = '';
+  if (result.stdout !== '') {
+    formatted += `stdout:\n${result.stdout}\n`;
+  } else {
+    formatted += 'stdout: Empty. Ensure you\'re writing output explicitly.\n';
+  }
+  if (result.stderr !== '') {
+    formatted += `stderr:\n${result.stderr}\n`;
+  }
+  if (result.exitCode != null && result.exitCode !== 0) {
+    formatted += `exit_code: ${result.exitCode}\n`;
+  }
+  if (result.timedOut) {
+    formatted += 'timed_out: true\n';
+  }
+  formatted += `working_directory: ${cwd}`;
+  return formatted.trim();
+}

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -407,10 +407,7 @@ function createCloudflareSpawn(
       try {
         const result = await ctx.sandbox.exec(rendered, {
           cwd,
-          env: {
-            ...ctx.env,
-            ...(options.env as Record<string, string | undefined> | undefined),
-          },
+          env: ctx.env,
           timeout: ctx.timeoutMs,
           signal: abortController.signal,
         });
@@ -462,7 +459,7 @@ export function createCloudflareLocalExecutionConfig(
   };
 }
 
-async function validateCloudflareBashCommand(
+export async function validateCloudflareBashCommand(
   command: string,
   args: readonly string[],
   config: t.CloudflareSandboxExecutionConfig

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -37,6 +37,11 @@ type SandboxRuntimeContext = {
   shell: string;
 };
 
+const sandboxFactoryCache = new WeakMap<
+  t.CloudflareSandboxExecutionConfig,
+  Promise<t.CloudflareSandboxRuntime>
+>();
+
 function normalizeWorkspaceRoot(workspaceRoot: string): string {
   const normalized = path.normalize(workspaceRoot);
   return normalized === '/' ? normalized : normalized.replace(/\/+$/, '');
@@ -54,7 +59,20 @@ export async function resolveCloudflareSandbox(
   config: t.CloudflareSandboxExecutionConfig
 ): Promise<t.CloudflareSandboxRuntime> {
   const sandbox = config.sandbox;
-  return typeof sandbox === 'function' ? await sandbox() : sandbox;
+  if (typeof sandbox !== 'function') {
+    return sandbox;
+  }
+  let cached = sandboxFactoryCache.get(config);
+  if (cached == null) {
+    cached = Promise.resolve()
+      .then(() => sandbox())
+      .catch((error: unknown) => {
+        sandboxFactoryCache.delete(config);
+        throw error;
+      });
+    sandboxFactoryCache.set(config, cached);
+  }
+  return cached;
 }
 
 async function getRuntimeContext(
@@ -76,6 +94,9 @@ function toSandboxPath(filePath: string, workspaceRoot: string): string {
   const resolved = raw.startsWith('/')
     ? path.normalize(raw)
     : path.resolve(root, raw);
+  if (root === '/') {
+    return resolved;
+  }
   if (resolved === root || resolved.startsWith(`${root}/`)) {
     return resolved;
   }
@@ -92,6 +113,15 @@ function quote(value: string): string {
     return value;
   }
   return `'${value.replace(/'/g, '\'\\\'\'')}'`;
+}
+
+function withInSandboxTimeout(command: string, timeoutMs: number): string {
+  const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1000));
+  return `timeout -k 2s ${timeoutSeconds}s ${command}`;
+}
+
+function outerTimeoutMs(timeoutMs: number): number {
+  return timeoutMs + 5000;
 }
 
 function truncateOutput(value: string, maxChars: number): string {
@@ -402,13 +432,14 @@ function createCloudflareSpawn(
     void (async (): Promise<void> => {
       const ctx = await getRuntimeContext(config);
       const rendered = [command, ...args].map(quote).join(' ');
+      const timedCommand = withInSandboxTimeout(rendered, ctx.timeoutMs);
       const cwd =
         options.cwd == null ? ctx.workspaceRoot : options.cwd.toString();
       try {
-        const result = await ctx.sandbox.exec(rendered, {
+        const result = await ctx.sandbox.exec(timedCommand, {
           cwd,
           env: ctx.env,
-          timeout: ctx.timeoutMs,
+          timeout: outerTimeoutMs(ctx.timeoutMs),
           signal: abortController.signal,
         });
         if (state.closed) {
@@ -495,11 +526,14 @@ export async function executeCloudflareBash(
     args.length > 0
       ? `${ctx.shell} -lc ${quote(command)} -- ${args.map(quote).join(' ')}`
       : `${ctx.shell} -lc ${quote(command)}`;
-  const result = await ctx.sandbox.exec(shellCommand, {
-    cwd: ctx.workspaceRoot,
-    env: ctx.env,
-    timeout: ctx.timeoutMs,
-  });
+  const result = await ctx.sandbox.exec(
+    withInSandboxTimeout(shellCommand, ctx.timeoutMs),
+    {
+      cwd: ctx.workspaceRoot,
+      env: ctx.env,
+      timeout: outerTimeoutMs(ctx.timeoutMs),
+    }
+  );
   return {
     stdout: truncateOutput(result.stdout, ctx.maxOutputChars),
     stderr: truncateOutput(result.stderr, ctx.maxOutputChars),
@@ -645,11 +679,14 @@ export async function executeCloudflareCode(
     );
   }
   try {
-    const result = await ctx.sandbox.exec(runtime.command, {
-      cwd: ctx.workspaceRoot,
-      env: ctx.env,
-      timeout: ctx.timeoutMs,
-    });
+    const result = await ctx.sandbox.exec(
+      withInSandboxTimeout(runtime.command, ctx.timeoutMs),
+      {
+        cwd: ctx.workspaceRoot,
+        env: ctx.env,
+        timeout: outerTimeoutMs(ctx.timeoutMs),
+      }
+    );
     return {
       stdout: truncateOutput(result.stdout, ctx.maxOutputChars),
       stderr: truncateOutput(result.stderr, ctx.maxOutputChars),

--- a/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
+++ b/src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts
@@ -124,6 +124,10 @@ function outerTimeoutMs(timeoutMs: number): number {
   return timeoutMs + 5000;
 }
 
+function isInSandboxTimeoutExit(exitCode: number | null): boolean {
+  return exitCode === 124 || exitCode === 137;
+}
+
 function truncateOutput(value: string, maxChars: number): string {
   if (maxChars <= 0 || value.length <= maxChars) {
     return value;
@@ -538,7 +542,7 @@ export async function executeCloudflareBash(
     stdout: truncateOutput(result.stdout, ctx.maxOutputChars),
     stderr: truncateOutput(result.stderr, ctx.maxOutputChars),
     exitCode: result.exitCode,
-    timedOut: false,
+    timedOut: isInSandboxTimeoutExit(result.exitCode),
   };
 }
 
@@ -691,7 +695,7 @@ export async function executeCloudflareCode(
       stdout: truncateOutput(result.stdout, ctx.maxOutputChars),
       stderr: truncateOutput(result.stderr, ctx.maxOutputChars),
       exitCode: result.exitCode,
-      timedOut: false,
+      timedOut: isInSandboxTimeoutExit(result.exitCode),
     };
   } finally {
     await ctx.sandbox

--- a/src/tools/cloudflare/CloudflareSandboxTools.ts
+++ b/src/tools/cloudflare/CloudflareSandboxTools.ts
@@ -1,0 +1,225 @@
+import { tool } from '@langchain/core/tools';
+import type { DynamicStructuredTool } from '@langchain/core/tools';
+import type * as t from '@/types';
+import {
+  CodeExecutionToolName,
+  CodeExecutionToolSchema,
+} from '@/tools/CodeExecutor';
+import {
+  BashExecutionToolName,
+  BashExecutionToolSchema,
+  BashToolOutputReferencesGuide,
+} from '@/tools/BashExecutor';
+import {
+  createLocalReadFileTool,
+  createLocalWriteFileTool,
+  createLocalEditFileTool,
+  createLocalGrepSearchTool,
+  createLocalGlobSearchTool,
+  createLocalListDirectoryTool,
+} from '@/tools/local/LocalCodingTools';
+import { createLocalFileCheckpointer } from '@/tools/local/FileCheckpointer';
+import { createCompileCheckTool } from '@/tools/local/CompileCheckTool';
+import { Constants } from '@/common';
+import {
+  createCloudflareLocalExecutionConfig,
+  createCloudflareWorkspaceFS,
+  executeCloudflareBash,
+  executeCloudflareCode,
+  formatCloudflareOutput,
+  getCloudflareWorkspaceRoot,
+} from './CloudflareSandboxExecutionEngine';
+import {
+  createCloudflareBashProgrammaticToolCallingTool,
+  createCloudflareProgrammaticToolCallingTool,
+} from './CloudflareProgrammaticToolCalling';
+
+export const CLOUDFLARE_CODING_TOOL_NAMES: readonly string[] = [
+  Constants.READ_FILE,
+  Constants.WRITE_FILE,
+  Constants.EDIT_FILE,
+  Constants.GREP_SEARCH,
+  Constants.GLOB_SEARCH,
+  Constants.LIST_DIRECTORY,
+  Constants.COMPILE_CHECK,
+  Constants.BASH_TOOL,
+  Constants.EXECUTE_CODE,
+  Constants.PROGRAMMATIC_TOOL_CALLING,
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+];
+
+export const CLOUDFLARE_BASH_CODING_TOOL_NAMES: readonly string[] = [
+  Constants.READ_FILE,
+  Constants.WRITE_FILE,
+  Constants.EDIT_FILE,
+  Constants.GREP_SEARCH,
+  Constants.GLOB_SEARCH,
+  Constants.LIST_DIRECTORY,
+  Constants.COMPILE_CHECK,
+  Constants.BASH_TOOL,
+  Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+];
+
+export const CloudflareCodeExecutionToolDescription = `
+Runs code inside the configured Cloudflare Sandbox workspace. The sandbox can see files and installed runtimes available inside the Cloudflare Sandbox container.
+
+Usage:
+- Commands execute in the Cloudflare Sandbox workspace and may modify sandbox files.
+- Input code is already displayed to the user, so do not repeat it unless asked.
+- Output is not displayed unless you print it explicitly.
+`.trim();
+
+export const CloudflareBashExecutionToolDescription = `
+Runs bash commands inside the configured Cloudflare Sandbox workspace.
+
+Usage:
+- Commands execute in the Cloudflare Sandbox workspace and may modify sandbox files.
+- Output is not displayed unless you print it explicitly.
+- Prefer project-native commands and inspect files before changing them.
+`.trim();
+
+export function createCloudflareCodeExecutionTool(
+  config: t.CloudflareSandboxExecutionConfig
+): DynamicStructuredTool {
+  return tool(
+    async (rawInput) => {
+      const input = rawInput as {
+        lang: string;
+        code: string;
+        args?: string[];
+      };
+      const cwd = getCloudflareWorkspaceRoot(config);
+      const result = await executeCloudflareCode(input, config);
+      return [
+        formatCloudflareOutput(result, cwd),
+        {
+          session_id: 'cloudflare-sandbox',
+          files: [],
+        } satisfies t.CodeExecutionArtifact,
+      ];
+    },
+    {
+      name: CodeExecutionToolName,
+      description: CloudflareCodeExecutionToolDescription,
+      schema: CodeExecutionToolSchema,
+      responseFormat: Constants.CONTENT_AND_ARTIFACT,
+    }
+  );
+}
+
+export function createCloudflareBashExecutionTool(options: {
+  config: t.CloudflareSandboxExecutionConfig;
+  enableToolOutputReferences?: boolean;
+}): DynamicStructuredTool {
+  const { config } = options;
+  return tool(
+    async (rawInput) => {
+      const input = rawInput as { command: string; args?: string[] };
+      const cwd = getCloudflareWorkspaceRoot(config);
+      const result = await executeCloudflareBash(
+        input.command,
+        config,
+        input.args ?? []
+      );
+      return [
+        formatCloudflareOutput(result, cwd),
+        {
+          session_id: 'cloudflare-sandbox',
+          files: [],
+        } satisfies t.CodeExecutionArtifact,
+      ];
+    },
+    {
+      name: BashExecutionToolName,
+      description:
+        options.enableToolOutputReferences === true
+          ? `${CloudflareBashExecutionToolDescription}\n\n${BashToolOutputReferencesGuide}`
+          : CloudflareBashExecutionToolDescription,
+      schema: BashExecutionToolSchema,
+      responseFormat: Constants.CONTENT_AND_ARTIFACT,
+    }
+  );
+}
+
+export type CloudflareCodingToolBundle = {
+  tools: DynamicStructuredTool[];
+  checkpointer?: t.LocalFileCheckpointer;
+};
+
+function getSelectedCodingToolNames(
+  config: t.CloudflareSandboxExecutionConfig
+): Set<string> {
+  return new Set(config.codingToolNames ?? CLOUDFLARE_CODING_TOOL_NAMES);
+}
+
+export function createCloudflareCodingTools(
+  config: t.CloudflareSandboxExecutionConfig,
+  options: { checkpointer?: t.LocalFileCheckpointer } = {}
+): DynamicStructuredTool[] {
+  const localConfig = createCloudflareLocalExecutionConfig(config);
+  const checkpointer =
+    options.checkpointer ??
+    (config.fileCheckpointing === true
+      ? createLocalFileCheckpointer({
+        fs: createCloudflareWorkspaceFS(config),
+      })
+      : undefined);
+  const tools = [
+    [Constants.READ_FILE, createLocalReadFileTool(localConfig)],
+    [Constants.WRITE_FILE, createLocalWriteFileTool(localConfig, checkpointer)],
+    [Constants.EDIT_FILE, createLocalEditFileTool(localConfig, checkpointer)],
+    [Constants.GREP_SEARCH, createLocalGrepSearchTool(localConfig)],
+    [Constants.GLOB_SEARCH, createLocalGlobSearchTool(localConfig)],
+    [Constants.LIST_DIRECTORY, createLocalListDirectoryTool(localConfig)],
+    [Constants.COMPILE_CHECK, createCompileCheckTool(localConfig)],
+    [Constants.BASH_TOOL, createCloudflareBashExecutionTool({ config })],
+    [Constants.EXECUTE_CODE, createCloudflareCodeExecutionTool(config)],
+    [
+      Constants.PROGRAMMATIC_TOOL_CALLING,
+      createCloudflareProgrammaticToolCallingTool(config),
+    ],
+    [
+      Constants.BASH_PROGRAMMATIC_TOOL_CALLING,
+      createCloudflareBashProgrammaticToolCallingTool(config),
+    ],
+  ] satisfies Array<[string, DynamicStructuredTool]>;
+  const selectedNames = getSelectedCodingToolNames(config);
+  return tools
+    .filter(([name]) => selectedNames.has(name))
+    .map(([, selectedTool]) => selectedTool);
+}
+
+export function createCloudflareCodingToolBundle(
+  config: t.CloudflareSandboxExecutionConfig,
+  options: { checkpointer?: t.LocalFileCheckpointer } = {}
+): CloudflareCodingToolBundle {
+  const checkpointer =
+    options.checkpointer ??
+    (config.fileCheckpointing === true
+      ? createLocalFileCheckpointer({
+        fs: createCloudflareWorkspaceFS(config),
+      })
+      : undefined);
+  return {
+    tools: createCloudflareCodingTools(config, { checkpointer }),
+    checkpointer,
+  };
+}
+
+export function createCloudflareExecutionTool(
+  name: string,
+  config: t.CloudflareSandboxExecutionConfig
+): t.GenericTool | undefined {
+  switch (name) {
+  case Constants.EXECUTE_CODE:
+    return createCloudflareCodeExecutionTool(config);
+  case Constants.BASH_TOOL:
+    return createCloudflareBashExecutionTool({ config });
+  case Constants.PROGRAMMATIC_TOOL_CALLING:
+    return createCloudflareProgrammaticToolCallingTool(config);
+  case Constants.BASH_PROGRAMMATIC_TOOL_CALLING:
+    return createCloudflareBashProgrammaticToolCallingTool(config);
+  default:
+    return undefined;
+  }
+}

--- a/src/tools/cloudflare/index.ts
+++ b/src/tools/cloudflare/index.ts
@@ -1,0 +1,4 @@
+export * from './CloudflareBridgeRuntime';
+export * from './CloudflareProgrammaticToolCalling';
+export * from './CloudflareSandboxExecutionEngine';
+export * from './CloudflareSandboxTools';

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -704,6 +704,8 @@ export interface SpawnLocalProcessOptions {
   internal?: boolean;
 }
 
+export const LOCAL_SPAWN_TIMEOUT_MS = Symbol('librechat.localSpawn.timeoutMs');
+
 export async function spawnLocalProcess(
   command: string,
   args: string[],
@@ -746,12 +748,16 @@ export async function spawnLocalProcess(
 
   const launcher = getSpawn(config);
   return new Promise<SpawnResult>((resolveResult, reject) => {
-    const child = launcher(spawnCommand, spawnArgs, {
+    const spawnOptions: import('child_process').SpawnOptions = {
       cwd,
       detached: process.platform !== 'win32',
       env: { ...process.env, ...(config.env ?? {}) },
       stdio: ['ignore', 'pipe', 'pipe'],
+    };
+    Object.defineProperty(spawnOptions, LOCAL_SPAWN_TIMEOUT_MS, {
+      value: timeoutMs,
     });
+    const child = launcher(spawnCommand, spawnArgs, spawnOptions);
 
     let stdout = '';
     let stderr = '';

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -1170,7 +1170,10 @@ function configShell(): string {
 const SIGKILL_ESCALATION_MS = 2000;
 
 function sigterm(child: ChildProcess): void {
-  if (child.pid == null) return;
+  if (child.pid == null) {
+    child.kill('SIGTERM');
+    return;
+  }
   try {
     if (process.platform === 'win32') {
       child.kill('SIGTERM');
@@ -1183,8 +1186,11 @@ function sigterm(child: ChildProcess): void {
 }
 
 function sigkill(child: ChildProcess): void {
-  if (child.pid == null) return;
   if (child.exitCode != null || child.signalCode != null) return;
+  if (child.pid == null) {
+    child.kill('SIGKILL');
+    return;
+  }
   try {
     if (process.platform === 'win32') {
       child.kill('SIGKILL');

--- a/src/tools/local/LocalExecutionEngine.ts
+++ b/src/tools/local/LocalExecutionEngine.ts
@@ -342,7 +342,11 @@ function shouldUseLocalSandbox(config: t.LocalExecutionConfig): boolean {
 let sandboxOffWarned = false;
 
 function maybeWarnSandboxOff(config: t.LocalExecutionConfig): void {
-  if (sandboxOffWarned || shouldUseLocalSandbox(config)) {
+  if (
+    sandboxOffWarned ||
+    shouldUseLocalSandbox(config) ||
+    config.exec?.sandboxed === true
+  ) {
     return;
   }
   sandboxOffWarned = true;

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -1,4 +1,8 @@
-import { Constants, CODE_EXECUTION_TOOLS } from '@/common';
+import {
+  Constants,
+  CODE_EXECUTION_TOOLS,
+  LOCAL_CODING_BUNDLE_NAMES,
+} from '@/common';
 import {
   createLocalBashExecutionTool,
   createLocalCodeExecutionTool,
@@ -65,6 +69,42 @@ function getCloudflareConfig(
   return config.cloudflare;
 }
 
+function getSelectedCloudflareCodingToolNames(
+  config: t.CloudflareSandboxExecutionConfig
+): Set<string> {
+  return new Set(config.codingToolNames ?? LOCAL_CODING_BUNDLE_NAMES);
+}
+
+function filterCloudflareCodingToolAllowlist(
+  tools: t.GraphTools | undefined,
+  selectedNames: Set<string>
+): t.GraphTools | undefined {
+  const existingTools = (tools as t.GenericTool[] | undefined) ?? [];
+  if (existingTools.length === 0) {
+    return tools;
+  }
+  return existingTools.filter((existingTool) => {
+    if (!('name' in existingTool) || typeof existingTool.name !== 'string') {
+      return true;
+    }
+    return (
+      !LOCAL_CODING_BUNDLE_NAMES.includes(existingTool.name) ||
+      selectedNames.has(existingTool.name)
+    );
+  });
+}
+
+function pruneCloudflareCodingToolAllowlist(
+  toolMap: t.ToolMap,
+  selectedNames: Set<string>
+): void {
+  for (const name of LOCAL_CODING_BUNDLE_NAMES) {
+    if (!selectedNames.has(name)) {
+      toolMap.delete(name);
+    }
+  }
+}
+
 function createLocalExecutionTool(
   name: string,
   config: t.LocalExecutionConfig
@@ -124,8 +164,10 @@ export function resolveLocalToolsForBinding(args: {
   if (shouldUseCloudflareSandboxExecution(args.toolExecution)) {
     const cloudflareConfig = getCloudflareConfig(args.toolExecution);
     if (shouldIncludeCodingTools(args.toolExecution)) {
+      const selectedNames =
+        getSelectedCloudflareCodingToolNames(cloudflareConfig);
       return mergeToolsByName(
-        args.tools,
+        filterCloudflareCodingToolAllowlist(args.tools, selectedNames),
         createCloudflareCodingTools(cloudflareConfig)
       );
     }
@@ -181,7 +223,16 @@ export function resolveLocalToolRegistry(args: {
   }
 
   const registry = new Map(args.toolRegistry ?? []);
+  const selectedNames = shouldUseCloudflareSandboxExecution(args.toolExecution)
+    ? getSelectedCloudflareCodingToolNames(
+      getCloudflareConfig(args.toolExecution)
+    )
+    : undefined;
   for (const definition of createLocalCodingToolDefinitions()) {
+    if (selectedNames != null && !selectedNames.has(definition.name)) {
+      registry.delete(definition.name);
+      continue;
+    }
     registry.set(definition.name, definition);
   }
   return registry;
@@ -217,6 +268,9 @@ export function resolveLocalExecutionTools(args: {
   if (shouldUseCloudflareSandboxExecution(args.toolExecution)) {
     const cloudflareConfig = getCloudflareConfig(args.toolExecution);
     if (shouldIncludeCodingTools(args.toolExecution)) {
+      const selectedNames =
+        getSelectedCloudflareCodingToolNames(cloudflareConfig);
+      pruneCloudflareCodingToolAllowlist(toolMap, selectedNames);
       if (
         cloudflareConfig.fileCheckpointing === true ||
         args.fileCheckpointer != null

--- a/src/tools/local/resolveLocalExecutionTools.ts
+++ b/src/tools/local/resolveLocalExecutionTools.ts
@@ -12,6 +12,11 @@ import {
   createLocalBashProgrammaticToolCallingTool,
   createLocalProgrammaticToolCallingTool,
 } from './LocalProgrammaticToolCalling';
+import {
+  createCloudflareCodingToolBundle,
+  createCloudflareCodingTools,
+  createCloudflareExecutionTool,
+} from '@/tools/cloudflare';
 import type * as t from '@/types';
 
 type ResolveLocalToolsResult = {
@@ -34,11 +39,30 @@ function shouldUseLocalExecution(config?: t.ToolExecutionConfig): boolean {
   return config?.engine === 'local';
 }
 
+function shouldUseCloudflareSandboxExecution(
+  config?: t.ToolExecutionConfig
+): boolean {
+  return config?.engine === 'cloudflare-sandbox';
+}
+
 function shouldIncludeCodingTools(config?: t.ToolExecutionConfig): boolean {
   return (
-    shouldUseLocalExecution(config) &&
-    config?.local?.includeCodingTools !== false
+    (shouldUseLocalExecution(config) &&
+      config?.local?.includeCodingTools !== false) ||
+    (shouldUseCloudflareSandboxExecution(config) &&
+      config?.cloudflare?.includeCodingTools !== false)
   );
+}
+
+function getCloudflareConfig(
+  config?: t.ToolExecutionConfig
+): t.CloudflareSandboxExecutionConfig {
+  if (config?.cloudflare == null) {
+    throw new Error(
+      'toolExecution.cloudflare is required when engine is "cloudflare-sandbox".'
+    );
+  }
+  return config.cloudflare;
 }
 
 function createLocalExecutionTool(
@@ -90,8 +114,40 @@ export function resolveLocalToolsForBinding(args: {
   tools?: t.GraphTools;
   toolExecution?: t.ToolExecutionConfig;
 }): t.GraphTools | undefined {
-  if (!shouldUseLocalExecution(args.toolExecution)) {
+  if (
+    !shouldUseLocalExecution(args.toolExecution) &&
+    !shouldUseCloudflareSandboxExecution(args.toolExecution)
+  ) {
     return args.tools;
+  }
+
+  if (shouldUseCloudflareSandboxExecution(args.toolExecution)) {
+    const cloudflareConfig = getCloudflareConfig(args.toolExecution);
+    if (shouldIncludeCodingTools(args.toolExecution)) {
+      return mergeToolsByName(
+        args.tools,
+        createCloudflareCodingTools(cloudflareConfig)
+      );
+    }
+
+    const replacements = ((args.tools as t.GenericTool[] | undefined) ?? [])
+      .filter(
+        (existingTool): existingTool is t.GenericTool & { name: string } =>
+          'name' in existingTool &&
+          typeof existingTool.name === 'string' &&
+          CODE_EXECUTION_TOOLS.has(existingTool.name)
+      )
+      .map((existingTool) =>
+        createCloudflareExecutionTool(existingTool.name, cloudflareConfig)
+      )
+      .filter(
+        (cloudflareTool): cloudflareTool is t.GenericTool =>
+          cloudflareTool != null
+      );
+
+    return replacements.length === 0
+      ? args.tools
+      : mergeToolsByName(args.tools, replacements);
   }
 
   const localConfig = args.toolExecution?.local ?? {};
@@ -145,16 +201,65 @@ export function resolveLocalExecutionTools(args: {
   fileCheckpointer?: t.LocalFileCheckpointer;
 }): ResolveLocalToolsResult {
   const directToolNames = new Set<string>();
-  if (!shouldUseLocalExecution(args.toolExecution)) {
+  if (
+    !shouldUseLocalExecution(args.toolExecution) &&
+    !shouldUseCloudflareSandboxExecution(args.toolExecution)
+  ) {
     return {
       toolMap: args.toolMap,
       directToolNames,
     };
   }
 
-  const localConfig = args.toolExecution?.local ?? {};
   const toolMap = new Map(args.toolMap);
   let fileCheckpointer: t.LocalFileCheckpointer | undefined;
+
+  if (shouldUseCloudflareSandboxExecution(args.toolExecution)) {
+    const cloudflareConfig = getCloudflareConfig(args.toolExecution);
+    if (shouldIncludeCodingTools(args.toolExecution)) {
+      if (
+        cloudflareConfig.fileCheckpointing === true ||
+        args.fileCheckpointer != null
+      ) {
+        const bundle = createCloudflareCodingToolBundle(cloudflareConfig, {
+          checkpointer: args.fileCheckpointer,
+        });
+        fileCheckpointer = bundle.checkpointer;
+        for (const cloudflareTool of bundle.tools) {
+          toolMap.set(cloudflareTool.name, cloudflareTool);
+          directToolNames.add(cloudflareTool.name);
+        }
+      } else {
+        for (const cloudflareTool of createCloudflareCodingTools(
+          cloudflareConfig
+        )) {
+          toolMap.set(cloudflareTool.name, cloudflareTool);
+          directToolNames.add(cloudflareTool.name);
+        }
+      }
+    }
+
+    const includeCodingTools = shouldIncludeCodingTools(args.toolExecution);
+    for (const name of CODE_EXECUTION_TOOLS) {
+      if (includeCodingTools) continue;
+      if (!toolMap.has(name)) continue;
+
+      const cloudflareTool = createCloudflareExecutionTool(
+        name,
+        cloudflareConfig
+      );
+      if (cloudflareTool == null) {
+        continue;
+      }
+
+      toolMap.set(name, cloudflareTool);
+      directToolNames.add(name);
+    }
+
+    return { toolMap, directToolNames, fileCheckpointer };
+  }
+
+  const localConfig = args.toolExecution?.local ?? {};
 
   if (shouldIncludeCodingTools(args.toolExecution)) {
     // Use the bundle factory when fileCheckpointing is on so we can
@@ -163,7 +268,10 @@ export function resolveLocalExecutionTools(args: {
     // immediately discarded, making the public `fileCheckpointing`
     // config flag a silent no-op outside of direct
     // `createLocalCodingToolBundle()` use.
-    if (localConfig.fileCheckpointing === true || args.fileCheckpointer != null) {
+    if (
+      localConfig.fileCheckpointing === true ||
+      args.fileCheckpointer != null
+    ) {
       const bundle = createLocalCodingToolBundle(localConfig, {
         checkpointer: args.fileCheckpointer,
       });

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -505,11 +505,12 @@ export type ToolOutputReferencesConfig = {
   maxTotalSize?: number;
 };
 
-export type ToolExecutionEngine = 'sandbox' | 'local';
+export type ToolExecutionEngine = 'sandbox' | 'local' | 'cloudflare-sandbox';
 
 /**
  * Records pre-write file contents so callers can rewind edits/writes
- * made by the local engine. Implementations live in `src/tools/local`.
+ * made by local-compatible coding-tool engines. Implementations live
+ * in `src/tools/local`.
  */
 export interface LocalFileCheckpointer {
   /**
@@ -634,6 +635,12 @@ export type LocalExecConfig = {
    * overridden together for non-host engines.
    */
   fs?: import('@/tools/local/workspaceFS').WorkspaceFS;
+  /**
+   * Set by custom execution backends that already provide their own
+   * sandbox boundary. Suppresses the local host-sandbox warning while
+   * preserving the warning for plain host `child_process` execution.
+   */
+  sandboxed?: boolean;
 };
 
 export type LocalExecutionConfig = {
@@ -790,11 +797,143 @@ export type LocalExecutionConfig = {
   };
 };
 
+export type CloudflareSandboxExecOptions = {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  timeout?: number;
+  stream?: boolean;
+  onOutput?: (stream: 'stdout' | 'stderr', data: string) => void;
+  signal?: AbortSignal;
+};
+
+export type CloudflareSandboxExecResult = {
+  success?: boolean;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  command?: string;
+  duration?: number;
+  timestamp?: string;
+};
+
+export type CloudflareSandboxReadFileResult =
+  | string
+  | Buffer
+  | Uint8Array
+  | {
+      content: string | Buffer | Uint8Array | ReadableStream<Uint8Array>;
+      size?: number;
+      mimeType?: string;
+      encoding?: 'utf-8' | 'utf8' | 'base64';
+      isBinary?: boolean;
+    };
+
+export type CloudflareSandboxListFilesOptions = {
+  recursive?: boolean;
+  includeHidden?: boolean;
+};
+
+export type CloudflareSandboxFileInfo = {
+  name: string;
+  absolutePath?: string;
+  relativePath?: string;
+  type?: 'file' | 'directory' | 'symlink' | 'other';
+  size?: number;
+  modifiedAt?: string;
+  mode?: string;
+};
+
+export type CloudflareSandboxListFilesResult =
+  | CloudflareSandboxFileInfo[]
+  | {
+      files: CloudflareSandboxFileInfo[];
+      count?: number;
+      path?: string;
+      success?: boolean;
+    };
+
+export interface CloudflareSandboxRuntime {
+  exec(
+    command: string,
+    options?: CloudflareSandboxExecOptions
+  ): Promise<CloudflareSandboxExecResult>;
+  readFile(
+    path: string,
+    options?: { encoding?: string }
+  ): Promise<CloudflareSandboxReadFileResult>;
+  writeFile(
+    path: string,
+    content: string | ReadableStream<Uint8Array>,
+    options?: { encoding?: string }
+  ): Promise<unknown>;
+  mkdir(path: string, options?: { recursive?: boolean }): Promise<unknown>;
+  listFiles(
+    path: string,
+    options?: CloudflareSandboxListFilesOptions
+  ): Promise<CloudflareSandboxListFilesResult>;
+  deleteFile(path: string): Promise<unknown>;
+}
+
+export type CloudflareSandboxExecutionConfig = {
+  sandbox:
+    | CloudflareSandboxRuntime
+    | (() => CloudflareSandboxRuntime | Promise<CloudflareSandboxRuntime>);
+  /** Working directory inside the sandbox. Defaults to `/workspace`. */
+  workspaceRoot?: string;
+  /** Extra environment variables merged into sandbox command executions. */
+  env?: Record<string, string | undefined>;
+  /** Default timeout for sandbox commands, in milliseconds. */
+  timeoutMs?: number;
+  /** Maximum stdout/stderr characters surfaced to the model. */
+  maxOutputChars?: number;
+  /**
+   * Add the built-in coding suite when `engine` is `cloudflare-sandbox`.
+   * Defaults to true, matching the local execution backend.
+   */
+  includeCodingTools?: boolean;
+  /**
+   * Optional exact coding-tool names to expose when `includeCodingTools`
+   * is on. Defaults to the full local-parity Cloudflare bundle. Use this
+   * to publish a bash-only sandbox surface, for example file/search tools
+   * plus `bash_tool` and `run_tools_with_bash`, without exposing
+   * `execute_code`.
+   */
+  codingToolNames?: readonly string[];
+  /** Optional shell executable for bash-style tools. Defaults to `bash`. */
+  shell?: string;
+  /**
+   * Optional project-level compile check configuration. Mirrors the local
+   * execution backend.
+   */
+  compileCheck?: LocalExecutionConfig['compileCheck'];
+  /** Optional read-only guard for mutating coding tools. */
+  readOnly?: boolean;
+  /** Permit dangerous commands that the validator otherwise blocks. */
+  allowDangerousCommands?: LocalExecutionConfig['allowDangerousCommands'];
+  /** Tree-sitter-bash AST validation pass for bash commands. */
+  bashAst?: LocalExecutionConfig['bashAst'];
+  /**
+   * Enable per-Run file checkpointing for `edit_file` / `write_file`
+   * against the Cloudflare Sandbox workspace.
+   */
+  fileCheckpointing?: LocalExecutionConfig['fileCheckpointing'];
+  /** Maximum bytes to read in `read_file` before returning a stub. */
+  maxReadBytes?: LocalExecutionConfig['maxReadBytes'];
+  /** Controls whether `read_file` returns binary files as attachments. */
+  attachReadAttachments?: LocalExecutionConfig['attachReadAttachments'];
+  /** Maximum pre-encoding byte size to embed inline. */
+  maxAttachmentBytes?: LocalExecutionConfig['maxAttachmentBytes'];
+  /** Run a fast per-file syntax check after successful edits/writes. */
+  postEditSyntaxCheck?: LocalExecutionConfig['postEditSyntaxCheck'];
+};
+
 export type ToolExecutionConfig = {
   /** `sandbox` preserves the remote Code API behavior and is the default. */
   engine?: ToolExecutionEngine;
   /** Local process execution settings used when `engine` is `local`. */
   local?: LocalExecutionConfig;
+  /** Cloudflare Sandbox execution settings used when `engine` is `cloudflare-sandbox`. */
+  cloudflare?: CloudflareSandboxExecutionConfig;
 };
 
 export type ProgrammaticCache = {


### PR DESCRIPTION
## Summary

I added Cloudflare Sandbox as a first-class execution backend for the Agents SDK, with local coding tool parity and a bridge runtime for local or non-Worker callers.

- Added a structural Cloudflare Sandbox runtime interface and execution config for `toolExecution.engine = "cloudflare-sandbox"`.
- Implemented Cloudflare-backed equivalents for file, search, compile, bash, code, and programmatic coding tools while preserving the existing local tool names and contracts.
- Added `createCloudflareBridgeRuntime()` so local SDK consumers can target a deployed Cloudflare Sandbox bridge Worker.
- Added bash-only coding tool constants for review workflows that want all execution routed through bash.
- Wired the Cloudflare backend into graph/tool resolution and shared file checkpointing.
- Documented OpenAI-compatible model usage with Cloudflare Workers AI and the bridge runtime path.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Ran `npx eslint src/graphs/Graph.ts src/index.ts src/tools/local/LocalExecutionEngine.ts src/tools/local/resolveLocalExecutionTools.ts src/types/tools.ts src/tools/cloudflare/CloudflareBridgeRuntime.ts src/tools/cloudflare/CloudflareProgrammaticToolCalling.ts src/tools/cloudflare/CloudflareSandboxExecutionEngine.ts src/tools/cloudflare/CloudflareSandboxTools.ts src/tools/cloudflare/index.ts`
- Ran `npx tsc --noEmit`
- Ran `npm run build`
- Live-smoked the direct Cloudflare Sandbox backend with the full local-equivalent coding bundle: 11 tools passed.
- Live-smoked the bash-only Cloudflare Sandbox backend: 9 tools passed, with `execute_code` and `run_tools_with_code` omitted.
- Live-smoked `createCloudflareBridgeRuntime()` from local Node through a deployed Cloudflare Sandbox bridge Worker.

### **Test Configuration**:

- Node.js `v20.19.5`
- npm `10.8.2`
- Cloudflare Sandbox `@cloudflare/sandbox@0.10.2`
- Temporary deployed Cloudflare Worker smoke target using `getSandbox(env.Sandbox, runId)` and bridge routes

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings