### PR TITLE
feat(search): add Parallel as a search and scraper provider

### DIFF
--- a/src/tools/search/parallel-scraper.ts
+++ b/src/tools/search/parallel-scraper.ts
@@ -1,0 +1,256 @@
+import axios from 'axios';
+import type * as t from './types';
+import { createDefaultLogger } from './utils';
+
+const DEFAULT_PARALLEL_EXTRACT_TIMEOUT = 60_000;
+const DEFAULT_PARALLEL_EXTRACT_URL = 'https://api.parallel.ai/v1/extract';
+const PARALLEL_EXTRACT_MAX_BATCH = 20;
+const PARALLEL_MIN_EXCERPT_CHARS = 1_000;
+
+const normalizeUrlKey = (url: string): string => {
+  try {
+    const parsedUrl = new URL(url);
+    parsedUrl.hash = '';
+    if (parsedUrl.pathname.length > 1) {
+      parsedUrl.pathname = parsedUrl.pathname.replace(/\/+$/, '');
+    }
+    return parsedUrl.toString();
+  } catch {
+    return url;
+  }
+};
+
+const setResult = <T extends { url: string }>(
+  map: Map<string, T>,
+  result: T
+): void => {
+  map.set(result.url, result);
+  const normalized = normalizeUrlKey(result.url);
+  if (!map.has(normalized)) {
+    map.set(normalized, result);
+  }
+};
+
+const buildExcerptContent = (result: t.ParallelExtractResult): string => {
+  const fullContent = result.full_content?.trim();
+  if (fullContent != null && fullContent.length > 0) {
+    return fullContent;
+  }
+  const excerpts = Array.isArray(result.excerpts) ? result.excerpts : [];
+  return excerpts.join('\n\n');
+};
+
+/**
+ * Parallel Web Systems Extract API scraper.
+ *
+ * Docs: https://docs.parallel.ai/api-reference/extract/extract
+ *
+ * Notes:
+ * - Auth header is `x-api-key`, not `Authorization: Bearer`.
+ * - The Extract API caps batches at 20 URLs; larger sets are chunked.
+ * - Defaults to excerpts-only (already markdown, LLM-ready). Set
+ *   `fullContent: true` in the config to also request the full page body.
+ */
+export class ParallelScraper implements t.BaseScraper {
+  private apiKey: string;
+  private apiUrl: string;
+  private timeout: number;
+  private logger: t.Logger;
+  private fullContent: boolean;
+  private objective?: string;
+  private searchQueries?: string[];
+  private maxCharsTotal?: number;
+  private maxCharsPerResult?: number;
+  private clientModel?: string;
+
+  constructor(config: t.ParallelScraperConfig = {}) {
+    this.apiKey = config.apiKey ?? process.env.PARALLEL_API_KEY ?? '';
+    this.apiUrl =
+      config.apiUrl ??
+      process.env.PARALLEL_EXTRACT_URL ??
+      DEFAULT_PARALLEL_EXTRACT_URL;
+    this.timeout = config.timeout ?? DEFAULT_PARALLEL_EXTRACT_TIMEOUT;
+    this.fullContent = config.fullContent ?? false;
+    this.objective = config.objective;
+    this.searchQueries = config.searchQueries;
+    this.maxCharsTotal = config.maxCharsTotal;
+    this.maxCharsPerResult = config.maxCharsPerResult;
+    this.clientModel = config.clientModel;
+    this.logger = config.logger || createDefaultLogger();
+
+    if (this.apiKey === '') {
+      this.logger.warn(
+        'PARALLEL_API_KEY is not set. Parallel Extract scraping will not work.'
+      );
+    }
+  }
+
+  async scrapeUrl(
+    url: string,
+    options: t.ParallelScrapeOptions = {}
+  ): Promise<[string, t.ParallelScrapeResponse]> {
+    const [result] = await this.scrapeUrls([url], options);
+    return result;
+  }
+
+  async scrapeUrls(
+    urls: string[],
+    options: t.ParallelScrapeOptions = {}
+  ): Promise<Array<[string, t.ParallelScrapeResponse]>> {
+    if (this.apiKey === '') {
+      return urls.map((url) => [
+        url,
+        { success: false, error: 'PARALLEL_API_KEY is not set' },
+      ]);
+    }
+
+    const batches: string[][] = [];
+    for (let i = 0; i < urls.length; i += PARALLEL_EXTRACT_MAX_BATCH) {
+      batches.push(urls.slice(i, i + PARALLEL_EXTRACT_MAX_BATCH));
+    }
+
+    const aggregated: Array<[string, t.ParallelScrapeResponse]> = [];
+    for (const batch of batches) {
+      const batchResults = await this.extractBatch(batch, options);
+      aggregated.push(...batchResults);
+    }
+    return aggregated;
+  }
+
+  private async extractBatch(
+    urls: string[],
+    options: t.ParallelScrapeOptions
+  ): Promise<Array<[string, t.ParallelScrapeResponse]>> {
+    const fullContent = options.fullContent ?? this.fullContent;
+    const objective = options.objective ?? this.objective;
+    const searchQueries = options.searchQueries ?? this.searchQueries;
+    const maxCharsTotal = options.maxCharsTotal ?? this.maxCharsTotal;
+    const maxCharsPerResult =
+      options.maxCharsPerResult ?? this.maxCharsPerResult;
+    const clientModel = options.clientModel ?? this.clientModel;
+    const timeout = options.timeout ?? this.timeout;
+
+    const payload: t.ParallelExtractPayload = { urls };
+    if (objective != null && objective.trim().length > 0) {
+      payload.objective = objective;
+    }
+    if (Array.isArray(searchQueries) && searchQueries.length > 0) {
+      payload.search_queries = searchQueries;
+    }
+    if (maxCharsTotal != null) {
+      payload.max_chars_total = maxCharsTotal;
+    }
+    if (clientModel != null) {
+      payload.client_model = clientModel;
+    }
+    if (options.sessionId != null && options.sessionId.length > 0) {
+      payload.session_id = options.sessionId;
+    }
+    const advanced: NonNullable<t.ParallelExtractPayload['advanced_settings']> =
+      {};
+    if (maxCharsPerResult != null) {
+      advanced.excerpt_settings = {
+        max_chars_per_result: Math.max(
+          PARALLEL_MIN_EXCERPT_CHARS,
+          maxCharsPerResult
+        ),
+      };
+    }
+    if (fullContent) {
+      advanced.full_content_settings = { enabled: true };
+    }
+    if (Object.keys(advanced).length > 0) {
+      payload.advanced_settings = advanced;
+    }
+
+    try {
+      const response = await axios.post<t.ParallelExtractResponse>(
+        this.apiUrl,
+        payload,
+        {
+          headers: {
+            'x-api-key': this.apiKey,
+            'Content-Type': 'application/json',
+          },
+          timeout,
+        }
+      );
+
+      const successMap = new Map<string, t.ParallelExtractResult>();
+      const errorMap = new Map<string, t.ParallelExtractError>();
+      for (const r of response.data.results ?? []) {
+        setResult(successMap, r);
+      }
+      for (const e of response.data.errors ?? []) {
+        setResult(errorMap, e);
+      }
+
+      return urls.map((url): [string, t.ParallelScrapeResponse] => {
+        const success =
+          successMap.get(url) ?? successMap.get(normalizeUrlKey(url));
+        if (success) {
+          const rawContent = buildExcerptContent(success);
+          return [
+            url,
+            {
+              success: true,
+              data: {
+                rawContent,
+                excerpts: success.excerpts ?? [],
+                ...(success.title != null && { title: success.title }),
+                ...(success.publish_date != null && {
+                  publishDate: success.publish_date,
+                }),
+              },
+            },
+          ];
+        }
+        const failure = errorMap.get(url) ?? errorMap.get(normalizeUrlKey(url));
+        const detail =
+          failure?.content ??
+          failure?.error_type ??
+          'URL not found in Parallel Extract response';
+        return [url, { success: false, error: detail }];
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return urls.map((url) => [
+        url,
+        {
+          success: false,
+          error: `Parallel Extract API request failed: ${errorMessage}`,
+        },
+      ]);
+    }
+  }
+
+  extractContent(
+    response: t.ParallelScrapeResponse
+  ): [string, undefined | t.References] {
+    if (!response.success) {
+      return ['', undefined];
+    }
+    return [response.data.rawContent, undefined];
+  }
+
+  extractMetadata(response: t.ParallelScrapeResponse): t.GenericScrapeMetadata {
+    if (!response.success) {
+      return {};
+    }
+    const metadata: t.GenericScrapeMetadata = {
+      excerpts_count: response.data.excerpts.length,
+    };
+    if (response.data.title != null) {
+      metadata.title = response.data.title;
+    }
+    if (response.data.publishDate != null) {
+      metadata.publish_date = response.data.publishDate;
+    }
+    return metadata;
+  }
+}
+
+export const createParallelScraper = (
+  config: t.ParallelScraperConfig = {}
+): ParallelScraper => new ParallelScraper(config);

--- a/src/tools/search/parallel-search.ts
+++ b/src/tools/search/parallel-search.ts
@@ -1,0 +1,193 @@
+import axios from 'axios';
+import type * as t from './types';
+
+const DEFAULT_PARALLEL_TIMEOUT = 30_000;
+const DEFAULT_PARALLEL_SEARCH_URL = 'https://api.parallel.ai/v1/search';
+const PARALLEL_MAX_SEARCH_QUERIES = 5;
+const PARALLEL_MIN_EXCERPT_CHARS = 1_000;
+
+const ISO_COUNTRY_RE = /^[a-z]{2}$/;
+
+const normalizeParallelLocation = (country?: string): string | undefined => {
+  const normalized = country?.trim().toLowerCase();
+  if (normalized == null || normalized === '') {
+    return undefined;
+  }
+  return ISO_COUNTRY_RE.test(normalized) ? normalized : undefined;
+};
+
+const trimQuery = (value: string): string => value.trim();
+
+const buildSearchQueries = (query: string, extras?: string[]): string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  const candidates = [query, ...(extras ?? [])].map(trimQuery);
+  for (const candidate of candidates) {
+    if (candidate.length === 0) continue;
+    const key = candidate.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(candidate);
+    if (result.length >= PARALLEL_MAX_SEARCH_QUERIES) break;
+  }
+  return result;
+};
+
+const buildObjective = (
+  query: string,
+  fixedObjective?: string
+): string | undefined => {
+  const trimmedQuery = trimQuery(query);
+  const trimmedFixed = fixedObjective?.trim() ?? '';
+  if (trimmedFixed.length > 0) {
+    return trimmedQuery.length > 0
+      ? `${trimmedFixed}\n\n${trimmedQuery}`
+      : trimmedFixed;
+  }
+  return trimmedQuery.length > 0 ? trimmedQuery : undefined;
+};
+
+const toOrganicResults = (
+  results: t.ParallelSearchResult[] | undefined
+): t.OrganicResult[] => {
+  if (!Array.isArray(results)) return [];
+  return results.map((result) => ({
+    title: result.title ?? '',
+    link: result.url,
+    snippet: Array.isArray(result.excerpts) ? result.excerpts.join('\n\n') : '',
+    date: result.publish_date ?? undefined,
+  }));
+};
+
+/**
+ * Parallel Web Systems Search API client.
+ *
+ * Docs: https://docs.parallel.ai/api-reference/search/search
+ * Best practices: https://docs.parallel.ai/search/best-practices
+ *
+ * Notes:
+ * - Auth header is `x-api-key`, not `Authorization: Bearer`.
+ * - The LLM-supplied `query` is used as both the `objective` and a
+ *   `search_queries[]` entry; admins can layer a fixed objective and
+ *   additional keyword queries via `parallelSearchOptions`.
+ * - Per Parallel best practices, restrictive `source_policy`, `location`,
+ *   and `max_results` are only emitted when explicitly configured.
+ */
+export const createParallelAPI = (
+  apiKey?: string,
+  apiUrl?: string,
+  options?: t.ParallelSearchOptions
+): {
+  getSources: (params: t.GetSourcesParams) => Promise<t.SearchResult>;
+} => {
+  const config = {
+    apiKey: apiKey ?? process.env.PARALLEL_API_KEY,
+    apiUrl:
+      apiUrl ?? process.env.PARALLEL_SEARCH_URL ?? DEFAULT_PARALLEL_SEARCH_URL,
+    timeout: options?.timeout ?? DEFAULT_PARALLEL_TIMEOUT,
+  };
+
+  if (config.apiKey === undefined || config.apiKey === '') {
+    throw new Error('PARALLEL_API_KEY is required for Parallel Search API');
+  }
+
+  const getSources = async ({
+    query,
+    country,
+  }: t.GetSourcesParams): Promise<t.SearchResult> => {
+    if (!query.trim()) {
+      return { success: false, error: 'Query cannot be empty' };
+    }
+
+    try {
+      const searchQueries = buildSearchQueries(query, options?.search_queries);
+      if (searchQueries.length === 0) {
+        return { success: false, error: 'Query cannot be empty' };
+      }
+
+      const payload: t.ParallelSearchPayload = {
+        search_queries: searchQueries,
+      };
+
+      const objective = buildObjective(query, options?.objective);
+      if (objective != null) {
+        payload.objective = objective;
+      }
+      if (options?.mode != null) {
+        payload.mode = options.mode;
+      }
+      if (options?.max_chars_total != null) {
+        payload.max_chars_total = options.max_chars_total;
+      }
+      if (options?.client_model != null) {
+        payload.client_model = options.client_model;
+      }
+
+      const advanced: NonNullable<
+        t.ParallelSearchPayload['advanced_settings']
+      > = {};
+      const includeDomains =
+        options?.include_domains?.filter((d) => d.trim().length > 0) ?? [];
+      const excludeDomains =
+        options?.exclude_domains?.filter((d) => d.trim().length > 0) ?? [];
+      if (includeDomains.length > 0 || excludeDomains.length > 0) {
+        advanced.source_policy = {
+          ...(includeDomains.length > 0 && { include_domains: includeDomains }),
+          ...(excludeDomains.length > 0 && { exclude_domains: excludeDomains }),
+        };
+      }
+      const location =
+        normalizeParallelLocation(options?.location) ??
+        normalizeParallelLocation(country);
+      if (location != null) {
+        advanced.location = location;
+      }
+      if (options?.max_results != null) {
+        advanced.max_results = options.max_results;
+      }
+      if (options?.max_chars_per_result != null) {
+        advanced.excerpt_settings = {
+          max_chars_per_result: Math.max(
+            PARALLEL_MIN_EXCERPT_CHARS,
+            options.max_chars_per_result
+          ),
+        };
+      }
+      if (Object.keys(advanced).length > 0) {
+        payload.advanced_settings = advanced;
+      }
+
+      const response = await axios.post<t.ParallelSearchResponse>(
+        config.apiUrl,
+        payload,
+        {
+          headers: {
+            'x-api-key': config.apiKey,
+            'Content-Type': 'application/json',
+          },
+          timeout: config.timeout,
+        }
+      );
+
+      const results: t.SearchResultData = {
+        organic: toOrganicResults(response.data.results),
+        images: [],
+        topStories: [],
+        videos: [],
+        news: [],
+        relatedSearches: [],
+      };
+
+      return { success: true, data: results };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        error: `Parallel Search API request failed: ${errorMessage}`,
+      };
+    }
+  };
+
+  return { getSources };
+};

--- a/src/tools/search/parallel.test.ts
+++ b/src/tools/search/parallel.test.ts
@@ -1,0 +1,458 @@
+import axios from 'axios';
+import type * as t from './types';
+import { ParallelScraper, createParallelScraper } from './parallel-scraper';
+import { createSearchAPI } from './search';
+import { createSearchTool } from './tool';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+} as unknown as t.Logger;
+
+describe('Parallel Search API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws when Parallel API key is missing', () => {
+    expect(() =>
+      createSearchAPI({
+        searchProvider: 'parallel',
+        parallelApiKey: '',
+      })
+    ).toThrow('PARALLEL_API_KEY is required for Parallel Search API');
+  });
+
+  it('returns an error for empty queries', async () => {
+    const searchAPI = createSearchAPI({
+      searchProvider: 'parallel',
+      parallelApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: '   ' });
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Query cannot be empty',
+    });
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the request fails', async () => {
+    mockedAxios.post.mockRejectedValueOnce(new Error('Network error'));
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'parallel',
+      parallelApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(
+      'Parallel Search API request failed: Network error'
+    );
+  });
+
+  it('sends x-api-key auth and maps response excerpts into organic results', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        search_id: 'srch_123',
+        results: [
+          {
+            url: 'https://example.com',
+            title: 'Example',
+            publish_date: '2026-01-02',
+            excerpts: ['First excerpt.', 'Second excerpt.'],
+          },
+          {
+            url: 'https://example.org',
+            excerpts: ['Plain excerpt.'],
+          },
+        ],
+      },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'parallel',
+      parallelApiKey: 'test-key',
+    });
+
+    const result = await searchAPI.getSources({ query: 'example query' });
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [url, payload, requestConfig] = mockedAxios.post.mock.calls[0] as [
+      string,
+      t.ParallelSearchPayload,
+      { headers: Record<string, string> },
+    ];
+
+    expect(url).toBe('https://api.parallel.ai/v1/search');
+    expect(requestConfig.headers).toMatchObject({
+      'x-api-key': 'test-key',
+      'Content-Type': 'application/json',
+    });
+    expect(payload).toMatchObject({
+      objective: 'example query',
+      search_queries: ['example query'],
+    });
+    expect(payload).not.toHaveProperty('advanced_settings');
+
+    expect(result.success).toBe(true);
+    expect(result.data?.organic).toHaveLength(2);
+    expect(result.data?.organic?.[0]).toMatchObject({
+      title: 'Example',
+      link: 'https://example.com',
+      snippet: 'First excerpt.\n\nSecond excerpt.',
+      date: '2026-01-02',
+    });
+    expect(result.data?.organic?.[1]).toMatchObject({
+      title: '',
+      link: 'https://example.org',
+      snippet: 'Plain excerpt.',
+    });
+  });
+
+  it('merges configured options into the request payload', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { search_id: 'srch_456', results: [] },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'parallel',
+      parallelApiKey: 'test-key',
+      parallelSearchUrl: 'https://api.parallel.ai/v1/search',
+      parallelSearchOptions: {
+        objective: 'Focus on releases from the last month.',
+        search_queries: ['bun runtime release'],
+        mode: 'basic',
+        client_model: 'claude-opus-4-7',
+        max_chars_total: 25_000,
+        max_chars_per_result: 4_000,
+        include_domains: ['example.com'],
+        exclude_domains: ['reddit.com'],
+        max_results: 8,
+        location: 'gb',
+      },
+    });
+
+    await searchAPI.getSources({ query: 'latest stable bun version' });
+    const [, payload] = mockedAxios.post.mock.calls[0] as [
+      string,
+      t.ParallelSearchPayload,
+    ];
+
+    expect(payload.objective).toBe(
+      'Focus on releases from the last month.\n\nlatest stable bun version'
+    );
+    expect(payload.search_queries).toEqual([
+      'latest stable bun version',
+      'bun runtime release',
+    ]);
+    expect(payload.mode).toBe('basic');
+    expect(payload.client_model).toBe('claude-opus-4-7');
+    expect(payload.max_chars_total).toBe(25_000);
+    expect(payload.advanced_settings).toEqual({
+      source_policy: {
+        include_domains: ['example.com'],
+        exclude_domains: ['reddit.com'],
+      },
+      location: 'gb',
+      max_results: 8,
+      excerpt_settings: { max_chars_per_result: 4_000 },
+    });
+  });
+
+  it('deduplicates queries and clamps to 5 entries', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { search_id: 'srch_789', results: [] },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'parallel',
+      parallelApiKey: 'test-key',
+      parallelSearchOptions: {
+        search_queries: [
+          'Same Query',
+          'Other 1',
+          'Other 2',
+          'Other 3',
+          'Other 4',
+          'Other 5',
+        ],
+      },
+    });
+
+    await searchAPI.getSources({ query: 'same query' });
+    const [, payload] = mockedAxios.post.mock.calls[0] as [
+      string,
+      t.ParallelSearchPayload,
+    ];
+
+    expect(payload.search_queries).toEqual([
+      'same query',
+      'Other 1',
+      'Other 2',
+      'Other 3',
+      'Other 4',
+    ]);
+  });
+
+  it('clamps excerpt cap to the 1000-char minimum from the API', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { search_id: 'srch_abc', results: [] },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'parallel',
+      parallelApiKey: 'test-key',
+      parallelSearchOptions: { max_chars_per_result: 500 },
+    });
+
+    await searchAPI.getSources({ query: 'q' });
+    const [, payload] = mockedAxios.post.mock.calls[0] as [
+      string,
+      t.ParallelSearchPayload,
+    ];
+
+    expect(payload.advanced_settings?.excerpt_settings).toEqual({
+      max_chars_per_result: 1_000,
+    });
+  });
+
+  it('falls back to country from the LLM when location is unset', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { search_id: 'srch_def', results: [] },
+    });
+
+    const searchAPI = createSearchAPI({
+      searchProvider: 'parallel',
+      parallelApiKey: 'test-key',
+    });
+
+    await searchAPI.getSources({ query: 'q', country: 'JP' });
+    const [, payload] = mockedAxios.post.mock.calls[0] as [
+      string,
+      t.ParallelSearchPayload,
+    ];
+
+    expect(payload.advanced_settings?.location).toBe('jp');
+  });
+});
+
+describe('Parallel Extract scraper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('warns instead of throwing when the API key is missing', () => {
+    const scraper = createParallelScraper({ apiKey: '', logger: mockLogger });
+    expect(scraper).toBeInstanceOf(ParallelScraper);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('PARALLEL_API_KEY is not set')
+    );
+  });
+
+  it('returns failures for every URL when the API key is missing', async () => {
+    const scraper = createParallelScraper({ apiKey: '', logger: mockLogger });
+    const results = await scraper.scrapeUrls(
+      ['https://example.com', 'https://example.org'],
+      {}
+    );
+
+    expect(results).toEqual([
+      [
+        'https://example.com',
+        {
+          success: false,
+          error: 'PARALLEL_API_KEY is not set',
+        },
+      ],
+      [
+        'https://example.org',
+        {
+          success: false,
+          error: 'PARALLEL_API_KEY is not set',
+        },
+      ],
+    ]);
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  it('sends x-api-key auth, defaults to excerpts only, and maps response', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        extract_id: 'ext_123',
+        results: [
+          {
+            url: 'https://example.com',
+            title: 'Example',
+            publish_date: '2026-01-02',
+            excerpts: ['Para 1.', 'Para 2.'],
+          },
+        ],
+      },
+    });
+
+    const scraper = createParallelScraper({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+
+    const [[url, response]] = await scraper.scrapeUrls(
+      ['https://example.com'],
+      {}
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [endpoint, payload, requestConfig] = mockedAxios.post.mock
+      .calls[0] as [
+      string,
+      t.ParallelExtractPayload,
+      { headers: Record<string, string> },
+    ];
+    expect(endpoint).toBe('https://api.parallel.ai/v1/extract');
+    expect(requestConfig.headers).toMatchObject({
+      'x-api-key': 'test-key',
+      'Content-Type': 'application/json',
+    });
+    expect(payload).toEqual({ urls: ['https://example.com'] });
+
+    expect(url).toBe('https://example.com');
+    expect(response.success).toBe(true);
+    if (response.success) {
+      expect(response.data.rawContent).toBe('Para 1.\n\nPara 2.');
+      expect(response.data.title).toBe('Example');
+      expect(response.data.publishDate).toBe('2026-01-02');
+      expect(response.data.excerpts).toEqual(['Para 1.', 'Para 2.']);
+    }
+
+    const metadata = scraper.extractMetadata(response);
+    expect(metadata).toMatchObject({
+      excerpts_count: 2,
+      title: 'Example',
+      publish_date: '2026-01-02',
+    });
+
+    const [content, refs] = scraper.extractContent(response);
+    expect(content).toBe('Para 1.\n\nPara 2.');
+    expect(refs).toBeUndefined();
+  });
+
+  it('opts into full-content output when configured', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        extract_id: 'ext_full',
+        results: [
+          {
+            url: 'https://example.com',
+            full_content: '# Full page\n\nbody here',
+            excerpts: ['ignored excerpt'],
+          },
+        ],
+      },
+    });
+
+    const scraper = createParallelScraper({
+      apiKey: 'test-key',
+      fullContent: true,
+      logger: mockLogger,
+    });
+
+    const [[, response]] = await scraper.scrapeUrls(
+      ['https://example.com'],
+      {}
+    );
+    const [, payload] = mockedAxios.post.mock.calls[0] as [
+      string,
+      t.ParallelExtractPayload,
+    ];
+
+    expect(payload.advanced_settings?.full_content_settings).toEqual({
+      enabled: true,
+    });
+    expect(response.success).toBe(true);
+    if (response.success) {
+      expect(response.data.rawContent).toBe('# Full page\n\nbody here');
+    }
+  });
+
+  it('reports per-URL errors from the extract response', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: {
+        extract_id: 'ext_err',
+        results: [],
+        errors: [
+          {
+            url: 'https://blocked.example.com',
+            error_type: 'fetch_blocked',
+            http_status_code: 403,
+            content: 'Origin blocked the fetch',
+          },
+        ],
+      },
+    });
+
+    const scraper = createParallelScraper({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+
+    const [[, response]] = await scraper.scrapeUrls(
+      ['https://blocked.example.com'],
+      {}
+    );
+
+    expect(response.success).toBe(false);
+    if (!response.success) {
+      expect(response.error).toBe('Origin blocked the fetch');
+    }
+  });
+
+  it('chunks requests larger than 20 URLs', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: { extract_id: 'ext_batch', results: [] },
+    });
+
+    const scraper = createParallelScraper({
+      apiKey: 'test-key',
+      logger: mockLogger,
+    });
+
+    const urls = Array.from({ length: 25 }, (_, i) => `https://e${i}.com`);
+    await scraper.scrapeUrls(urls, {});
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    const firstBatch = (
+      mockedAxios.post.mock.calls[0] as [string, t.ParallelExtractPayload]
+    )[1].urls;
+    const secondBatch = (
+      mockedAxios.post.mock.calls[1] as [string, t.ParallelExtractPayload]
+    )[1].urls;
+    expect(firstBatch).toHaveLength(20);
+    expect(secondBatch).toHaveLength(5);
+  });
+});
+
+describe('createSearchTool with parallel provider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds a tool that uses the Parallel scraper when both providers are set', () => {
+    const tool = createSearchTool({
+      searchProvider: 'parallel',
+      scraperProvider: 'parallel',
+      parallelApiKey: 'test-key',
+      rerankerType: 'none',
+      logger: mockLogger,
+    });
+
+    expect(tool).toBeDefined();
+    expect(tool.name).toBeDefined();
+  });
+});

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -3,6 +3,7 @@ import { RecursiveCharacterTextSplitter } from '@langchain/textsplitters';
 import type * as t from './types';
 import { getAttribution, createDefaultLogger } from './utils';
 import { createTavilyAPI } from './tavily-search';
+import { createParallelAPI } from './parallel-search';
 import { BaseReranker } from './rerankers';
 
 const chunker = {
@@ -422,6 +423,9 @@ export const createSearchAPI = (
     tavilyApiKey,
     tavilySearchUrl,
     tavilySearchOptions,
+    parallelApiKey,
+    parallelSearchUrl,
+    parallelSearchOptions,
   } = config;
 
   if (searchProvider.toLowerCase() === 'serper') {
@@ -430,9 +434,15 @@ export const createSearchAPI = (
     return createSearXNGAPI(searxngInstanceUrl, searxngApiKey);
   } else if (searchProvider.toLowerCase() === 'tavily') {
     return createTavilyAPI(tavilyApiKey, tavilySearchUrl, tavilySearchOptions);
+  } else if (searchProvider.toLowerCase() === 'parallel') {
+    return createParallelAPI(
+      parallelApiKey,
+      parallelSearchUrl,
+      parallelSearchOptions
+    );
   } else {
     throw new Error(
-      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', or 'tavily'`
+      `Invalid search provider: ${searchProvider}. Must be 'serper', 'searxng', 'tavily', or 'parallel'`
     );
   }
 };

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -16,6 +16,7 @@ import { createSearchAPI, createSourceProcessor } from './search';
 import { createSerperScraper } from './serper-scraper';
 import { createTavilyScraper } from './tavily-scraper';
 import { createFirecrawlScraper } from './firecrawl';
+import { createParallelScraper } from './parallel-scraper';
 import { expandHighlights } from './highlights';
 import { formatResultsForLLM } from './format';
 import { createDefaultLogger } from './utils';
@@ -338,6 +339,11 @@ export const createSearchTool = (
     tavilySearchUrl,
     tavilyExtractUrl,
     tavilySearchOptions,
+    parallelApiKey,
+    parallelSearchUrl,
+    parallelExtractUrl,
+    parallelSearchOptions,
+    parallelScraperOptions,
     rerankerType = 'cohere',
     topResults = 5,
     strategies = ['no_extraction'],
@@ -375,7 +381,11 @@ export const createSearchTool = (
     news: newsSchema,
   };
 
-  if (searchProvider === 'serper' || searchProvider === 'tavily') {
+  if (
+    searchProvider === 'serper' ||
+    searchProvider === 'tavily' ||
+    searchProvider === 'parallel'
+  ) {
     schemaProperties.country = countrySchema;
   }
 
@@ -393,6 +403,9 @@ export const createSearchTool = (
     tavilyApiKey,
     tavilySearchUrl,
     tavilySearchOptions: effectiveTavilySearchOptions,
+    parallelApiKey,
+    parallelSearchUrl,
+    parallelSearchOptions,
   });
 
   /** Create scraper based on scraperProvider */
@@ -414,6 +427,17 @@ export const createSearchTool = (
         process.env.TAVILY_API_KEY,
       apiUrl: tavilyScraperOptions?.apiUrl ?? tavilyExtractUrl,
       timeout: scraperTimeout ?? tavilyScraperOptions?.timeout,
+      logger,
+    });
+  } else if (scraperProvider === 'parallel') {
+    scraperInstance = createParallelScraper({
+      ...parallelScraperOptions,
+      apiKey:
+        parallelScraperOptions?.apiKey ??
+        parallelApiKey ??
+        process.env.PARALLEL_API_KEY,
+      apiUrl: parallelScraperOptions?.apiUrl ?? parallelExtractUrl,
+      timeout: scraperTimeout ?? parallelScraperOptions?.timeout,
       logger,
     });
   } else {
@@ -454,7 +478,8 @@ export const createSearchTool = (
   const search = createSearchProcessor({
     searchAPI,
     safeSearch,
-    supportsVideos: searchProvider !== 'tavily',
+    supportsVideos:
+      searchProvider !== 'tavily' && searchProvider !== 'parallel',
     sourceProcessor,
     onGetHighlights,
     logger,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -3,8 +3,8 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseReranker } from './rerankers';
 import { DATE_RANGE } from './schema';
 
-export type SearchProvider = 'serper' | 'searxng' | 'tavily';
-export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily';
+export type SearchProvider = 'serper' | 'searxng' | 'tavily' | 'parallel';
+export type ScraperProvider = 'firecrawl' | 'serper' | 'tavily' | 'parallel';
 export type RerankerType = 'infinity' | 'jina' | 'cohere' | 'none';
 
 export interface Highlight {
@@ -106,6 +106,85 @@ export interface TavilySearchPayload {
   chunks_per_source?: number;
 }
 
+/**
+ * Parallel Search API
+ * Docs: https://docs.parallel.ai/api-reference/search/search
+ *
+ * Notes for tool-callers:
+ * - Provide both `objective` and `search_queries` for best results.
+ * - `search_queries` should be 2-3 diverse keyword queries, each 3-6 words; max 5.
+ * - Restrictive options (`include_domains`, `exclude_domains`, `location`,
+ *   `max_results`) can reduce result quality; only use when needed.
+ */
+export interface ParallelSearchOptions {
+  /**
+   * Optional natural-language objective that always accompanies the LLM query.
+   * When set, the runtime objective is `"${objective}\n\n${query}"`.
+   */
+  objective?: string;
+  /** Extra keyword queries appended to the LLM-supplied query. */
+  search_queries?: string[];
+  /**
+   * Search mode preset. `advanced` (default) for highest quality, `basic` for
+   * lower latency on simple lookups. See https://docs.parallel.ai/search/modes.
+   */
+  mode?: 'basic' | 'advanced';
+  /** Upper bound on total characters across excerpts from all results. */
+  max_chars_total?: number;
+  /**
+   * The model generating the request and consuming the results, e.g.
+   * `claude-opus-4-7`. Enables model-specific result tuning.
+   */
+  client_model?: string;
+  /** ISO 3166-1 alpha-2 country code (e.g. `us`, `gb`, `de`). */
+  location?: string;
+  /** Domain restriction list — see Parallel docs. */
+  include_domains?: string[];
+  /** Domain exclusion list — see Parallel docs. */
+  exclude_domains?: string[];
+  /** Upper bound on excerpt size per result. Minimum 1000 chars. */
+  max_chars_per_result?: number;
+  /** Upper bound on number of results. Defaults to 10. */
+  max_results?: number;
+  /** Override request timeout in ms. */
+  timeout?: number;
+}
+
+export interface ParallelSearchPayload {
+  objective?: string;
+  search_queries: string[];
+  mode?: ParallelSearchOptions['mode'];
+  max_chars_total?: number;
+  client_model?: string;
+  session_id?: string;
+  advanced_settings?: {
+    source_policy?: {
+      include_domains?: string[];
+      exclude_domains?: string[];
+    };
+    location?: string;
+    max_results?: number;
+    excerpt_settings?: {
+      max_chars_per_result?: number;
+    };
+  };
+}
+
+export interface ParallelSearchResult {
+  url: string;
+  title?: string | null;
+  publish_date?: string | null;
+  excerpts: string[];
+}
+
+export interface ParallelSearchResponse {
+  search_id: string;
+  results?: ParallelSearchResult[];
+  warnings?: unknown;
+  usage?: Array<{ name: string; count: number }>;
+  session_id?: string;
+}
+
 export interface SearchConfig {
   searchProvider?: SearchProvider;
   serperApiKey?: string;
@@ -115,6 +194,10 @@ export interface SearchConfig {
   tavilySearchUrl?: string;
   tavilyExtractUrl?: string;
   tavilySearchOptions?: TavilySearchOptions;
+  parallelApiKey?: string;
+  parallelSearchUrl?: string;
+  parallelExtractUrl?: string;
+  parallelSearchOptions?: ParallelSearchOptions;
 }
 
 export type References = {
@@ -164,6 +247,87 @@ export interface TavilyScraperConfig {
   includeFavicon?: boolean;
   format?: 'markdown' | 'text';
 }
+
+/**
+ * Parallel Extract API config
+ * Docs: https://docs.parallel.ai/api-reference/extract/extract
+ */
+export interface ParallelScraperConfig {
+  apiKey?: string;
+  apiUrl?: string;
+  timeout?: number;
+  logger?: Logger;
+  /**
+   * If true, request full page content in addition to excerpts. Defaults to false
+   * (excerpts only — already markdown-formatted and LLM-ready).
+   */
+  fullContent?: boolean;
+  /** Optional default objective applied to every extract call. */
+  objective?: string;
+  /** Optional default keyword queries to focus excerpts. */
+  searchQueries?: string[];
+  /** Per-call cap on total chars across excerpts. */
+  maxCharsTotal?: number;
+  /** Per-result excerpt cap (minimum 1000). */
+  maxCharsPerResult?: number;
+  /**
+   * The model generating the request and consuming the results, e.g.
+   * `claude-opus-4-7`. Enables model-specific result tuning.
+   */
+  clientModel?: string;
+}
+
+export interface ParallelExtractPayload {
+  urls: string[];
+  objective?: string;
+  search_queries?: string[];
+  max_chars_total?: number;
+  session_id?: string;
+  client_model?: string;
+  advanced_settings?: {
+    excerpt_settings?: {
+      max_chars_per_result?: number;
+    };
+    full_content_settings?: {
+      enabled?: boolean;
+    };
+  };
+}
+
+export interface ParallelExtractResult {
+  url: string;
+  title?: string | null;
+  publish_date?: string | null;
+  excerpts?: string[];
+  full_content?: string | null;
+}
+
+export interface ParallelExtractError {
+  url: string;
+  error_type?: string;
+  http_status_code?: number;
+  content?: string;
+}
+
+export interface ParallelExtractResponse {
+  extract_id: string;
+  results?: ParallelExtractResult[];
+  errors?: ParallelExtractError[];
+  warnings?: unknown;
+  usage?: Array<{ name: string; count: number }>;
+  session_id?: string;
+}
+
+export interface ParallelScrapeData {
+  rawContent: string;
+  title?: string;
+  publishDate?: string;
+  excerpts: string[];
+}
+
+export type ParallelScrapeResponse =
+  | { success: true; data: ParallelScrapeData; error?: undefined }
+  | { success: false; data?: undefined; error: string };
 
 export interface ScraperContentResult {
   content: string;
@@ -223,6 +387,7 @@ export interface SearchToolConfig
   scraperProvider?: ScraperProvider;
   scraperTimeout?: number;
   serperScraperOptions?: SerperScraperConfig;
+  parallelScraperOptions?: ParallelScraperConfig;
   onSearchResults?: (
     results: SearchResult,
     runnableConfig?: RunnableConfig
@@ -244,7 +409,8 @@ export type UsedReferences = {
 export type AnyScraperResponse =
   | FirecrawlScrapeResponse
   | SerperScrapeResponse
-  | TavilyScrapeResponse;
+  | TavilyScrapeResponse
+  | ParallelScrapeResponse;
 
 /** Base Scraper Interface */
 export interface BaseScraper {
@@ -279,6 +445,14 @@ export type TavilyScrapeOptions = Omit<
   TavilyScraperConfig,
   'apiKey' | 'apiUrl' | 'logger'
 >;
+
+export type ParallelScrapeOptions = Omit<
+  ParallelScraperConfig,
+  'apiKey' | 'apiUrl' | 'logger'
+> & {
+  /** Optional session id to group this call with related Search/Extract calls. */
+  sessionId?: string;
+};
 
 export interface TavilyExtractPayload {
   urls: string[];


### PR DESCRIPTION
## Summary

Adds **Parallel Web Systems** as a dual search/scraper provider, mirroring the existing Tavily integration where one API key drives both surfaces.

- **Search** (`SearchProvider = 'parallel'`) → `POST https://api.parallel.ai/v1/search`
- **Scraper** (`ScraperProvider = 'parallel'`) → `POST https://api.parallel.ai/v1/extract`

Parallel's Search API returns LLM-optimized excerpts ranked for reasoning utility (rather than human engagement), so the natural pairing is `searchProvider: parallel` + `scraperProvider: parallel` + `rerankerType: none`. Each provider can still be used independently.

## Why this fits the existing architecture

| Role | Existing precedent | New entry |
|---|---|---|
| Search engine that returns ranked LLM-ready excerpts | `tavily` | `parallel` |
| URL→content extractor with batch API + per-URL error reporting | `tavily` | `parallel` |
| Single API key drives both surfaces | `tavily` ✅ | `parallel` ✅ |

The integration follows Tavily's shape almost identically: `createXxxAPI(apiKey, apiUrl, options)` for search, `XxxScraper implements BaseScraper` for the scraper.

## Implementation notes

- **Auth**: `x-api-key: ...` header (Parallel's REST scheme). Not `Authorization: Bearer ...` — that form is reserved for the MCP surface and is out of scope here.
- **Query handling**: the LLM-supplied query becomes both the `objective` and the first entry of `search_queries[]`. Admins can layer a fixed objective and additional supplementary keyword queries via `parallelSearchOptions`.
- **Advanced settings**: per Parallel's best-practices doc, restrictive options (`include_domains`, `exclude_domains`, `location`, `max_results`) are only emitted when explicitly configured. The default request is minimal.
- **Excerpt cap**: `max_chars_per_result` is clamped to the API minimum of 1000 chars to match documented behavior.
- **Batch chunking**: Extract requests are split into 20-URL chunks to match the documented limit.
- **Full-page content**: defaults to excerpts-only (already markdown + ranked). `parallelScraperOptions.fullContent: true` opts into full page bodies via `advanced_settings.full_content_settings.enabled`.

## Files changed

| File | Change |
|---|---|
| `src/tools/search/parallel-search.ts` | new — `createParallelAPI` |
| `src/tools/search/parallel-scraper.ts` | new — `ParallelScraper` / `createParallelScraper` |
| `src/tools/search/parallel.test.ts` | new — 15 unit tests, axios mocked |
| `src/tools/search/search.ts` | wired `parallel` into `createSearchAPI` switch |
| `src/tools/search/tool.ts` | wired `parallel` into `createSearchTool` (scraper + supportsVideos + country schema) |
| `src/tools/search/types.ts` | added enum members + typed request/response payloads + option types |

## Config surface added

```ts
type SearchToolConfig = {
  // ...existing fields
  parallelApiKey?: string;             // PARALLEL_API_KEY
  parallelSearchUrl?: string;          // PARALLEL_SEARCH_URL (default: https://api.parallel.ai/v1/search)
  parallelExtractUrl?: string;         // PARALLEL_EXTRACT_URL (default: https://api.parallel.ai/v1/extract)
  parallelSearchOptions?: ParallelSearchOptions;
  parallelScraperOptions?: ParallelScraperConfig;
};
```

## Testing

- `npx jest src/tools/search/parallel.test.ts` → **15/15 passing** (15 new tests)
- `npx jest src/tools/search/` → **63/63 passing** (no regressions in Tavily/Serper/etc.)
- `npx tsc -p tsconfig.json --noEmit` → 0 errors
- `npx eslint` on all touched files → 0 errors / 0 warnings

Tests cover: missing-key throw, empty query, network failure mapping, x-api-key header, payload shape (with and without advanced_settings), query dedup + 5-entry clamp, excerpt-cap minimum clamp, country→location fallback, per-URL error mapping, 20-URL batch chunking, full-content opt-in, and the `createSearchTool` smoke test.

## Follow-up PR

A companion PR for `danny-avila/LibreChat` will plumb the schema, enums, and `librechat.yaml` keys (`parallelApiKey`, `searchProvider: parallel`, etc.) so end-users can configure this from the LibreChat config layer.

## Docs

- Search API: https://docs.parallel.ai/api-reference/search/search
- Extract API: https://docs.parallel.ai/api-reference/extract/extract
- Best practices: https://docs.parallel.ai/search/best-practices