### PR TITLE
🪢 fix: Route Langfuse spans through isolated provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@langfuse/langchain": "^5.3.0",
         "@langfuse/otel": "^5.3.0",
         "@langfuse/tracing": "^5.3.0",
+        "@opentelemetry/context-async-hooks": "2.7.1",
         "@opentelemetry/sdk-node": "^0.218.0",
         "@scarf/scarf": "^1.4.0",
         "@types/diff": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -230,6 +230,7 @@
     "@langfuse/langchain": "^5.3.0",
     "@langfuse/otel": "^5.3.0",
     "@langfuse/tracing": "^5.3.0",
+    "@opentelemetry/context-async-hooks": "2.7.1",
     "@opentelemetry/sdk-node": "^0.218.0",
     "@scarf/scarf": "^1.4.0",
     "@types/diff": "^7.0.2",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,17 +1,27 @@
-import { NodeSDK } from '@opentelemetry/sdk-node';
 import { LangfuseSpanProcessor } from '@langfuse/otel';
-import { isPresent } from '@/utils/misc';
+import { setLangfuseTracerProvider } from '@langfuse/tracing';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import { hasLangfuseEnvConfig } from '@/langfuse';
 
-if (
-  isPresent(process.env.LANGFUSE_SECRET_KEY) &&
-  isPresent(process.env.LANGFUSE_PUBLIC_KEY) &&
-  isPresent(process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL)
-) {
+let langfuseTracerProvider: BasicTracerProvider | undefined;
+
+export function initializeLangfuseTracingFromEnv():
+  | BasicTracerProvider
+  | undefined {
+  if (langfuseTracerProvider != null) {
+    return langfuseTracerProvider;
+  }
+  if (!hasLangfuseEnvConfig()) {
+    return undefined;
+  }
+
   const langfuseSpanProcessor = new LangfuseSpanProcessor();
-
-  const sdk = new NodeSDK({
+  langfuseTracerProvider = new BasicTracerProvider({
     spanProcessors: [langfuseSpanProcessor],
   });
 
-  sdk.start();
+  setLangfuseTracerProvider(langfuseTracerProvider);
+  return langfuseTracerProvider;
 }
+
+initializeLangfuseTracingFromEnv();

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,9 +1,33 @@
 import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { setLangfuseTracerProvider } from '@langfuse/tracing';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import { context, ROOT_CONTEXT, createContextKey } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { hasLangfuseEnvConfig } from '@/langfuse';
 
 let langfuseTracerProvider: BasicTracerProvider | undefined;
+const contextManagerProbeKey = createContextKey(
+  'langfuse-context-manager-probe'
+);
+
+function hasActiveContextManager(): boolean {
+  return context.with(
+    ROOT_CONTEXT.setValue(contextManagerProbeKey, true),
+    () => context.active().getValue(contextManagerProbeKey) === true
+  );
+}
+
+export function ensureOpenTelemetryContextManager(): void {
+  if (hasActiveContextManager()) {
+    return;
+  }
+
+  const contextManager = new AsyncLocalStorageContextManager();
+  contextManager.enable();
+  if (!context.setGlobalContextManager(contextManager)) {
+    contextManager.disable();
+  }
+}
 
 export function initializeLangfuseTracingFromEnv():
   | BasicTracerProvider
@@ -15,6 +39,7 @@ export function initializeLangfuseTracingFromEnv():
     return undefined;
   }
 
+  ensureOpenTelemetryContextManager();
   const langfuseSpanProcessor = new LangfuseSpanProcessor();
   langfuseTracerProvider = new BasicTracerProvider({
     spanProcessors: [langfuseSpanProcessor],

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -3,6 +3,23 @@ const mockLangfuseSpanProcessor = jest.fn(
   () => mockLangfuseSpanProcessorInstance
 );
 const mockSetLangfuseTracerProvider = jest.fn();
+let mockContextHasActiveValue = false;
+const mockContextKey = Symbol('mock-context-key');
+const mockContextActive = jest.fn(() => ({
+  getValue: jest.fn(() => mockContextHasActiveValue),
+}));
+const mockContextWith = jest.fn(
+  (_contextValue: unknown, callback: () => boolean) => callback()
+);
+const mockSetGlobalContextManager = jest.fn(() => true);
+const mockRootContext = {
+  setValue: jest.fn(() => ({})),
+};
+const mockContextManager = {
+  disable: jest.fn(),
+  enable: jest.fn(),
+};
+const mockAsyncLocalStorageContextManager = jest.fn(() => mockContextManager);
 const mockTracerProvider = {
   forceFlush: jest.fn(),
   getTracer: jest.fn(),
@@ -20,6 +37,22 @@ jest.mock('@langfuse/tracing', () => ({
   setLangfuseTracerProvider: mockSetLangfuseTracerProvider,
 }));
 
+jest.mock('@opentelemetry/api', () => ({
+  ...jest.requireActual('@opentelemetry/api'),
+  context: {
+    ...jest.requireActual('@opentelemetry/api').context,
+    active: mockContextActive,
+    setGlobalContextManager: mockSetGlobalContextManager,
+    with: mockContextWith,
+  },
+  createContextKey: jest.fn(() => mockContextKey),
+  ROOT_CONTEXT: mockRootContext,
+}));
+
+jest.mock('@opentelemetry/context-async-hooks', () => ({
+  AsyncLocalStorageContextManager: mockAsyncLocalStorageContextManager,
+}));
+
 jest.mock('@opentelemetry/sdk-trace-base', () => ({
   BasicTracerProvider: mockBasicTracerProvider,
   SpanStatusCode: jest.requireActual('@opentelemetry/api').SpanStatusCode,
@@ -31,6 +64,8 @@ describe('Langfuse instrumentation', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
+    mockContextHasActiveValue = false;
+    mockSetGlobalContextManager.mockReturnValue(true);
     process.env = { ...originalEnv };
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_PUBLIC_KEY;
@@ -50,6 +85,7 @@ describe('Langfuse instrumentation', () => {
     expect(initializeLangfuseTracingFromEnv()).toBeUndefined();
     expect(mockLangfuseSpanProcessor).not.toHaveBeenCalled();
     expect(mockBasicTracerProvider).not.toHaveBeenCalled();
+    expect(mockAsyncLocalStorageContextManager).not.toHaveBeenCalled();
     expect(mockSetLangfuseTracerProvider).not.toHaveBeenCalled();
   });
 
@@ -71,6 +107,11 @@ describe('Langfuse instrumentation', () => {
     expect(mockSetLangfuseTracerProvider).toHaveBeenCalledWith(
       mockTracerProvider
     );
+    expect(mockAsyncLocalStorageContextManager).toHaveBeenCalledTimes(1);
+    expect(mockContextManager.enable).toHaveBeenCalledTimes(1);
+    expect(mockSetGlobalContextManager).toHaveBeenCalledWith(
+      mockContextManager
+    );
   });
 
   it('reuses the isolated provider after initialization', async () => {
@@ -89,5 +130,32 @@ describe('Langfuse instrumentation', () => {
     expect(mockLangfuseSpanProcessor).toHaveBeenCalledTimes(1);
     expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
     expect(mockSetLangfuseTracerProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not replace an existing active context manager', async () => {
+    mockContextHasActiveValue = true;
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.test';
+
+    await import('@/instrumentation');
+
+    expect(mockAsyncLocalStorageContextManager).not.toHaveBeenCalled();
+    expect(mockSetGlobalContextManager).not.toHaveBeenCalled();
+  });
+
+  it('disables the local context manager when registration is rejected', async () => {
+    mockSetGlobalContextManager.mockReturnValue(false);
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.test';
+
+    await import('@/instrumentation');
+
+    expect(mockContextManager.enable).toHaveBeenCalledTimes(1);
+    expect(mockSetGlobalContextManager).toHaveBeenCalledWith(
+      mockContextManager
+    );
+    expect(mockContextManager.disable).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -1,0 +1,93 @@
+const mockLangfuseSpanProcessorInstance = {};
+const mockLangfuseSpanProcessor = jest.fn(
+  () => mockLangfuseSpanProcessorInstance
+);
+const mockSetLangfuseTracerProvider = jest.fn();
+const mockTracerProvider = {
+  forceFlush: jest.fn(),
+  getTracer: jest.fn(),
+  shutdown: jest.fn(),
+};
+const mockBasicTracerProvider = jest.fn(() => mockTracerProvider);
+
+jest.mock('@langfuse/otel', () => ({
+  LangfuseSpanProcessor: mockLangfuseSpanProcessor,
+  isDefaultExportSpan: jest.fn(() => false),
+}));
+
+jest.mock('@langfuse/tracing', () => ({
+  ...jest.requireActual('@langfuse/tracing'),
+  setLangfuseTracerProvider: mockSetLangfuseTracerProvider,
+}));
+
+jest.mock('@opentelemetry/sdk-trace-base', () => ({
+  BasicTracerProvider: mockBasicTracerProvider,
+  SpanStatusCode: jest.requireActual('@opentelemetry/api').SpanStatusCode,
+}));
+
+describe('Langfuse instrumentation', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.LANGFUSE_BASEURL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('does not initialize tracing when Langfuse env vars are missing', async () => {
+    const { initializeLangfuseTracingFromEnv } = await import(
+      '@/instrumentation'
+    );
+
+    expect(initializeLangfuseTracingFromEnv()).toBeUndefined();
+    expect(mockLangfuseSpanProcessor).not.toHaveBeenCalled();
+    expect(mockBasicTracerProvider).not.toHaveBeenCalled();
+    expect(mockSetLangfuseTracerProvider).not.toHaveBeenCalled();
+  });
+
+  it('registers an isolated Langfuse tracer provider from env config', async () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.test';
+
+    const { initializeLangfuseTracingFromEnv } = await import(
+      '@/instrumentation'
+    );
+    const provider = initializeLangfuseTracingFromEnv();
+
+    expect(provider).toBe(mockTracerProvider);
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledTimes(1);
+    expect(mockBasicTracerProvider).toHaveBeenCalledWith({
+      spanProcessors: [mockLangfuseSpanProcessorInstance],
+    });
+    expect(mockSetLangfuseTracerProvider).toHaveBeenCalledWith(
+      mockTracerProvider
+    );
+  });
+
+  it('reuses the isolated provider after initialization', async () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.test';
+
+    const { initializeLangfuseTracingFromEnv } = await import(
+      '@/instrumentation'
+    );
+    const firstProvider = initializeLangfuseTracingFromEnv();
+    const secondProvider = initializeLangfuseTracingFromEnv();
+
+    expect(firstProvider).toBe(mockTracerProvider);
+    expect(secondProvider).toBe(mockTracerProvider);
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledTimes(1);
+    expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
+    expect(mockSetLangfuseTracerProvider).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

I fixed Langfuse instrumentation so it registers an isolated tracer provider instead of starting a second global OpenTelemetry NodeSDK.

- Registered the Langfuse span processor with a BasicTracerProvider and passed it to setLangfuseTracerProvider.
- Restored async context propagation for standalone env-based tracing by installing AsyncLocalStorageContextManager only when no active OpenTelemetry context manager is present.
- Reused the shared Langfuse env config check so LANGFUSE_BASE_URL and LANGFUSE_BASEURL behavior stays centralized.
- Added regression coverage for missing config, provider registration, context-manager registration, existing context-manager preservation, rejected context-manager registration, and idempotent initialization.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- npx eslint src/instrumentation.ts src/specs/langfuse-instrumentation.test.ts
- npx jest --runTestsByPath src/specs/langfuse-instrumentation.test.ts src/specs/langfuse-config.test.ts src/specs/langfuse-callbacks.test.ts src/specs/langfuse-metadata.test.ts --runInBand
- npx tsc --noEmit
- npm run build
- Ran a direct live staging Langfuse export smoke test with the staging creds from .env.staging: started an existing global NodeSDK first, imported the built instrumentation, emitted trace b88706b1098ae43ace0b88fed866783f, force-flushed, and verified it via the Langfuse public traces API.
- Ran an actual @librechat/agents SDK live staging smoke test with the built SDK: imported Run from dist/esm/main.mjs, created a standard agent run, used overrideTestModel to avoid external LLM credentials, called processStream through the env-driven Langfuse callback path, and verified trace ed7357d3d5518c5f4f9900efabecca62 via the Langfuse public traces API.
- Ran a standalone @librechat/agents SDK live staging context-propagation smoke test without starting a global NodeSDK first, then verified trace 5156fea88876949a621a0f76a693cc99 included userId, sessionId, tags, and trace metadata via the Langfuse public traces API.

### **Test Configuration**:

- Local macOS checkout
- Staging Langfuse credentials from /Users/danny/Projects/ClickHouse-LibreChat/.env.staging
- Existing-global-OTel smoke test simulated LibreChat's current OpenTelemetry setup by starting NodeSDK before importing the built agents SDK
- Standalone smoke test verified env-based tracing restores context propagation when no host context manager is present
- Build completed with the existing empty chunk warning

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes