### PR TITLE
🏷️ ci: Automate Release Tag Creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     environment: publish # Must match npm trusted publisher config
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -220,3 +222,66 @@ jobs:
         run: npm publish $(ls librechat-agents-*.tgz) --access public --provenance --tag ${{ steps.publish_tag.outputs.tag }}
         env:
           NODE_ENV: production
+
+  release:
+    needs: publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Detect version commit
+        id: version
+        run: |
+          VERSION=$(git log -1 --pretty=%s "$GITHUB_SHA")
+          if echo "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "is_version=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "is_version=false" >> "$GITHUB_OUTPUT"
+          echo "Head commit subject '$VERSION' is not a release commit; skipping."
+
+      - name: Validate package version
+        if: steps.version.outputs.is_version == 'true'
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          VERSION="${{ steps.version.outputs.version }}"
+          if [ "v$PACKAGE_VERSION" != "$VERSION" ]; then
+            echo "::error title=Version mismatch::Commit subject is $VERSION, but package.json version is $PACKAGE_VERSION."
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        if: steps.version.outputs.is_version == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if git rev-parse --verify --quiet "refs/tags/$VERSION" >/dev/null; then
+            TAG_SHA=$(git rev-list -n 1 "$VERSION")
+            if [ "$TAG_SHA" != "$GITHUB_SHA" ]; then
+              echo "::error title=Tag points at a different commit::Tag $VERSION points to $TAG_SHA, expected $GITHUB_SHA."
+              exit 1
+            fi
+          fi
+
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists; skipping."
+            exit 0
+          fi
+
+          gh release create "$VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "$VERSION" \
+            --generate-notes


### PR DESCRIPTION
## Summary

I added release automation to the publish workflow so version commits create GitHub releases with generated notes after publish succeeds.

- Added full-history checkout in the publish workflow so version-range logic and tag checks can inspect prior version commits.
- Added a `release` job that runs after `publish` on `main` pushes and detects exact `vX.Y.Z` commit subjects.
- Validated the detected release version against `package.json` before creating a release.
- Created GitHub releases with `gh release create --target "$GITHUB_SHA" --generate-notes`, while skipping existing releases and failing when an existing tag points elsewhere.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml'); puts 'yaml ok'"`.
- Ran `npx prettier --check .github/workflows/publish.yml`.
- Ran `git diff --check HEAD~1 HEAD`.
- Ran a local detection check against the current `v3.1.92` version commit and `package.json` version.

### **Test Configuration**:

- Local worktree on macOS with GitHub CLI `2.92.0`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings