### PR TITLE
🪢 fix: Flatten Text-Only Assistant Content To String

### DIFF
--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -374,23 +374,23 @@ function getToolUseId(part: MessageContentComplex): string | undefined {
 /**
  * Builds the `content` for an assistant message in a single pass.
  *
- * Text-only parts are joined into a string because the Chat Completions
- * schema requires `assistant.content` to be a string; an array of text parts
- * is rejected by strict OpenAI-compatible proxies. Parts with any non-text
- * block keep their array shape.
+ * Text-only parts are joined with a newline into a string. The original text is
+ * not trimmed, so whitespace-sensitive replies (indented code, trailing
+ * newlines) replay verbatim. Parts with any non-text block keep their array
+ * shape.
  *
  * @param parts - The accumulated assistant content parts.
  * @returns A string for text-only content, otherwise the content array.
  */
 function buildAssistantContent(parts: MessageContentComplex[]): MessageContent {
-  let text = '';
+  const texts: string[] = [];
   for (const part of parts) {
     if (part.type !== ContentTypes.TEXT) {
       return toLangChainContent(parts);
     }
-    text += `${getTextContent(part)}\n`;
+    texts.push(getTextContent(part));
   }
-  return text.trim();
+  return texts.join('\n');
 }
 
 /**

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -372,6 +372,28 @@ function getToolUseId(part: MessageContentComplex): string | undefined {
 }
 
 /**
+ * Builds the `content` for an assistant message in a single pass.
+ *
+ * Text-only parts are joined into a string because the Chat Completions
+ * schema requires `assistant.content` to be a string; an array of text parts
+ * is rejected by strict OpenAI-compatible proxies. Parts with any non-text
+ * block keep their array shape.
+ *
+ * @param parts - The accumulated assistant content parts.
+ * @returns A string for text-only content, otherwise the content array.
+ */
+function buildAssistantContent(parts: MessageContentComplex[]): MessageContent {
+  let text = '';
+  for (const part of parts) {
+    if (part.type !== ContentTypes.TEXT) {
+      return toLangChainContent(parts);
+    }
+    text += `${getTextContent(part)}\n`;
+  }
+  return text.trim();
+}
+
+/**
  * Helper function to format an assistant message
  * @param message The message to format
  * @param options Optional formatting options
@@ -384,7 +406,6 @@ function formatAssistantMessage(
   const formattedMessages: Array<AIMessage | ToolMessage> = [];
   let currentContent: MessageContentComplex[] = [];
   let lastAIMessage: AIMessage | null = null;
-  let hasReasoning = false;
   let pendingReasoningContent = '';
   const emittedServerToolUseIds = new Set<string>();
   const pendingServerToolUses = new Map<string, MessageContentComplex>();
@@ -550,7 +571,6 @@ function formatAssistantMessage(
         part.type === ContentTypes.REASONING_CONTENT ||
         part.type === 'redacted_thinking'
       ) {
-        hasReasoning = true;
         pendingReasoningContent += extractReasoningContent(part);
         continue;
       } else if (
@@ -571,24 +591,11 @@ function formatAssistantMessage(
     }
   }
 
-  if (hasReasoning && currentContent.length > 0) {
-    let content = '';
-    for (const part of currentContent) {
-      if (part.type !== ContentTypes.TEXT) {
-        formattedMessages.push(
-          createAIMessage(toLangChainContent(currentContent))
-        );
-        return formattedMessages;
-      }
-      content += `${getTextContent(part)}\n`;
-    }
-    content = content.trim();
-
-    if (content) {
+  if (currentContent.length > 0) {
+    const content = buildAssistantContent(currentContent);
+    if (content !== '') {
       formattedMessages.push(createAIMessage(content));
     }
-  } else if (currentContent.length > 0) {
-    formattedMessages.push(createAIMessage(toLangChainContent(currentContent)));
   }
 
   return formattedMessages;

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -469,6 +469,25 @@ describe('formatAgentMessages', () => {
     expect(result.messages[1].content).toBe('Test received.');
   });
 
+  it('preserves whitespace-sensitive text when flattening assistant content', () => {
+    const preformatted = '    def foo():\n        return 1\n';
+    const payload: TPayload = [
+      { role: 'user', content: 'Show me indented code' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: preformatted },
+        ],
+      },
+      { role: 'user', content: 'Thanks' },
+    ];
+    const result = formatAgentMessages(payload);
+    expect(result.messages[1]).toBeInstanceOf(AIMessage);
+    expect(typeof result.messages[1].content).toBe('string');
+    // Leading indentation and the trailing newline must survive the flatten.
+    expect(result.messages[1].content).toBe(preformatted);
+  });
+
   it('should heal invalid tool call structure by creating a preceding AIMessage', () => {
     const payload = [
       {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -97,12 +97,7 @@ describe('formatAgentMessages', () => {
     expect(result.summary!.tokenCount).toBe(12);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
     expect(result.messages[1]).toBeInstanceOf(HumanMessage);
-    expect(
-      (result.messages[0].content as MessageContentComplex[])[0]
-    ).toMatchObject({
-      type: ContentTypes.TEXT,
-      text: 'Preserved tail',
-    });
+    expect(result.messages[0].content).toBe('Preserved tail');
     expect(result.indexTokenCountMap?.[0]).toBeLessThan(18);
     expect(result.indexTokenCountMap?.[0]).toBeGreaterThan(0);
     expect(result.indexTokenCountMap?.[1]).toBe(4);
@@ -134,12 +129,7 @@ describe('formatAgentMessages', () => {
     expect(result.summary!.text).toBe('Newest summary');
     expect(result.summary!.tokenCount).toBe(9);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
-    expect(
-      (result.messages[0].content as MessageContentComplex[])[0]
-    ).toMatchObject({
-      type: ContentTypes.TEXT,
-      text: 'Keep this part',
-    });
+    expect(result.messages[0].content).toBe('Keep this part');
   });
 
   it('should format messages with content arrays', () => {
@@ -228,12 +218,7 @@ describe('formatAgentMessages', () => {
       result.messages.some((message) => message instanceof ToolMessage)
     ).toBe(false);
     expect((result.messages[1] as AIMessage).tool_calls).toHaveLength(0);
-    expect(result.messages[1].content).toEqual([
-      {
-        type: ContentTypes.TEXT,
-        [ContentTypes.TEXT]: 'Philadelphia 76ers',
-      },
-    ]);
+    expect(result.messages[1].content).toBe('Philadelphia 76ers');
   });
 
   it('preserves paused Anthropic server tool calls without creating ToolMessages', () => {
@@ -266,8 +251,9 @@ describe('formatAgentMessages', () => {
 
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
-    expect(result.messages.some((message) => message instanceof ToolMessage))
-      .toBe(false);
+    expect(
+      result.messages.some((message) => message instanceof ToolMessage)
+    ).toBe(false);
     expect((result.messages[0] as AIMessage).tool_calls).toHaveLength(0);
     expect(result.messages[0].content).toEqual([
       {
@@ -369,6 +355,10 @@ describe('formatAgentMessages', () => {
 
     expect(anthropicPayload.messages).toHaveLength(3);
     for (const message of anthropicPayload.messages) {
+      if (typeof message.content === 'string') {
+        expect(message.content.trim().length).toBeGreaterThan(0);
+        continue;
+      }
       expect(Array.isArray(message.content)).toBe(true);
       const content = message.content as Array<{
         text?: unknown;
@@ -444,7 +434,7 @@ describe('formatAgentMessages', () => {
     expect(result.messages.length).toBeGreaterThan(0);
   });
 
-  it('should handle multiple content parts in assistant messages', () => {
+  it('should join multiple text-only parts in assistant messages into a string', () => {
     const payload = [
       {
         role: 'assistant',
@@ -457,7 +447,26 @@ describe('formatAgentMessages', () => {
     const result = formatAgentMessages(payload);
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
-    expect(result.messages[0].content).toHaveLength(2);
+    expect(typeof result.messages[0].content).toBe('string');
+    expect(result.messages[0].content).toBe('Part 1\nPart 2');
+  });
+
+  it('flattens single-text-part assistant content to a string on multi-turn replays', () => {
+    const payload: TPayload = [
+      { role: 'user', content: 'Test1' },
+      {
+        role: 'assistant',
+        content: [
+          { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Test received.' },
+        ],
+      },
+      { role: 'user', content: 'Test2' },
+    ];
+    const result = formatAgentMessages(payload);
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[1]).toBeInstanceOf(AIMessage);
+    expect(typeof result.messages[1].content).toBe('string');
+    expect(result.messages[1].content).toBe('Test received.');
   });
 
   it('should heal invalid tool call structure by creating a preceding AIMessage', () => {
@@ -614,9 +623,7 @@ describe('formatAgentMessages', () => {
     expect(result.messages[3].content).toBe('23.89°C');
 
     // Check final AIMessage
-    expect(result.messages[4].content).toStrictEqual([
-      { [ContentTypes.TEXT]: 'Here\'s your answer.', type: ContentTypes.TEXT },
-    ]);
+    expect(result.messages[4].content).toBe('Here\'s your answer.');
   });
 
   it('should dynamically discover tools from tool_search output and keep their tool calls', () => {
@@ -1423,13 +1430,8 @@ describe('formatAgentMessages', () => {
 
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
-    const content = result.messages[0].content;
-    expect(Array.isArray(content)).toBe(true);
-    expect(
-      (content as { type: string; text?: string }[]).every(
-        (p) => (p.text ?? '').trim() !== ''
-      )
-    ).toBe(true);
+    expect(typeof result.messages[0].content).toBe('string');
+    expect(result.messages[0].content).toBe('Actual content here.');
   });
 
   it('should preserve whitespace-only text that has tool_call_ids (common Bedrock pattern)', () => {
@@ -1511,19 +1513,8 @@ describe('formatAgentMessages', () => {
 
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
-    expect(result.messages[0].content).toEqual([
-      { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Hello there' },
-      { type: ContentTypes.TEXT, [ContentTypes.TEXT]: 'Final answer' },
-    ]);
-
-    const hasErrorContent =
-      Array.isArray(result.messages[0].content) &&
-      result.messages[0].content.some(
-        (item) =>
-          item.type === ContentTypes.ERROR ||
-          JSON.stringify(item).includes('An error occurred')
-      );
-    expect(hasErrorContent).toBe(false);
+    expect(result.messages[0].content).toBe('Hello there\nFinal answer');
+    expect(result.messages[0].content).not.toContain('An error occurred');
   });
   it('should handle indexTokenCountMap and return updated map', () => {
     const payload = [
@@ -2093,12 +2084,7 @@ describe('formatAgentMessages', () => {
     // The AIMessage should have no tool calls or an empty array
     const toolCalls = (result.messages[0] as AIMessage).tool_calls;
     expect(toolCalls === undefined || toolCalls.length === 0).toBe(true);
-    expect(result.messages[0].content).toStrictEqual([
-      {
-        type: ContentTypes.TEXT,
-        [ContentTypes.TEXT]: 'Here is the information.',
-      },
-    ]);
+    expect(result.messages[0].content).toBe('Here is the information.');
   });
 
   it('should NOT skip tool calls with no name but valid output', () => {


### PR DESCRIPTION
## Summary

For non-reasoning replies, `formatAssistantMessage` emits assistant `content` as
an array of text parts (`[{ type: "text", text: "..." }]`). The Chat Completions
spec allows both a string and an array here, so `api.openai.com` accepts it -
but strict OpenAI-compatible proxies validate literally and only allow a string,
rejecting the array with `400`. Since the array first appears when a prior
assistant turn is replayed, this breaks the **second** turn of a conversation.

Observed against Langdock's OpenAI-compatible EU endpoint:

```json
{"code":"invalid_type","expected":"string","path":["messages",1,"content"],
 "message":"Invalid input: expected string, received array"}
```

The fix unifies the two tail branches of `formatAssistantMessage` into a
single-pass `buildAssistantContent` helper: text-only content is joined into a
string (the canonical, universally valid shape), while content with any non-text
part keeps its array form. This also drops the now-redundant `hasReasoning`
branch, which did the same flattening - reasoning content is still attached via
`createAIMessage`. No behavior change for any other input class.

### Reproduction

Reproduces only against a strict proxy (real OpenAI returns `200` for both). The
requests differ solely in `assistant.content`:

```jsonc
// 200 (post-fix)
"messages": [ {user}, {"role":"assistant","content":"Received."}, {user} ]

// 400 against a strict proxy (pre-fix)
"messages": [ {user}, {"role":"assistant","content":[{"type":"text","text":"Received."}]}, {user} ]
```

### Scope

Strict proxies apply the same string-only constraint to the `tool` (and
`function`) roles, so a tool returning array/structured content would hit the
same `400`. This PR intentionally covers only the `assistant` role - the
reported and most common case. The same flattening could be extended to those
roles if you'd like; flagging it here rather than widening this change
unprompted.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/messages/` - 328 passed, 1 skipped
- `npx tsc --noEmit` / `npx eslint "src/**/*.ts"` - clean
- Added a regression test for multi-turn text-only content; updated 8 existing
  assertions that encoded the old array shape.
- Verified end-to-end through LibreChat against Langdock: with the fix
  `assistant.content` goes out as a string (`200`); reverting it reproduces the
  array and the `400` (negative control).

### Test Configuration

- Node.js: v22.22.2
- Package: `@librechat/agents@3.1.97`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes