### PR TITLE
🧾 fix: normalize PTC JSON-string inputs

### DIFF
--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -630,6 +630,122 @@ export function unwrapToolResponse(
   return result;
 }
 
+type ToolInputSchemaKind = {
+  object: boolean;
+  string: boolean;
+};
+
+function detectSchemaKind(schema: unknown): ToolInputSchemaKind {
+  const kind: ToolInputSchemaKind = { object: false, string: false };
+
+  if (!schema || typeof schema !== 'object') {
+    return kind;
+  }
+
+  const jsonSchemaType = (schema as { type?: unknown }).type;
+  if (jsonSchemaType === 'object') {
+    kind.object = true;
+  } else if (jsonSchemaType === 'string') {
+    kind.string = true;
+  } else if (Array.isArray(jsonSchemaType)) {
+    kind.object = jsonSchemaType.includes('object');
+    kind.string = jsonSchemaType.includes('string');
+  }
+
+  const zodDef = (schema as { _def?: unknown })._def;
+  if (!zodDef || typeof zodDef !== 'object') {
+    return kind;
+  }
+
+  const zodType = (zodDef as { type?: unknown; typeName?: unknown }).type;
+  const zodTypeName = (zodDef as { type?: unknown; typeName?: unknown })
+    .typeName;
+
+  if (zodType === 'object' || zodTypeName === 'ZodObject') {
+    kind.object = true;
+  } else if (zodType === 'string' || zodTypeName === 'ZodString') {
+    kind.string = true;
+  }
+
+  const innerSchema =
+    (
+      zodDef as {
+        innerType?: unknown;
+        schema?: unknown;
+        type?: unknown;
+      }
+    ).innerType ?? (zodDef as { schema?: unknown }).schema;
+  if (innerSchema) {
+    const innerKind = detectSchemaKind(innerSchema);
+    kind.object ||= innerKind.object;
+    kind.string ||= innerKind.string;
+  }
+
+  const options = (zodDef as { options?: unknown }).options;
+  if (Array.isArray(options)) {
+    for (const option of options) {
+      const optionKind = detectSchemaKind(option);
+      kind.object ||= optionKind.object;
+      kind.string ||= optionKind.string;
+    }
+  }
+
+  return kind;
+}
+
+function getToolInputSchemaKind(tool: t.GenericTool): ToolInputSchemaKind {
+  if (tool.constructor.name === 'DynamicTool') {
+    return { object: false, string: true };
+  }
+
+  const schema = (tool as { schema?: unknown }).schema;
+  return detectSchemaKind(schema);
+}
+
+function normalizeToolInput(
+  input: t.PTCToolCall['input'],
+  tool: t.GenericTool
+): t.PTCToolCall['input'] {
+  const schemaKind = getToolInputSchemaKind(tool);
+
+  if (typeof input !== 'string') {
+    if (!schemaKind.string || schemaKind.object) {
+      return input;
+    }
+
+    const inputValue = (input as { input?: unknown }).input;
+    if (typeof inputValue === 'string') {
+      return input;
+    }
+
+    return JSON.stringify(input);
+  }
+
+  if (!schemaKind.object || schemaKind.string) {
+    return input;
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('{')) {
+    return input;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return input;
+  }
+
+  return input;
+}
+
 /**
  * Executes tools in parallel when requested by the API.
  * Uses Promise.all for parallel execution, catching individual errors.
@@ -656,7 +772,7 @@ export async function executeTools(
     }
 
     try {
-      const result = await tool.invoke(call.input, {
+      const result = await tool.invoke(normalizeToolInput(call.input, tool), {
         metadata: { [programmaticToolName]: true },
       });
 

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -86,6 +86,135 @@ describe('ProgrammaticToolCalling', () => {
       });
     });
 
+    it('parses JSON-string inputs before invoking structured tools', async () => {
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'get_weather',
+          input: '{"city":"San Francisco"}',
+        },
+      ];
+
+      const results = await executeTools(toolCalls, toolMap);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].call_id).toBe('call_001');
+      expect(results[0].is_error).toBe(false);
+      expect(results[0].result).toEqual({
+        temperature: 65,
+        condition: 'Foggy',
+      });
+    });
+
+    it('preserves JSON-looking strings for string-input tools', async () => {
+      const invoke = jest.fn<
+        (_input: unknown, _config: unknown) => Promise<unknown>
+          >(async (input) => input);
+      const customTool = {
+        name: 'string_tool',
+        schema: { type: 'string' },
+        invoke,
+      } as unknown as t.GenericTool;
+      const customToolMap: t.ToolMap = new Map([['string_tool', customTool]]);
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'string_tool',
+          input: '{"raw":true}',
+        },
+      ];
+
+      const results = await executeTools(toolCalls, customToolMap);
+
+      expect(results[0].is_error).toBe(false);
+      expect(results[0].result).toBe('{"raw":true}');
+      expect(invoke).toHaveBeenCalledWith('{"raw":true}', {
+        metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
+      });
+    });
+
+    it('stringifies object inputs before invoking string-input tools', async () => {
+      const invoke = jest.fn<
+        (_input: unknown, _config: unknown) => Promise<unknown>
+          >(async (input) => input);
+      const customTool = {
+        name: 'string_tool',
+        schema: { type: 'string' },
+        invoke,
+      } as unknown as t.GenericTool;
+      const customToolMap: t.ToolMap = new Map([['string_tool', customTool]]);
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'string_tool',
+          input: { raw: true },
+        },
+      ];
+
+      const results = await executeTools(toolCalls, customToolMap);
+
+      expect(results[0].is_error).toBe(false);
+      expect(results[0].result).toBe('{"raw":true}');
+      expect(invoke).toHaveBeenCalledWith('{"raw":true}', {
+        metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
+      });
+    });
+
+    it('preserves object inputs for mixed object-or-string schemas', async () => {
+      const invoke = jest.fn<
+        (_input: unknown, _config: unknown) => Promise<unknown>
+          >(async (input) => input);
+      const customTool = {
+        name: 'mixed_tool',
+        schema: { type: ['object', 'string'] },
+        invoke,
+      } as unknown as t.GenericTool;
+      const customToolMap: t.ToolMap = new Map([['mixed_tool', customTool]]);
+      const input = { raw: true };
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'mixed_tool',
+          input,
+        },
+      ];
+
+      const results = await executeTools(toolCalls, customToolMap);
+
+      expect(results[0].is_error).toBe(false);
+      expect(results[0].result).toBe(input);
+      expect(invoke).toHaveBeenCalledWith(input, {
+        metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
+      });
+    });
+
+    it('preserves JSON-looking strings for mixed object-or-string schemas', async () => {
+      const invoke = jest.fn<
+        (_input: unknown, _config: unknown) => Promise<unknown>
+          >(async (input) => input);
+      const customTool = {
+        name: 'mixed_tool',
+        schema: { type: ['object', 'string'] },
+        invoke,
+      } as unknown as t.GenericTool;
+      const customToolMap: t.ToolMap = new Map([['mixed_tool', customTool]]);
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'mixed_tool',
+          input: '{"raw":true}',
+        },
+      ];
+
+      const results = await executeTools(toolCalls, customToolMap);
+
+      expect(results[0].is_error).toBe(false);
+      expect(results[0].result).toBe('{"raw":true}');
+      expect(invoke).toHaveBeenCalledWith('{"raw":true}', {
+        metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
+      });
+    });
+
     it('marks bash PTC inner tool invocations with bash metadata', async () => {
       const invoke = jest.fn<
         (_input: unknown, _config: unknown) => Promise<{ ok: boolean }>

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1025,9 +1025,9 @@ export type PTCToolCall = {
   id: string;
   /** Tool name */
   name: string;
-  /** Input parameters */
+  /** Input parameters. Some bridges may serialize object input as JSON text. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  input: Record<string, any>;
+  input: Record<string, any> | string;
 };
 
 /**


### PR DESCRIPTION
## Summary

I fixed programmatic tool execution so bridge/runtime input shapes are normalized according to the target tool schema before LangChain validates the call.

- Parse JSON-object strings only when the target tool advertises an object-only schema.
- Preserve literal JSON-looking strings for string-shaped and mixed object-or-string tools.
- Stringify object input back to JSON text only for string-only tools when a bridge has already parsed a JSON-looking string.
- Preserve object input unchanged for mixed object-or-string schemas.
- Widen `PTCToolCall.input` to reflect that bridge callers can provide either object input or serialized JSON text.
- Add regression coverage for object-schema JSON strings, string-schema JSON-looking strings, string-schema object input, and mixed object-or-string schemas in both directions.
- Root cause: LangChain validates tool input before `_call`; when `executeTools()` passed a JSON string directly into a tool with a `z.object(...)` schema, validation failed with `Received tool input did not match expected schema` before the MCP tool or `_ptc` layer ran.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

```bash
npm test -- --runTestsByPath /Users/danny/Projects/agents/src/tools/__tests__/ProgrammaticToolCalling.test.ts --runInBand --testPathIgnorePatterns='/.claude/'
```

```bash
# Local CodeAPI / OrbStack validation
curl -sS http://localhost:3112/v1/health
# OK

# Recreated sandbox-runner from the real codeapi checkout after finding a stale bind mount.
docker compose -p codeapi -f docker-compose.yaml -f docker-compose.mac.yml up -d

# Verified /exec works and both Bash/Python PTC wrapper paths complete through localhost:3112/v1
# with a Zod object-schema mock ClickHouse tool.
# Verified Bash PTC with a Zod string-schema mock tool preserves a JSON-looking string as string input.
```

### **Test Configuration**:

- Repo: `/Users/danny/Projects/agents`
- CodeAPI checkout: `/Users/danny/Projects/clickhouse-ai/services/codeapi`
- CodeAPI endpoint: `http://localhost:3112/v1`
- Branch: `danny-avila/fix-ptc-json-string-input`
- Node test runner: project `npm test` script

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes