### PR TITLE
🧾 fix: Normalize Bash PTC JSON String Results

### DIFF
--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -71,7 +71,7 @@ const CORE_RULES = `Rules:
 - Tools are pre-defined as bash functions—DO NOT redefine them
 - Each tool function accepts a JSON string argument
 - Save tool output with raw=$(tool '{}'); printf '%s\n' "$raw" > /mnt/data/file.json; direct tool > file may be empty
-- jq: use fromjson? // . on saved tool stdout and again on JSON-string fields; check types since arrays may contain strings
+- Tool stdout is normalized to one compact JSON value when possible; parse saved stdout once, then use fromjson? // . only for JSON-string fields
 - Only echo/printf output returns to the model
 - ${CODE_ARTIFACT_PATH_GUIDANCE}
 - ${BASH_SHELL_GUIDANCE}
@@ -148,6 +148,38 @@ export const BashProgrammaticToolCallingDefinition = {
   description: BashProgrammaticToolCallingDescription,
   schema: BashProgrammaticToolCallingSchema,
 } as const;
+
+function maybeParseJsonResultString(result: unknown): unknown {
+  if (typeof result !== 'string') {
+    return result;
+  }
+
+  const trimmed = result.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return result;
+  }
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return result;
+  }
+}
+
+export function normalizeBashToolResultsForReplay(
+  toolResults: t.PTCToolResult[]
+): t.PTCToolResult[] {
+  return toolResults.map((toolResult) => {
+    if (toolResult.is_error) {
+      return toolResult;
+    }
+
+    return {
+      ...toolResult,
+      result: maybeParseJsonResultString(toolResult.result),
+    };
+  });
+}
 
 // ============================================================================
 // Helper Functions
@@ -355,10 +387,12 @@ export function createBashProgrammaticToolCallingTool(
             );
           }
 
-          const toolResults = await executeTools(
-            response.tool_calls ?? [],
-            toolMap,
-            Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+          const toolResults = normalizeBashToolResultsForReplay(
+            await executeTools(
+              response.tool_calls ?? [],
+              toolMap,
+              Constants.BASH_PROGRAMMATIC_TOOL_CALLING
+            )
           );
 
           response = await makeRequest(

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -34,6 +34,8 @@ type FetchMock = jest.MockedFunction<
 
 type CodeApiRequestBody = {
   timeout?: number;
+  continuation_token?: string;
+  tool_results?: t.PTCToolResult[];
 };
 
 type TimeoutSchemaForTest = {
@@ -385,6 +387,58 @@ describe('CodeAPI auth header injection', () => {
         }),
       })
     );
+  });
+
+  it('normalizes JSON-looking bash programmatic tool results before continuation', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          status: 'tool_call_required',
+          continuation_token: 'continue_123',
+          tool_calls: [{ id: 'call_001', name: 'lookup_user', input: {} }],
+        })
+      )
+      .mockResolvedValueOnce(completedResponse('done'));
+    const tool = createBashProgrammaticToolCallingTool();
+    const customToolMap = new Map([
+      [
+        'lookup_user',
+        {
+          name: 'lookup_user',
+          invoke: jest.fn(async () =>
+            JSON.stringify({
+              result: {
+                data: [{ id: 'user_123', name: 'Ada' }],
+              },
+            })
+          ),
+        },
+      ],
+    ]) as unknown as t.ToolMap;
+
+    await tool.invoke(
+      { code: 'lookup_user "{}"' },
+      {
+        toolCall: {
+          name: 'bash_programmatic_code_execution',
+          args: {},
+          toolMap: customToolMap,
+          toolDefs,
+        },
+      }
+    );
+
+    expect(requestBodyAt(1).tool_results).toEqual([
+      {
+        call_id: 'call_001',
+        result: {
+          result: {
+            data: [{ id: 'user_123', name: 'Ada' }],
+          },
+        },
+        is_error: false,
+      },
+    ]);
   });
 
   it('reminds that failed bash programmatic executions do not register new files', async () => {

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -16,7 +16,10 @@ import {
   normalizeToPythonIdentifier,
   unwrapToolResponse,
 } from '../ProgrammaticToolCalling';
-import { createBashProgrammaticToolCallingSchema } from '../BashProgrammaticToolCalling';
+import {
+  createBashProgrammaticToolCallingSchema,
+  normalizeBashToolResultsForReplay,
+} from '../BashProgrammaticToolCalling';
 import {
   createProgrammaticToolRegistry,
   createGetTeamMembersTool,
@@ -40,9 +43,11 @@ describe('ProgrammaticToolCalling', () => {
       const schema = createBashProgrammaticToolCallingSchema();
       const description = schema.properties.code.description;
 
-      expect(description).toContain('jq: use fromjson? // .');
-      expect(description).toContain('again on JSON-string fields');
-      expect(description).toContain('arrays may contain strings');
+      expect(description).toContain(
+        'Tool stdout is normalized to one compact JSON value'
+      );
+      expect(description).toContain('use fromjson? // .');
+      expect(description).toContain('only for JSON-string fields');
       expect(description).toContain('raw=$(tool');
       expect(description).toContain('direct tool > file may be empty');
       expect(description).toContain('/mnt/data/sf.json');
@@ -50,6 +55,69 @@ describe('ProgrammaticToolCalling', () => {
         'failed executions do not register new files'
       );
       expect(description).toContain('not later-call storage');
+    });
+  });
+
+  describe('normalizeBashToolResultsForReplay', () => {
+    it('decodes JSON-looking string results before bash replay', () => {
+      const results = normalizeBashToolResultsForReplay([
+        {
+          call_id: 'call_001',
+          result: JSON.stringify({
+            result: {
+              data: [{ station_id: 'USW00094725', winter_days: 91 }],
+            },
+          }),
+          is_error: false,
+        },
+      ]);
+
+      expect(results[0].result).toEqual({
+        result: {
+          data: [{ station_id: 'USW00094725', winter_days: 91 }],
+        },
+      });
+    });
+
+    it('decodes JSON-looking array string results before bash replay', () => {
+      const results = normalizeBashToolResultsForReplay([
+        {
+          call_id: 'call_001',
+          result: '[{"name":"tempAvg"},{"name":"snowDepth"}]',
+          is_error: false,
+        },
+      ]);
+
+      expect(results[0].result).toEqual([
+        { name: 'tempAvg' },
+        { name: 'snowDepth' },
+      ]);
+    });
+
+    it('preserves plain strings, invalid JSON strings, and error results', () => {
+      const errorJson = '{"message":"tool failed"}';
+      const results = normalizeBashToolResultsForReplay([
+        {
+          call_id: 'call_001',
+          result: 'plain text',
+          is_error: false,
+        },
+        {
+          call_id: 'call_002',
+          result: '{not json}',
+          is_error: false,
+        },
+        {
+          call_id: 'call_003',
+          result: errorJson,
+          is_error: true,
+          error_message: 'tool failed',
+        },
+      ]);
+
+      expect(results[0].result).toBe('plain text');
+      expect(results[1].result).toBe('{not json}');
+      expect(results[2].result).toBe(errorJson);
     });
   });
 


### PR DESCRIPTION
## Summary

I normalized bash PTC replay results so JSON-looking string outputs are sent back to CodeAPI as JSON values instead of replaying as double-encoded strings.

- Added a bash PTC replay normalizer that decodes successful tool results when they are JSON object or array strings.
- Preserved plain strings, invalid JSON strings, and error results without coercion.
- Applied the normalizer only on the bash PTC continuation path before submitting `tool_results` back to CodeAPI.
- Updated bash PTC guidance to describe the normalized one-JSON-value stdout shape.
- Added unit coverage for object strings, array strings, invalid strings, plain strings, and error results.
- Added continuation-path coverage proving JSON-looking bash tool results are normalized before the request body is sent to CodeAPI.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm test -- src/tools/__tests__/CodeApiAuthHeaders.test.ts --runInBand`.
- Ran `npm test -- --runTestsByPath ./src/tools/__tests__/ProgrammaticToolCalling.test.ts --runInBand`.
- Ran `npx eslint src/tools/BashProgrammaticToolCalling.ts src/tools/__tests__/ProgrammaticToolCalling.test.ts src/tools/__tests__/CodeApiAuthHeaders.test.ts --fix`.
- Ran `npm run build`.

### **Test Configuration**:

- macOS local development environment
- Node/npm workspace install already present

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
