### PR TITLE
⏱️ fix: Loosen PTC Timeout Schema

### DIFF
--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -16,6 +16,7 @@ import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCa
 import {
   clampCodeApiRunTimeoutMs,
   createCodeApiRunTimeoutSchema,
+  MAX_CODE_API_RUN_TIMEOUT_SCHEMA_MS,
 } from '../ptcTimeout';
 import {
   createLocalProgrammaticToolCallingTool,
@@ -292,9 +293,11 @@ describe('CodeAPI auth header injection', () => {
 
     expect(clampCodeApiRunTimeoutMs(60000, 15000)).toBe(15000);
     expect(schema.default).toBe(15000);
-    expect(schema.maximum).toBe(15000);
+    expect(schema.maximum).toBe(MAX_CODE_API_RUN_TIMEOUT_SCHEMA_MS);
     expect(schema.description).toContain('one sandbox run');
     expect(schema.description).toContain('not the total multi-round-trip');
+    expect(schema.description).toContain('clamped before execution');
+    expect(schema.description).toContain('Configured cap: 15 seconds');
   });
 
   it('keeps local programmatic timeout schemas aligned with local execution defaults', () => {

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -268,6 +268,26 @@ describe('CodeAPI auth header injection', () => {
     expect(requestBodyAt(0).timeout).toBe(15000);
   });
 
+  it('accepts larger programmatic timeout inputs and clamps before execution', async () => {
+    const tool = createProgrammaticToolCallingTool({
+      runTimeoutMs: 15000,
+    });
+
+    await tool.invoke(
+      { code: 'result = await lookup_user()\nprint(result)', timeout: 30000 },
+      {
+        toolCall: {
+          name: 'programmatic_code_execution',
+          args: {},
+          toolMap: toolMap(),
+          toolDefs,
+        },
+      }
+    );
+
+    expect(requestBodyAt(0).timeout).toBe(15000);
+  });
+
   it('defaults bash programmatic timeout to the configured CodeAPI run cap', async () => {
     const tool = createBashProgrammaticToolCallingTool({
       runTimeoutMs: 15000,
@@ -275,6 +295,26 @@ describe('CodeAPI auth header injection', () => {
 
     await tool.invoke(
       { code: 'lookup_user "{}"' },
+      {
+        toolCall: {
+          name: 'bash_programmatic_code_execution',
+          args: {},
+          toolMap: toolMap(),
+          toolDefs,
+        },
+      }
+    );
+
+    expect(requestBodyAt(0).timeout).toBe(15000);
+  });
+
+  it('accepts larger bash programmatic timeout inputs and clamps before execution', async () => {
+    const tool = createBashProgrammaticToolCallingTool({
+      runTimeoutMs: 15000,
+    });
+
+    await tool.invoke(
+      { code: 'lookup_user "{}"', timeout: 30000 },
       {
         toolCall: {
           name: 'bash_programmatic_code_execution',

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -106,6 +106,49 @@ describe('ProgrammaticToolCalling', () => {
       });
     });
 
+    it('parses ClickHouse-style JSON strings with SQL punctuation for object-schema tools', async () => {
+      const invoke = jest.fn<
+        (_input: unknown, _config: unknown) => Promise<unknown>
+          >(async (input) => input);
+      const customTool = {
+        name: 'run_select_query_mcp_ClickHouse',
+        schema: {
+          type: 'object',
+          properties: {
+            serviceId: { type: 'string' },
+            query: { type: 'string' },
+          },
+          required: ['serviceId', 'query'],
+        },
+        invoke,
+      } as unknown as t.GenericTool;
+      const customToolMap: t.ToolMap = new Map([
+        ['run_select_query_mcp_ClickHouse', customTool],
+      ]);
+      const input = {
+        serviceId: '45886e06-932b-4cff-bb49-3f7281d80717',
+        query:
+          'SELECT name, round(avg(tempAvg)/10.0, 2) AS avg_temp_c ' +
+          'FROM system.columns WHERE database=\'default\' ' +
+          'AND table=\'uk_prices_3\' AND tempAvg != -9999',
+      };
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'run_select_query_mcp_ClickHouse',
+          input: JSON.stringify(input),
+        },
+      ];
+
+      const results = await executeTools(toolCalls, customToolMap);
+
+      expect(results[0].is_error).toBe(false);
+      expect(results[0].result).toEqual(input);
+      expect(invoke).toHaveBeenCalledWith(input, {
+        metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
+      });
+    });
+
     it('preserves JSON-looking strings for string-input tools', async () => {
       const invoke = jest.fn<
         (_input: unknown, _config: unknown) => Promise<unknown>
@@ -129,6 +172,39 @@ describe('ProgrammaticToolCalling', () => {
       expect(results[0].is_error).toBe(false);
       expect(results[0].result).toBe('{"raw":true}');
       expect(invoke).toHaveBeenCalledWith('{"raw":true}', {
+        metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
+      });
+    });
+
+    it('preserves ClickHouse-style JSON strings for raw string-input tools', async () => {
+      const invoke = jest.fn<
+        (_input: unknown, _config: unknown) => Promise<unknown>
+          >(async (input) => input);
+      const customTool = {
+        name: 'string_tool',
+        schema: { type: 'string' },
+        invoke,
+      } as unknown as t.GenericTool;
+      const customToolMap: t.ToolMap = new Map([['string_tool', customTool]]);
+      const input = JSON.stringify({
+        serviceId: '45886e06-932b-4cff-bb49-3f7281d80717',
+        query:
+          'SELECT round(avg(tempAvg)/10.0, 2) AS avg_temp_c ' +
+          'FROM default.weather_noaa_mt WHERE database=\'default\'',
+      });
+      const toolCalls: t.PTCToolCall[] = [
+        {
+          id: 'call_001',
+          name: 'string_tool',
+          input,
+        },
+      ];
+
+      const results = await executeTools(toolCalls, customToolMap);
+
+      expect(results[0].is_error).toBe(false);
+      expect(results[0].result).toBe(input);
+      expect(invoke).toHaveBeenCalledWith(input, {
         metadata: { [Constants.PROGRAMMATIC_TOOL_CALLING]: true },
       });
     });

--- a/src/tools/ptcTimeout.ts
+++ b/src/tools/ptcTimeout.ts
@@ -2,6 +2,7 @@ import { EnvVar } from '@/common';
 
 export const DEFAULT_CODE_API_RUN_TIMEOUT_MS = 15_000;
 export const MIN_CODE_API_RUN_TIMEOUT_MS = 1_000;
+export const MAX_CODE_API_RUN_TIMEOUT_SCHEMA_MS = 300_000;
 
 type TimeoutSchema = {
   type: 'integer';
@@ -74,16 +75,25 @@ export function createCodeApiRunTimeoutSchema(
 ): TimeoutSchema {
   const normalizedMaxRunTimeoutMs =
     normalizeTimeoutMs(maxRunTimeoutMs) ?? DEFAULT_CODE_API_RUN_TIMEOUT_MS;
+  const normalizedSchemaMaxRunTimeoutMs = Math.max(
+    normalizedMaxRunTimeoutMs,
+    MAX_CODE_API_RUN_TIMEOUT_SCHEMA_MS
+  );
   const formattedTimeout = formatTimeout(normalizedMaxRunTimeoutMs);
+  const formattedSchemaMaxTimeout = formatTimeout(
+    normalizedSchemaMaxRunTimeoutMs
+  );
 
   return {
     type: 'integer',
     minimum: MIN_CODE_API_RUN_TIMEOUT_MS,
-    maximum: normalizedMaxRunTimeoutMs,
+    maximum: normalizedSchemaMaxRunTimeoutMs,
     default: normalizedMaxRunTimeoutMs,
     description:
       'Maximum wall-clock time in milliseconds for one sandbox run or replay iteration. ' +
       'This is not the total multi-round-trip task budget. ' +
-      `Default: ${formattedTimeout}. Max: ${formattedTimeout}.`,
+      `Default: ${formattedTimeout}. ` +
+      'Accepted values above the configured cap are clamped before execution. ' +
+      `Schema max: ${formattedSchemaMaxTimeout}. Configured cap: ${formattedTimeout}.`,
   };
 }


### PR DESCRIPTION
## Summary

I loosened the CodeAPI programmatic timeout schema so agent calls such as `timeout: 30000` validate before execution, while preserving the configured runtime cap through the existing clamp behavior.

- Added a 300,000 ms schema ceiling for CodeAPI programmatic timeout inputs so reasonable model-supplied values are not rejected by wrapper validation before reaching execution.
- Kept the runtime default/cap unchanged, so values above the configured cap are still clamped before requests are sent to CodeAPI.
- Updated the timeout schema description and unit expectations to document the distinction between accepted schema max and configured execution cap.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npm test -- src/tools/__tests__/CodeApiAuthHeaders.test.ts --runInBand`
- `npm test -- --runTestsByPath ./src/tools/__tests__/ProgrammaticToolCalling.test.ts --runInBand`
- Note: `npm test -- src/tools/__tests__/ProgrammaticToolCalling.test.ts --runInBand` also executed stale `.claude/worktrees/...` copies and failed in those unrelated worktrees; the root test file passed when run with `--runTestsByPath`.

### **Test Configuration**:

- Node.js: 20.19.5
- Package: `@librechat/agents@3.1.94`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
