### PR TITLE
🧰 feat: Classify Langfuse ToolNode spans

### DIFF
--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -20,6 +20,7 @@ const langfuseConfigKey = createContextKey('librechat.langfuse.config');
 const toolOutputTracingStorage =
   new AsyncLocalStorage<ResolvedLangfuseToolOutputTracingConfig>();
 const langfuseConfigStorage = new AsyncLocalStorage<t.LangfuseConfig>();
+const LANGGRAPH_TOOL_NODE_PREFIX = 'tools=';
 
 const CHAT_ROLES = new Set([
   'assistant',
@@ -446,6 +447,26 @@ function isToolObservation(attributes: Record<string, unknown>): boolean {
   return typeof type === 'string' && type.toLowerCase() === 'tool';
 }
 
+function classifyLangGraphToolNodeSpan(
+  attributes: Record<string, unknown>
+): void {
+  const type = attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE];
+  if (typeof type !== 'string' || type.toLowerCase() !== 'span') {
+    return;
+  }
+
+  const langGraphNode =
+    attributes[
+      `${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`
+    ];
+  if (
+    typeof langGraphNode === 'string' &&
+    langGraphNode.startsWith(LANGGRAPH_TOOL_NODE_PREFIX)
+  ) {
+    attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE] = 'tool';
+  }
+}
+
 function redactToolObservationOutput(
   span: ReadableSpan,
   attributes: Record<string, unknown>,
@@ -469,11 +490,13 @@ export function redactLangfuseSpanToolOutputs(
   span: ReadableSpan,
   config: ResolvedLangfuseToolOutputTracingConfig
 ): void {
+  const attributes = (span as SpanWithAttributes).attributes;
+  classifyLangGraphToolNodeSpan(attributes);
+
   if (!shouldApplyToolOutputRedaction(config)) {
     return;
   }
 
-  const attributes = (span as SpanWithAttributes).attributes;
   redactToolObservationOutput(span, attributes, config);
 
   for (const key of [
@@ -618,10 +641,7 @@ function hasLangfuseConfigKeys(langfuse?: t.LangfuseConfig): boolean {
   if (langfuse == null) {
     return false;
   }
-  return (
-    isPresent(langfuse.secretKey) &&
-    isPresent(langfuse.publicKey)
-  );
+  return isPresent(langfuse.secretKey) && isPresent(langfuse.publicKey);
 }
 
 export function shouldTraceToolNodeForLangfuse({
@@ -639,8 +659,7 @@ export function shouldTraceToolNodeForLangfuse({
   const explicit = langfuse?.toolNodeTracing?.enabled;
   if (explicit != null) {
     return (
-      explicit &&
-      (hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys())
+      explicit && (hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys())
     );
   }
 

--- a/src/specs/langfuse-tool-output-tracing.test.ts
+++ b/src/specs/langfuse-tool-output-tracing.test.ts
@@ -180,6 +180,34 @@ describe('Langfuse tool output tracing redaction', () => {
     ).toBe(false);
   });
 
+  it('classifies LangGraph tool-node spans as Langfuse tool observations', () => {
+    const span = createSpan('tool_batch', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'span',
+      [`${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`]:
+        'tools=agent_1',
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig());
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE]).toBe(
+      'tool'
+    );
+  });
+
+  it('does not reclassify non-tool LangGraph spans', () => {
+    const span = createSpan('agent=agent_1', {
+      [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'span',
+      [`${LangfuseOtelSpanAttributes.OBSERVATION_METADATA}.langgraph_node`]:
+        'agent=agent_1',
+    });
+
+    redactLangfuseSpanToolOutputs(span, createConfig());
+
+    expect(span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_TYPE]).toBe(
+      'span'
+    );
+  });
+
   it('redacts raw tool observation output when tool output tracing is disabled', () => {
     const span = createSpan('execute_sql', {
       [LangfuseOtelSpanAttributes.OBSERVATION_TYPE]: 'tool',

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -103,6 +103,8 @@ type RunToolBatchContext = {
   additionalContextsSink?: string[];
 };
 
+const TOOL_NODE_RUN_NAME = 'tool_batch';
+
 /**
  * Per-batch context for `dispatchToolEvents` / `executeViaEvent`.
  * Mirrors {@link RunToolBatchContext} for the event-driven path,
@@ -500,7 +502,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     toolExecution,
     fileCheckpointer,
   }: t.ToolNodeConstructorParams) {
-    super({ name, tags, func: (input, config) => this.run(input, config) });
+    super({
+      name: name ?? TOOL_NODE_RUN_NAME,
+      tags,
+      func: (input, config) => this.run(input, config),
+    });
     this.trace = trace ?? this.trace;
     this.runLangfuse = runLangfuse;
     this.agentLangfuse = agentLangfuse;

--- a/src/tools/__tests__/ToolNode.langfuse.test.ts
+++ b/src/tools/__tests__/ToolNode.langfuse.test.ts
@@ -15,6 +15,12 @@ describe('ToolNode Langfuse redaction context', () => {
     mockWithLangfuseToolOutputTracingConfig.mockClear();
   });
 
+  it('uses a stable default run name for tracing', () => {
+    const node = new ToolNode({ tools: [] });
+
+    expect(node.name).toBe('tool_batch');
+  });
+
   it('scopes ToolNode invocation with run and agent Langfuse config', async () => {
     const runLangfuse = {
       toolOutputTracing: { enabled: true },


### PR DESCRIPTION
## Summary

I classified LangGraph ToolNode observations as Langfuse tools and replaced the anonymous `func` trace name with a stable ToolNode run name.

- Set the default ToolNode run name to `tool_batch` so event-driven tool batches no longer show up as `func`.
- Reclassify LangGraph spans with `langgraph_node` beginning `tools=` as Langfuse `tool` observations during the existing Langfuse span export pass.
- Keep the classification path cheap by using direct span attribute lookups and a prefix check; no extra JSON parsing or tool execution plumbing is added.
- Add focused coverage for ToolNode naming and tool-node span classification.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/specs/langfuse-tool-output-tracing.test.ts src/tools/__tests__/ToolNode.langfuse.test.ts --runInBand`
- `npm run build`
- Live staging Langfuse smoke test with marker `toolnode-classification-1779891139253`; verified Langfuse exported `TOOL tool_batch` with `langgraph_node: tools=codex-live-classification` and kept the nested direct tool as `TOOL classification_echo`.

### **Test Configuration**:

- Node.js local project environment
- Langfuse staging credentials from `/Users/danny/Projects/ClickHouse-LibreChat/.env.staging`

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes