### PR TITLE
🕶️ feat: Configurable Redaction of Langfuse Tool Outputs

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -67,6 +67,11 @@ import {
   disposeLangfuseHandler,
   createLangfuseTraceMetadata,
 } from '@/langfuse';
+import {
+  resolveLangfuseConfig,
+  shouldTraceToolNodeForLangfuse,
+  withLangfuseToolOutputTracingConfig,
+} from '@/langfuseToolOutputTracing';
 import { HandlerRegistry } from '@/events';
 import { ChatOpenAI } from '@/llm/openai';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
@@ -175,6 +180,10 @@ export abstract class Graph<
    */
   toolOutputReferences: t.ToolOutputReferencesConfig | undefined;
   /**
+   * Run-scoped Langfuse defaults. Per-agent config wins when present.
+   */
+  langfuse: t.LangfuseConfig | undefined;
+  /**
    * Run-scoped opt-in for eager event-driven tool execution. The stream
    * handler may prestart eligible event-driven tools; ToolNode later
    * consumes the settled promises while preserving final ToolMessage order.
@@ -225,6 +234,7 @@ export abstract class Graph<
     this.hookRegistry = undefined;
     this.humanInTheLoop = undefined;
     this.toolOutputReferences = undefined;
+    this.langfuse = undefined;
     this.eagerEventToolExecution = undefined;
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
@@ -427,6 +437,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     runId,
     signal,
     agents,
+    langfuse,
     tokenCounter,
     indexTokenCountMap,
     calibrationRatio,
@@ -434,6 +445,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     super();
     this.runId = runId;
     this.signal = signal;
+    this.langfuse = langfuse;
 
     if (agents.length === 0) {
       throw new Error('At least one agent configuration is required');
@@ -743,6 +755,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const toolDefinitions = agentContext?.toolDefinitions;
     const eventDrivenMode =
       toolDefinitions != null && toolDefinitions.length > 0;
+    const traceToolNode = shouldTraceToolNodeForLangfuse({
+      runLangfuse: this.langfuse,
+      agentLangfuse: agentContext?.langfuse,
+    });
 
     if (eventDrivenMode) {
       const schemaTools = createSchemaOnlyTools(toolDefinitions);
@@ -770,6 +786,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const node = new CustomToolNode<t.BaseGraphState>({
         tools: allTools,
         toolMap: allToolMap,
+        trace: traceToolNode,
+        runLangfuse: this.langfuse,
+        agentLangfuse: agentContext?.langfuse,
         eventDrivenMode: true,
         sessions: this.sessions,
         toolDefinitions: toolDefMap,
@@ -815,6 +834,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const node = new CustomToolNode<t.BaseGraphState>({
       tools: allTraditionalTools,
       toolMap: traditionalToolMap,
+      trace: traceToolNode,
+      runLangfuse: this.langfuse,
+      agentLangfuse: agentContext?.langfuse,
       toolCallStepIds: this.toolCallStepIds,
       errorHandler: (data, metadata): Promise<void> =>
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),
@@ -1338,8 +1360,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         { force: true }
       );
 
+      const langfuse = resolveLangfuseConfig(
+        this.langfuse,
+        agentContext.langfuse
+      );
       const langfuseHandler = createLangfuseHandler({
-        langfuse: agentContext.langfuse,
+        langfuse,
         userId: config.configurable?.user_id as string | undefined,
         sessionId: config.configurable?.thread_id as string | undefined,
         traceMetadata: createLangfuseTraceMetadata({
@@ -1358,24 +1384,34 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         : config;
 
       try {
-        result = await attemptInvoke(
-          {
-            model: (this.overrideModel ?? model) as t.ChatModel,
-            messages: finalMessages,
-            provider: agentContext.provider,
-            context: this,
-          },
-          invokeConfig
+        result = await withLangfuseToolOutputTracingConfig(
+          this.langfuse,
+          () =>
+            attemptInvoke(
+              {
+                model: (this.overrideModel ?? model) as t.ChatModel,
+                messages: finalMessages,
+                provider: agentContext.provider,
+                context: this,
+              },
+              invokeConfig
+            ),
+          agentContext.langfuse
         );
       } catch (primaryError) {
-        result = await tryFallbackProviders({
-          fallbacks,
-          tools: agentContext.tools,
-          messages: finalMessages,
-          config: invokeConfig,
-          primaryError,
-          context: this,
-        });
+        result = await withLangfuseToolOutputTracingConfig(
+          this.langfuse,
+          () =>
+            tryFallbackProviders({
+              fallbacks,
+              tools: agentContext.tools,
+              messages: finalMessages,
+              config: invokeConfig,
+              primaryError,
+              context: this,
+            }),
+          agentContext.langfuse
+        );
       } finally {
         await disposeLangfuseHandler(langfuseHandler);
       }
@@ -1599,6 +1635,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           parentHandlerRegistry: getParentHandlerRegistry,
           parentRunId: this.runId ?? '',
           parentAgentId: agentContext.agentId,
+          langfuse: this.langfuse,
           tokenCounter: agentContext.tokenCounter,
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1369,26 +1369,35 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         this.langfuse,
         agentContext.langfuse
       );
+      const traceMetadata = createLangfuseTraceMetadata({
+        messageId: this.runId,
+        parentMessageId: config.configurable?.requestBody?.parentMessageId,
+        agentId,
+        agentName: agentContext.name,
+      });
       let langfuseHandler: CallbackEntry | undefined;
-      let invokeConfig = config;
+      let invokeConfig = {
+        ...config,
+        metadata: {
+          ...(config.metadata ?? {}),
+          ...traceMetadata,
+        },
+      };
       initializeLangfuseTracing(langfuse);
       if (findCallback(config.callbacks, isLangfuseCallbackHandler) == null) {
         langfuseHandler = createLangfuseHandler({
           langfuse,
           userId: config.configurable?.user_id as string | undefined,
           sessionId: config.configurable?.thread_id as string | undefined,
-          traceMetadata: createLangfuseTraceMetadata({
-            messageId: this.runId,
-            parentMessageId: config.configurable?.requestBody?.parentMessageId,
-            agentId,
-            agentName: agentContext.name,
-          }),
+          traceMetadata,
           tags: ['librechat', 'agent'],
         });
         if (langfuseHandler != null) {
           invokeConfig = {
-            ...config,
-            callbacks: appendCallbacks(config.callbacks, [langfuseHandler]),
+            ...invokeConfig,
+            callbacks: appendCallbacks(invokeConfig.callbacks, [
+              langfuseHandler,
+            ]),
           };
         }
       }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -52,6 +52,11 @@ import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { shouldTriggerSummarization } from '@/summarization';
 import { createSummarizeNode } from '@/summarization/node';
 import { messagesStateReducer } from '@/messages/reducer';
+import {
+  appendCallbacks,
+  findCallback,
+  type CallbackEntry,
+} from '@/utils/callbacks';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
 import { createFakeStreamingLLM } from '@/llm/fake';
@@ -62,6 +67,14 @@ import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
 import { isThinkingEnabled } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import {
+  createLangfuseHandler,
+  createLangfuseTraceMetadata,
+  disposeLangfuseHandler,
+  isLangfuseCallbackHandler,
+} from '@/langfuse';
+import { initializeLangfuseTracing } from '@/instrumentation';
+import {
+  resolveLangfuseConfig,
   shouldTraceToolNodeForLangfuse,
   withLangfuseToolOutputTracingConfig,
 } from '@/langfuseToolOutputTracing';
@@ -1352,7 +1365,33 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         { force: true }
       );
 
-      const invokeConfig = config;
+      const langfuse = resolveLangfuseConfig(
+        this.langfuse,
+        agentContext.langfuse
+      );
+      let langfuseHandler: CallbackEntry | undefined;
+      let invokeConfig = config;
+      if (findCallback(config.callbacks, isLangfuseCallbackHandler) == null) {
+        initializeLangfuseTracing(langfuse);
+        langfuseHandler = createLangfuseHandler({
+          langfuse,
+          userId: config.configurable?.user_id as string | undefined,
+          sessionId: config.configurable?.thread_id as string | undefined,
+          traceMetadata: createLangfuseTraceMetadata({
+            messageId: this.runId,
+            parentMessageId: config.configurable?.requestBody?.parentMessageId,
+            agentId,
+            agentName: agentContext.name,
+          }),
+          tags: ['librechat', 'agent'],
+        });
+        if (langfuseHandler != null) {
+          invokeConfig = {
+            ...config,
+            callbacks: appendCallbacks(config.callbacks, [langfuseHandler]),
+          };
+        }
+      }
 
       try {
         result = await withLangfuseToolOutputTracingConfig(
@@ -1383,6 +1422,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             }),
           agentContext.langfuse
         );
+      } finally {
+        await disposeLangfuseHandler(langfuseHandler);
       }
 
       if (!result) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -52,7 +52,6 @@ import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { shouldTriggerSummarization } from '@/summarization';
 import { createSummarizeNode } from '@/summarization/node';
 import { messagesStateReducer } from '@/messages/reducer';
-import { appendCallbacks } from '@/utils/callbacks';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
 import { createFakeStreamingLLM } from '@/llm/fake';
@@ -63,12 +62,6 @@ import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
 import { isThinkingEnabled } from '@/llm/request';
 import { initializeModel } from '@/llm/init';
 import {
-  createLangfuseHandler,
-  disposeLangfuseHandler,
-  createLangfuseTraceMetadata,
-} from '@/langfuse';
-import {
-  resolveLangfuseConfig,
   shouldTraceToolNodeForLangfuse,
   withLangfuseToolOutputTracingConfig,
 } from '@/langfuseToolOutputTracing';
@@ -234,7 +227,6 @@ export abstract class Graph<
     this.hookRegistry = undefined;
     this.humanInTheLoop = undefined;
     this.toolOutputReferences = undefined;
-    this.langfuse = undefined;
     this.eagerEventToolExecution = undefined;
     this.eagerEventToolExecutions.clear();
     this.clearEagerEventToolUsageCounts();
@@ -1360,28 +1352,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         { force: true }
       );
 
-      const langfuse = resolveLangfuseConfig(
-        this.langfuse,
-        agentContext.langfuse
-      );
-      const langfuseHandler = createLangfuseHandler({
-        langfuse,
-        userId: config.configurable?.user_id as string | undefined,
-        sessionId: config.configurable?.thread_id as string | undefined,
-        traceMetadata: createLangfuseTraceMetadata({
-          messageId: this.runId,
-          parentMessageId: config.configurable?.requestBody?.parentMessageId,
-          agentId,
-          agentName: agentContext.name,
-        }),
-        tags: ['librechat', 'agent'],
-      });
-      const invokeConfig = langfuseHandler
-        ? {
-          ...config,
-          callbacks: appendCallbacks(config.callbacks, [langfuseHandler]),
-        }
-        : config;
+      const invokeConfig = config;
 
       try {
         result = await withLangfuseToolOutputTracingConfig(
@@ -1412,8 +1383,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             }),
           agentContext.langfuse
         );
-      } finally {
-        await disposeLangfuseHandler(langfuseHandler);
       }
 
       if (!result) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1371,8 +1371,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       );
       let langfuseHandler: CallbackEntry | undefined;
       let invokeConfig = config;
+      initializeLangfuseTracing(langfuse);
       if (findCallback(config.callbacks, isLangfuseCallbackHandler) == null) {
-        initializeLangfuseTracing(langfuse);
         langfuseHandler = createLangfuseHandler({
           langfuse,
           userId: config.configurable?.user_id as string | undefined,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -13,6 +13,7 @@ import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type * as t from '@/types';
 
 let langfuseTracerProvider: BasicTracerProvider | undefined;
+let langfuseTracerProviderKey: string | undefined;
 const contextManagerProbeKey = createContextKey(
   'langfuse-context-manager-probe'
 );
@@ -42,44 +43,70 @@ function getLangfuseSpanProcessorParams(
   if (langfuse?.enabled === false) {
     return undefined;
   }
-  const baseUrl = isPresent(langfuse?.baseUrl)
-    ? { baseUrl: langfuse.baseUrl }
-    : {};
   if (hasLangfuseConfigCredentials(langfuse)) {
     return {
       publicKey: langfuse.publicKey,
       secretKey: langfuse.secretKey,
-      ...baseUrl,
+      ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
     };
   }
-  if (
-    hasLangfuseEnvConfig() ||
-    (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials())
-  ) {
-    return baseUrl;
+  if (hasLangfuseEnvConfig()) {
+    return {
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
+      secretKey: process.env.LANGFUSE_SECRET_KEY as string,
+      baseUrl: langfuse?.baseUrl ??
+        process.env.LANGFUSE_BASE_URL ??
+        process.env.LANGFUSE_BASEURL,
+    };
+  }
+  if (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials()) {
+    return {
+      publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
+      secretKey: process.env.LANGFUSE_SECRET_KEY as string,
+      baseUrl: langfuse.baseUrl,
+    };
   }
   return undefined;
+}
+
+function getLangfuseTracerProviderKey(
+  params: LangfuseSpanProcessorParams,
+  langfuse?: t.LangfuseConfig
+): string {
+  return JSON.stringify({
+    publicKey: params.publicKey,
+    secretKey: params.secretKey,
+    baseUrl: params.baseUrl,
+    environment: params.environment,
+    toolOutputTracing: langfuse?.toolOutputTracing,
+  });
 }
 
 export function initializeLangfuseTracing(
   langfuse?: t.LangfuseConfig
 ): BasicTracerProvider | undefined {
-  if (langfuseTracerProvider != null) {
-    return langfuseTracerProvider;
-  }
-
   const params = getLangfuseSpanProcessorParams(langfuse);
   if (params == null) {
     return undefined;
   }
 
+  const providerKey = getLangfuseTracerProviderKey(params, langfuse);
+  if (
+    langfuseTracerProvider != null &&
+    langfuseTracerProviderKey === providerKey
+  ) {
+    return langfuseTracerProvider;
+  }
+
   ensureOpenTelemetryContextManager();
   const langfuseSpanProcessor = createLangfuseSpanProcessor(
-    Object.keys(params).length > 0 ? params : undefined
+    params,
+    langfuse
   );
   langfuseTracerProvider = new BasicTracerProvider({
     spanProcessors: [langfuseSpanProcessor],
   });
+  langfuseTracerProviderKey = providerKey;
 
   setLangfuseTracerProvider(langfuseTracerProvider);
   return langfuseTracerProvider;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,8 +2,15 @@ import { setLangfuseTracerProvider } from '@langfuse/tracing';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { context, ROOT_CONTEXT, createContextKey } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import { hasLangfuseEnvConfig } from '@/langfuse';
+import {
+  hasLangfuseConfigCredentials,
+  hasLangfuseEnvCredentials,
+  hasLangfuseEnvConfig,
+} from '@/langfuse';
 import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
+import { isPresent } from '@/utils/misc';
+import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
+import type * as t from '@/types';
 
 let langfuseTracerProvider: BasicTracerProvider | undefined;
 const contextManagerProbeKey = createContextKey(
@@ -29,24 +36,59 @@ export function ensureOpenTelemetryContextManager(): void {
   }
 }
 
-export function initializeLangfuseTracingFromEnv():
-  | BasicTracerProvider
-  | undefined {
+function getLangfuseSpanProcessorParams(
+  langfuse?: t.LangfuseConfig
+): LangfuseSpanProcessorParams | undefined {
+  if (langfuse?.enabled === false) {
+    return undefined;
+  }
+  const baseUrl = isPresent(langfuse?.baseUrl)
+    ? { baseUrl: langfuse.baseUrl }
+    : {};
+  if (hasLangfuseConfigCredentials(langfuse)) {
+    return {
+      publicKey: langfuse.publicKey,
+      secretKey: langfuse.secretKey,
+      ...baseUrl,
+    };
+  }
+  if (
+    hasLangfuseEnvConfig() ||
+    (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials())
+  ) {
+    return baseUrl;
+  }
+  return undefined;
+}
+
+export function initializeLangfuseTracing(
+  langfuse?: t.LangfuseConfig
+): BasicTracerProvider | undefined {
   if (langfuseTracerProvider != null) {
     return langfuseTracerProvider;
   }
-  if (!hasLangfuseEnvConfig()) {
+
+  const params = getLangfuseSpanProcessorParams(langfuse);
+  if (params == null) {
     return undefined;
   }
 
   ensureOpenTelemetryContextManager();
-  const langfuseSpanProcessor = createLangfuseSpanProcessor();
+  const langfuseSpanProcessor = createLangfuseSpanProcessor(
+    Object.keys(params).length > 0 ? params : undefined
+  );
   langfuseTracerProvider = new BasicTracerProvider({
     spanProcessors: [langfuseSpanProcessor],
   });
 
   setLangfuseTracerProvider(langfuseTracerProvider);
   return langfuseTracerProvider;
+}
+
+export function initializeLangfuseTracingFromEnv():
+  | BasicTracerProvider
+  | undefined {
+  return initializeLangfuseTracing();
 }
 
 initializeLangfuseTracingFromEnv();

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,9 +1,9 @@
-import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { setLangfuseTracerProvider } from '@langfuse/tracing';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { context, ROOT_CONTEXT, createContextKey } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { hasLangfuseEnvConfig } from '@/langfuse';
+import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
 
 let langfuseTracerProvider: BasicTracerProvider | undefined;
 const contextManagerProbeKey = createContextKey(
@@ -40,7 +40,7 @@ export function initializeLangfuseTracingFromEnv():
   }
 
   ensureOpenTelemetryContextManager();
-  const langfuseSpanProcessor = new LangfuseSpanProcessor();
+  const langfuseSpanProcessor = createLangfuseSpanProcessor();
   langfuseTracerProvider = new BasicTracerProvider({
     spanProcessors: [langfuseSpanProcessor],
   });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -7,13 +7,22 @@ import {
   hasLangfuseEnvCredentials,
   hasLangfuseEnvConfig,
 } from '@/langfuse';
-import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
+import {
+  createLangfuseSpanProcessor,
+  getContextLangfuseConfig,
+} from '@/langfuseToolOutputTracing';
 import { isPresent } from '@/utils/misc';
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
+import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
 
 let langfuseTracerProvider: BasicTracerProvider | undefined;
-let langfuseTracerProviderKey: string | undefined;
+let langfuseRoutingSpanProcessor: RoutingLangfuseSpanProcessor | undefined;
 const contextManagerProbeKey = createContextKey(
   'langfuse-context-manager-probe'
 );
@@ -51,12 +60,14 @@ function getLangfuseSpanProcessorParams(
     };
   }
   if (hasLangfuseEnvConfig()) {
+    const baseUrl =
+      langfuse?.baseUrl ??
+      process.env.LANGFUSE_BASE_URL ??
+      process.env.LANGFUSE_BASEURL;
     return {
       publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
       secretKey: process.env.LANGFUSE_SECRET_KEY as string,
-      baseUrl: langfuse?.baseUrl ??
-        process.env.LANGFUSE_BASE_URL ??
-        process.env.LANGFUSE_BASEURL,
+      ...(isPresent(baseUrl) ? { baseUrl } : {}),
     };
   }
   if (isPresent(langfuse?.baseUrl) && hasLangfuseEnvCredentials()) {
@@ -82,6 +93,58 @@ function getLangfuseTracerProviderKey(
   });
 }
 
+class RoutingLangfuseSpanProcessor implements SpanProcessor {
+  private readonly processors = new Map<string, SpanProcessor>();
+  private readonly spanProcessors = new WeakMap<object, SpanProcessor>();
+
+  ensureProcessor(langfuse?: t.LangfuseConfig): SpanProcessor | undefined {
+    const params = getLangfuseSpanProcessorParams(langfuse);
+    if (params == null) {
+      return undefined;
+    }
+
+    const processorKey = getLangfuseTracerProviderKey(params, langfuse);
+    const existing = this.processors.get(processorKey);
+    if (existing != null) {
+      return existing;
+    }
+
+    const processor = createLangfuseSpanProcessor(params, langfuse);
+    this.processors.set(processorKey, processor);
+    return processor;
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    const processor = this.ensureProcessor(
+      getContextLangfuseConfig(parentContext)
+    );
+    if (processor == null) {
+      return;
+    }
+
+    this.spanProcessors.set(span, processor);
+    processor.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    this.spanProcessors.get(span)?.onEnd(span);
+  }
+
+  async forceFlush(): Promise<void> {
+    await Promise.all(
+      Array.from(this.processors.values(), (processor) =>
+        processor.forceFlush()
+      )
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    await Promise.all(
+      Array.from(this.processors.values(), (processor) => processor.shutdown())
+    );
+  }
+}
+
 export function initializeLangfuseTracing(
   langfuse?: t.LangfuseConfig
 ): BasicTracerProvider | undefined {
@@ -90,23 +153,17 @@ export function initializeLangfuseTracing(
     return undefined;
   }
 
-  const providerKey = getLangfuseTracerProviderKey(params, langfuse);
-  if (
-    langfuseTracerProvider != null &&
-    langfuseTracerProviderKey === providerKey
-  ) {
+  if (langfuseTracerProvider != null) {
+    langfuseRoutingSpanProcessor?.ensureProcessor(langfuse);
     return langfuseTracerProvider;
   }
 
   ensureOpenTelemetryContextManager();
-  const langfuseSpanProcessor = createLangfuseSpanProcessor(
-    params,
-    langfuse
-  );
+  langfuseRoutingSpanProcessor = new RoutingLangfuseSpanProcessor();
+  langfuseRoutingSpanProcessor.ensureProcessor(langfuse);
   langfuseTracerProvider = new BasicTracerProvider({
-    spanProcessors: [langfuseSpanProcessor],
+    spanProcessors: [langfuseRoutingSpanProcessor],
   });
-  langfuseTracerProviderKey = providerKey;
 
   setLangfuseTracerProvider(langfuseTracerProvider);
   return langfuseTracerProvider;

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,5 +1,5 @@
 import { CallbackHandler } from '@langfuse/langchain';
-import { isDefaultExportSpan, LangfuseSpanProcessor } from '@langfuse/otel';
+import { isDefaultExportSpan } from '@langfuse/otel';
 import {
   LangfuseOtelSpanAttributes,
   createObservationAttributes,
@@ -7,10 +7,12 @@ import {
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { SpanStatusCode } from '@opentelemetry/api';
+import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
 import type { Serialized } from '@langchain/core/load/serializable';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { LLMResult } from '@langchain/core/outputs';
 import type { Attributes, Span } from '@opentelemetry/api';
+import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import type * as t from '@/types';
 import { isPresent } from '@/utils/misc';
 
@@ -185,7 +187,7 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
   name = 'librechat_langfuse_agent_handler';
 
   private readonly provider: BasicTracerProvider;
-  private readonly processor: LangfuseSpanProcessor;
+  private readonly processor: SpanProcessor;
   private readonly userId?: string;
   private readonly sessionId?: string;
   private readonly traceMetadata?: LangfuseTraceMetadata;
@@ -204,19 +206,23 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
     this.sessionId = sessionId;
     this.traceMetadata = traceMetadata;
     this.tags = tags;
-    this.processor = new LangfuseSpanProcessor({
-      publicKey: langfuse.publicKey,
-      secretKey: langfuse.secretKey,
-      ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
-      environment:
-        process.env.LANGFUSE_TRACING_ENVIRONMENT ??
-        process.env.NODE_ENV ??
-        'development',
-      exportMode: 'immediate',
-      shouldExportSpan: ({ otelSpan }): boolean =>
-        isDefaultExportSpan(otelSpan) ||
-        otelSpan.instrumentationScope.name === LANGFUSE_TRACER_NAME,
-    });
+    this.processor = createLangfuseSpanProcessor(
+      {
+        publicKey: langfuse.publicKey,
+        secretKey: langfuse.secretKey,
+        ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
+        environment:
+          process.env.LANGFUSE_TRACING_ENVIRONMENT ??
+          process.env.NODE_ENV ??
+          'development',
+        exportMode: 'immediate',
+        shouldExportSpan: ({ otelSpan }): boolean =>
+          isDefaultExportSpan(otelSpan) ||
+          otelSpan.instrumentationScope.name === LANGFUSE_TRACER_NAME,
+      },
+      undefined,
+      langfuse
+    );
     this.provider = new BasicTracerProvider({
       spanProcessors: [this.processor],
     });
@@ -412,7 +418,12 @@ export function hasExplicitLangfuseConfig(
   contexts: Iterable<{ langfuse?: t.LangfuseConfig }>
 ): boolean {
   for (const context of contexts) {
-    if (context.langfuse != null) {
+    if (
+      context.langfuse?.enabled != null ||
+      isPresent(context.langfuse?.publicKey) ||
+      isPresent(context.langfuse?.secretKey) ||
+      isPresent(context.langfuse?.baseUrl)
+    ) {
       return true;
     }
   }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -42,6 +42,37 @@ function getEnvLangfuseBaseUrl(): string | undefined {
   return process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL;
 }
 
+function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
+  return (
+    langfuse?.toolNodeTracing != null || langfuse?.toolOutputTracing != null
+  );
+}
+
+function resolveRequiredLangfuseConfig(
+  langfuse?: t.LangfuseConfig
+): ResolvedLangfuseConfig | undefined {
+  if (hasRequiredLangfuseConfig(langfuse)) {
+    return langfuse;
+  }
+  if (langfuse?.enabled === false) {
+    return undefined;
+  }
+  if (
+    !hasLangfuseEnvConfig() ||
+    (langfuse?.enabled !== true && !hasLangfuseTracingConfig(langfuse))
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...langfuse,
+    enabled: true,
+    publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
+    secretKey: process.env.LANGFUSE_SECRET_KEY as string,
+    baseUrl: getEnvLangfuseBaseUrl(),
+  };
+}
+
 function createTraceMetadata(
   metadata: Record<string, unknown>
 ): LangfuseTraceMetadata {
@@ -401,12 +432,13 @@ export function createLangfuseHandler({
   traceMetadata,
   tags,
 }: AgentLangfuseHandlerParams): LangfuseAgentCallbackHandler | undefined {
-  if (!hasRequiredLangfuseConfig(langfuse)) {
+  const resolvedLangfuse = resolveRequiredLangfuseConfig(langfuse);
+  if (resolvedLangfuse == null) {
     return undefined;
   }
 
   return new LangfuseAgentCallbackHandler({
-    langfuse,
+    langfuse: resolvedLangfuse,
     userId,
     sessionId,
     traceMetadata,
@@ -422,7 +454,8 @@ export function hasExplicitLangfuseConfig(
       context.langfuse?.enabled != null ||
       isPresent(context.langfuse?.publicKey) ||
       isPresent(context.langfuse?.secretKey) ||
-      isPresent(context.langfuse?.baseUrl)
+      isPresent(context.langfuse?.baseUrl) ||
+      hasLangfuseTracingConfig(context.langfuse)
     ) {
       return true;
     }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,23 +1,8 @@
 import { CallbackHandler } from '@langfuse/langchain';
-import { isDefaultExportSpan } from '@langfuse/otel';
-import {
-  LangfuseOtelSpanAttributes,
-  createObservationAttributes,
-} from '@langfuse/tracing';
-import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
-import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
-import { SpanStatusCode } from '@opentelemetry/api';
-import { createLangfuseSpanProcessor } from '@/langfuseToolOutputTracing';
-import type { Serialized } from '@langchain/core/load/serializable';
-import type { BaseMessage } from '@langchain/core/messages';
-import type { LLMResult } from '@langchain/core/outputs';
-import type { Attributes, Span } from '@opentelemetry/api';
-import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import type * as t from '@/types';
 import { isPresent } from '@/utils/misc';
 
 const TRACE_METADATA_MAX_LENGTH = 200;
-const LANGFUSE_TRACER_NAME = 'langfuse-sdk';
 
 export type LangfuseTraceMetadata = Record<string, string>;
 
@@ -30,17 +15,7 @@ type LangfuseHandlerParams = {
 
 type AgentLangfuseHandlerParams = LangfuseHandlerParams & {
   langfuse?: t.LangfuseConfig;
-  callbackScope?: LangfuseCallbackScope;
-  useToolOutputTracingFallback?: boolean;
 };
-
-type ResolvedLangfuseConfig = t.LangfuseConfig & {
-  enabled: true;
-  publicKey: string;
-  secretKey: string;
-};
-
-type LangfuseCallbackScope = 'all' | 'models' | 'tools';
 
 function getEnvLangfuseBaseUrl(): string | undefined {
   return process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL;
@@ -50,6 +25,23 @@ function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
   return (
     langfuse?.toolNodeTracing != null || langfuse?.toolOutputTracing != null
   );
+}
+
+export function hasLangfuseConfigCredentials(
+  langfuse?: t.LangfuseConfig
+): langfuse is t.LangfuseConfig & {
+  publicKey: string;
+  secretKey: string;
+} {
+  return (
+    langfuse != null &&
+    isPresent(langfuse.publicKey) &&
+    isPresent(langfuse.secretKey)
+  );
+}
+
+function hasLangfuseConfigBaseUrl(langfuse?: t.LangfuseConfig): boolean {
+  return isPresent(langfuse?.baseUrl);
 }
 
 export function isExplicitLangfuseConfig(
@@ -62,31 +54,6 @@ export function isExplicitLangfuseConfig(
     isPresent(langfuse?.baseUrl) ||
     hasLangfuseTracingConfig(langfuse)
   );
-}
-
-function resolveRequiredLangfuseConfig(
-  langfuse?: t.LangfuseConfig
-): ResolvedLangfuseConfig | undefined {
-  if (hasRequiredLangfuseConfig(langfuse)) {
-    return langfuse;
-  }
-  if (langfuse?.enabled === false) {
-    return undefined;
-  }
-  if (
-    !hasLangfuseEnvConfig() ||
-    (langfuse?.enabled !== true && !hasLangfuseTracingConfig(langfuse))
-  ) {
-    return undefined;
-  }
-
-  return {
-    ...langfuse,
-    enabled: true,
-    publicKey: process.env.LANGFUSE_PUBLIC_KEY as string,
-    secretKey: process.env.LANGFUSE_SECRET_KEY as string,
-    baseUrl: getEnvLangfuseBaseUrl(),
-  };
 }
 
 function createTraceMetadata(
@@ -128,93 +95,6 @@ export function createLangfuseTraceMetadata({
   });
 }
 
-function getModelName(serialized: Serialized): string {
-  const serializedRecord = serialized as unknown as Record<string, unknown>;
-  const kwargs = serializedRecord.kwargs as Record<string, unknown> | undefined;
-  const modelName =
-    kwargs?.model ??
-    kwargs?.model_name ??
-    kwargs?.modelName ??
-    kwargs?.model_id ??
-    kwargs?.modelId ??
-    serializedRecord.name;
-
-  if (typeof modelName === 'string' && modelName.trim() !== '') {
-    return modelName;
-  }
-
-  if (Array.isArray(serializedRecord.id) && serializedRecord.id.length > 0) {
-    return String(serializedRecord.id[serializedRecord.id.length - 1]);
-  }
-
-  return 'ChatModel';
-}
-
-function getModelParameters(
-  extraParams?: Record<string, unknown>
-): Record<string, string | number> {
-  const invocationParams = extraParams?.invocation_params;
-  const params =
-    invocationParams != null && typeof invocationParams === 'object'
-      ? (invocationParams as Record<string, unknown>)
-      : (extraParams ?? {});
-
-  return Object.fromEntries(
-    Object.entries(params).filter(([, value]) => {
-      return typeof value === 'string' || typeof value === 'number';
-    })
-  ) as Record<string, string | number>;
-}
-
-function getToolName(serialized: Serialized): string {
-  const serializedRecord = serialized as unknown as Record<string, unknown>;
-  const kwargs = serializedRecord.kwargs as Record<string, unknown> | undefined;
-  const toolName =
-    kwargs?.name ??
-    kwargs?.tool_name ??
-    kwargs?.toolName ??
-    serializedRecord.name;
-
-  if (typeof toolName === 'string' && toolName.trim() !== '') {
-    return toolName;
-  }
-
-  if (Array.isArray(serializedRecord.id) && serializedRecord.id.length > 0) {
-    return String(serializedRecord.id[serializedRecord.id.length - 1]);
-  }
-
-  return 'Tool';
-}
-
-function getOutput(output: LLMResult): unknown {
-  return output.generations.map((generation) =>
-    generation.map((item) => {
-      if ('message' in item && item.message != null) {
-        return (item.message as { content?: unknown }).content;
-      }
-      return item.text;
-    })
-  );
-}
-
-function getUsageDetails(
-  output: LLMResult
-): Record<string, number> | undefined {
-  const llmOutput = output.llmOutput as Record<string, unknown> | undefined;
-  const usage = llmOutput?.tokenUsage ?? llmOutput?.usage;
-  if (usage == null || typeof usage !== 'object') {
-    return undefined;
-  }
-
-  const usageEntries = Object.entries(usage as Record<string, unknown>).filter(
-    ([, value]) => typeof value === 'number'
-  );
-
-  return usageEntries.length > 0
-    ? (Object.fromEntries(usageEntries) as Record<string, number>)
-    : undefined;
-}
-
 export function getLangfuseTraceName(
   traceMetadata?: LangfuseTraceMetadata,
   fallback: string = 'LibreChat Agent'
@@ -223,367 +103,27 @@ export function getLangfuseTraceName(
   return isPresent(agentName) ? `${fallback}: ${agentName}` : fallback;
 }
 
-function getTraceAttributes({
-  userId,
-  sessionId,
-  traceMetadata,
-  tags,
-}: LangfuseHandlerParams): Attributes {
-  const attributes: Attributes = {
-    [LangfuseOtelSpanAttributes.TRACE_NAME]:
-      getLangfuseTraceName(traceMetadata),
-  };
-
-  if (isPresent(userId)) {
-    attributes[LangfuseOtelSpanAttributes.TRACE_USER_ID] = userId;
-  }
-  if (isPresent(sessionId)) {
-    attributes[LangfuseOtelSpanAttributes.TRACE_SESSION_ID] = sessionId;
-  }
-  if (tags != null && tags.length > 0) {
-    attributes[LangfuseOtelSpanAttributes.TRACE_TAGS] = tags;
-  }
-  for (const [key, value] of Object.entries(traceMetadata ?? {})) {
-    attributes[`${LangfuseOtelSpanAttributes.TRACE_METADATA}.${key}`] = value;
-  }
-
-  return attributes;
+export function hasLangfuseEnvConfig(): boolean {
+  return hasLangfuseEnvCredentials() && isPresent(getEnvLangfuseBaseUrl());
 }
 
-export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
-  name = 'librechat_langfuse_agent_handler';
-
-  private readonly provider: BasicTracerProvider;
-  private readonly processor: SpanProcessor;
-  private readonly userId?: string;
-  private readonly sessionId?: string;
-  private readonly traceMetadata?: LangfuseTraceMetadata;
-  private readonly tags?: string[];
-  private readonly callbackScope: LangfuseCallbackScope;
-  private readonly spans = new Map<string, Span>();
-
-  constructor({
-    langfuse,
-    userId,
-    sessionId,
-    traceMetadata,
-    tags,
-    callbackScope = 'all',
-    useToolOutputTracingFallback = true,
-  }: LangfuseHandlerParams & {
-    langfuse: ResolvedLangfuseConfig;
-    callbackScope?: LangfuseCallbackScope;
-    useToolOutputTracingFallback?: boolean;
-  }) {
-    super();
-    this.userId = userId;
-    this.sessionId = sessionId;
-    this.traceMetadata = traceMetadata;
-    this.tags = tags;
-    this.callbackScope = callbackScope;
-    this.processor = createLangfuseSpanProcessor(
-      {
-        publicKey: langfuse.publicKey,
-        secretKey: langfuse.secretKey,
-        ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
-        environment:
-          process.env.LANGFUSE_TRACING_ENVIRONMENT ??
-          process.env.NODE_ENV ??
-          'development',
-        exportMode: 'immediate',
-        shouldExportSpan: ({ otelSpan }): boolean =>
-          isDefaultExportSpan(otelSpan) ||
-          otelSpan.instrumentationScope.name === LANGFUSE_TRACER_NAME,
-      },
-      undefined,
-      useToolOutputTracingFallback ? langfuse : undefined
-    );
-    this.provider = new BasicTracerProvider({
-      spanProcessors: [this.processor],
-    });
-  }
-
-  private shouldHandleModels(): boolean {
-    return this.callbackScope !== 'tools';
-  }
-
-  private shouldHandleTools(): boolean {
-    return this.callbackScope !== 'models';
-  }
-
-  private startGenerationSpan({
-    llm,
-    input,
-    runId,
-    extraParams,
-    metadata,
-    name,
-  }: {
-    llm: Serialized;
-    input: unknown;
-    runId: string;
-    extraParams?: Record<string, unknown>;
-    metadata?: Record<string, unknown>;
-    name?: string;
-  }): void {
-    if (!this.shouldHandleModels()) {
-      return;
-    }
-    if (this.spans.has(runId)) {
-      return;
-    }
-
-    const tracer = this.provider.getTracer(LANGFUSE_TRACER_NAME);
-    const spanName =
-      typeof name === 'string' && name.trim() !== '' ? name : getModelName(llm);
-    const span = tracer.startSpan(spanName, {
-      attributes: {
-        ...getTraceAttributes({
-          userId: this.userId,
-          sessionId: this.sessionId,
-          traceMetadata: this.traceMetadata,
-          tags: this.tags,
-        }),
-        ...createObservationAttributes('generation', {
-          input,
-          model: getModelName(llm),
-          modelParameters: getModelParameters(extraParams),
-          metadata: {
-            ...metadata,
-            ...this.traceMetadata,
-          },
-        }),
-      },
-    });
-    this.spans.set(runId, span);
-  }
-
-  private startToolSpan({
-    tool,
-    input,
-    runId,
-    metadata,
-    name,
-    toolCallId,
-  }: {
-    tool: Serialized;
-    input: string;
-    runId: string;
-    metadata?: Record<string, unknown>;
-    name?: string;
-    toolCallId?: string;
-  }): void {
-    if (!this.shouldHandleTools()) {
-      return;
-    }
-    if (this.spans.has(runId)) {
-      return;
-    }
-
-    const tracer = this.provider.getTracer(LANGFUSE_TRACER_NAME);
-    const spanName =
-      typeof name === 'string' && name.trim() !== '' ? name : getToolName(tool);
-    const span = tracer.startSpan(spanName, {
-      attributes: {
-        ...getTraceAttributes({
-          userId: this.userId,
-          sessionId: this.sessionId,
-          traceMetadata: this.traceMetadata,
-          tags: this.tags,
-        }),
-        ...createObservationAttributes('tool', {
-          input,
-          metadata: {
-            ...metadata,
-            ...this.traceMetadata,
-            ...(isPresent(toolCallId) ? { toolCallId } : {}),
-          },
-        }),
-      },
-    });
-    this.spans.set(runId, span);
-  }
-
-  async handleChatModelStart(
-    llm: Serialized,
-    messages: BaseMessage[][],
-    runId: string,
-    _parentRunId?: string,
-    extraParams?: Record<string, unknown>,
-    _tags?: string[],
-    metadata?: Record<string, unknown>,
-    name?: string
-  ): Promise<void> {
-    this.startGenerationSpan({
-      llm,
-      input: messages,
-      runId,
-      extraParams,
-      metadata,
-      name,
-    });
-  }
-
-  async handleLLMStart(
-    llm: Serialized,
-    prompts: string[],
-    runId: string,
-    _parentRunId?: string,
-    extraParams?: Record<string, unknown>,
-    _tags?: string[],
-    metadata?: Record<string, unknown>,
-    name?: string
-  ): Promise<void> {
-    this.startGenerationSpan({
-      llm,
-      input: prompts,
-      runId,
-      extraParams,
-      metadata,
-      name,
-    });
-  }
-
-  async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
-    if (!this.shouldHandleModels()) {
-      return;
-    }
-    const span = this.spans.get(runId);
-    if (!span) {
-      return;
-    }
-
-    span.setAttributes(
-      createObservationAttributes('generation', {
-        output: getOutput(output),
-        usageDetails: getUsageDetails(output),
-      })
-    );
-    span.end();
-    this.spans.delete(runId);
-    await this.flush();
-  }
-
-  async handleLLMError(err: unknown, runId: string): Promise<void> {
-    if (!this.shouldHandleModels()) {
-      return;
-    }
-    const span = this.spans.get(runId);
-    if (!span) {
-      return;
-    }
-
-    const message = err instanceof Error ? err.message : String(err);
-    span.setStatus({ code: SpanStatusCode.ERROR, message });
-    span.setAttributes(
-      createObservationAttributes('generation', {
-        level: 'ERROR',
-        statusMessage: message,
-      })
-    );
-    span.end();
-    this.spans.delete(runId);
-    await this.flush();
-  }
-
-  async handleToolStart(
-    tool: Serialized,
-    input: string,
-    runId: string,
-    _parentRunId?: string,
-    _tags?: string[],
-    metadata?: Record<string, unknown>,
-    name?: string,
-    toolCallId?: string
-  ): Promise<void> {
-    this.startToolSpan({
-      tool,
-      input,
-      runId,
-      metadata,
-      name,
-      toolCallId,
-    });
-  }
-
-  async handleToolEnd(output: unknown, runId: string): Promise<void> {
-    if (!this.shouldHandleTools()) {
-      return;
-    }
-    const span = this.spans.get(runId);
-    if (!span) {
-      return;
-    }
-
-    span.setAttributes(
-      createObservationAttributes('tool', {
-        output,
-      })
-    );
-    span.end();
-    this.spans.delete(runId);
-    await this.flush();
-  }
-
-  async handleToolError(err: unknown, runId: string): Promise<void> {
-    if (!this.shouldHandleTools()) {
-      return;
-    }
-    const span = this.spans.get(runId);
-    if (!span) {
-      return;
-    }
-
-    const message = err instanceof Error ? err.message : String(err);
-    span.setStatus({ code: SpanStatusCode.ERROR, message });
-    span.setAttributes(
-      createObservationAttributes('tool', {
-        level: 'ERROR',
-        statusMessage: message,
-      })
-    );
-    span.end();
-    this.spans.delete(runId);
-    await this.flush();
-  }
-
-  private async flush(): Promise<void> {
-    try {
-      await this.provider.forceFlush();
-    } catch (error) {
-      process.emitWarning(
-        `[LangfuseAgentCallbackHandler] Failed to flush Langfuse spans: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    }
-  }
-
-  async dispose(): Promise<void> {
-    for (const span of this.spans.values()) {
-      span.end();
-    }
-    this.spans.clear();
-    await this.flush();
-    try {
-      await this.provider.shutdown();
-    } catch (error) {
-      process.emitWarning(
-        `[LangfuseAgentCallbackHandler] Failed to shut down Langfuse provider: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-    }
-  }
-}
-
-function hasRequiredLangfuseConfig(
-  langfuse?: t.LangfuseConfig
-): langfuse is ResolvedLangfuseConfig {
+export function hasLangfuseEnvCredentials(): boolean {
   return (
-    langfuse?.enabled === true &&
-    isPresent(langfuse.publicKey) &&
-    isPresent(langfuse.secretKey)
+    isPresent(process.env.LANGFUSE_SECRET_KEY) &&
+    isPresent(process.env.LANGFUSE_PUBLIC_KEY)
+  );
+}
+
+export function shouldCreateLangfuseHandler(
+  langfuse?: t.LangfuseConfig
+): boolean {
+  if (langfuse?.enabled === false) {
+    return false;
+  }
+  return (
+    hasLangfuseEnvConfig() ||
+    hasLangfuseConfigCredentials(langfuse) ||
+    (hasLangfuseConfigBaseUrl(langfuse) && hasLangfuseEnvCredentials())
   );
 }
 
@@ -599,22 +139,15 @@ export function createLangfuseHandler({
   sessionId,
   traceMetadata,
   tags,
-  callbackScope,
-  useToolOutputTracingFallback,
-}: AgentLangfuseHandlerParams): LangfuseAgentCallbackHandler | undefined {
-  const resolvedLangfuse = resolveRequiredLangfuseConfig(langfuse);
-  if (resolvedLangfuse == null) {
+}: AgentLangfuseHandlerParams): CallbackHandler | undefined {
+  if (!shouldCreateLangfuseHandler(langfuse)) {
     return undefined;
   }
-
-  return new LangfuseAgentCallbackHandler({
-    langfuse: resolvedLangfuse,
+  return new CallbackHandler({
     userId,
     sessionId,
     traceMetadata,
     tags,
-    callbackScope,
-    useToolOutputTracingFallback,
   });
 }
 
@@ -629,23 +162,11 @@ export function hasExplicitLangfuseConfig(
   return false;
 }
 
-export function hasLangfuseEnvConfig(): boolean {
-  return (
-    isPresent(process.env.LANGFUSE_SECRET_KEY) &&
-    isPresent(process.env.LANGFUSE_PUBLIC_KEY) &&
-    isPresent(getEnvLangfuseBaseUrl())
-  );
-}
-
 export function isLangfuseCallbackHandler(value: unknown): boolean {
-  return (
-    value instanceof CallbackHandler ||
-    value instanceof LangfuseAgentCallbackHandler
-  );
+  return value instanceof CallbackHandler;
 }
 
-export async function disposeLangfuseHandler(value: unknown): Promise<void> {
-  if (value instanceof LangfuseAgentCallbackHandler) {
-    await value.dispose();
-  }
+export async function disposeLangfuseHandler(_value: unknown): Promise<void> {
+  // The official Langfuse LangChain callback handler is flushed by the
+  // configured OpenTelemetry span processor.
 }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -30,6 +30,8 @@ type LangfuseHandlerParams = {
 
 type AgentLangfuseHandlerParams = LangfuseHandlerParams & {
   langfuse?: t.LangfuseConfig;
+  callbackScope?: LangfuseCallbackScope;
+  useToolOutputTracingFallback?: boolean;
 };
 
 type ResolvedLangfuseConfig = t.LangfuseConfig & {
@@ -38,6 +40,8 @@ type ResolvedLangfuseConfig = t.LangfuseConfig & {
   secretKey: string;
 };
 
+type LangfuseCallbackScope = 'all' | 'models' | 'tools';
+
 function getEnvLangfuseBaseUrl(): string | undefined {
   return process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL;
 }
@@ -45,6 +49,18 @@ function getEnvLangfuseBaseUrl(): string | undefined {
 function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
   return (
     langfuse?.toolNodeTracing != null || langfuse?.toolOutputTracing != null
+  );
+}
+
+export function isExplicitLangfuseConfig(
+  langfuse?: t.LangfuseConfig
+): boolean {
+  return (
+    langfuse?.enabled != null ||
+    isPresent(langfuse?.publicKey) ||
+    isPresent(langfuse?.secretKey) ||
+    isPresent(langfuse?.baseUrl) ||
+    hasLangfuseTracingConfig(langfuse)
   );
 }
 
@@ -150,6 +166,26 @@ function getModelParameters(
   ) as Record<string, string | number>;
 }
 
+function getToolName(serialized: Serialized): string {
+  const serializedRecord = serialized as unknown as Record<string, unknown>;
+  const kwargs = serializedRecord.kwargs as Record<string, unknown> | undefined;
+  const toolName =
+    kwargs?.name ??
+    kwargs?.tool_name ??
+    kwargs?.toolName ??
+    serializedRecord.name;
+
+  if (typeof toolName === 'string' && toolName.trim() !== '') {
+    return toolName;
+  }
+
+  if (Array.isArray(serializedRecord.id) && serializedRecord.id.length > 0) {
+    return String(serializedRecord.id[serializedRecord.id.length - 1]);
+  }
+
+  return 'Tool';
+}
+
 function getOutput(output: LLMResult): unknown {
   return output.generations.map((generation) =>
     generation.map((item) => {
@@ -223,6 +259,7 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
   private readonly sessionId?: string;
   private readonly traceMetadata?: LangfuseTraceMetadata;
   private readonly tags?: string[];
+  private readonly callbackScope: LangfuseCallbackScope;
   private readonly spans = new Map<string, Span>();
 
   constructor({
@@ -231,12 +268,19 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
     sessionId,
     traceMetadata,
     tags,
-  }: LangfuseHandlerParams & { langfuse: ResolvedLangfuseConfig }) {
+    callbackScope = 'all',
+    useToolOutputTracingFallback = true,
+  }: LangfuseHandlerParams & {
+    langfuse: ResolvedLangfuseConfig;
+    callbackScope?: LangfuseCallbackScope;
+    useToolOutputTracingFallback?: boolean;
+  }) {
     super();
     this.userId = userId;
     this.sessionId = sessionId;
     this.traceMetadata = traceMetadata;
     this.tags = tags;
+    this.callbackScope = callbackScope;
     this.processor = createLangfuseSpanProcessor(
       {
         publicKey: langfuse.publicKey,
@@ -252,11 +296,19 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
           otelSpan.instrumentationScope.name === LANGFUSE_TRACER_NAME,
       },
       undefined,
-      langfuse
+      useToolOutputTracingFallback ? langfuse : undefined
     );
     this.provider = new BasicTracerProvider({
       spanProcessors: [this.processor],
     });
+  }
+
+  private shouldHandleModels(): boolean {
+    return this.callbackScope !== 'tools';
+  }
+
+  private shouldHandleTools(): boolean {
+    return this.callbackScope !== 'models';
   }
 
   private startGenerationSpan({
@@ -274,6 +326,9 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
     metadata?: Record<string, unknown>;
     name?: string;
   }): void {
+    if (!this.shouldHandleModels()) {
+      return;
+    }
     if (this.spans.has(runId)) {
       return;
     }
@@ -296,6 +351,52 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
           metadata: {
             ...metadata,
             ...this.traceMetadata,
+          },
+        }),
+      },
+    });
+    this.spans.set(runId, span);
+  }
+
+  private startToolSpan({
+    tool,
+    input,
+    runId,
+    metadata,
+    name,
+    toolCallId,
+  }: {
+    tool: Serialized;
+    input: string;
+    runId: string;
+    metadata?: Record<string, unknown>;
+    name?: string;
+    toolCallId?: string;
+  }): void {
+    if (!this.shouldHandleTools()) {
+      return;
+    }
+    if (this.spans.has(runId)) {
+      return;
+    }
+
+    const tracer = this.provider.getTracer(LANGFUSE_TRACER_NAME);
+    const spanName =
+      typeof name === 'string' && name.trim() !== '' ? name : getToolName(tool);
+    const span = tracer.startSpan(spanName, {
+      attributes: {
+        ...getTraceAttributes({
+          userId: this.userId,
+          sessionId: this.sessionId,
+          traceMetadata: this.traceMetadata,
+          tags: this.tags,
+        }),
+        ...createObservationAttributes('tool', {
+          input,
+          metadata: {
+            ...metadata,
+            ...this.traceMetadata,
+            ...(isPresent(toolCallId) ? { toolCallId } : {}),
           },
         }),
       },
@@ -344,6 +445,9 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
   }
 
   async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
+    if (!this.shouldHandleModels()) {
+      return;
+    }
     const span = this.spans.get(runId);
     if (!span) {
       return;
@@ -361,6 +465,9 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
   }
 
   async handleLLMError(err: unknown, runId: string): Promise<void> {
+    if (!this.shouldHandleModels()) {
+      return;
+    }
     const span = this.spans.get(runId);
     if (!span) {
       return;
@@ -370,6 +477,67 @@ export class LangfuseAgentCallbackHandler extends BaseCallbackHandler {
     span.setStatus({ code: SpanStatusCode.ERROR, message });
     span.setAttributes(
       createObservationAttributes('generation', {
+        level: 'ERROR',
+        statusMessage: message,
+      })
+    );
+    span.end();
+    this.spans.delete(runId);
+    await this.flush();
+  }
+
+  async handleToolStart(
+    tool: Serialized,
+    input: string,
+    runId: string,
+    _parentRunId?: string,
+    _tags?: string[],
+    metadata?: Record<string, unknown>,
+    name?: string,
+    toolCallId?: string
+  ): Promise<void> {
+    this.startToolSpan({
+      tool,
+      input,
+      runId,
+      metadata,
+      name,
+      toolCallId,
+    });
+  }
+
+  async handleToolEnd(output: unknown, runId: string): Promise<void> {
+    if (!this.shouldHandleTools()) {
+      return;
+    }
+    const span = this.spans.get(runId);
+    if (!span) {
+      return;
+    }
+
+    span.setAttributes(
+      createObservationAttributes('tool', {
+        output,
+      })
+    );
+    span.end();
+    this.spans.delete(runId);
+    await this.flush();
+  }
+
+  async handleToolError(err: unknown, runId: string): Promise<void> {
+    if (!this.shouldHandleTools()) {
+      return;
+    }
+    const span = this.spans.get(runId);
+    if (!span) {
+      return;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    span.setStatus({ code: SpanStatusCode.ERROR, message });
+    span.setAttributes(
+      createObservationAttributes('tool', {
         level: 'ERROR',
         statusMessage: message,
       })
@@ -431,6 +599,8 @@ export function createLangfuseHandler({
   sessionId,
   traceMetadata,
   tags,
+  callbackScope,
+  useToolOutputTracingFallback,
 }: AgentLangfuseHandlerParams): LangfuseAgentCallbackHandler | undefined {
   const resolvedLangfuse = resolveRequiredLangfuseConfig(langfuse);
   if (resolvedLangfuse == null) {
@@ -443,6 +613,8 @@ export function createLangfuseHandler({
     sessionId,
     traceMetadata,
     tags,
+    callbackScope,
+    useToolOutputTracingFallback,
   });
 }
 
@@ -450,13 +622,7 @@ export function hasExplicitLangfuseConfig(
   contexts: Iterable<{ langfuse?: t.LangfuseConfig }>
 ): boolean {
   for (const context of contexts) {
-    if (
-      context.langfuse?.enabled != null ||
-      isPresent(context.langfuse?.publicKey) ||
-      isPresent(context.langfuse?.secretKey) ||
-      isPresent(context.langfuse?.baseUrl) ||
-      hasLangfuseTracingConfig(context.langfuse)
-    ) {
+    if (isExplicitLangfuseConfig(context.langfuse)) {
       return true;
     }
   }

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -17,10 +17,6 @@ type AgentLangfuseHandlerParams = LangfuseHandlerParams & {
   langfuse?: t.LangfuseConfig;
 };
 
-function getEnvLangfuseBaseUrl(): string | undefined {
-  return process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL;
-}
-
 function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
   return (
     langfuse?.toolNodeTracing != null || langfuse?.toolOutputTracing != null
@@ -104,7 +100,7 @@ export function getLangfuseTraceName(
 }
 
 export function hasLangfuseEnvConfig(): boolean {
-  return hasLangfuseEnvCredentials() && isPresent(getEnvLangfuseBaseUrl());
+  return hasLangfuseEnvCredentials();
 }
 
 export function hasLangfuseEnvCredentials(): boolean {

--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,3 +1,4 @@
+import { getLangfuseTracerProvider } from '@langfuse/tracing';
 import { CallbackHandler } from '@langfuse/langchain';
 import type * as t from '@/types';
 import { isPresent } from '@/utils/misc';
@@ -15,6 +16,10 @@ type LangfuseHandlerParams = {
 
 type AgentLangfuseHandlerParams = LangfuseHandlerParams & {
   langfuse?: t.LangfuseConfig;
+};
+
+type FlushableTracerProvider = {
+  forceFlush?: () => Promise<void> | void;
 };
 
 function hasLangfuseTracingConfig(langfuse?: t.LangfuseConfig): boolean {
@@ -162,7 +167,10 @@ export function isLangfuseCallbackHandler(value: unknown): boolean {
   return value instanceof CallbackHandler;
 }
 
-export async function disposeLangfuseHandler(_value: unknown): Promise<void> {
-  // The official Langfuse LangChain callback handler is flushed by the
-  // configured OpenTelemetry span processor.
+export async function disposeLangfuseHandler(value: unknown): Promise<void> {
+  if (value == null) {
+    return;
+  }
+  const provider = getLangfuseTracerProvider() as FlushableTracerProvider;
+  await provider.forceFlush?.();
 }

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -16,8 +16,10 @@ export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
 const langfuseToolOutputTracingConfigKey = createContextKey(
   'librechat.langfuse.tool-output-tracing'
 );
+const langfuseConfigKey = createContextKey('librechat.langfuse.config');
 const toolOutputTracingStorage =
   new AsyncLocalStorage<ResolvedLangfuseToolOutputTracingConfig>();
+const langfuseConfigStorage = new AsyncLocalStorage<t.LangfuseConfig>();
 
 const CHAT_ROLES = new Set([
   'assistant',
@@ -498,6 +500,18 @@ function getContextToolOutputTracingConfig(
     : undefined;
 }
 
+export function getContextLangfuseConfig(
+  activeContext: Context
+): t.LangfuseConfig | undefined {
+  const asyncConfig = langfuseConfigStorage.getStore();
+  if (asyncConfig != null) {
+    return asyncConfig;
+  }
+
+  const value = activeContext.getValue(langfuseConfigKey);
+  return isRecord(value) ? (value as t.LangfuseConfig) : undefined;
+}
+
 class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
   private readonly processor: LangfuseSpanProcessor;
   private readonly fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig;
@@ -516,7 +530,7 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
 
   onStart(span: Span, parentContext: Context): void {
     const config =
-      this.fallbackConfig ?? getContextToolOutputTracingConfig(parentContext);
+      getContextToolOutputTracingConfig(parentContext) ?? this.fallbackConfig;
     if (config != null) {
       this.spanConfigs.set(span, config);
     }
@@ -559,27 +573,44 @@ export function withLangfuseToolOutputTracingConfig<T>(
   action: () => T,
   agentLangfuse?: t.LangfuseConfig
 ): T {
-  if (
+  const langfuse = resolveLangfuseConfig(runLangfuse, agentLangfuse);
+  const hasNoToolOutputConfig =
     runLangfuse?.toolOutputTracing == null &&
-    agentLangfuse?.toolOutputTracing == null
-  ) {
+    agentLangfuse?.toolOutputTracing == null;
+
+  if (langfuse == null && hasNoToolOutputConfig) {
     return action();
   }
 
-  const config = resolveToolOutputTracingConfig(runLangfuse, agentLangfuse);
-  const activeContext = context
-    .active()
-    .setValue(langfuseToolOutputTracingConfigKey, config);
-  return toolOutputTracingStorage.run(config, () =>
-    context.with(activeContext, action)
-  );
+  const config = hasNoToolOutputConfig
+    ? undefined
+    : resolveToolOutputTracingConfig(runLangfuse, agentLangfuse);
+  let activeContext = context.active();
+  if (langfuse != null) {
+    activeContext = activeContext.setValue(langfuseConfigKey, langfuse);
+  }
+  if (config != null) {
+    activeContext = activeContext.setValue(
+      langfuseToolOutputTracingConfigKey,
+      config
+    );
+  }
+
+  const runWithContext = (): T => context.with(activeContext, action);
+  const runWithToolOutputConfig = (): T =>
+    config != null
+      ? toolOutputTracingStorage.run(config, runWithContext)
+      : runWithContext();
+
+  return langfuse != null
+    ? langfuseConfigStorage.run(langfuse, runWithToolOutputConfig)
+    : runWithToolOutputConfig();
 }
 
 function hasLangfuseEnvKeys(): boolean {
   return (
     isPresent(process.env.LANGFUSE_SECRET_KEY) &&
-    isPresent(process.env.LANGFUSE_PUBLIC_KEY) &&
-    isPresent(process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL)
+    isPresent(process.env.LANGFUSE_PUBLIC_KEY)
   );
 }
 
@@ -589,9 +620,7 @@ function hasLangfuseConfigKeys(langfuse?: t.LangfuseConfig): boolean {
   }
   return (
     isPresent(langfuse.secretKey) &&
-    isPresent(langfuse.publicKey) &&
-    (isPresent(langfuse.baseUrl) ||
-      isPresent(process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL))
+    isPresent(langfuse.publicKey)
   );
 }
 
@@ -602,25 +631,20 @@ export function shouldTraceToolNodeForLangfuse({
   runLangfuse?: t.LangfuseConfig;
   agentLangfuse?: t.LangfuseConfig;
 }): boolean {
-  const explicit =
-    agentLangfuse?.toolNodeTracing?.enabled ??
-    runLangfuse?.toolNodeTracing?.enabled;
+  const langfuse = resolveLangfuseConfig(runLangfuse, agentLangfuse);
+  const explicit = langfuse?.toolNodeTracing?.enabled;
   if (explicit != null) {
     return (
       explicit &&
-      (hasLangfuseConfigKeys(resolveLangfuseConfig(runLangfuse, agentLangfuse)) ||
-        hasLangfuseEnvKeys())
+      (hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys())
     );
   }
 
-  if (agentLangfuse?.enabled === false || runLangfuse?.enabled === false) {
+  if (langfuse?.enabled === false) {
     return false;
   }
 
-  return (
-    hasLangfuseConfigKeys(resolveLangfuseConfig(runLangfuse, agentLangfuse)) ||
-    hasLangfuseEnvKeys()
-  );
+  return hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys();
 }
 
 export function resolveLangfuseConfig(
@@ -634,16 +658,26 @@ export function resolveLangfuseConfig(
     return runLangfuse;
   }
 
+  const toolNodeTracing =
+    runLangfuse.toolNodeTracing != null || agentLangfuse.toolNodeTracing != null
+      ? {
+        ...runLangfuse.toolNodeTracing,
+        ...agentLangfuse.toolNodeTracing,
+      }
+      : undefined;
+  const toolOutputTracing =
+    runLangfuse.toolOutputTracing != null ||
+    agentLangfuse.toolOutputTracing != null
+      ? {
+        ...runLangfuse.toolOutputTracing,
+        ...agentLangfuse.toolOutputTracing,
+      }
+      : undefined;
+
   return {
     ...runLangfuse,
     ...agentLangfuse,
-    toolNodeTracing: {
-      ...runLangfuse.toolNodeTracing,
-      ...agentLangfuse.toolNodeTracing,
-    },
-    toolOutputTracing: {
-      ...runLangfuse.toolOutputTracing,
-      ...agentLangfuse.toolOutputTracing,
-    },
+    ...(toolNodeTracing != null ? { toolNodeTracing } : {}),
+    ...(toolOutputTracing != null ? { toolOutputTracing } : {}),
   };
 }

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -43,6 +43,10 @@ type RedactionResult = {
   changed: boolean;
 };
 
+type RedactionContext = {
+  toolNamesByCallId: Map<string, string>;
+};
+
 const TOOL_OUTPUT_FIELD_KEYS = ['content', 'artifact'];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -223,18 +227,40 @@ function getNestedStringField(
   return getStringField(nested, fieldKey);
 }
 
-function getSerializedToolName(
+function getSerializedToolCallId(
   value: Record<string, unknown>
 ): string | undefined {
-  const role = getStringField(value, 'role');
   return (
+    getStringField(value, 'tool_call_id') ??
+    getNestedStringField(value, 'kwargs', 'tool_call_id') ??
+    getNestedStringField(value, 'additional_kwargs', 'tool_call_id') ??
+    getNestedStringField(value, 'data', 'tool_call_id') ??
+    (typeof value.id === 'string' ? value.id : undefined)
+  );
+}
+
+function getSerializedToolName(
+  value: Record<string, unknown>,
+  redactionContext?: RedactionContext
+): string | undefined {
+  const role = getStringField(value, 'role');
+  const explicitName =
     getStringField(value, 'name') ??
     getStringField(value, 'tool_name') ??
+    getNestedStringField(value, 'function', 'name') ??
     getNestedStringField(value, 'kwargs', 'name') ??
     getNestedStringField(value, 'additional_kwargs', 'name') ??
     getNestedStringField(value, 'data', 'name') ??
-    (role != null && role.toLowerCase() !== 'tool' ? role : undefined)
-  );
+    (role != null && role.toLowerCase() !== 'tool' ? role : undefined);
+
+  if (explicitName != null) {
+    return explicitName;
+  }
+
+  const toolCallId = getSerializedToolCallId(value);
+  return toolCallId != null
+    ? redactionContext?.toolNamesByCallId.get(toolCallId)
+    : undefined;
 }
 
 function hasToolMessageIdentity(value: Record<string, unknown>): boolean {
@@ -300,15 +326,42 @@ function redactToolContentFields(
   return next;
 }
 
+function collectToolCallNames(
+  value: unknown,
+  redactionContext: RedactionContext
+): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectToolCallNames(item, redactionContext);
+    }
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const toolCallId = getSerializedToolCallId(value);
+  const toolName = getSerializedToolName(value);
+  if (toolCallId != null && toolName != null) {
+    redactionContext.toolNamesByCallId.set(toolCallId, toolName);
+  }
+
+  for (const child of Object.values(value)) {
+    collectToolCallNames(child, redactionContext);
+  }
+}
+
 function redactValue(
   value: unknown,
-  config: ResolvedLangfuseToolOutputTracingConfig
+  config: ResolvedLangfuseToolOutputTracingConfig,
+  redactionContext: RedactionContext
 ): RedactionResult {
   if (Array.isArray(value)) {
     let changed = false;
     const next: unknown[] = [];
     for (const item of value) {
-      const result = redactValue(item, config);
+      const result = redactValue(item, config, redactionContext);
       if (result.changed) {
         changed = true;
       }
@@ -321,7 +374,7 @@ function redactValue(
     return { value, changed: false };
   }
 
-  const toolName = getSerializedToolName(value);
+  const toolName = getSerializedToolName(value, redactionContext);
   if (hasToolMessageIdentity(value) && shouldRedactTool(toolName, config)) {
     return {
       value: redactToolContentFields(value, config),
@@ -332,7 +385,7 @@ function redactValue(
   let changed = false;
   const next: Record<string, unknown> = {};
   for (const [key, child] of Object.entries(value)) {
-    const result = redactValue(child, config);
+    const result = redactValue(child, config, redactionContext);
     if (result.changed) {
       changed = true;
     }
@@ -346,8 +399,12 @@ function redactSerializedValue(
   value: unknown,
   config: ResolvedLangfuseToolOutputTracingConfig
 ): RedactionResult {
+  const redactionContext: RedactionContext = {
+    toolNamesByCallId: new Map(),
+  };
   if (typeof value !== 'string') {
-    return redactValue(value, config);
+    collectToolCallNames(value, redactionContext);
+    return redactValue(value, config, redactionContext);
   }
 
   const trimmed = value.trim();
@@ -357,7 +414,8 @@ function redactSerializedValue(
 
   try {
     const parsed = JSON.parse(value) as unknown;
-    const result = redactValue(parsed, config);
+    collectToolCallNames(parsed, redactionContext);
+    const result = redactValue(parsed, config, redactionContext);
     return result.changed
       ? { value: JSON.stringify(result.value), changed: true }
       : { value, changed: false };

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -1,0 +1,572 @@
+import { context, createContextKey } from '@opentelemetry/api';
+import { LangfuseSpanProcessor } from '@langfuse/otel';
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
+import type { Context } from '@opentelemetry/api';
+import type * as t from '@/types';
+
+export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
+
+const langfuseToolOutputTracingConfigKey = createContextKey(
+  'librechat.langfuse.tool-output-tracing'
+);
+const toolOutputTracingStorage =
+  new AsyncLocalStorage<ResolvedLangfuseToolOutputTracingConfig>();
+
+const CHAT_ROLES = new Set([
+  'assistant',
+  'developer',
+  'human',
+  'system',
+  'user',
+]);
+
+export type ResolvedLangfuseToolOutputTracingConfig = {
+  enabled: boolean;
+  redactedToolNames: Set<string>;
+  redactedToolNameMatchMode: 'exact' | 'partial';
+  redactionText: string;
+};
+
+type SpanWithAttributes = ReadableSpan & {
+  attributes: Record<string, unknown>;
+};
+
+type RedactionResult = {
+  value: unknown;
+  changed: boolean;
+};
+
+const TOOL_OUTPUT_FIELD_KEYS = ['content', 'artifact'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPresent(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value == null) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+}
+
+function normalizeToolName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function normalizeToolNames(names: string[] | undefined): Set<string> {
+  const normalized = new Set<string>();
+  for (const name of names ?? []) {
+    if (isPresent(name)) {
+      normalized.add(normalizeToolName(name));
+    }
+  }
+  return normalized;
+}
+
+function parseToolNames(value: string | undefined): string[] | undefined {
+  if (!isPresent(value)) {
+    return undefined;
+  }
+
+  return value
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => name !== '');
+}
+
+function getEnvToolOutputTracingEnabled(): boolean | undefined {
+  const traceToolOutputs = parseBoolean(
+    process.env.LANGFUSE_TRACE_TOOL_OUTPUTS
+  );
+  if (traceToolOutputs != null) {
+    return traceToolOutputs;
+  }
+
+  const redactToolOutputs = parseBoolean(
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUTS
+  );
+  if (redactToolOutputs != null) {
+    return !redactToolOutputs;
+  }
+
+  return parseBoolean(process.env.LANGFUSE_TOOL_OUTPUT_TRACING_ENABLED);
+}
+
+function getEnvRedactedToolNames(): string[] | undefined {
+  return (
+    parseToolNames(process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAMES) ??
+    parseToolNames(process.env.LANGFUSE_REDACT_TOOL_NAMES)
+  );
+}
+
+function getEnvRedactionText(): string | undefined {
+  return isPresent(process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT)
+    ? process.env.LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    : undefined;
+}
+
+function getEnvToolNameMatchMode(): 'exact' | 'partial' | undefined {
+  const mode = (
+    process.env.LANGFUSE_REDACT_TOOL_OUTPUT_NAME_MATCH_MODE ??
+    process.env.LANGFUSE_REDACT_TOOL_NAME_MATCH_MODE
+  )
+    ?.trim()
+    .toLowerCase();
+  if (mode === 'exact' || mode === 'partial') {
+    return mode;
+  }
+  return undefined;
+}
+
+function resolveToolOutputTracingConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): ResolvedLangfuseToolOutputTracingConfig {
+  const runConfig = runLangfuse?.toolOutputTracing;
+  const agentConfig = agentLangfuse?.toolOutputTracing;
+
+  return {
+    enabled:
+      agentConfig?.enabled ??
+      runConfig?.enabled ??
+      getEnvToolOutputTracingEnabled() ??
+      true,
+    redactedToolNames: normalizeToolNames(
+      agentConfig?.redactedToolNames ??
+        runConfig?.redactedToolNames ??
+        getEnvRedactedToolNames()
+    ),
+    redactedToolNameMatchMode:
+      agentConfig?.redactedToolNameMatchMode ??
+      runConfig?.redactedToolNameMatchMode ??
+      getEnvToolNameMatchMode() ??
+      'exact',
+    redactionText:
+      agentConfig?.redactionText ??
+      runConfig?.redactionText ??
+      getEnvRedactionText() ??
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+  };
+}
+
+function shouldApplyToolOutputRedaction(
+  config: ResolvedLangfuseToolOutputTracingConfig
+): boolean {
+  return config.enabled === false || config.redactedToolNames.size > 0;
+}
+
+function toolNameMatches(
+  toolName: string | undefined,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): boolean {
+  if (!isPresent(toolName)) {
+    return false;
+  }
+
+  const normalizedToolName = normalizeToolName(toolName);
+  if (config.redactedToolNameMatchMode === 'partial') {
+    for (const redactedToolName of config.redactedToolNames) {
+      if (normalizedToolName.includes(redactedToolName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  return config.redactedToolNames.has(normalizedToolName);
+}
+
+function shouldRedactTool(
+  toolName: string | undefined,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): boolean {
+  return config.enabled === false || toolNameMatches(toolName, config);
+}
+
+function getStringField(
+  value: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const field = value[key];
+  return typeof field === 'string' ? field : undefined;
+}
+
+function getNestedStringField(
+  value: Record<string, unknown>,
+  objectKey: string,
+  fieldKey: string
+): string | undefined {
+  const nested = value[objectKey];
+  if (!isRecord(nested)) {
+    return undefined;
+  }
+  return getStringField(nested, fieldKey);
+}
+
+function getSerializedToolName(
+  value: Record<string, unknown>
+): string | undefined {
+  const role = getStringField(value, 'role');
+  return (
+    getStringField(value, 'name') ??
+    getStringField(value, 'tool_name') ??
+    getNestedStringField(value, 'kwargs', 'name') ??
+    getNestedStringField(value, 'additional_kwargs', 'name') ??
+    getNestedStringField(value, 'data', 'name') ??
+    (role != null && role.toLowerCase() !== 'tool' ? role : undefined)
+  );
+}
+
+function hasToolMessageIdentity(value: Record<string, unknown>): boolean {
+  const type = getStringField(value, 'type') ?? getStringField(value, '_type');
+  if (type === 'tool' || type === 'tool_message') {
+    return true;
+  }
+
+  const id = value.id;
+  if (
+    Array.isArray(id) &&
+    id.some((part) => typeof part === 'string' && part.includes('ToolMessage'))
+  ) {
+    return true;
+  }
+
+  if (
+    'tool_call_id' in value ||
+    getNestedStringField(value, 'kwargs', 'tool_call_id') != null ||
+    getNestedStringField(value, 'additional_kwargs', 'tool_call_id') != null
+  ) {
+    return true;
+  }
+
+  const role = getStringField(value, 'role');
+  return (
+    role != null &&
+    !CHAT_ROLES.has(role.toLowerCase()) &&
+    ('content' in value || isRecord(value.kwargs) || isRecord(value.data))
+  );
+}
+
+function redactToolContentFields(
+  value: Record<string, unknown>,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): Record<string, unknown> {
+  const next = { ...value };
+
+  for (const outputKey of TOOL_OUTPUT_FIELD_KEYS) {
+    if (outputKey in next) {
+      next[outputKey] = config.redactionText;
+    }
+  }
+
+  for (const nestedKey of ['kwargs', 'data', 'additional_kwargs']) {
+    const nested = next[nestedKey];
+    if (!isRecord(nested)) {
+      continue;
+    }
+    const nextNested = { ...nested };
+    let changed = false;
+    for (const outputKey of TOOL_OUTPUT_FIELD_KEYS) {
+      if (outputKey in nextNested) {
+        nextNested[outputKey] = config.redactionText;
+        changed = true;
+      }
+    }
+    if (changed) {
+      next[nestedKey] = nextNested;
+    }
+  }
+
+  return next;
+}
+
+function redactValue(
+  value: unknown,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): RedactionResult {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next: unknown[] = [];
+    for (const item of value) {
+      const result = redactValue(item, config);
+      if (result.changed) {
+        changed = true;
+      }
+      next.push(result.value);
+    }
+    return changed ? { value: next, changed } : { value, changed };
+  }
+
+  if (!isRecord(value)) {
+    return { value, changed: false };
+  }
+
+  const toolName = getSerializedToolName(value);
+  if (hasToolMessageIdentity(value) && shouldRedactTool(toolName, config)) {
+    return {
+      value: redactToolContentFields(value, config),
+      changed: true,
+    };
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const result = redactValue(child, config);
+    if (result.changed) {
+      changed = true;
+    }
+    next[key] = result.value;
+  }
+
+  return changed ? { value: next, changed } : { value, changed };
+}
+
+function redactSerializedValue(
+  value: unknown,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): RedactionResult {
+  if (typeof value !== 'string') {
+    return redactValue(value, config);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return { value, changed: false };
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    const result = redactValue(parsed, config);
+    return result.changed
+      ? { value: JSON.stringify(result.value), changed: true }
+      : { value, changed: false };
+  } catch {
+    return { value, changed: false };
+  }
+}
+
+function redactAttribute(
+  attributes: Record<string, unknown>,
+  key: string,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): void {
+  if (!(key in attributes)) {
+    return;
+  }
+
+  const result = redactSerializedValue(attributes[key], config);
+  if (result.changed) {
+    attributes[key] = result.value;
+  }
+}
+
+function isToolObservation(attributes: Record<string, unknown>): boolean {
+  const type = attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE];
+  return typeof type === 'string' && type.toLowerCase() === 'tool';
+}
+
+function redactToolObservationOutput(
+  span: ReadableSpan,
+  attributes: Record<string, unknown>,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): void {
+  if (
+    !(
+      isToolObservation(attributes) &&
+      shouldRedactTool(span.name, config) &&
+      LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT in attributes
+    )
+  ) {
+    return;
+  }
+
+  attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] =
+    config.redactionText;
+}
+
+export function redactLangfuseSpanToolOutputs(
+  span: ReadableSpan,
+  config: ResolvedLangfuseToolOutputTracingConfig
+): void {
+  if (!shouldApplyToolOutputRedaction(config)) {
+    return;
+  }
+
+  const attributes = (span as SpanWithAttributes).attributes;
+  redactToolObservationOutput(span, attributes, config);
+
+  for (const key of [
+    LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+    LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+    LangfuseOtelSpanAttributes.TRACE_INPUT,
+    LangfuseOtelSpanAttributes.TRACE_OUTPUT,
+  ]) {
+    redactAttribute(attributes, key, config);
+  }
+}
+
+function getContextToolOutputTracingConfig(
+  activeContext: Context
+): ResolvedLangfuseToolOutputTracingConfig | undefined {
+  const asyncConfig = toolOutputTracingStorage.getStore();
+  if (asyncConfig != null) {
+    return asyncConfig;
+  }
+
+  const value = activeContext.getValue(langfuseToolOutputTracingConfigKey);
+  return isRecord(value)
+    ? (value as ResolvedLangfuseToolOutputTracingConfig)
+    : undefined;
+}
+
+class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
+  private readonly processor: LangfuseSpanProcessor;
+  private readonly fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig;
+  private readonly spanConfigs = new WeakMap<
+    object,
+    ResolvedLangfuseToolOutputTracingConfig
+  >();
+
+  constructor(
+    params?: LangfuseSpanProcessorParams,
+    fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig
+  ) {
+    this.processor = new LangfuseSpanProcessor(params);
+    this.fallbackConfig = fallbackConfig;
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    const config =
+      this.fallbackConfig ?? getContextToolOutputTracingConfig(parentContext);
+    if (config != null) {
+      this.spanConfigs.set(span, config);
+    }
+    this.processor.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    const config =
+      this.spanConfigs.get(span) ??
+      toolOutputTracingStorage.getStore() ??
+      this.fallbackConfig ??
+      resolveToolOutputTracingConfig();
+    redactLangfuseSpanToolOutputs(span, config);
+    this.processor.onEnd(span);
+  }
+
+  forceFlush(): Promise<void> {
+    return this.processor.forceFlush();
+  }
+
+  shutdown(): Promise<void> {
+    return this.processor.shutdown();
+  }
+}
+
+export function createLangfuseSpanProcessor(
+  params?: LangfuseSpanProcessorParams,
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): SpanProcessor {
+  const fallbackConfig =
+    runLangfuse != null || agentLangfuse != null
+      ? resolveToolOutputTracingConfig(runLangfuse, agentLangfuse)
+      : undefined;
+  return new ToolOutputRedactingLangfuseSpanProcessor(params, fallbackConfig);
+}
+
+export function withLangfuseToolOutputTracingConfig<T>(
+  runLangfuse: t.LangfuseConfig | undefined,
+  action: () => T,
+  agentLangfuse?: t.LangfuseConfig
+): T {
+  if (
+    runLangfuse?.toolOutputTracing == null &&
+    agentLangfuse?.toolOutputTracing == null
+  ) {
+    return action();
+  }
+
+  const config = resolveToolOutputTracingConfig(runLangfuse, agentLangfuse);
+  const activeContext = context
+    .active()
+    .setValue(langfuseToolOutputTracingConfigKey, config);
+  return toolOutputTracingStorage.run(config, () =>
+    context.with(activeContext, action)
+  );
+}
+
+function hasLangfuseEnvKeys(): boolean {
+  return (
+    isPresent(process.env.LANGFUSE_SECRET_KEY) &&
+    isPresent(process.env.LANGFUSE_PUBLIC_KEY) &&
+    isPresent(process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL)
+  );
+}
+
+export function shouldTraceToolNodeForLangfuse({
+  runLangfuse,
+  agentLangfuse,
+}: {
+  runLangfuse?: t.LangfuseConfig;
+  agentLangfuse?: t.LangfuseConfig;
+}): boolean {
+  const explicit =
+    agentLangfuse?.toolNodeTracing?.enabled ??
+    runLangfuse?.toolNodeTracing?.enabled;
+  if (explicit != null) {
+    return explicit && hasLangfuseEnvKeys();
+  }
+
+  if (agentLangfuse?.enabled === false || runLangfuse?.enabled === false) {
+    return false;
+  }
+
+  return hasLangfuseEnvKeys();
+}
+
+export function resolveLangfuseConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): t.LangfuseConfig | undefined {
+  if (runLangfuse == null) {
+    return agentLangfuse;
+  }
+  if (agentLangfuse == null) {
+    return runLangfuse;
+  }
+
+  return {
+    ...runLangfuse,
+    ...agentLangfuse,
+    toolNodeTracing: {
+      ...runLangfuse.toolNodeTracing,
+      ...agentLangfuse.toolNodeTracing,
+    },
+    toolOutputTracing: {
+      ...runLangfuse.toolOutputTracing,
+      ...agentLangfuse.toolOutputTracing,
+    },
+  };
+}

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -583,6 +583,18 @@ function hasLangfuseEnvKeys(): boolean {
   );
 }
 
+function hasLangfuseConfigKeys(langfuse?: t.LangfuseConfig): boolean {
+  if (langfuse == null) {
+    return false;
+  }
+  return (
+    isPresent(langfuse.secretKey) &&
+    isPresent(langfuse.publicKey) &&
+    (isPresent(langfuse.baseUrl) ||
+      isPresent(process.env.LANGFUSE_BASE_URL ?? process.env.LANGFUSE_BASEURL))
+  );
+}
+
 export function shouldTraceToolNodeForLangfuse({
   runLangfuse,
   agentLangfuse,
@@ -594,14 +606,21 @@ export function shouldTraceToolNodeForLangfuse({
     agentLangfuse?.toolNodeTracing?.enabled ??
     runLangfuse?.toolNodeTracing?.enabled;
   if (explicit != null) {
-    return explicit && hasLangfuseEnvKeys();
+    return (
+      explicit &&
+      (hasLangfuseConfigKeys(resolveLangfuseConfig(runLangfuse, agentLangfuse)) ||
+        hasLangfuseEnvKeys())
+    );
   }
 
   if (agentLangfuse?.enabled === false || runLangfuse?.enabled === false) {
     return false;
   }
 
-  return hasLangfuseEnvKeys();
+  return (
+    hasLangfuseConfigKeys(resolveLangfuseConfig(runLangfuse, agentLangfuse)) ||
+    hasLangfuseEnvKeys()
+  );
 }
 
 export function resolveLangfuseConfig(

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -632,16 +632,16 @@ export function shouldTraceToolNodeForLangfuse({
   agentLangfuse?: t.LangfuseConfig;
 }): boolean {
   const langfuse = resolveLangfuseConfig(runLangfuse, agentLangfuse);
+  if (langfuse?.enabled === false) {
+    return false;
+  }
+
   const explicit = langfuse?.toolNodeTracing?.enabled;
   if (explicit != null) {
     return (
       explicit &&
       (hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys())
     );
-  }
-
-  if (langfuse?.enabled === false) {
-    return false;
   }
 
   return hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys();

--- a/src/run.ts
+++ b/src/run.ts
@@ -907,7 +907,7 @@ export class Run<_T extends t.BaseGraphState> {
 
     try {
       await withLangfuseToolOutputTracingConfig(
-        this.langfuse,
+        streamLangfuseConfig,
         consumeStream,
         this.getStreamToolOutputTracingLangfuseConfig(graph)
       );

--- a/src/run.ts
+++ b/src/run.ts
@@ -45,6 +45,10 @@ import {
   hasLangfuseEnvConfig,
   isLangfuseCallbackHandler,
 } from '@/langfuse';
+import {
+  resolveLangfuseConfig,
+  withLangfuseToolOutputTracingConfig,
+} from '@/langfuseToolOutputTracing';
 import type { HookRegistry } from '@/hooks';
 
 export const defaultOmitOptions = new Set([
@@ -120,6 +124,7 @@ export class Run<_T extends t.BaseGraphState> {
   private handlerRegistry?: HandlerRegistry;
   private hookRegistry?: HookRegistry;
   private humanInTheLoop?: t.HumanInTheLoopConfig;
+  private langfuse?: t.LangfuseConfig;
   private toolOutputReferences?: t.ToolOutputReferencesConfig;
   private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
   private toolExecution?: t.ToolExecutionConfig;
@@ -166,6 +171,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.handlerRegistry = handlerRegistry;
     this.hookRegistry = config.hooks;
     this.humanInTheLoop = config.humanInTheLoop;
+    this.langfuse = config.langfuse;
     this.toolOutputReferences = config.toolOutputReferences;
     this.eagerEventToolExecution = config.eagerEventToolExecution;
     this.toolExecution = config.toolExecution;
@@ -238,6 +244,7 @@ export class Run<_T extends t.BaseGraphState> {
       signal,
       runId: this.id,
       agents: [agentConfig],
+      langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
       indexTokenCountMap: this.indexTokenCountMap,
       calibrationRatio: this.calibrationRatio,
@@ -264,6 +271,7 @@ export class Run<_T extends t.BaseGraphState> {
       runId: this.id,
       agents,
       edges,
+      langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
       indexTokenCountMap: this.indexTokenCountMap,
       calibrationRatio: this.calibrationRatio,
@@ -546,6 +554,18 @@ export class Run<_T extends t.BaseGraphState> {
     };
   }
 
+  private shouldClearHookSession(streamThrew: boolean): boolean {
+    return (
+      this._interrupt == null || this._haltedReason != null || streamThrew
+    );
+  }
+
+  private isAwaitingResume(streamThrew: boolean): boolean {
+    return (
+      this._interrupt != null && this._haltedReason == null && !streamThrew
+    );
+  }
+
   async processStream(
     inputs: t.IState | Command,
     callerConfig: Partial<RunnableConfig> & {
@@ -564,6 +584,8 @@ export class Run<_T extends t.BaseGraphState> {
         'Graph not initialized. Make sure to use Run.create() to instantiate the Run.'
       );
     }
+    const graphRunnable = this.graphRunnable;
+    const graph = this.Graph;
 
     /**
      * `Command` inputs (currently only `Command({ resume })`) are
@@ -596,7 +618,7 @@ export class Run<_T extends t.BaseGraphState> {
      * boundary.
      */
     if (!isResume) {
-      this.Graph.resetValues(streamOptions?.keepContent);
+      graph.resetValues(streamOptions?.keepContent);
     }
     this._interrupt = undefined;
     this._haltedReason = undefined;
@@ -619,10 +641,12 @@ export class Run<_T extends t.BaseGraphState> {
       streamCallbacks ? [streamCallbacks, customHandler] : [customHandler]
     );
 
-    if (
-      hasLangfuseEnvConfig() &&
-      !hasExplicitLangfuseConfig(this.Graph.agentContexts.values())
-    ) {
+    const hasExplicitLangfuse =
+      this.langfuse?.enabled === true ||
+      this.langfuse?.enabled === false ||
+      hasExplicitLangfuseConfig(graph.agentContexts.values());
+    const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
+    if (hasLangfuseEnvConfig() && !hasExplicitLangfuse) {
       const userId =
         typeof config.configurable?.user_id === 'string'
           ? config.configurable.user_id
@@ -631,9 +655,6 @@ export class Run<_T extends t.BaseGraphState> {
         typeof config.configurable?.thread_id === 'string'
           ? config.configurable.thread_id
           : undefined;
-      const primaryContext = this.Graph.agentContexts.get(
-        this.Graph.defaultAgentId
-      );
       const traceMetadata = createLangfuseTraceMetadata({
         messageId: this.id,
         parentMessageId: config.configurable?.requestBody?.parentMessageId,
@@ -672,25 +693,6 @@ export class Run<_T extends t.BaseGraphState> {
     }
 
     /**
-     * `streamEvents` accepts both state inputs and `Command` (resume) at
-     * runtime, but our `CompiledStateWorkflow` type narrows the first
-     * arg to `BaseGraphState`. Cast on the call so the resume path
-     * type-checks without widening the wrapper for every caller.
-     */
-    const stream = this.graphRunnable.streamEvents(inputs as t.IState, config, {
-      raiseError: true,
-      /**
-       * Prevent EventStreamCallbackHandler from processing custom events.
-       * Custom events are already handled via our createCustomEventCallback()
-       * which routes them through the handlerRegistry.
-       * Without this flag, EventStreamCallbackHandler throws errors when
-       * custom events are dispatched for run IDs not in its internal map
-       * (due to timing issues in parallel execution or after run cleanup).
-       */
-      ignoreCustomEvent: true,
-    });
-
-    /**
      * Tracks whether the stream loop threw. Used by the `finally`
      * block to decide whether to honor the interrupt-preservation
      * guard for session hooks: a captured `_interrupt` is only
@@ -701,7 +703,26 @@ export class Run<_T extends t.BaseGraphState> {
      */
     let streamThrew = false;
 
-    try {
+    const consumeStream = async (): Promise<void> => {
+      /**
+       * `streamEvents` accepts both state inputs and `Command` (resume) at
+       * runtime, but our `CompiledStateWorkflow` type narrows the first
+       * arg to `BaseGraphState`. Cast on the call so the resume path
+       * type-checks without widening the wrapper for every caller.
+       */
+      const stream = graphRunnable.streamEvents(inputs as t.IState, config, {
+        raiseError: true,
+        /**
+         * Prevent EventStreamCallbackHandler from processing custom events.
+         * Custom events are already handled via our createCustomEventCallback()
+         * which routes them through the handlerRegistry.
+         * Without this flag, EventStreamCallbackHandler throws errors when
+         * custom events are dispatched for run IDs not in its internal map
+         * (due to timing issues in parallel execution or after run cleanup).
+         */
+        ignoreCustomEvent: true,
+      });
+
       for await (const event of stream) {
         const { data, metadata, ...info } = event;
 
@@ -797,9 +818,8 @@ export class Run<_T extends t.BaseGraphState> {
             hook_event_name: 'Stop',
             runId: this.id,
             threadId,
-            agentId: this.Graph.defaultAgentId,
-            messages:
-              this.Graph.getRunMessages() ?? stateInputs?.messages ?? [],
+            agentId: graph.defaultAgentId,
+            messages: graph.getRunMessages() ?? stateInputs?.messages ?? [],
             stopHookActive: false, // will be true when stop is triggered by a hook (Phase 2)
           },
           sessionId: this.id,
@@ -807,6 +827,10 @@ export class Run<_T extends t.BaseGraphState> {
           /* Stop hook errors must not masquerade as stream failures */
         });
       }
+    };
+
+    try {
+      await withLangfuseToolOutputTracingConfig(this.langfuse, consumeStream);
     } catch (err) {
       streamThrew = true;
       if (this.hookRegistry?.hasHookFor('StopFailure', this.id) === true) {
@@ -842,11 +866,7 @@ export class Run<_T extends t.BaseGraphState> {
        * expected, sessions must drop). Every state where no resume
        * is expected clears.
        */
-      if (
-        this._interrupt == null ||
-        this._haltedReason != null ||
-        streamThrew
-      ) {
+      if (this.shouldClearHookSession(streamThrew)) {
         this.hookRegistry?.clearSession(this.id);
       }
       /**
@@ -915,8 +935,7 @@ export class Run<_T extends t.BaseGraphState> {
        * Run from scratch) is a separate concern; see
        * `HumanInTheLoopConfig` JSDoc.
        */
-      const awaitingResume =
-        this._interrupt != null && this._haltedReason == null && !streamThrew;
+      const awaitingResume = this.isAwaitingResume(streamThrew);
       if (!this.skipCleanup && !awaitingResume) {
         this.Graph.clearHeavyState();
       }
@@ -1173,17 +1192,22 @@ export class Run<_T extends t.BaseGraphState> {
           ? chainOptions.configurable.thread_id
           : undefined;
       const hasExplicitLangfuse =
-        this.Graph != null &&
-        hasExplicitLangfuseConfig(this.Graph.agentContexts.values());
-      if (titleContext?.langfuse != null) {
-        titleLangfuseHandler = createLangfuseHandler({
-          langfuse: titleContext.langfuse,
-          userId,
-          sessionId,
-          traceMetadata,
-          tags: ['librechat', 'title'],
-        });
-      } else if (hasLangfuseEnvConfig() && !hasExplicitLangfuse) {
+        this.langfuse?.enabled === true ||
+        this.langfuse?.enabled === false ||
+        (this.Graph != null &&
+          hasExplicitLangfuseConfig(this.Graph.agentContexts.values()));
+      titleLangfuseHandler = createLangfuseHandler({
+        langfuse: resolveLangfuseConfig(this.langfuse, titleContext?.langfuse),
+        userId,
+        sessionId,
+        traceMetadata,
+        tags: ['librechat', 'title'],
+      });
+      if (
+        titleLangfuseHandler == null &&
+        hasLangfuseEnvConfig() &&
+        !hasExplicitLangfuse
+      ) {
         titleLangfuseHandler = createLegacyLangfuseHandler({
           userId,
           sessionId,
@@ -1263,9 +1287,14 @@ export class Run<_T extends t.BaseGraphState> {
 
     try {
       try {
-        return await fullChain.invoke(
-          { input: inputText, output: response },
-          invokeConfig
+        return await withLangfuseToolOutputTracingConfig(
+          this.langfuse,
+          () =>
+            fullChain.invoke(
+              { input: inputText, output: response },
+              invokeConfig
+            ),
+          titleContext?.langfuse
         );
       } catch (_e) {
         // Fallback: strip callbacks to avoid EventStream tracer errors in certain environments
@@ -1278,9 +1307,14 @@ export class Run<_T extends t.BaseGraphState> {
         const safeConfig = Object.assign({}, rest, {
           callbacks: langfuseHandler ? [langfuseHandler] : [],
         });
-        return await fullChain.invoke(
-          { input: inputText, output: response },
-          safeConfig as Partial<RunnableConfig>
+        return await withLangfuseToolOutputTracingConfig(
+          this.langfuse,
+          () =>
+            fullChain.invoke(
+              { input: inputText, output: response },
+              safeConfig as Partial<RunnableConfig>
+            ),
+          titleContext?.langfuse
         );
       }
     } finally {

--- a/src/run.ts
+++ b/src/run.ts
@@ -44,6 +44,7 @@ import {
   hasExplicitLangfuseConfig,
   hasLangfuseEnvConfig,
   isLangfuseCallbackHandler,
+  isExplicitLangfuseConfig,
 } from '@/langfuse';
 import {
   resolveLangfuseConfig,
@@ -566,6 +567,30 @@ export class Run<_T extends t.BaseGraphState> {
     );
   }
 
+  private getStreamToolLangfuseConfig(
+    graph: StandardGraph | MultiAgentGraph
+  ): t.LangfuseConfig | undefined {
+    if (this.langfuse != null) {
+      return this.langfuse;
+    }
+
+    const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
+    if (
+      primaryContext?.langfuse != null &&
+      primaryContext.langfuse.enabled !== false
+    ) {
+      return primaryContext.langfuse;
+    }
+
+    for (const context of graph.agentContexts.values()) {
+      if (context.langfuse != null && context.langfuse.enabled !== false) {
+        return context.langfuse;
+      }
+    }
+
+    return undefined;
+  }
+
   async processStream(
     inputs: t.IState | Command,
     callerConfig: Partial<RunnableConfig> & {
@@ -642,24 +667,23 @@ export class Run<_T extends t.BaseGraphState> {
     );
 
     const hasExplicitLangfuse =
-      this.langfuse?.enabled === true ||
-      this.langfuse?.enabled === false ||
+      isExplicitLangfuseConfig(this.langfuse) ||
       hasExplicitLangfuseConfig(graph.agentContexts.values());
     const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
+    const userId =
+      typeof config.configurable?.user_id === 'string'
+        ? config.configurable.user_id
+        : undefined;
+    const sessionId =
+      typeof config.configurable?.thread_id === 'string'
+        ? config.configurable.thread_id
+        : undefined;
+    const traceMetadata = createLangfuseTraceMetadata({
+      messageId: this.id,
+      parentMessageId: config.configurable?.requestBody?.parentMessageId,
+      agentName: primaryContext?.name,
+    });
     if (hasLangfuseEnvConfig() && !hasExplicitLangfuse) {
-      const userId =
-        typeof config.configurable?.user_id === 'string'
-          ? config.configurable.user_id
-          : undefined;
-      const sessionId =
-        typeof config.configurable?.thread_id === 'string'
-          ? config.configurable.thread_id
-          : undefined;
-      const traceMetadata = createLangfuseTraceMetadata({
-        messageId: this.id,
-        parentMessageId: config.configurable?.requestBody?.parentMessageId,
-        agentName: primaryContext?.name,
-      });
       const handler = createLegacyLangfuseHandler({
         userId,
         sessionId,
@@ -702,6 +726,7 @@ export class Run<_T extends t.BaseGraphState> {
      * preserving session hooks would leak them into the next run.
      */
     let streamThrew = false;
+    let toolLangfuseHandler: CallbackEntry | undefined;
 
     const consumeStream = async (): Promise<void> => {
       /**
@@ -830,6 +855,22 @@ export class Run<_T extends t.BaseGraphState> {
     };
 
     try {
+      if (hasExplicitLangfuse) {
+        toolLangfuseHandler = createLangfuseHandler({
+          langfuse: this.getStreamToolLangfuseConfig(graph),
+          userId,
+          sessionId,
+          traceMetadata,
+          tags: ['librechat', 'agent'],
+          callbackScope: 'tools',
+          useToolOutputTracingFallback: false,
+        });
+        if (toolLangfuseHandler != null) {
+          config.callbacks = appendCallbacks(config.callbacks, [
+            toolLangfuseHandler,
+          ]);
+        }
+      }
       await withLangfuseToolOutputTracingConfig(this.langfuse, consumeStream);
     } catch (err) {
       streamThrew = true;
@@ -852,6 +893,7 @@ export class Run<_T extends t.BaseGraphState> {
       }
       throw err;
     } finally {
+      await disposeLangfuseHandler(toolLangfuseHandler);
       /**
        * Preserve session-scoped hooks when the run paused on a HITL
        * interrupt — the very next call will be `Run.resume()`, which

--- a/src/run.ts
+++ b/src/run.ts
@@ -958,6 +958,7 @@ export class Run<_T extends t.BaseGraphState> {
        * unaffected — their entries live under their own session ids.
        */
       this.hookRegistry?.clearHaltSignal(this.id);
+      await disposeLangfuseHandler(langfuseHandler);
 
       /**
        * Break the reference chain that keeps heavy data alive via

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,5 @@
 // src/run.ts
-import './instrumentation';
+import { initializeLangfuseTracing } from './instrumentation';
 import { PromptTemplate } from '@langchain/core/prompts';
 import { RunnableLambda } from '@langchain/core/runnables';
 import { AzureChatOpenAI, ChatOpenAI } from '@langchain/openai';
@@ -36,15 +36,11 @@ import {
   type CallbackEntry,
 } from '@/utils/callbacks';
 import {
-  createLegacyLangfuseHandler,
   createLangfuseTraceMetadata,
   createLangfuseHandler,
   disposeLangfuseHandler,
   getLangfuseTraceName,
-  hasExplicitLangfuseConfig,
-  hasLangfuseEnvConfig,
   isLangfuseCallbackHandler,
-  isExplicitLangfuseConfig,
 } from '@/langfuse';
 import {
   resolveLangfuseConfig,
@@ -567,28 +563,82 @@ export class Run<_T extends t.BaseGraphState> {
     );
   }
 
-  private getStreamToolLangfuseConfig(
+  private getStreamLangfuseConfig(
     graph: StandardGraph | MultiAgentGraph
   ): t.LangfuseConfig | undefined {
-    if (this.langfuse != null) {
-      return this.langfuse;
-    }
-
     const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
-    if (
-      primaryContext?.langfuse != null &&
-      primaryContext.langfuse.enabled !== false
-    ) {
-      return primaryContext.langfuse;
+    if (primaryContext != null) {
+      return resolveLangfuseConfig(this.langfuse, primaryContext.langfuse);
     }
 
     for (const context of graph.agentContexts.values()) {
-      if (context.langfuse != null && context.langfuse.enabled !== false) {
-        return context.langfuse;
+      const langfuse = resolveLangfuseConfig(this.langfuse, context.langfuse);
+      if (langfuse != null) {
+        return langfuse;
       }
     }
 
-    return undefined;
+    return this.langfuse;
+  }
+
+  private getStreamToolOutputTracingLangfuseConfig(
+    graph: StandardGraph | MultiAgentGraph
+  ): t.LangfuseConfig | undefined {
+    if (this.langfuse?.toolOutputTracing != null) {
+      return undefined;
+    }
+
+    const toolOutputTracingConfigs = Array.from(
+      graph.agentContexts.values()
+    )
+      .map((context) => context.langfuse?.toolOutputTracing)
+      .filter((config): config is t.LangfuseToolOutputTracingConfig => {
+        return config != null;
+      });
+
+    if (toolOutputTracingConfigs.length === 0) {
+      return undefined;
+    }
+    if (toolOutputTracingConfigs.length === 1) {
+      return { toolOutputTracing: toolOutputTracingConfigs[0] };
+    }
+
+    let enabled: boolean | undefined;
+    let redactionText: string | undefined;
+    let redactedToolNameMatchMode: 'exact' | 'partial' | undefined;
+    const redactedToolNames = new Set<string>();
+
+    for (const config of toolOutputTracingConfigs) {
+      if (config.enabled === false) {
+        enabled = false;
+      } else if (enabled !== false && config.enabled != null) {
+        enabled = config.enabled;
+      }
+
+      redactionText ??= config.redactionText;
+      if (config.redactedToolNameMatchMode === 'partial') {
+        redactedToolNameMatchMode = 'partial';
+      } else {
+        redactedToolNameMatchMode ??= config.redactedToolNameMatchMode;
+      }
+
+      for (const toolName of config.redactedToolNames ?? []) {
+        redactedToolNames.add(toolName);
+      }
+    }
+
+    return {
+      toolOutputTracing: {
+        ...(enabled != null ? { enabled } : {}),
+        ...(redactedToolNames.size > 0
+          ? { redactedToolNames: Array.from(redactedToolNames) }
+          : {}),
+        ...(redactedToolNameMatchMode != null
+          ? { redactedToolNameMatchMode }
+          : {}),
+        ...(redactionText != null ? { redactionText } : {}),
+      },
+    };
   }
 
   async processStream(
@@ -666,9 +716,6 @@ export class Run<_T extends t.BaseGraphState> {
       streamCallbacks ? [streamCallbacks, customHandler] : [customHandler]
     );
 
-    const hasExplicitLangfuse =
-      isExplicitLangfuseConfig(this.langfuse) ||
-      hasExplicitLangfuseConfig(graph.agentContexts.values());
     const primaryContext = graph.agentContexts.get(graph.defaultAgentId);
     const userId =
       typeof config.configurable?.user_id === 'string'
@@ -681,17 +728,21 @@ export class Run<_T extends t.BaseGraphState> {
     const traceMetadata = createLangfuseTraceMetadata({
       messageId: this.id,
       parentMessageId: config.configurable?.requestBody?.parentMessageId,
+      agentId: graph.defaultAgentId,
       agentName: primaryContext?.name,
     });
-    if (hasLangfuseEnvConfig() && !hasExplicitLangfuse) {
-      const handler = createLegacyLangfuseHandler({
-        userId,
-        sessionId,
-        traceMetadata,
-        tags: ['librechat', 'agent'],
-      });
+    const streamLangfuseConfig = this.getStreamLangfuseConfig(graph);
+    initializeLangfuseTracing(streamLangfuseConfig);
+    const langfuseHandler = createLangfuseHandler({
+      langfuse: streamLangfuseConfig,
+      userId,
+      sessionId,
+      traceMetadata,
+      tags: ['librechat', 'agent'],
+    });
+    if (langfuseHandler != null) {
       config.runName = config.runName ?? getLangfuseTraceName(traceMetadata);
-      config.callbacks = appendCallbacks(config.callbacks, [handler]);
+      config.callbacks = appendCallbacks(config.callbacks, [langfuseHandler]);
     }
 
     if (!this.id) {
@@ -726,7 +777,6 @@ export class Run<_T extends t.BaseGraphState> {
      * preserving session hooks would leak them into the next run.
      */
     let streamThrew = false;
-    let toolLangfuseHandler: CallbackEntry | undefined;
 
     const consumeStream = async (): Promise<void> => {
       /**
@@ -855,23 +905,11 @@ export class Run<_T extends t.BaseGraphState> {
     };
 
     try {
-      if (hasExplicitLangfuse) {
-        toolLangfuseHandler = createLangfuseHandler({
-          langfuse: this.getStreamToolLangfuseConfig(graph),
-          userId,
-          sessionId,
-          traceMetadata,
-          tags: ['librechat', 'agent'],
-          callbackScope: 'tools',
-          useToolOutputTracingFallback: false,
-        });
-        if (toolLangfuseHandler != null) {
-          config.callbacks = appendCallbacks(config.callbacks, [
-            toolLangfuseHandler,
-          ]);
-        }
-      }
-      await withLangfuseToolOutputTracingConfig(this.langfuse, consumeStream);
+      await withLangfuseToolOutputTracingConfig(
+        this.langfuse,
+        consumeStream,
+        this.getStreamToolOutputTracingLangfuseConfig(graph)
+      );
     } catch (err) {
       streamThrew = true;
       if (this.hookRegistry?.hasHookFor('StopFailure', this.id) === true) {
@@ -893,7 +931,6 @@ export class Run<_T extends t.BaseGraphState> {
       }
       throw err;
     } finally {
-      await disposeLangfuseHandler(toolLangfuseHandler);
       /**
        * Preserve session-scoped hooks when the run paused on a HITL
        * interrupt — the very next call will be `Run.resume()`, which
@@ -1233,30 +1270,18 @@ export class Run<_T extends t.BaseGraphState> {
         typeof chainOptions.configurable?.thread_id === 'string'
           ? chainOptions.configurable.thread_id
           : undefined;
-      const hasExplicitLangfuse =
-        this.langfuse?.enabled === true ||
-        this.langfuse?.enabled === false ||
-        (this.Graph != null &&
-          hasExplicitLangfuseConfig(this.Graph.agentContexts.values()));
+      const titleLangfuseConfig = resolveLangfuseConfig(
+        this.langfuse,
+        titleContext?.langfuse
+      );
+      initializeLangfuseTracing(titleLangfuseConfig);
       titleLangfuseHandler = createLangfuseHandler({
-        langfuse: resolveLangfuseConfig(this.langfuse, titleContext?.langfuse),
+        langfuse: titleLangfuseConfig,
         userId,
         sessionId,
         traceMetadata,
         tags: ['librechat', 'title'],
       });
-      if (
-        titleLangfuseHandler == null &&
-        hasLangfuseEnvConfig() &&
-        !hasExplicitLangfuse
-      ) {
-        titleLangfuseHandler = createLegacyLangfuseHandler({
-          userId,
-          sessionId,
-          traceMetadata,
-          tags: ['librechat', 'title'],
-        });
-      }
 
       if (titleLangfuseHandler != null) {
         chainOptions.callbacks = appendCallbacks(chainOptions.callbacks, [

--- a/src/run.ts
+++ b/src/run.ts
@@ -584,20 +584,21 @@ export class Run<_T extends t.BaseGraphState> {
   private getStreamToolOutputTracingLangfuseConfig(
     graph: StandardGraph | MultiAgentGraph
   ): t.LangfuseConfig | undefined {
-    if (this.langfuse?.toolOutputTracing != null) {
-      return undefined;
-    }
-
     const toolOutputTracingConfigs = Array.from(
       graph.agentContexts.values()
     )
-      .map((context) => context.langfuse?.toolOutputTracing)
+      .map((context) => {
+        return resolveLangfuseConfig(this.langfuse, context.langfuse)
+          ?.toolOutputTracing;
+      })
       .filter((config): config is t.LangfuseToolOutputTracingConfig => {
         return config != null;
       });
 
     if (toolOutputTracingConfigs.length === 0) {
-      return undefined;
+      return this.langfuse?.toolOutputTracing != null
+        ? { toolOutputTracing: this.langfuse.toolOutputTracing }
+        : undefined;
     }
     if (toolOutputTracingConfigs.length === 1) {
       return { toolOutputTracing: toolOutputTracingConfigs[0] };

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -85,6 +85,7 @@ describe('Langfuse callback composition', () => {
     await run.processStream({ messages: [new HumanMessage('hello')] }, config);
 
     expect(mockStartActiveSpan).toHaveBeenCalled();
+    expect(mockForceFlush).toHaveBeenCalled();
   });
 
   it('attaches Langfuse callbacks for direct graph invocations', async () => {
@@ -177,6 +178,74 @@ describe('Langfuse callback composition', () => {
         publicKey: 'pk-agent',
         secretKey: 'sk-agent',
         baseUrl: 'https://langfuse.agent',
+      })
+    );
+  });
+
+  it('adds current agent metadata when a stream Langfuse callback already exists', async () => {
+    const metadataSpy = jest.fn();
+    const { createLangfuseHandler } = await import('@/langfuse');
+    const streamHandler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-run',
+        secretKey: 'sk-run',
+        baseUrl: 'https://langfuse.run',
+      },
+    });
+    const run = await Run.create<t.IState>({
+      runId: 'test-langfuse-agent-metadata-with-stream-callback',
+      graphConfig: {
+        type: 'multi-agent',
+        agents: [
+          {
+            agentId: 'agent_default',
+            name: 'Default Agent',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4' },
+            tools: [],
+          },
+          {
+            agentId: 'agent_specialist',
+            name: 'Specialist Agent',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4' },
+            tools: [],
+          },
+        ],
+        edges: [],
+      },
+      skipCleanup: true,
+    });
+
+    run.Graph?.overrideTestModel(['hello from specialist']);
+    const agentNode = run.Graph?.createAgentNode('agent_specialist');
+    await agentNode?.invoke(
+      { messages: [new HumanMessage('hello')] },
+      {
+        callbacks: [
+          ...(streamHandler != null ? [streamHandler] : []),
+          {
+            handleChatModelStart: async (
+              _llm: unknown,
+              _messages: unknown,
+              _runId: string,
+              _parentRunId?: string,
+              _extraParams?: unknown,
+              _tags?: string[],
+              metadata?: Record<string, unknown>
+            ): Promise<void> => {
+              metadataSpy(metadata);
+            },
+          },
+        ],
+        configurable: { thread_id: 'thread-1', user_id: 'user-1' },
+      }
+    );
+
+    expect(metadataSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent_specialist',
+        agentName: 'Specialist Agent',
       })
     );
   });

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -6,10 +6,23 @@ import type * as t from '@/types';
 
 const mockSpan = {
   end: jest.fn(),
+  spanContext: jest.fn(() => ({
+    traceId: 'trace-id',
+    spanId: 'span-id',
+    traceFlags: 1,
+  })),
   setAttributes: jest.fn(),
   setStatus: jest.fn(),
 };
 const mockStartSpan = jest.fn(() => mockSpan);
+const mockStartActiveSpan = jest.fn(
+  (
+    _name: string,
+    _options: unknown,
+    _context: unknown,
+    callback: (span: typeof mockSpan) => unknown
+  ) => callback(mockSpan)
+);
 const mockForceFlush = jest.fn();
 const mockShutdown = jest.fn();
 
@@ -22,6 +35,7 @@ jest.mock('@opentelemetry/sdk-trace-base', () => ({
   BasicTracerProvider: jest.fn().mockImplementation(() => ({
     forceFlush: mockForceFlush,
     getTracer: jest.fn(() => ({
+      startActiveSpan: mockStartActiveSpan,
       startSpan: mockStartSpan,
     })),
     shutdown: mockShutdown,
@@ -70,6 +84,6 @@ describe('Langfuse callback composition', () => {
 
     await run.processStream({ messages: [new HumanMessage('hello')] }, config);
 
-    expect(mockStartSpan).toHaveBeenCalled();
+    expect(mockStartActiveSpan).toHaveBeenCalled();
   });
 });

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -122,4 +122,62 @@ describe('Langfuse callback composition', () => {
 
     expect(mockStartActiveSpan).toHaveBeenCalled();
   });
+
+  it('preserves per-agent Langfuse config when a stream callback already exists', async () => {
+    const { LangfuseSpanProcessor } = await import('@langfuse/otel');
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const { createLangfuseHandler } = await import('@/langfuse');
+    initializeLangfuseTracing({
+      publicKey: 'pk-run',
+      secretKey: 'sk-run',
+      baseUrl: 'https://langfuse.run',
+    });
+    const streamHandler = createLangfuseHandler({
+      langfuse: {
+        publicKey: 'pk-run',
+        secretKey: 'sk-run',
+        baseUrl: 'https://langfuse.run',
+      },
+    });
+    const run = await Run.create<t.IState>({
+      runId: 'test-langfuse-agent-callback-override',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'agent_abc123',
+            name: 'DWAINE',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4' },
+            tools: [],
+            langfuse: {
+              enabled: true,
+              publicKey: 'pk-agent',
+              secretKey: 'sk-agent',
+              baseUrl: 'https://langfuse.agent',
+            },
+          },
+        ],
+      },
+      skipCleanup: true,
+    });
+
+    run.Graph?.overrideTestModel(['hello']);
+    const workflow = run.Graph?.createWorkflow();
+    await workflow?.invoke(
+      { messages: [new HumanMessage('hello')] },
+      {
+        callbacks: streamHandler != null ? [streamHandler] : [],
+        configurable: { thread_id: 'thread-1', user_id: 'user-1' },
+      }
+    );
+
+    expect(LangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: 'pk-agent',
+        secretKey: 'sk-agent',
+        baseUrl: 'https://langfuse.agent',
+      })
+    );
+  });
 });

--- a/src/specs/langfuse-callbacks.test.ts
+++ b/src/specs/langfuse-callbacks.test.ts
@@ -86,4 +86,40 @@ describe('Langfuse callback composition', () => {
 
     expect(mockStartActiveSpan).toHaveBeenCalled();
   });
+
+  it('attaches Langfuse callbacks for direct graph invocations', async () => {
+    const run = await Run.create<t.IState>({
+      runId: 'test-langfuse-direct-graph',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'agent_abc123',
+            name: 'DWAINE',
+            provider: Providers.OPENAI,
+            clientOptions: { model: 'gpt-4' },
+            tools: [],
+            langfuse: {
+              enabled: true,
+              publicKey: 'pk-test',
+              secretKey: 'sk-test',
+            },
+          },
+        ],
+      },
+      skipCleanup: true,
+    });
+
+    run.Graph?.overrideTestModel(['hello']);
+    const workflow = run.Graph?.createWorkflow();
+    await workflow?.invoke(
+      { messages: [new HumanMessage('hello')] },
+      {
+        callbacks: [],
+        configurable: { thread_id: 'thread-1', user_id: 'user-1' },
+      }
+    );
+
+    expect(mockStartActiveSpan).toHaveBeenCalled();
+  });
 });

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -1,33 +1,17 @@
-import { LangfuseSpanProcessor } from '@langfuse/otel';
-import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
-import { HumanMessage } from '@langchain/core/messages';
-import type { Serialized } from '@langchain/core/load/serializable';
-import { createLangfuseHandler } from '@/langfuse';
+import { CallbackHandler } from '@langfuse/langchain';
+import {
+  createLangfuseHandler,
+  hasLangfuseConfigCredentials,
+  shouldCreateLangfuseHandler,
+} from '@/langfuse';
 
-const mockSpan = {
-  end: jest.fn(),
-  setAttributes: jest.fn(),
-  setStatus: jest.fn(),
-};
-const mockStartSpan = jest.fn(() => mockSpan);
-const mockGetTracer = jest.fn(() => ({
-  startSpan: mockStartSpan,
-}));
-const mockForceFlush = jest.fn();
-const mockShutdown = jest.fn();
-
-jest.mock('@langfuse/otel', () => ({
-  LangfuseSpanProcessor: jest.fn().mockImplementation(() => ({})),
-  isDefaultExportSpan: jest.fn(() => false),
+jest.mock('@langfuse/langchain', () => ({
+  CallbackHandler: jest.fn().mockImplementation((params) => ({ params })),
 }));
 
-jest.mock('@opentelemetry/sdk-trace-base', () => ({
-  BasicTracerProvider: jest.fn().mockImplementation(() => ({
-    forceFlush: mockForceFlush,
-    getTracer: mockGetTracer,
-    shutdown: mockShutdown,
-  })),
-}));
+const MockedCallbackHandler = CallbackHandler as jest.MockedClass<
+  typeof CallbackHandler
+>;
 
 describe('createLangfuseHandler', () => {
   const originalEnv = process.env;
@@ -45,166 +29,45 @@ describe('createLangfuseHandler', () => {
     process.env = originalEnv;
   });
 
-  it('creates a handler when keys are provided and baseUrl is omitted', () => {
+  it('creates the official Langfuse callback handler when env keys are present', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.env';
+
+    const handler = createLangfuseHandler({
+      userId: 'user-1',
+      sessionId: 'thread-1',
+      traceMetadata: {
+        messageId: 'message-1',
+        agentId: 'agent-1',
+        agentName: 'DWAINE',
+      },
+      tags: ['librechat', 'agent'],
+    });
+
+    expect(handler).toBeDefined();
+    expect(MockedCallbackHandler).toHaveBeenCalledWith({
+      userId: 'user-1',
+      sessionId: 'thread-1',
+      traceMetadata: {
+        messageId: 'message-1',
+        agentId: 'agent-1',
+        agentName: 'DWAINE',
+      },
+      tags: ['librechat', 'agent'],
+    });
+  });
+
+  it('creates a handler for explicit credentials supplied in config', () => {
     const handler = createLangfuseHandler({
       langfuse: {
-        enabled: true,
         publicKey: 'pk-test',
         secretKey: 'sk-test',
       },
     });
 
     expect(handler).toBeDefined();
-    expect(LangfuseSpanProcessor).toHaveBeenCalledWith(
-      expect.objectContaining({
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
-        exportMode: 'immediate',
-      })
-    );
-    expect(
-      (LangfuseSpanProcessor as jest.Mock).mock.calls[0][0].baseUrl
-    ).toBeUndefined();
-    expect(BasicTracerProvider).toHaveBeenCalledTimes(1);
-  });
-
-  it('starts per-agent spans with v5 trace attributes', async () => {
-    const handler = createLangfuseHandler({
-      langfuse: {
-        enabled: true,
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
-      },
-      userId: 'user-1',
-      sessionId: 'thread-1',
-      traceMetadata: {
-        messageId: 'message-1',
-        agentId: 'agent-1',
-        agentName: 'DWAINE',
-      },
-      tags: ['librechat', 'agent'],
-    });
-
-    await handler?.handleChatModelStart(
-      {
-        id: ['langchain', 'chat_models', 'ChatOpenAI'],
-        kwargs: { model: 'gpt-4o' },
-      } as unknown as Serialized,
-      [[new HumanMessage('hello')]],
-      'run-1'
-    );
-
-    expect(mockGetTracer).toHaveBeenCalledWith('langfuse-sdk');
-    expect(mockStartSpan).toHaveBeenCalledWith(
-      'gpt-4o',
-      expect.objectContaining({
-        attributes: expect.objectContaining({
-          'langfuse.trace.name': 'LibreChat Agent: DWAINE',
-          'langfuse.trace.metadata.agentId': 'agent-1',
-          'langfuse.trace.metadata.messageId': 'message-1',
-          'langfuse.observation.model.name': 'gpt-4o',
-          'langfuse.observation.type': 'generation',
-          'user.id': 'user-1',
-          'session.id': 'thread-1',
-          'langfuse.trace.tags': ['librechat', 'agent'],
-        }),
-      })
-    );
-  });
-
-  it('starts tool spans with input and output attributes', async () => {
-    const handler = createLangfuseHandler({
-      langfuse: {
-        enabled: true,
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
-      },
-      userId: 'user-1',
-      sessionId: 'thread-1',
-      traceMetadata: {
-        messageId: 'message-1',
-        agentId: 'agent-1',
-        agentName: 'DWAINE',
-      },
-      tags: ['librechat', 'agent'],
-      callbackScope: 'tools',
-      useToolOutputTracingFallback: false,
-    });
-
-    await handler?.handleToolStart(
-      {
-        id: ['langchain', 'tools', 'DynamicStructuredTool'],
-        kwargs: { name: 'mcp_clickhouse' },
-      } as unknown as Serialized,
-      '{"query":"select 1"}',
-      'tool-run-1',
-      undefined,
-      undefined,
-      { langgraph_node: 'tools=agent-1' },
-      undefined,
-      'call-1'
-    );
-    await handler?.handleToolEnd('secret rows', 'tool-run-1');
-
-    expect(mockStartSpan).toHaveBeenCalledWith(
-      'mcp_clickhouse',
-      expect.objectContaining({
-        attributes: expect.objectContaining({
-          'langfuse.trace.name': 'LibreChat Agent: DWAINE',
-          'langfuse.trace.metadata.agentId': 'agent-1',
-          'langfuse.trace.metadata.messageId': 'message-1',
-          'langfuse.observation.type': 'tool',
-          'langfuse.observation.input': '{"query":"select 1"}',
-          'langfuse.observation.metadata.toolCallId': 'call-1',
-          'user.id': 'user-1',
-          'session.id': 'thread-1',
-          'langfuse.trace.tags': ['librechat', 'agent'],
-        }),
-      })
-    );
-    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
-      expect.objectContaining({
-        'langfuse.observation.type': 'tool',
-        'langfuse.observation.output': 'secret rows',
-      })
-    );
-    expect(mockSpan.end).toHaveBeenCalledTimes(1);
-    expect(mockForceFlush).toHaveBeenCalled();
-  });
-
-  it('does not start model spans for a tool-only handler', async () => {
-    const handler = createLangfuseHandler({
-      langfuse: {
-        enabled: true,
-        publicKey: 'pk-test',
-        secretKey: 'sk-test',
-      },
-      callbackScope: 'tools',
-    });
-
-    await handler?.handleChatModelStart(
-      {
-        id: ['langchain', 'chat_models', 'ChatOpenAI'],
-        kwargs: { model: 'gpt-4o' },
-      } as unknown as Serialized,
-      [[new HumanMessage('hello')]],
-      'run-1'
-    );
-
-    expect(mockStartSpan).not.toHaveBeenCalled();
-  });
-
-  it('does not create a handler when a required key is missing', () => {
-    const handler = createLangfuseHandler({
-      langfuse: {
-        enabled: true,
-        publicKey: 'pk-test',
-      },
-    });
-
-    expect(handler).toBeUndefined();
-    expect(LangfuseSpanProcessor).not.toHaveBeenCalled();
-    expect(BasicTracerProvider).not.toHaveBeenCalled();
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
   });
 
   it('hydrates redaction-only config from env keys', () => {
@@ -219,14 +82,69 @@ describe('createLangfuseHandler', () => {
     });
 
     expect(handler).toBeDefined();
-    expect(LangfuseSpanProcessor).toHaveBeenCalledWith(
-      expect.objectContaining({
-        publicKey: 'pk-env',
-        secretKey: 'sk-env',
-        baseUrl: 'https://langfuse.env',
-        exportMode: 'immediate',
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create a handler when Langfuse is disabled', () => {
+    const handler = createLangfuseHandler({
+      langfuse: {
+        enabled: false,
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+    });
+
+    expect(handler).toBeUndefined();
+    expect(MockedCallbackHandler).not.toHaveBeenCalled();
+  });
+
+  it('does not create a handler when credentials are unavailable', () => {
+    const handler = createLangfuseHandler({
+      langfuse: {
+        enabled: true,
+        publicKey: 'pk-test',
+      },
+    });
+
+    expect(handler).toBeUndefined();
+    expect(MockedCallbackHandler).not.toHaveBeenCalled();
+  });
+
+  it('detects complete config credentials', () => {
+    expect(
+      hasLangfuseConfigCredentials({
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
       })
-    );
-    expect(BasicTracerProvider).toHaveBeenCalledTimes(1);
+    ).toBe(true);
+    expect(
+      hasLangfuseConfigCredentials({
+        publicKey: 'pk-test',
+      })
+    ).toBe(false);
+  });
+
+  it('uses env credentials for redaction-only configs', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.env';
+
+    expect(
+      shouldCreateLangfuseHandler({
+        toolOutputTracing: { enabled: false },
+      })
+    ).toBe(true);
+  });
+
+  it('uses env credentials with a config-provided baseUrl', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+
+    expect(
+      shouldCreateLangfuseHandler({
+        baseUrl: 'https://langfuse.config',
+        toolOutputTracing: { enabled: false },
+      })
+    ).toBe(true);
   });
 });

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -13,6 +13,8 @@ const mockStartSpan = jest.fn(() => mockSpan);
 const mockGetTracer = jest.fn(() => ({
   startSpan: mockStartSpan,
 }));
+const mockForceFlush = jest.fn();
+const mockShutdown = jest.fn();
 
 jest.mock('@langfuse/otel', () => ({
   LangfuseSpanProcessor: jest.fn().mockImplementation(() => ({})),
@@ -21,9 +23,9 @@ jest.mock('@langfuse/otel', () => ({
 
 jest.mock('@opentelemetry/sdk-trace-base', () => ({
   BasicTracerProvider: jest.fn().mockImplementation(() => ({
-    forceFlush: jest.fn(),
+    forceFlush: mockForceFlush,
     getTracer: mockGetTracer,
-    shutdown: jest.fn(),
+    shutdown: mockShutdown,
   })),
 }));
 
@@ -108,6 +110,88 @@ describe('createLangfuseHandler', () => {
         }),
       })
     );
+  });
+
+  it('starts tool spans with input and output attributes', async () => {
+    const handler = createLangfuseHandler({
+      langfuse: {
+        enabled: true,
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+      userId: 'user-1',
+      sessionId: 'thread-1',
+      traceMetadata: {
+        messageId: 'message-1',
+        agentId: 'agent-1',
+        agentName: 'DWAINE',
+      },
+      tags: ['librechat', 'agent'],
+      callbackScope: 'tools',
+      useToolOutputTracingFallback: false,
+    });
+
+    await handler?.handleToolStart(
+      {
+        id: ['langchain', 'tools', 'DynamicStructuredTool'],
+        kwargs: { name: 'mcp_clickhouse' },
+      } as unknown as Serialized,
+      '{"query":"select 1"}',
+      'tool-run-1',
+      undefined,
+      undefined,
+      { langgraph_node: 'tools=agent-1' },
+      undefined,
+      'call-1'
+    );
+    await handler?.handleToolEnd('secret rows', 'tool-run-1');
+
+    expect(mockStartSpan).toHaveBeenCalledWith(
+      'mcp_clickhouse',
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          'langfuse.trace.name': 'LibreChat Agent: DWAINE',
+          'langfuse.trace.metadata.agentId': 'agent-1',
+          'langfuse.trace.metadata.messageId': 'message-1',
+          'langfuse.observation.type': 'tool',
+          'langfuse.observation.input': '{"query":"select 1"}',
+          'langfuse.observation.metadata.toolCallId': 'call-1',
+          'user.id': 'user-1',
+          'session.id': 'thread-1',
+          'langfuse.trace.tags': ['librechat', 'agent'],
+        }),
+      })
+    );
+    expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'langfuse.observation.type': 'tool',
+        'langfuse.observation.output': 'secret rows',
+      })
+    );
+    expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    expect(mockForceFlush).toHaveBeenCalled();
+  });
+
+  it('does not start model spans for a tool-only handler', async () => {
+    const handler = createLangfuseHandler({
+      langfuse: {
+        enabled: true,
+        publicKey: 'pk-test',
+        secretKey: 'sk-test',
+      },
+      callbackScope: 'tools',
+    });
+
+    await handler?.handleChatModelStart(
+      {
+        id: ['langchain', 'chat_models', 'ChatOpenAI'],
+        kwargs: { model: 'gpt-4o' },
+      } as unknown as Serialized,
+      [[new HumanMessage('hello')]],
+      'run-1'
+    );
+
+    expect(mockStartSpan).not.toHaveBeenCalled();
   });
 
   it('does not create a handler when a required key is missing', () => {

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -28,8 +28,19 @@ jest.mock('@opentelemetry/sdk-trace-base', () => ({
 }));
 
 describe('createLangfuseHandler', () => {
+  const originalEnv = process.env;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.LANGFUSE_BASEURL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   it('creates a handler when keys are provided and baseUrl is omitted', () => {
@@ -110,5 +121,28 @@ describe('createLangfuseHandler', () => {
     expect(handler).toBeUndefined();
     expect(LangfuseSpanProcessor).not.toHaveBeenCalled();
     expect(BasicTracerProvider).not.toHaveBeenCalled();
+  });
+
+  it('hydrates redaction-only config from env keys', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.env';
+
+    const handler = createLangfuseHandler({
+      langfuse: {
+        toolOutputTracing: { enabled: false },
+      },
+    });
+
+    expect(handler).toBeDefined();
+    expect(LangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: 'pk-env',
+        secretKey: 'sk-env',
+        baseUrl: 'https://langfuse.env',
+        exportMode: 'immediate',
+      })
+    );
+    expect(BasicTracerProvider).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -165,10 +165,64 @@ describe('Langfuse instrumentation', () => {
     expect(provider).toBe(mockTracerProvider);
     expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
       expect.objectContaining({
+        publicKey: 'pk-env',
+        secretKey: 'sk-env',
         baseUrl: 'https://langfuse.config',
       })
     );
     expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a new isolated provider when explicit credentials change', async () => {
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-first',
+      secretKey: 'sk-first',
+      baseUrl: 'https://langfuse.first',
+    });
+    initializeLangfuseTracing({
+      publicKey: 'pk-second',
+      secretKey: 'sk-second',
+      baseUrl: 'https://langfuse.second',
+    });
+
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledTimes(2);
+    expect(mockLangfuseSpanProcessor).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        publicKey: 'pk-first',
+        secretKey: 'sk-first',
+        baseUrl: 'https://langfuse.first',
+      })
+    );
+    expect(mockLangfuseSpanProcessor).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        publicKey: 'pk-second',
+        secretKey: 'sk-second',
+        baseUrl: 'https://langfuse.second',
+      })
+    );
+    expect(mockBasicTracerProvider).toHaveBeenCalledTimes(2);
+    expect(mockSetLangfuseTracerProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes explicit redaction config into the redacting processor fallback', async () => {
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    initializeLangfuseTracing({
+      publicKey: 'pk-config',
+      secretKey: 'sk-config',
+      baseUrl: 'https://langfuse.config',
+      toolOutputTracing: { enabled: false },
+    });
+
+    const providerInput = mockBasicTracerProvider.mock
+      .calls[0][0] as BasicTracerProviderInput;
+    expect(providerInput.spanProcessors[0]).toMatchObject({
+      fallbackConfig: expect.objectContaining({
+        enabled: false,
+      }),
+    });
   });
 
   it('reuses the isolated provider after initialization', async () => {

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -25,7 +25,17 @@ const mockTracerProvider = {
   getTracer: jest.fn(),
   shutdown: jest.fn(),
 };
-const mockBasicTracerProvider = jest.fn(() => mockTracerProvider);
+type BasicTracerProviderInput = {
+  spanProcessors: Array<{
+    forceFlush?: unknown;
+    onEnd?: unknown;
+    onStart?: unknown;
+    shutdown?: unknown;
+  }>;
+};
+const mockBasicTracerProvider = jest.fn(
+  (_input?: BasicTracerProviderInput) => mockTracerProvider
+);
 
 jest.mock('@langfuse/otel', () => ({
   LangfuseSpanProcessor: mockLangfuseSpanProcessor,
@@ -101,8 +111,17 @@ describe('Langfuse instrumentation', () => {
 
     expect(provider).toBe(mockTracerProvider);
     expect(mockLangfuseSpanProcessor).toHaveBeenCalledTimes(1);
-    expect(mockBasicTracerProvider).toHaveBeenCalledWith({
-      spanProcessors: [mockLangfuseSpanProcessorInstance],
+    const providerInput = mockBasicTracerProvider.mock
+      .calls[0][0] as BasicTracerProviderInput;
+    expect(providerInput.spanProcessors).toHaveLength(1);
+    expect(providerInput.spanProcessors[0]).not.toBe(
+      mockLangfuseSpanProcessorInstance
+    );
+    expect(providerInput.spanProcessors[0]).toMatchObject({
+      forceFlush: expect.any(Function),
+      onEnd: expect.any(Function),
+      onStart: expect.any(Function),
+      shutdown: expect.any(Function),
     });
     expect(mockSetLangfuseTracerProvider).toHaveBeenCalledWith(
       mockTracerProvider

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -33,6 +33,16 @@ type BasicTracerProviderInput = {
     shutdown?: unknown;
   }>;
 };
+type RoutingSpanProcessorForTest = BasicTracerProviderInput['spanProcessors'][0] & {
+  processors: Map<
+    string,
+    {
+      fallbackConfig?: {
+        enabled?: boolean;
+      };
+    }
+  >;
+};
 const mockBasicTracerProvider = jest.fn(
   (_input?: BasicTracerProviderInput) => mockTracerProvider
 );
@@ -173,7 +183,7 @@ describe('Langfuse instrumentation', () => {
     expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
   });
 
-  it('creates a new isolated provider when explicit credentials change', async () => {
+  it('does not replace the global provider when explicit credentials change', async () => {
     const { initializeLangfuseTracing } = await import('@/instrumentation');
     initializeLangfuseTracing({
       publicKey: 'pk-first',
@@ -203,8 +213,8 @@ describe('Langfuse instrumentation', () => {
         baseUrl: 'https://langfuse.second',
       })
     );
-    expect(mockBasicTracerProvider).toHaveBeenCalledTimes(2);
-    expect(mockSetLangfuseTracerProvider).toHaveBeenCalledTimes(2);
+    expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
+    expect(mockSetLangfuseTracerProvider).toHaveBeenCalledTimes(1);
   });
 
   it('passes explicit redaction config into the redacting processor fallback', async () => {
@@ -218,10 +228,11 @@ describe('Langfuse instrumentation', () => {
 
     const providerInput = mockBasicTracerProvider.mock
       .calls[0][0] as BasicTracerProviderInput;
-    expect(providerInput.spanProcessors[0]).toMatchObject({
-      fallbackConfig: expect.objectContaining({
-        enabled: false,
-      }),
+    const routingProcessor =
+      providerInput.spanProcessors[0] as RoutingSpanProcessorForTest;
+    const childProcessors = Array.from(routingProcessor.processors.values());
+    expect(childProcessors[0]?.fallbackConfig).toMatchObject({
+      enabled: false,
     });
   });
 

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -133,6 +133,44 @@ describe('Langfuse instrumentation', () => {
     );
   });
 
+  it('registers tracing from explicit Langfuse config credentials', async () => {
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const provider = initializeLangfuseTracing({
+      publicKey: 'pk-config',
+      secretKey: 'sk-config',
+      baseUrl: 'https://langfuse.config',
+    });
+
+    expect(provider).toBe(mockTracerProvider);
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicKey: 'pk-config',
+        secretKey: 'sk-config',
+        baseUrl: 'https://langfuse.config',
+      })
+    );
+    expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses env credentials with a config-provided Langfuse baseUrl', async () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+
+    const { initializeLangfuseTracing } = await import('@/instrumentation');
+    const provider = initializeLangfuseTracing({
+      baseUrl: 'https://langfuse.config',
+      toolOutputTracing: { enabled: false },
+    });
+
+    expect(provider).toBe(mockTracerProvider);
+    expect(mockLangfuseSpanProcessor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: 'https://langfuse.config',
+      })
+    );
+    expect(mockBasicTracerProvider).toHaveBeenCalledTimes(1);
+  });
+
   it('reuses the isolated provider after initialization', async () => {
     process.env.LANGFUSE_SECRET_KEY = 'sk-test';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';

--- a/src/specs/langfuse-metadata.test.ts
+++ b/src/specs/langfuse-metadata.test.ts
@@ -106,4 +106,18 @@ describe('Langfuse trace metadata includes agentName', () => {
 
     expect(MockedCallbackHandler).not.toHaveBeenCalled();
   });
+
+  it('keeps env Langfuse enabled for redaction-only agent config', async () => {
+    const run = await createTestRun('DWAINE', {
+      langfuse: {
+        toolOutputTracing: { enabled: false },
+      },
+    });
+    await run.processStream(
+      { messages: [] },
+      { configurable: { thread_id: 't1', user_id: 'u1' }, version: 'v2' }
+    );
+
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/specs/langfuse-metadata.test.ts
+++ b/src/specs/langfuse-metadata.test.ts
@@ -107,7 +107,7 @@ describe('Langfuse trace metadata includes agentName', () => {
     expect(MockedCallbackHandler).not.toHaveBeenCalled();
   });
 
-  it('keeps env Langfuse enabled for redaction-only agent config', async () => {
+  it('does not use the legacy CallbackHandler for redaction-only agent config', async () => {
     const run = await createTestRun('DWAINE', {
       langfuse: {
         toolOutputTracing: { enabled: false },
@@ -118,6 +118,6 @@ describe('Langfuse trace metadata includes agentName', () => {
       { configurable: { thread_id: 't1', user_id: 'u1' }, version: 'v2' }
     );
 
-    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+    expect(MockedCallbackHandler).not.toHaveBeenCalled();
   });
 });

--- a/src/specs/langfuse-metadata.test.ts
+++ b/src/specs/langfuse-metadata.test.ts
@@ -109,7 +109,7 @@ describe('Langfuse trace metadata includes agentName', () => {
     expect(MockedCallbackHandler).not.toHaveBeenCalled();
   });
 
-  it('does not use the legacy CallbackHandler for redaction-only agent config', async () => {
+  it('uses the nested Langfuse CallbackHandler for redaction-only agent config', async () => {
     const run = await createTestRun('DWAINE', {
       langfuse: {
         toolOutputTracing: { enabled: false },
@@ -120,10 +120,10 @@ describe('Langfuse trace metadata includes agentName', () => {
       { configurable: { thread_id: 't1', user_id: 'u1' }, version: 'v2' }
     );
 
-    expect(MockedCallbackHandler).not.toHaveBeenCalled();
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('does not use the legacy CallbackHandler for redaction-only run config', async () => {
+  it('uses the nested Langfuse CallbackHandler for redaction-only run config', async () => {
     const run = await createTestRun(
       'DWAINE',
       {},
@@ -138,6 +138,25 @@ describe('Langfuse trace metadata includes agentName', () => {
       { configurable: { thread_id: 't1', user_id: 'u1' }, version: 'v2' }
     );
 
-    expect(MockedCallbackHandler).not.toHaveBeenCalled();
+    expect(MockedCallbackHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves run-level Langfuse config after graph cleanup for later turns', async () => {
+    const langfuse = {
+      toolOutputTracing: { enabled: false },
+    };
+    const run = await createTestRun(
+      'DWAINE',
+      {},
+      {
+        langfuse,
+      }
+    );
+    await run.processStream(
+      { messages: [] },
+      { configurable: { thread_id: 't1', user_id: 'u1' }, version: 'v2' }
+    );
+
+    expect(run.Graph?.langfuse).toBe(langfuse);
   });
 });

--- a/src/specs/langfuse-metadata.test.ts
+++ b/src/specs/langfuse-metadata.test.ts
@@ -12,7 +12,8 @@ const MockedCallbackHandler = CallbackHandler as jest.MockedClass<
 
 async function createTestRun(
   agentName?: string,
-  agentOverrides: Record<string, unknown> = {}
+  agentOverrides: Record<string, unknown> = {},
+  runOverrides: Record<string, unknown> = {}
 ): Promise<Run<never>> {
   const run = await Run.create({
     runId: 'test-run-id',
@@ -29,6 +30,7 @@ async function createTestRun(
         },
       ],
     },
+    ...runOverrides,
   });
 
   const emptyStream = (async function* (): AsyncGenerator {
@@ -113,6 +115,24 @@ describe('Langfuse trace metadata includes agentName', () => {
         toolOutputTracing: { enabled: false },
       },
     });
+    await run.processStream(
+      { messages: [] },
+      { configurable: { thread_id: 't1', user_id: 'u1' }, version: 'v2' }
+    );
+
+    expect(MockedCallbackHandler).not.toHaveBeenCalled();
+  });
+
+  it('does not use the legacy CallbackHandler for redaction-only run config', async () => {
+    const run = await createTestRun(
+      'DWAINE',
+      {},
+      {
+        langfuse: {
+          toolOutputTracing: { enabled: false },
+        },
+      }
+    );
     await run.processStream(
       { messages: [] },
       { configurable: { thread_id: 't1', user_id: 'u1' }, version: 'v2' }

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -166,6 +166,20 @@ describe('Langfuse tool output tracing redaction', () => {
     ).toBe(true);
   });
 
+  it('keeps ToolNode tracing disabled when resolved Langfuse is disabled', () => {
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+
+    expect(
+      shouldTraceToolNodeForLangfuse({
+        runLangfuse: {
+          enabled: false,
+          toolNodeTracing: { enabled: true },
+        },
+      })
+    ).toBe(false);
+  });
+
   it('redacts raw tool observation output when tool output tracing is disabled', () => {
     const span = createSpan('execute_sql', {
       [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -1,0 +1,497 @@
+import { AIMessage, ToolMessage, HumanMessage } from '@langchain/core/messages';
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { TPayload } from '@/types';
+import {
+  LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+  redactLangfuseSpanToolOutputs,
+  resolveLangfuseConfig,
+  shouldTraceToolNodeForLangfuse,
+  type ResolvedLangfuseToolOutputTracingConfig,
+} from '@/langfuseToolOutputTracing';
+import { formatAgentMessages } from '@/messages/format';
+import { ContentTypes } from '@/common';
+
+type SerializedLangfuseChatMessage = {
+  content: BaseMessage['content'];
+  role?: string;
+  additional_kwargs?: BaseMessage['additional_kwargs'];
+  tool_calls?:
+    | NonNullable<AIMessage['tool_calls']>
+    | NonNullable<BaseMessage['additional_kwargs']['tool_calls']>;
+};
+
+type RedactedMessage = {
+  role?: string;
+  content?: string;
+  tool_calls?: Array<{
+    id?: string;
+    name?: string;
+    args?: {
+      query?: string;
+    };
+  }>;
+};
+
+function createSpan(
+  name: string,
+  attributes: Record<string, unknown>
+): ReadableSpan {
+  return { name, attributes } as unknown as ReadableSpan;
+}
+
+function createConfig(
+  overrides: Partial<ResolvedLangfuseToolOutputTracingConfig> = {}
+): ResolvedLangfuseToolOutputTracingConfig {
+  return {
+    enabled: true,
+    redactedToolNames: new Set<string>(),
+    redactedToolNameMatchMode: 'exact',
+    redactionText: LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT,
+    ...overrides,
+  };
+}
+
+function serializeMessageForLangfuse(
+  message: BaseMessage
+): SerializedLangfuseChatMessage {
+  if (message instanceof HumanMessage) {
+    return { content: message.content, role: 'user' };
+  }
+
+  if (message instanceof AIMessage) {
+    const response: SerializedLangfuseChatMessage = {
+      content: message.content,
+      role: 'assistant',
+    };
+    if (message.tool_calls != null && message.tool_calls.length > 0) {
+      response.tool_calls = message.tool_calls;
+    }
+    if (message.additional_kwargs.tool_calls != null) {
+      response.tool_calls = message.additional_kwargs.tool_calls;
+    }
+    return response;
+  }
+
+  if (message instanceof ToolMessage) {
+    return {
+      content: message.content,
+      additional_kwargs: message.additional_kwargs,
+      role: message.name,
+    };
+  }
+
+  return message.name != null
+    ? { content: message.content, role: message.name }
+    : { content: message.content };
+}
+
+function readJsonAttribute<T>(span: ReadableSpan, key: string): T {
+  return JSON.parse(span.attributes[key] as string) as T;
+}
+
+describe('Langfuse tool output tracing redaction', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('enables ToolNode tracing only when Langfuse is active by default', () => {
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+
+    expect(shouldTraceToolNodeForLangfuse({})).toBe(false);
+    expect(
+      shouldTraceToolNodeForLangfuse({
+        runLangfuse: {
+          enabled: true,
+          publicKey: 'pk-run',
+          secretKey: 'sk-run',
+          baseUrl: 'https://langfuse.test',
+        },
+      })
+    ).toBe(false);
+
+    process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.test';
+
+    expect(shouldTraceToolNodeForLangfuse({})).toBe(true);
+    expect(
+      shouldTraceToolNodeForLangfuse({
+        runLangfuse: { toolNodeTracing: { enabled: true } },
+      })
+    ).toBe(true);
+    expect(
+      shouldTraceToolNodeForLangfuse({
+        runLangfuse: { toolNodeTracing: { enabled: false } },
+      })
+    ).toBe(false);
+  });
+
+  it('redacts raw tool observation output when tool output tracing is disabled', () => {
+    const span = createSpan('execute_sql', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: '{"query":"select 1"}',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'secret rows',
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig({ enabled: false }));
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT]).toBe(
+      '{"query":"select 1"}'
+    );
+  });
+
+  it('redacts ToolMessage content inside serialized generation inputs', () => {
+    const messages = [
+      { role: 'user', content: 'show tables' },
+      {
+        role: 'execute_sql',
+        content: 'private query result',
+        additional_kwargs: {},
+      },
+    ];
+    const span = createSpan('gpt-4o', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(messages),
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig({ enabled: false }));
+
+    const redacted = JSON.parse(
+      span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT] as string
+    ) as Array<{ role: string; content: string }>;
+    expect(redacted[0].content).toBe('show tables');
+    expect(redacted[1].content).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it('redacts only configured tool names when output tracing stays enabled', () => {
+    const messages = [
+      { role: 'execute_sql', content: 'private query result' },
+      { role: 'bash', content: 'public build log' },
+    ];
+    const span = createSpan('LangGraph', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: JSON.stringify({
+        messages,
+      }),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+      })
+    );
+
+    const redacted = JSON.parse(
+      span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT] as string
+    ) as { messages: Array<{ role: string; content: string }> };
+    expect(redacted.messages[0].content).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(redacted.messages[1].content).toBe('public build log');
+  });
+
+  it('uses nested ToolMessage names instead of generic tool role', () => {
+    const messages = [
+      {
+        role: 'tool',
+        content: 'private query result',
+        kwargs: {
+          name: 'execute_sql',
+          tool_call_id: 'call_1',
+        },
+      },
+    ];
+    const span = createSpan('gpt-4o', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(messages),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+      })
+    );
+
+    const redacted = readJsonAttribute<Array<{ content: string }>>(
+      span,
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    );
+    expect(redacted[0].content).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+  });
+
+  it('does not redact partial tool name matches by default', () => {
+    const span = createSpan('clickhouse_execute_sql_prod', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'secret rows',
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+      })
+    );
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      'secret rows'
+    );
+  });
+
+  it('redacts configured partial tool name matches when enabled', () => {
+    const span = createSpan('clickhouse_execute_sql_prod', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',
+      [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]: 'secret rows',
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+        redactedToolNameMatchMode: 'partial',
+      })
+    );
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+  });
+
+  it('redacts prior tool outputs from multi-turn generation inputs', () => {
+    const messages = [
+      { role: 'user', content: 'run the query' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_sql',
+            name: 'execute_sql',
+            args: { query: 'select * from private_table' },
+          },
+        ],
+      },
+      {
+        role: 'execute_sql',
+        content: 'sensitive row output',
+        additional_kwargs: {},
+      },
+      { role: 'assistant', content: 'I found the answer.' },
+      { role: 'user', content: 'explain the first row' },
+    ];
+    const span = createSpan('gpt-4o', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(messages),
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig({ enabled: false }));
+
+    const redacted = readJsonAttribute<RedactedMessage[]>(
+      span,
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    );
+    expect(redacted[0].content).toBe('run the query');
+    expect(redacted[1].tool_calls?.[0]?.args?.query).toBe(
+      'select * from private_table'
+    );
+    expect(redacted[2].content).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted[3].content).toBe('I found the answer.');
+    expect(redacted[4].content).toBe('explain the first row');
+  });
+
+  it('redacts tool outputs after formatAgentMessages rehydrates content parts', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'show me the private numbers' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'I will query ClickHouse.',
+            tool_call_ids: ['call_sql'],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'call_sql',
+              name: 'execute_sql',
+              args: '{"query":"select secret_value from prod"}',
+              output: 'secret_value: 12345',
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'can you summarize it?' },
+    ];
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['execute_sql'])
+    );
+    const serialized = messages.map(serializeMessageForLangfuse);
+    const span = createSpan('gpt-4o', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]:
+        JSON.stringify(serialized),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+      })
+    );
+
+    const redacted = readJsonAttribute<RedactedMessage[]>(
+      span,
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    );
+    expect(redacted[1].tool_calls?.[0]?.args?.query).toBe(
+      'select secret_value from prod'
+    );
+    expect(redacted[2].role).toBe('execute_sql');
+    expect(redacted[2].content).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(JSON.stringify(redacted)).not.toContain('secret_value: 12345');
+  });
+
+  it('redacts constructor-serialized ToolMessages from rehydrated content parts', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'show the stored result' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            [ContentTypes.TEXT]: 'I will query ClickHouse.',
+            tool_call_ids: ['call_sql'],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: 'call_sql',
+              name: 'execute_sql',
+              args: '{"query":"select constructor_path from prod"}',
+              output: 'constructor path secret',
+            },
+          },
+        ],
+      },
+    ];
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['execute_sql'])
+    );
+    const span = createSpan('gpt-4o', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify([
+        messages,
+      ]),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+      })
+    );
+
+    const redacted = span.attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    expect(redacted).toContain('select constructor_path from prod');
+    expect(redacted).toContain(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted).not.toContain('constructor path secret');
+  });
+
+  it('redacts ToolMessage artifacts because they are tool output', () => {
+    const messages = [
+      {
+        id: ['langchain_core', 'messages', 'ToolMessage'],
+        kwargs: {
+          name: 'execute_sql',
+          tool_call_id: 'call_sql',
+          content: 'safe display content',
+          artifact: {
+            rows: ['artifact secret row'],
+          },
+        },
+      },
+    ];
+    const span = createSpan('gpt-4o', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(messages),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+      })
+    );
+
+    const redacted = readJsonAttribute<
+      Array<{
+        kwargs: {
+          artifact: string;
+          content: string;
+        };
+      }>
+    >(span, LangfuseOtelSpanAttributes.OBSERVATION_INPUT);
+    expect(redacted[0].kwargs.content).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(redacted[0].kwargs.artifact).toBe(
+      LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT
+    );
+    expect(JSON.stringify(redacted)).not.toContain('artifact secret row');
+  });
+
+  it('merges run Langfuse defaults with agent redaction overrides', () => {
+    const resolved = resolveLangfuseConfig(
+      {
+        enabled: true,
+        publicKey: 'pk-run',
+        secretKey: 'sk-run',
+        baseUrl: 'https://langfuse.test',
+        toolNodeTracing: { enabled: true },
+        toolOutputTracing: {
+          enabled: true,
+          redactionText: '[redacted]',
+        },
+      },
+      {
+        toolOutputTracing: {
+          enabled: false,
+          redactedToolNames: ['execute_sql'],
+        },
+      }
+    );
+
+    expect(resolved).toMatchObject({
+      enabled: true,
+      publicKey: 'pk-run',
+      secretKey: 'sk-run',
+      baseUrl: 'https://langfuse.test',
+      toolNodeTracing: { enabled: true },
+      toolOutputTracing: {
+        enabled: false,
+        redactedToolNames: ['execute_sql'],
+        redactionText: '[redacted]',
+      },
+    });
+  });
+});

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -233,6 +233,53 @@ describe('Langfuse tool output tracing redaction', () => {
     expect(redacted[0].content).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
   });
 
+  it('maps tool_call_id to the preceding tool call name for allowlisted redaction', () => {
+    const messages = [
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_sql',
+            name: 'execute_sql',
+            args: { query: 'select * from private_table' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call_sql',
+        content: 'sensitive row output',
+      },
+      {
+        role: 'tool',
+        tool_call_id: 'call_bash',
+        content: 'public build log',
+      },
+    ];
+    const span = createSpan('gpt-4o', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'generation',
+      [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]: JSON.stringify(messages),
+    });
+
+    redactLangfuseSpanToolOutputs(
+      span,
+      createConfig({
+        redactedToolNames: new Set(['execute_sql']),
+      })
+    );
+
+    const redacted = readJsonAttribute<RedactedMessage[]>(
+      span,
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    );
+    expect(redacted[0].tool_calls?.[0]?.args?.query).toBe(
+      'select * from private_table'
+    );
+    expect(redacted[1].content).toBe(LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT);
+    expect(redacted[2].content).toBe('public build log');
+  });
+
   it('does not redact partial tool name matches by default', () => {
     const span = createSpan('clickhouse_execute_sql_prod', {
       [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -114,7 +114,6 @@ describe('Langfuse tool output tracing redaction', () => {
           enabled: true,
           publicKey: 'pk-run',
           secretKey: 'sk-run',
-          baseUrl: 'https://langfuse.test',
         },
       })
     ).toBe(true);
@@ -145,6 +144,26 @@ describe('Langfuse tool output tracing redaction', () => {
         runLangfuse: { toolNodeTracing: { enabled: false } },
       })
     ).toBe(false);
+  });
+
+  it('lets agent Langfuse enablement override disabled run defaults for ToolNode tracing', () => {
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+
+    expect(
+      shouldTraceToolNodeForLangfuse({
+        runLangfuse: {
+          enabled: false,
+        },
+        agentLangfuse: {
+          enabled: true,
+          publicKey: 'pk-agent',
+          secretKey: 'sk-agent',
+          baseUrl: 'https://langfuse.test',
+        },
+      })
+    ).toBe(true);
   });
 
   it('redacts raw tool observation output when tool output tracing is disabled', () => {

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -117,7 +117,18 @@ describe('Langfuse tool output tracing redaction', () => {
           baseUrl: 'https://langfuse.test',
         },
       })
-    ).toBe(false);
+    ).toBe(true);
+    expect(
+      shouldTraceToolNodeForLangfuse({
+        agentLangfuse: {
+          enabled: true,
+          publicKey: 'pk-agent',
+          secretKey: 'sk-agent',
+          baseUrl: 'https://langfuse.test',
+          toolNodeTracing: { enabled: true },
+        },
+      })
+    ).toBe(true);
 
     process.env.LANGFUSE_SECRET_KEY = 'sk-test';
     process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -41,6 +41,7 @@ import {
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { executeHooks } from '@/hooks';
 import { toLangChainContent } from '@/messages/langchain';
+import { withLangfuseToolOutputTracingConfig } from '@/langfuseToolOutputTracing';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import {
   buildReferenceKey,
@@ -394,6 +395,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private loadRuntimeTools?: t.ToolRefGenerator;
   handleToolErrors = true;
   trace = false;
+  private runLangfuse?: t.LangfuseConfig;
+  private agentLangfuse?: t.LangfuseConfig;
   toolCallStepIds?: Map<string, string>;
   errorHandler?: t.ToolNodeConstructorParams['errorHandler'];
   private toolUsageCount: Map<string, number>;
@@ -473,6 +476,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolMap,
     name,
     tags,
+    trace,
+    runLangfuse,
+    agentLangfuse,
     errorHandler,
     toolCallStepIds,
     handleToolErrors,
@@ -495,6 +501,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     fileCheckpointer,
   }: t.ToolNodeConstructorParams) {
     super({ name, tags, func: (input, config) => this.run(input, config) });
+    this.trace = trace ?? this.trace;
+    this.runLangfuse = runLangfuse;
+    this.agentLangfuse = agentLangfuse;
     this.toolMap = toolMap ?? new Map(tools.map((tool) => [tool.name, tool]));
     this.toolCallStepIds = toolCallStepIds;
     this.handleToolErrors = handleToolErrors ?? this.handleToolErrors;
@@ -543,6 +552,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         maxTotalSize: toolOutputReferences.maxTotalSize,
       });
     }
+  }
+
+  override async invoke(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    input: any,
+    options?: Partial<RunnableConfig>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Promise<any> {
+    return withLangfuseToolOutputTracingConfig(
+      this.runLangfuse,
+      () => super.invoke(input, options),
+      this.agentLangfuse
+    );
   }
 
   /**
@@ -2140,13 +2162,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
         /**
          * `interrupt()` reads the current `RunnableConfig` from
-         * AsyncLocalStorage, but our `RunnableCallable` sets
-         * `trace = false` for ToolNode (intentional — avoids LangSmith
-         * tracing per tool call). Without the trace path, the upstream
-         * `runWithConfig` frame is never established, so we re-anchor
-         * here using the node's own `config` — Pregel hands us a
-         * config that already carries every checkpoint/scratchpad key
-         * `interrupt()` needs to suspend and resume.
+         * AsyncLocalStorage. ToolNode usually runs with tracing disabled
+         * (unless Langfuse explicitly enables it), so the upstream
+         * `runWithConfig` frame may not exist. Re-anchor here using the
+         * node's own `config` — Pregel hands us a config that already
+         * carries every checkpoint/scratchpad key `interrupt()` needs to
+         * suspend and resume.
          */
         const resumeValue = AsyncLocalStorageProviderSingleton.runWithConfig(
           config,

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -424,6 +424,38 @@ describe('SubagentExecutor', () => {
     expect(clearHeavyState).toHaveBeenCalled();
   });
 
+  it('passes parent Langfuse config to the child graph', async () => {
+    const langfuse = {
+      enabled: true,
+      publicKey: 'pk-run',
+      secretKey: 'sk-run',
+      baseUrl: 'https://langfuse.test',
+      toolOutputTracing: { enabled: false },
+    };
+    let observedLangfuse: typeof langfuse | undefined;
+    const executor = createExecutor({
+      langfuse,
+      createChildGraph: (input): StandardGraph => {
+        observedLangfuse = input.langfuse as typeof langfuse;
+        return {
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest.fn().mockResolvedValue({
+              messages: [new AIMessage('child done')],
+            }),
+          }),
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      },
+    });
+
+    await executor.execute({
+      description: 'Research this topic',
+      subagentType: 'researcher',
+    });
+
+    expect(observedLangfuse).toBe(langfuse);
+  });
+
   it('returns error message when child graph throws', async () => {
     const executor = createExecutor({
       createChildGraph: makeThrowingGraphFactory(

--- a/src/tools/__tests__/ToolNode.langfuse.test.ts
+++ b/src/tools/__tests__/ToolNode.langfuse.test.ts
@@ -1,0 +1,41 @@
+const mockWithLangfuseToolOutputTracingConfig = jest.fn(
+  (_runLangfuse: unknown, action: () => unknown, _agentLangfuse: unknown) =>
+    action()
+);
+
+jest.mock('@/langfuseToolOutputTracing', () => ({
+  ...jest.requireActual('@/langfuseToolOutputTracing'),
+  withLangfuseToolOutputTracingConfig: mockWithLangfuseToolOutputTracingConfig,
+}));
+
+import { ToolNode } from '../ToolNode';
+
+describe('ToolNode Langfuse redaction context', () => {
+  beforeEach(() => {
+    mockWithLangfuseToolOutputTracingConfig.mockClear();
+  });
+
+  it('scopes ToolNode invocation with run and agent Langfuse config', async () => {
+    const runLangfuse = {
+      toolOutputTracing: { enabled: true },
+    };
+    const agentLangfuse = {
+      toolOutputTracing: { enabled: false },
+    };
+    const node = new ToolNode({
+      tools: [],
+      runLangfuse,
+      agentLangfuse,
+    });
+
+    await expect(node.invoke([])).rejects.toThrow(
+      'ToolNode only accepts AIMessages'
+    );
+
+    expect(mockWithLangfuseToolOutputTracingConfig).toHaveBeenCalledWith(
+      runLangfuse,
+      expect.any(Function),
+      agentLangfuse
+    );
+  });
+});

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -213,6 +213,7 @@ export type SubagentExecutorOptions = {
   hookRegistry?: HookRegistry;
   parentRunId: string;
   parentAgentId?: string;
+  langfuse?: StandardGraphInput['langfuse'];
   tokenCounter?: TokenCounter;
   /** Remaining nesting budget. 0 or negative blocks execution. */
   maxDepth?: number;
@@ -243,6 +244,7 @@ export class SubagentExecutor {
   private readonly hookRegistry?: HookRegistry;
   private readonly parentRunId: string;
   private readonly parentAgentId?: string;
+  private readonly langfuse?: StandardGraphInput['langfuse'];
   private readonly tokenCounter?: TokenCounter;
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
@@ -256,6 +258,7 @@ export class SubagentExecutor {
     this.hookRegistry = options.hookRegistry;
     this.parentRunId = options.parentRunId;
     this.parentAgentId = options.parentAgentId;
+    this.langfuse = options.langfuse;
     this.tokenCounter = options.tokenCounter;
     this.maxDepth = options.maxDepth ?? 1;
     this.createChildGraph = options.createChildGraph;
@@ -352,18 +355,20 @@ export class SubagentExecutor {
       runId: childRunId,
       signal: this.parentSignal,
       agents: [childInputs],
+      langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
     });
 
-    const forwarding = forwardingEnabled
-      ? this.createForwarderCallback({
+    let forwarding: ForwarderCallback | undefined;
+    if (forwardingEnabled) {
+      forwarding = this.createForwarderCallback({
         parentRegistry: parentRegistry!,
         subagentType,
         subagentAgentId: childAgentId,
         childRunId,
         parentToolCallId,
-      })
-      : undefined;
+      });
+    }
     const forwarder = forwarding?.handler;
 
     if (forwarder) {
@@ -444,7 +449,7 @@ export class SubagentExecutor {
       );
     } catch (error) {
       const errorMessage = truncateErrorMessage(error);
-      if (forwarder) {
+      if (forwarding) {
         await forwarding.drain();
         await this.emitSubagentUpdate(parentRegistry!, {
           childRunId,
@@ -491,7 +496,7 @@ export class SubagentExecutor {
       });
     }
 
-    if (forwarder) {
+    if (forwarding) {
       await forwarding.drain();
       await this.emitSubagentUpdate(parentRegistry!, {
         childRunId,

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -295,6 +295,7 @@ export type StandardGraphInput = {
   runId?: string;
   signal?: AbortSignal;
   agents: AgentInputs[];
+  langfuse?: LangfuseConfig;
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;
   calibrationRatio?: number;
@@ -408,11 +409,42 @@ export interface SubagentUpdateEvent {
   timestamp: string;
 }
 
+export type LangfuseToolOutputTracingConfig = {
+  /**
+   * Whether tool outputs should be exported to Langfuse. Defaults to
+   * `true`. Set to `false` to keep tool spans and redact their output.
+   */
+  enabled?: boolean;
+  /**
+   * Optional allowlist of tool names whose outputs should be redacted even
+   * when `enabled` is true.
+   */
+  redactedToolNames?: string[];
+  /**
+   * Match strategy for `redactedToolNames`. Defaults to `exact`; use
+   * `partial` to redact tools whose names contain a configured value.
+   */
+  redactedToolNameMatchMode?: 'exact' | 'partial';
+  /** Replacement text used for redacted tool outputs. */
+  redactionText?: string;
+};
+
+export type LangfuseToolNodeTracingConfig = {
+  /**
+   * Overrides ToolNode callback tracing. ToolNode spans are exported by the
+   * env-backed Langfuse callback, so this only enables tracing when that
+   * callback is configured.
+   */
+  enabled?: boolean;
+};
+
 export interface LangfuseConfig {
   enabled?: boolean;
   publicKey?: string;
   secretKey?: string;
   baseUrl?: string;
+  toolNodeTracing?: LangfuseToolNodeTracingConfig;
+  toolOutputTracing?: LangfuseToolOutputTracingConfig;
 }
 
 export interface AgentInputs {

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -118,6 +118,12 @@ export type StandardGraphConfig = Omit<
 export type RunConfig = {
   runId: string;
   graphConfig: LegacyGraphConfig | StandardGraphConfig | MultiAgentGraphConfig;
+  /**
+   * Run-scoped Langfuse configuration. Per-agent `AgentInputs.langfuse`
+   * takes precedence for agent-specific spans; this object supplies defaults
+   * for run-wide tracing controls such as tool-output redaction.
+   */
+  langfuse?: g.LangfuseConfig;
   customHandlers?: Record<string, g.EventHandler>;
   /**
    * Pre-constructed hook registry for this run. Hooks fire at lifecycle

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -6,6 +6,7 @@ import type { HookRegistry } from '@/hooks';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type { MessageContentComplex, ToolErrorData } from './stream';
 import type { HumanInTheLoopConfig } from './hitl';
+import type { LangfuseConfig } from './graph';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
 export type CustomToolCall = {
@@ -69,6 +70,12 @@ export type EagerEventToolCallChunkState = {
 export type ToolNodeOptions = {
   name?: string;
   tags?: string[];
+  /** Enables LangChain/LangGraph tracing for this ToolNode. Defaults to false. */
+  trace?: boolean;
+  /** Run-level Langfuse config used to scope ToolNode trace redaction. */
+  runLangfuse?: LangfuseConfig;
+  /** Agent-level Langfuse config used to scope ToolNode trace redaction. */
+  agentLangfuse?: LangfuseConfig;
   handleToolErrors?: boolean;
   loadRuntimeTools?: ToolRefGenerator;
   toolCallStepIds?: Map<string, string>;


### PR DESCRIPTION
## Summary

I added configurable Langfuse tool-output redaction and enabled ToolNode tracing only when Langfuse tracing is active.

- Added a shared Langfuse span processor wrapper that redacts tool observation outputs and ToolMessage content in chain/model trace payloads while preserving tool inputs.
- Added `RunConfig.langfuse` defaults plus per-agent `langfuse.toolOutputTracing` and `langfuse.toolNodeTracing` controls.
- Added env support for `LANGFUSE_TRACE_TOOL_OUTPUTS=false`, `LANGFUSE_REDACT_TOOL_OUTPUTS=true`, `LANGFUSE_REDACT_TOOL_OUTPUT_NAMES`, `LANGFUSE_REDACT_TOOL_NAMES`, `LANGFUSE_REDACT_TOOL_OUTPUT_NAME_MATCH_MODE`, `LANGFUSE_REDACT_TOOL_NAME_MATCH_MODE`, and `LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT`.
- Added exact and partial redacted-tool-name matching through `redactedToolNameMatchMode` so targeted tools can be matched by full name or naming convention.
- Enabled ToolNode tracing automatically when Langfuse is configured, with explicit override support.
- Preserved env-based Langfuse tracing when a config block only carries redaction settings.
- Added focused regression coverage for raw tool observations, multi-turn generation inputs, `formatAgentMessages()` rehydration, LangChain constructor serialization, tool-input preservation, ToolNode tracing activation, env tracing compatibility, and isolated Langfuse instrumentation wrapper registration.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- Ran `npm test -- src/specs/langfuse-instrumentation.test.ts src/specs/langfuse-tool-output-tracing.test.ts src/specs/langfuse-metadata.test.ts src/specs/langfuse-config.test.ts --runInBand`.
- Ran `npx tsc -p tsconfig.json --noEmit`.
- Ran `npx eslint src/langfuseToolOutputTracing.ts src/langfuse.ts src/instrumentation.ts src/graphs/Graph.ts src/run.ts src/types/graph.ts src/types/run.ts src/types/tools.ts src/specs/langfuse-tool-output-tracing.test.ts src/specs/langfuse-metadata.test.ts src/specs/langfuse-config.test.ts src/specs/langfuse-instrumentation.test.ts`.
- Ran `npx prettier --check src/langfuseToolOutputTracing.ts src/types/graph.ts src/specs/langfuse-tool-output-tracing.test.ts src/specs/langfuse-instrumentation.test.ts`.
- Ran `git diff --check`.
- Live-tested against staging Langfuse credentials from `.env.staging` with the actual SDK, a fake model, and an `execute_sql` tool. Verified an actual tool-call run and a `formatAgentMessages()` rehydrated run both keep tool inputs visible while omitting output-only secret markers from Langfuse traces.
- Verified the fake-model live smoke returned trace IDs `37fc48d8d95b91b078164b2dcf5bf6dc`, `096ad1a91ef92d097256facb55dbb872`, and `0fb186c911c978e25bd4b68bacc923cd`, with `hasActualSecretOutput=false`, `hasRehydratedSecretOutput=false`, `hasActualToolInput=true`, `hasRehydratedToolInput=true`, and `redactedOutputCount=2`.
- Live-tested with a real OpenAI `gpt-4.1-mini` SDK run using the repo `Calculator` tool and staging Langfuse. Verified local tool execution produced `33333333`, final model output was `CALC_TOOL_LIVE_OK`, and Langfuse trace inputs had `hasCalcInput=true`, `hasRawCalcOutputInInputs=false`, `hasRedactedToolOutputInInputs=true`, and `redactedOutputCount=1`.

### **Test Configuration**:

- Node.js 20 local worktree.
- LLM credentials loaded from `/Users/danny/Projects/agents/.env`.
- Langfuse staging credentials loaded from `/Users/danny/Projects/ClickHouse-LibreChat/.env.staging`.
- Fake-model live smoke session ID: `live-tool-config-redaction-1779860005728439000`.
- Real-provider live smoke session ID: `live-real-llm-calc-redaction-1779860689844235000`; trace IDs `ee99260149a54d9ef4f3e2a79ace704f` and `c5e3cc48e122537960260a8975e145e9`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
