### PR TITLE
🪨 refactor: Cache Bedrock Prompt and Tool Prefixes

### DIFF
--- a/src/agents/__tests__/AgentContext.anthropic.live.test.ts
+++ b/src/agents/__tests__/AgentContext.anthropic.live.test.ts
@@ -9,6 +9,14 @@ import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
 
 import { describe, expect, it } from '@jest/globals';
+import {
+  AIMessage,
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+  type MessageContentComplex,
+} from '@langchain/core/messages';
 import type * as t from '@/types';
 import {
   runLiveTurn,
@@ -18,6 +26,9 @@ import {
   waitForCachePropagation,
 } from './promptCacheLiveHelpers';
 import { Providers } from '@/common';
+import { addCacheControl } from '@/messages/cache';
+import { toLangChainContent } from '@/messages/langchain';
+import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 
 const shouldRunLive =
   process.env.RUN_ANTHROPIC_PROMPT_CACHE_LIVE_TESTS === '1' &&
@@ -44,6 +55,268 @@ function createClientOptions(): t.AnthropicClientOptions {
       },
     },
   };
+}
+
+type AnthropicCacheUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreation: number;
+  cacheRead: number;
+  latencyMs: number;
+};
+
+type AnthropicUsageResponse = {
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number | null;
+    cache_read_input_tokens?: number | null;
+  };
+};
+
+type AnthropicMessagesClient = {
+  messages: {
+    create: (
+      request: Record<string, unknown>,
+      options: { headers: Record<string, string> }
+    ) => Promise<AnthropicUsageResponse>;
+  };
+};
+
+const benchmarkTool = {
+  name: 'lookup_cache_probe',
+  description: 'Returns prompt cache benchmark data.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      step: { type: 'integer' },
+    },
+    required: ['step'],
+  },
+};
+
+function cloneLiveMessage(
+  message: BaseMessage,
+  content: MessageContentComplex[]
+): BaseMessage {
+  const baseParams = {
+    content: toLangChainContent(content),
+    additional_kwargs: { ...message.additional_kwargs },
+    response_metadata: { ...message.response_metadata },
+    id: message.id,
+    name: message.name,
+  };
+
+  const messageType = message.getType();
+  if (messageType === 'ai') {
+    return new AIMessage({
+      ...baseParams,
+      tool_calls: (message as AIMessage).tool_calls,
+    });
+  }
+  if (messageType === 'human') {
+    return new HumanMessage(baseParams);
+  }
+  if (messageType === 'system') {
+    return new SystemMessage(baseParams);
+  }
+  if (messageType === 'tool') {
+    return new ToolMessage({
+      ...baseParams,
+      tool_call_id: (message as ToolMessage).tool_call_id,
+    });
+  }
+
+  return message;
+}
+
+function addLatestUserOnlyAnthropicCacheControl(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  const updatedMessages = [...messages];
+  let addedCacheControl = false;
+
+  for (let i = updatedMessages.length - 1; i >= 0; i--) {
+    const message = updatedMessages[i];
+    const content = message.content;
+    const hasArrayContent = Array.isArray(content);
+    const canAddCache =
+      !addedCacheControl &&
+      message.getType() === 'human' &&
+      (typeof content === 'string' || hasArrayContent);
+
+    if (!canAddCache && !hasArrayContent) {
+      continue;
+    }
+
+    let workingContent: MessageContentComplex[];
+    let modified = false;
+
+    if (hasArrayContent) {
+      workingContent = [];
+      let lastTextIndex = -1;
+      for (const block of content as MessageContentComplex[]) {
+        if ('cachePoint' in block && !('type' in block)) {
+          modified = true;
+          continue;
+        }
+        const cloned = { ...block };
+        if ('cache_control' in cloned) {
+          delete (cloned as Record<string, unknown>).cache_control;
+          modified = true;
+        }
+        if ('type' in cloned && cloned.type === 'text') {
+          const text = (cloned as { text?: string }).text;
+          if (text != null && text.trim() !== '') {
+            lastTextIndex = workingContent.length;
+          }
+        }
+        workingContent.push(cloned as MessageContentComplex);
+      }
+
+      if (canAddCache && lastTextIndex >= 0) {
+        (
+          workingContent[lastTextIndex] as MessageContentComplex & {
+            cache_control?: { type: 'ephemeral' };
+          }
+        ).cache_control = { type: 'ephemeral' };
+        addedCacheControl = true;
+        modified = true;
+      }
+
+      if (!modified) {
+        continue;
+      }
+    } else if (typeof content === 'string' && content.trim() !== '' && canAddCache) {
+      workingContent = [
+        {
+          type: 'text',
+          text: content,
+          cache_control: { type: 'ephemeral' },
+        },
+      ] as unknown as MessageContentComplex[];
+      addedCacheControl = true;
+    } else {
+      continue;
+    }
+
+    updatedMessages[i] = cloneLiveMessage(message, workingContent);
+  }
+
+  return updatedMessages;
+}
+
+function repeated(label: string, count: number): string {
+  return Array.from(
+    { length: count },
+    (_, index) =>
+      `${label} reference ${index}: stable schema, metric definition, access policy, dashboard note, and query planning guidance.`
+  ).join('\n');
+}
+
+function buildMultiTurnToolMessages({
+  nonce,
+  marker,
+}: {
+  nonce: string;
+  marker: string;
+}): BaseMessage[] {
+  const stableFirstUser = [
+    `Anthropic prompt cache placement benchmark ${nonce}.`,
+    'This first user turn is intentionally stable across calls in the same benchmark case.',
+    repeated(`${nonce} stable-user-context`, 190),
+  ].join('\n');
+  const latestUser = [
+    `Current user request marker: ${marker}.`,
+    'Use the final tool result to answer with the marker only.',
+    repeated(`${nonce} latest-user-${marker}`, 18),
+  ].join('\n');
+  const volatileToolPayload = repeated(`${nonce} volatile-tool-${marker}`, 70);
+
+  return [
+    new HumanMessage(stableFirstUser),
+    new AIMessage('I will keep this stable context in mind.'),
+    new HumanMessage(latestUser),
+    new AIMessage({
+      content: `I will inspect cache probe step 1 for ${marker}.\n${volatileToolPayload}`,
+      tool_calls: [
+        {
+          id: `call_${marker}_1`,
+          name: 'lookup_cache_probe',
+          args: { step: 1 },
+        },
+      ],
+    }),
+    new ToolMessage({
+      content: `Tool result 1 for ${marker}.\n${volatileToolPayload}`,
+      tool_call_id: `call_${marker}_1`,
+    }),
+    new AIMessage({
+      content: `I will inspect cache probe step 2 for ${marker}.\n${volatileToolPayload}`,
+      tool_calls: [
+        {
+          id: `call_${marker}_2`,
+          name: 'lookup_cache_probe',
+          args: { step: 2 },
+        },
+      ],
+    }),
+    new ToolMessage({
+      content: [
+        `Final tool result marker: ${marker}.`,
+        'Reply with the marker and no extra explanation.',
+        volatileToolPayload,
+      ].join('\n'),
+      tool_call_id: `call_${marker}_2`,
+    }),
+  ];
+}
+
+function extractCacheUsage(
+  response: AnthropicUsageResponse,
+  latencyMs: number
+): AnthropicCacheUsage {
+  if (response.usage == null) {
+    throw new Error('Missing Anthropic usage metadata for cache benchmark');
+  }
+
+  return {
+    inputTokens: response.usage.input_tokens ?? 0,
+    outputTokens: response.usage.output_tokens ?? 0,
+    cacheCreation: response.usage.cache_creation_input_tokens ?? 0,
+    cacheRead: response.usage.cache_read_input_tokens ?? 0,
+    latencyMs,
+  };
+}
+
+async function runAnthropicCacheBenchmarkTurn({
+  client,
+  messages,
+}: {
+  client: AnthropicMessagesClient;
+  messages: BaseMessage[];
+}): Promise<AnthropicCacheUsage> {
+  const payload = _convertMessagesToAnthropicPayload(messages);
+  const startedAt = Date.now();
+  const response = await client.messages.create(
+    {
+      ...payload,
+      model: modelName,
+      max_tokens: 16,
+      temperature: 0,
+      tools: [benchmarkTool],
+    },
+    {
+      headers: {
+        'anthropic-beta': 'prompt-caching-2024-07-31',
+      },
+    }
+  );
+
+  return extractCacheUsage(
+    response as AnthropicUsageResponse,
+    Date.now() - startedAt
+  );
 }
 
 describeIfLive('AgentContext Anthropic prompt cache live API', () => {
@@ -109,4 +382,63 @@ describeIfLive('AgentContext Anthropic prompt cache live API', () => {
     expect(second.text.toLowerCase()).toContain('bravo');
     expect(second.usage.input_token_details?.cache_read).toBeGreaterThan(0);
   }, 120_000);
+
+  it('compares current two-user cache placement against latest-user-only', async () => {
+    const Anthropic = (await import('@anthropic-ai/sdk')).default;
+    const client = new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    }) as unknown as AnthropicMessagesClient;
+    const nonce = `anthropic-cache-placement-${Date.now()}`;
+    const currentNonce = `${nonce}-current`;
+    const latestOnlyNonce = `${nonce}-latest-only`;
+
+    const currentFirst = await runAnthropicCacheBenchmarkTurn({
+      client,
+      messages: addCacheControl(
+        buildMultiTurnToolMessages({ nonce: currentNonce, marker: 'alpha' })
+      ),
+    });
+
+    await waitForCachePropagation();
+
+    const currentSecond = await runAnthropicCacheBenchmarkTurn({
+      client,
+      messages: addCacheControl(
+        buildMultiTurnToolMessages({ nonce: currentNonce, marker: 'bravo' })
+      ),
+    });
+
+    const latestOnlyFirst = await runAnthropicCacheBenchmarkTurn({
+      client,
+      messages: addLatestUserOnlyAnthropicCacheControl(
+        buildMultiTurnToolMessages({ nonce: latestOnlyNonce, marker: 'alpha' })
+      ),
+    });
+
+    await waitForCachePropagation();
+
+    const latestOnlySecond = await runAnthropicCacheBenchmarkTurn({
+      client,
+      messages: addLatestUserOnlyAnthropicCacheControl(
+        buildMultiTurnToolMessages({ nonce: latestOnlyNonce, marker: 'bravo' })
+      ),
+    });
+
+    process.stdout.write(
+      `Anthropic cache placement benchmark ${JSON.stringify({
+        currentFirst,
+        currentSecond,
+        latestOnlyFirst,
+        latestOnlySecond,
+        cacheWriteDelta:
+          currentSecond.cacheCreation - latestOnlySecond.cacheCreation,
+      })}\n`
+    );
+
+    expect(currentSecond.cacheRead).toBeGreaterThan(0);
+    expect(currentSecond.cacheRead).toBeGreaterThan(latestOnlySecond.cacheRead);
+    expect(currentSecond.cacheCreation).toBeLessThan(
+      latestOnlySecond.cacheCreation
+    );
+  }, 180_000);
 });

--- a/src/agents/__tests__/AgentContext.bedrock.live.test.ts
+++ b/src/agents/__tests__/AgentContext.bedrock.live.test.ts
@@ -11,6 +11,18 @@ import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
 
 import { describe, expect, it } from '@jest/globals';
+import {
+  AIMessage,
+  BaseMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+  type MessageContentComplex,
+} from '@langchain/core/messages';
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from '@aws-sdk/client-bedrock-runtime';
 import type * as t from '@/types';
 import {
   runLiveTurn,
@@ -20,6 +32,9 @@ import {
   waitForCachePropagation,
 } from './promptCacheLiveHelpers';
 import { Providers } from '@/common';
+import { addBedrockCacheControl } from '@/messages/cache';
+import { toLangChainContent } from '@/messages/langchain';
+import { convertToConverseMessages } from '@/llm/bedrock/utils';
 
 const accessKeyId =
   process.env.BEDROCK_AWS_ACCESS_KEY_ID ?? process.env.AWS_ACCESS_KEY_ID;
@@ -75,6 +90,373 @@ function createClientOptions(): t.BedrockAnthropicClientOptions {
     promptCache: true,
     ...(credentials != null ? { credentials } : {}),
   };
+}
+
+type BedrockCacheUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cacheCreation: number;
+  cacheRead: number;
+  latencyMs: number;
+};
+
+type ConverseUsageResponse = {
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    cacheReadInputTokens?: number;
+    cacheWriteInputTokens?: number;
+  };
+};
+
+const benchmarkToolConfig = {
+  tools: [
+    {
+      toolSpec: {
+        name: 'lookup_cache_probe',
+        description: 'Returns prompt cache benchmark data.',
+        inputSchema: {
+          json: {
+            type: 'object',
+            properties: {
+              step: { type: 'integer' },
+            },
+            required: ['step'],
+          },
+        },
+      },
+    },
+  ],
+};
+
+function cachePointBlock(): MessageContentComplex {
+  return { cachePoint: { type: 'default' } } as MessageContentComplex;
+}
+
+function stripCacheMarkers(
+  content: MessageContentComplex[]
+): MessageContentComplex[] {
+  return content
+    .filter((block) => !('cachePoint' in block && !('type' in block)))
+    .map((block) => {
+      const cloned = { ...block };
+      delete (cloned as Record<string, unknown>).cache_control;
+      return cloned as MessageContentComplex;
+    });
+}
+
+function cloneLiveMessage(
+  message: BaseMessage,
+  content: MessageContentComplex[]
+): BaseMessage {
+  const baseParams = {
+    content: toLangChainContent(content),
+    additional_kwargs: { ...message.additional_kwargs },
+    response_metadata: { ...message.response_metadata },
+    id: message.id,
+    name: message.name,
+  };
+
+  const messageType = message.getType();
+  if (messageType === 'ai') {
+    return new AIMessage({
+      ...baseParams,
+      tool_calls: (message as AIMessage).tool_calls,
+    });
+  }
+  if (messageType === 'human') {
+    return new HumanMessage(baseParams);
+  }
+  if (messageType === 'system') {
+    return new SystemMessage(baseParams);
+  }
+  if (messageType === 'tool') {
+    return new ToolMessage({
+      ...baseParams,
+      tool_call_id: (message as ToolMessage).tool_call_id,
+    });
+  }
+
+  return message;
+}
+
+function addLegacyMovingTailBedrockCacheControl(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  const updatedMessages = [...messages];
+  let messagesModified = 0;
+
+  for (let i = updatedMessages.length - 1; i >= 0; i--) {
+    const message = updatedMessages[i];
+    const messageType = message.getType();
+    if (messageType === 'system' || messageType === 'tool') {
+      continue;
+    }
+
+    const content = message.content;
+    if (typeof content === 'string') {
+      if (content === '' || messagesModified >= 2) {
+        continue;
+      }
+      updatedMessages[i] = cloneLiveMessage(message, [
+        { type: 'text', text: content } as MessageContentComplex,
+        cachePointBlock(),
+      ]);
+      messagesModified++;
+      continue;
+    }
+
+    if (!Array.isArray(content)) {
+      continue;
+    }
+
+    const workingContent = stripCacheMarkers(
+      content as MessageContentComplex[]
+    );
+    const lastTextIndex = workingContent.findLastIndex((block) => {
+      const type = (block as { type?: string }).type;
+      const text = (block as { text?: string }).text;
+      return (type === 'text' || type === 'input_text') && text?.trim() !== '';
+    });
+
+    if (messagesModified < 2 && lastTextIndex >= 0) {
+      workingContent.splice(lastTextIndex + 1, 0, cachePointBlock());
+      messagesModified++;
+    }
+
+    updatedMessages[i] = cloneLiveMessage(message, workingContent);
+  }
+
+  return updatedMessages;
+}
+
+function addLatestUserOnlyBedrockCacheControl(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  const updatedMessages = [...messages];
+  let addedCachePoint = false;
+
+  for (let i = updatedMessages.length - 1; i >= 0; i--) {
+    const message = updatedMessages[i];
+    const messageType = message.getType();
+    if (messageType === 'system') {
+      continue;
+    }
+
+    const content = message.content;
+    const hasArrayContent = Array.isArray(content);
+    const canAddCache =
+      !addedCachePoint &&
+      messageType === 'human' &&
+      (typeof content === 'string' || hasArrayContent);
+
+    if (!canAddCache && !hasArrayContent) {
+      continue;
+    }
+
+    let workingContent: MessageContentComplex[];
+    let modified = false;
+
+    if (hasArrayContent) {
+      workingContent = stripCacheMarkers(content as MessageContentComplex[]);
+      modified = workingContent.length !== content.length;
+      const lastTextIndex = workingContent.findLastIndex((block) => {
+        const type = (block as { type?: string }).type;
+        const text = (block as { text?: string }).text;
+        return (
+          (type === 'text' || type === 'input_text') && text?.trim() !== ''
+        );
+      });
+
+      if (canAddCache && lastTextIndex >= 0) {
+        workingContent.splice(lastTextIndex + 1, 0, cachePointBlock());
+        addedCachePoint = true;
+        modified = true;
+      }
+
+      if (!modified) {
+        continue;
+      }
+    } else if (typeof content === 'string' && content.trim() !== '' && canAddCache) {
+      workingContent = [
+        { type: 'text', text: content } as MessageContentComplex,
+        cachePointBlock(),
+      ];
+      addedCachePoint = true;
+    } else {
+      continue;
+    }
+
+    updatedMessages[i] = cloneLiveMessage(message, workingContent);
+  }
+
+  return updatedMessages;
+}
+
+function repeated(label: string, count: number): string {
+  return Array.from(
+    { length: count },
+    (_, index) =>
+      `${label} reference ${index}: stable schema, metric definition, access policy, dashboard note, and query planning guidance.`
+  ).join('\n');
+}
+
+function buildToolLoopMessages({
+  nonce,
+  marker,
+}: {
+  nonce: string;
+  marker: string;
+}): BaseMessage[] {
+  const stableUserContext = [
+    `Bedrock prompt cache placement benchmark ${nonce}.`,
+    'The first user turn is intentionally stable across calls in the same benchmark case.',
+    repeated(`${nonce} user-context`, 190),
+    'Use the final tool result to answer with the requested marker.',
+  ].join('\n');
+  const volatileToolPayload = repeated(`${nonce} volatile-${marker}`, 70);
+
+  return [
+    new HumanMessage(stableUserContext),
+    new AIMessage({
+      content: `I will inspect cache probe step 1 for ${marker}.\n${volatileToolPayload}`,
+      tool_calls: [
+        {
+          id: `call_${marker}_1`,
+          name: 'lookup_cache_probe',
+          args: { step: 1 },
+        },
+      ],
+    }),
+    new ToolMessage({
+      content: `Tool result 1 for ${marker}.\n${volatileToolPayload}`,
+      tool_call_id: `call_${marker}_1`,
+    }),
+    new AIMessage({
+      content: `I will inspect cache probe step 2 for ${marker}.\n${volatileToolPayload}`,
+      tool_calls: [
+        {
+          id: `call_${marker}_2`,
+          name: 'lookup_cache_probe',
+          args: { step: 2 },
+        },
+      ],
+    }),
+    new ToolMessage({
+      content: [
+        `Final tool result marker: ${marker}.`,
+        'Reply with the marker and no extra explanation.',
+        volatileToolPayload,
+      ].join('\n'),
+      tool_call_id: `call_${marker}_2`,
+    }),
+  ];
+}
+
+function buildMultiTurnToolMessages({
+  nonce,
+  marker,
+}: {
+  nonce: string;
+  marker: string;
+}): BaseMessage[] {
+  const stableFirstUser = [
+    `Bedrock multi-turn prompt cache benchmark ${nonce}.`,
+    'This first user turn is intentionally stable across calls in the same benchmark case.',
+    repeated(`${nonce} stable-user-context`, 190),
+  ].join('\n');
+  const latestUser = [
+    `Current user request marker: ${marker}.`,
+    'Use the final tool result to answer with the marker only.',
+    repeated(`${nonce} latest-user-${marker}`, 18),
+  ].join('\n');
+  const volatileToolPayload = repeated(`${nonce} volatile-tool-${marker}`, 70);
+
+  return [
+    new HumanMessage(stableFirstUser),
+    new AIMessage('I will keep this stable context in mind.'),
+    new HumanMessage(latestUser),
+    new AIMessage({
+      content: `I will inspect cache probe step 1 for ${marker}.\n${volatileToolPayload}`,
+      tool_calls: [
+        {
+          id: `call_${marker}_1`,
+          name: 'lookup_cache_probe',
+          args: { step: 1 },
+        },
+      ],
+    }),
+    new ToolMessage({
+      content: `Tool result 1 for ${marker}.\n${volatileToolPayload}`,
+      tool_call_id: `call_${marker}_1`,
+    }),
+    new AIMessage({
+      content: `I will inspect cache probe step 2 for ${marker}.\n${volatileToolPayload}`,
+      tool_calls: [
+        {
+          id: `call_${marker}_2`,
+          name: 'lookup_cache_probe',
+          args: { step: 2 },
+        },
+      ],
+    }),
+    new ToolMessage({
+      content: [
+        `Final tool result marker: ${marker}.`,
+        'Reply with the marker and no extra explanation.',
+        volatileToolPayload,
+      ].join('\n'),
+      tool_call_id: `call_${marker}_2`,
+    }),
+  ];
+}
+
+function extractCacheUsage(
+  response: ConverseUsageResponse,
+  latencyMs: number
+): BedrockCacheUsage {
+  if (response.usage == null) {
+    throw new Error('Missing Bedrock usage metadata for cache benchmark');
+  }
+
+  const inputTokens = response.usage.inputTokens ?? 0;
+  const outputTokens = response.usage.outputTokens ?? 0;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: response.usage.totalTokens ?? inputTokens + outputTokens,
+    cacheCreation: response.usage.cacheWriteInputTokens ?? 0,
+    cacheRead: response.usage.cacheReadInputTokens ?? 0,
+    latencyMs,
+  };
+}
+
+async function runConverseCacheBenchmarkTurn({
+  client,
+  messages,
+}: {
+  client: BedrockRuntimeClient;
+  messages: BaseMessage[];
+}): Promise<BedrockCacheUsage> {
+  const { converseMessages, converseSystem } =
+    convertToConverseMessages(messages);
+  const startedAt = Date.now();
+  const response = await client.send(
+    new ConverseCommand({
+      modelId: model,
+      ...(converseSystem.length > 0 ? { system: converseSystem } : {}),
+      messages: converseMessages,
+      toolConfig: benchmarkToolConfig,
+      inferenceConfig: { maxTokens: 16, temperature: 0 },
+    })
+  );
+
+  return extractCacheUsage(
+    response as ConverseUsageResponse,
+    Date.now() - startedAt
+  );
 }
 
 describeIfLive('AgentContext Bedrock prompt cache live API', () => {
@@ -146,4 +528,126 @@ describeIfLive('AgentContext Bedrock prompt cache live API', () => {
     expect(second.text.toLowerCase()).toContain('bravo');
     expect(second.usage.input_token_details?.cache_read).toBeGreaterThan(0);
   }, 180_000);
+
+  it('reduces repeated cache writes versus the previous moving-tail placement', async () => {
+    const credentials = getCredentials();
+    const client = new BedrockRuntimeClient({
+      region,
+      ...(credentials != null ? { credentials } : {}),
+    });
+    const nonce = `bedrock-cache-placement-${Date.now()}`;
+    const legacyNonce = `${nonce}-legacy`;
+    const currentNonce = `${nonce}-current`;
+
+    const legacyFirst = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addLegacyMovingTailBedrockCacheControl(
+        buildToolLoopMessages({ nonce: legacyNonce, marker: 'alpha' })
+      ),
+    });
+
+    await waitForCachePropagation();
+
+    const legacySecond = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addLegacyMovingTailBedrockCacheControl(
+        buildToolLoopMessages({ nonce: legacyNonce, marker: 'bravo' })
+      ),
+    });
+
+    const currentFirst = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addBedrockCacheControl(
+        buildToolLoopMessages({ nonce: currentNonce, marker: 'alpha' })
+      ),
+    });
+
+    await waitForCachePropagation();
+
+    const currentSecond = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addBedrockCacheControl(
+        buildToolLoopMessages({ nonce: currentNonce, marker: 'bravo' })
+      ),
+    });
+
+    const cacheWriteReduction =
+      legacySecond.cacheCreation - currentSecond.cacheCreation;
+    process.stdout.write(
+      `Bedrock cache placement benchmark ${JSON.stringify({
+        legacyFirst,
+        legacySecond,
+        currentFirst,
+        currentSecond,
+        cacheWriteReduction,
+      })}\n`
+    );
+
+    expect(currentSecond.cacheRead).toBeGreaterThan(0);
+    expect(cacheWriteReduction).toBeGreaterThan(0);
+    expect(currentSecond.cacheCreation).toBeLessThan(
+      Math.ceil(legacySecond.cacheCreation * 0.5)
+    );
+  }, 240_000);
+
+  it('reuses prior user cache points when the latest user turn changes', async () => {
+    const credentials = getCredentials();
+    const client = new BedrockRuntimeClient({
+      region,
+      ...(credentials != null ? { credentials } : {}),
+    });
+    const nonce = `bedrock-multiturn-cache-placement-${Date.now()}`;
+    const currentNonce = `${nonce}-current`;
+    const latestOnlyNonce = `${nonce}-latest-only`;
+
+    const currentFirst = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addBedrockCacheControl(
+        buildMultiTurnToolMessages({ nonce: currentNonce, marker: 'alpha' })
+      ),
+    });
+
+    await waitForCachePropagation();
+
+    const currentSecond = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addBedrockCacheControl(
+        buildMultiTurnToolMessages({ nonce: currentNonce, marker: 'bravo' })
+      ),
+    });
+
+    const latestOnlyFirst = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addLatestUserOnlyBedrockCacheControl(
+        buildMultiTurnToolMessages({ nonce: latestOnlyNonce, marker: 'alpha' })
+      ),
+    });
+
+    await waitForCachePropagation();
+
+    const latestOnlySecond = await runConverseCacheBenchmarkTurn({
+      client,
+      messages: addLatestUserOnlyBedrockCacheControl(
+        buildMultiTurnToolMessages({ nonce: latestOnlyNonce, marker: 'bravo' })
+      ),
+    });
+
+    process.stdout.write(
+      `Bedrock multi-turn cache placement benchmark ${JSON.stringify({
+        currentFirst,
+        currentSecond,
+        latestOnlyFirst,
+        latestOnlySecond,
+        cacheWriteDelta:
+          currentSecond.cacheCreation - latestOnlySecond.cacheCreation,
+      })}\n`
+    );
+
+    expect(currentSecond.cacheRead).toBeGreaterThan(
+      latestOnlySecond.cacheRead
+    );
+    expect(currentSecond.cacheCreation).toBeLessThan(
+      latestOnlySecond.cacheCreation
+    );
+  }, 240_000);
 });

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -81,6 +81,7 @@ import {
 import { HandlerRegistry } from '@/events';
 import { ChatOpenAI } from '@/llm/openai';
 import { partitionAndMarkOpenRouterToolCache } from '@/llm/openrouter/toolCache';
+import { partitionAndMarkBedrockToolCache } from '@/llm/bedrock/toolCache';
 import type { HookRegistry } from '@/hooks';
 
 const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
@@ -959,6 +960,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       ) {
         toolsForBinding =
           partitionAndMarkOpenRouterToolCache(
+            rawToolsForBinding,
+            makeIsDeferred(agentContext.toolDefinitions)
+          ) ?? rawToolsForBinding;
+      } else if (
+        agentContext.provider === Providers.BEDROCK &&
+        (
+          agentContext.clientOptions as
+            | t.BedrockAnthropicClientOptions
+            | undefined
+        )?.promptCache === true
+      ) {
+        toolsForBinding =
+          partitionAndMarkBedrockToolCache(
             rawToolsForBinding,
             makeIsDeferred(agentContext.toolDefinitions)
           ) ?? rawToolsForBinding;

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -28,6 +28,7 @@ import { ChatGenerationChunk, ChatResult } from '@langchain/core/outputs';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { ChatBedrockConverseInput } from '@langchain/aws';
 import type { BaseMessage, ResponseMetadata } from '@langchain/core/messages';
+import { insertBedrockToolCachePoint } from './toolCache';
 import {
   convertToConverseMessages,
   handleConverseStreamContentBlockStart,
@@ -49,6 +50,11 @@ export type ServiceTierType = 'priority' | 'default' | 'flex' | 'reserved';
  */
 export interface CustomChatBedrockConverseInput
   extends ChatBedrockConverseInput {
+  /**
+   * Enables Bedrock prompt cache checkpoints for message and tool prefixes.
+   */
+  promptCache?: boolean;
+
   /**
    * Application Inference Profile ARN to use for the model.
    * For example, "arn:aws:bedrock:eu-west-1:123456789102:application-inference-profile/fm16bt65tzgx"
@@ -84,6 +90,11 @@ export interface CustomChatBedrockConverseCallOptions {
 
 export class CustomChatBedrockConverse extends ChatBedrockConverse {
   /**
+   * Whether to insert Bedrock prompt cache checkpoints when available.
+   */
+  promptCache?: boolean;
+
+  /**
    * Application Inference Profile ARN to use instead of model ID.
    */
   applicationInferenceProfile?: string;
@@ -95,6 +106,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
 
   constructor(fields?: CustomChatBedrockConverseInput) {
     super(fields);
+    this.promptCache = fields?.promptCache;
     this.applicationInferenceProfile = fields?.applicationInferenceProfile;
     this.serviceTier = fields?.serviceTier;
   }
@@ -120,12 +132,17 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     serviceTier?: { type: ServiceTierType };
   } {
     const baseParams = super.invocationParams(options);
+    const toolConfig =
+      this.promptCache === true
+        ? insertBedrockToolCachePoint(baseParams.toolConfig, true)
+        : baseParams.toolConfig;
 
     /** Service tier from options or fall back to class-level setting */
     const serviceTierType = options?.serviceTier ?? this.serviceTier;
 
     return {
       ...baseParams,
+      toolConfig,
       serviceTier: serviceTierType ? { type: serviceTierType } : undefined,
     };
   }

--- a/src/llm/bedrock/llm.spec.ts
+++ b/src/llm/bedrock/llm.spec.ts
@@ -18,14 +18,16 @@ import {
   ConverseCommand,
   ConverseStreamCommand,
 } from '@aws-sdk/client-bedrock-runtime';
-import type { ConverseResponse } from '@aws-sdk/client-bedrock-runtime';
+import type { ConverseResponse, Tool } from '@aws-sdk/client-bedrock-runtime';
 import {
   convertConverseMessageToLangChainMessage,
   handleConverseStreamMetadata,
   convertToConverseMessages,
 } from './utils';
+import type { GraphTools } from '@/types';
 import { toLangChainContent } from '@/messages/langchain';
 import { CustomChatBedrockConverse, ServiceTierType } from './index';
+import { partitionAndMarkBedrockToolCache } from './toolCache';
 
 jest.setTimeout(120000);
 
@@ -83,6 +85,17 @@ function humanMessageWithContent(
   content: MessageContentComplex[]
 ): HumanMessage {
   return new HumanMessage({ content: toLangChainContent(content) });
+}
+
+function getBedrockToolName(entry: Tool): string {
+  if ('cachePoint' in entry) {
+    return 'cachePoint';
+  }
+  return entry.toolSpec?.name ?? 'missing';
+}
+
+function getBedrockToolNames(tools: Tool[] | undefined): string[] {
+  return (tools ?? []).map(getBedrockToolName);
 }
 
 describe('CustomChatBedrockConverse', () => {
@@ -310,6 +323,101 @@ describe('CustomChatBedrockConverse', () => {
       expect(params.inferenceConfig?.temperature).toBe(0.5);
       expect(params.inferenceConfig?.maxTokens).toBe(100);
       expect(params.inferenceConfig?.stopSequences).toEqual(['stop_sequence']);
+    });
+  });
+
+  describe('promptCache tool configuration', () => {
+    test('adds a Bedrock cache point for directly-bound tools', () => {
+      const model = new CustomChatBedrockConverse({
+        ...baseConstructorArgs,
+        promptCache: true,
+      });
+
+      const params = model.invocationParams({
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'direct_tool',
+              description: 'Direct tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ],
+      });
+
+      expect(getBedrockToolNames(params.toolConfig?.tools)).toEqual([
+        'direct_tool',
+        'cachePoint',
+      ]);
+    });
+
+    test('adds the Bedrock cache point before deferred tools', () => {
+      const model = new CustomChatBedrockConverse({
+        ...baseConstructorArgs,
+        promptCache: true,
+      });
+      const tools = partitionAndMarkBedrockToolCache(
+        [
+          {
+            type: 'function',
+            function: {
+              name: 'static_tool',
+              description: 'Static tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+          {
+            type: 'function',
+            function: {
+              name: 'deferred_tool',
+              description: 'Deferred tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ] as GraphTools,
+        (name) => name === 'deferred_tool'
+      );
+
+      const params = model.invocationParams({ tools });
+
+      expect(getBedrockToolNames(params.toolConfig?.tools)).toEqual([
+        'static_tool',
+        'cachePoint',
+        'deferred_tool',
+      ]);
+      expect(JSON.stringify(params.toolConfig?.tools)).not.toContain(
+        '__lc_bedrock_cache_point_after'
+      );
+    });
+
+    test('does not fall back to caching when Graph marks all tools deferred', () => {
+      const model = new CustomChatBedrockConverse({
+        ...baseConstructorArgs,
+        promptCache: true,
+      });
+      const tools = partitionAndMarkBedrockToolCache(
+        [
+          {
+            type: 'function',
+            function: {
+              name: 'deferred_tool',
+              description: 'Deferred tool',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ] as GraphTools,
+        () => true
+      );
+
+      const params = model.invocationParams({ tools });
+
+      expect(getBedrockToolNames(params.toolConfig?.tools)).toEqual([
+        'deferred_tool',
+      ]);
+      expect(JSON.stringify(params.toolConfig?.tools)).not.toContain(
+        '__lc_bedrock_skip_tool_cache'
+      );
     });
   });
 

--- a/src/llm/bedrock/toolCache.test.ts
+++ b/src/llm/bedrock/toolCache.test.ts
@@ -1,0 +1,131 @@
+import { tool } from '@langchain/core/tools';
+import type { Tool } from '@aws-sdk/client-bedrock-runtime';
+import type { GraphTools } from '@/types';
+import {
+  insertBedrockToolCachePoint,
+  partitionAndMarkBedrockToolCache,
+} from './toolCache';
+
+type OpenAITool = {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: object;
+  };
+};
+
+function createOpenAITool(name: string): OpenAITool {
+  return {
+    type: 'function',
+    function: {
+      name,
+      description: `${name} description`,
+      parameters: {
+        type: 'object',
+        properties: {},
+      },
+    },
+  };
+}
+
+function toolName(entry: Tool): string {
+  if ('cachePoint' in entry) {
+    return 'cachePoint';
+  }
+  return entry.toolSpec?.name ?? 'missing';
+}
+
+function toolNames(tools: Tool[] | undefined): string[] {
+  return (tools ?? []).map(toolName);
+}
+
+describe('partitionAndMarkBedrockToolCache', () => {
+  it('inserts the Bedrock cache point after the last static tool', () => {
+    const tools = [
+      createOpenAITool('static_one'),
+      createOpenAITool('static_two'),
+      createOpenAITool('dynamic_one'),
+    ] as GraphTools;
+
+    const marked = partitionAndMarkBedrockToolCache(
+      tools,
+      (name) => name === 'dynamic_one'
+    ) as Tool[];
+    const result = insertBedrockToolCachePoint({ tools: marked }, false);
+
+    expect(toolNames(result?.tools)).toEqual([
+      'static_one',
+      'static_two',
+      'cachePoint',
+      'dynamic_one',
+    ]);
+    expect(JSON.stringify(result?.tools)).not.toContain(
+      '__lc_bedrock_cache_point_after'
+    );
+  });
+
+  it('converts LangChain tools to Bedrock tool specs before marking', () => {
+    const staticTool = tool(async () => 'static', {
+      name: 'static_tool',
+      description: 'Static tool',
+      schema: {
+        type: 'object',
+        properties: {},
+      },
+    });
+    const dynamicTool = tool(async () => 'dynamic', {
+      name: 'dynamic_tool',
+      description: 'Dynamic tool',
+      schema: {
+        type: 'object',
+        properties: {},
+      },
+    });
+
+    const marked = partitionAndMarkBedrockToolCache(
+      [dynamicTool, staticTool] as GraphTools,
+      (name) => name === 'dynamic_tool'
+    ) as Tool[];
+    const result = insertBedrockToolCachePoint({ tools: marked }, false);
+
+    expect(toolNames(result?.tools)).toEqual([
+      'static_tool',
+      'cachePoint',
+      'dynamic_tool',
+    ]);
+  });
+
+  it('does not add a cache point when every tool is deferred', () => {
+    const tools = [createOpenAITool('dynamic_one')] as GraphTools;
+    const marked = partitionAndMarkBedrockToolCache(
+      tools,
+      () => true
+    ) as Tool[];
+    const result = insertBedrockToolCachePoint({ tools: marked }, false);
+
+    expect(toolNames(result?.tools)).toEqual(['dynamic_one']);
+    expect(JSON.stringify(result?.tools)).not.toContain(
+      '__lc_bedrock_skip_tool_cache'
+    );
+  });
+
+  it('can fall back to caching all directly-bound tools', () => {
+    const result = insertBedrockToolCachePoint(
+      {
+        tools: [
+          {
+            toolSpec: {
+              name: 'direct_tool',
+              description: 'Direct tool',
+              inputSchema: { json: { type: 'object', properties: {} } },
+            },
+          },
+        ],
+      },
+      true
+    );
+
+    expect(toolNames(result?.tools)).toEqual(['direct_tool', 'cachePoint']);
+  });
+});

--- a/src/llm/bedrock/toolCache.ts
+++ b/src/llm/bedrock/toolCache.ts
@@ -1,0 +1,191 @@
+import type { Tool, ToolConfiguration } from '@aws-sdk/client-bedrock-runtime';
+import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
+import type { OpenAIClient } from '@langchain/openai';
+import type { DocumentType } from '@smithy/types';
+import type { GraphTools } from '@/types';
+import { _convertToOpenAITool } from '@/llm/openai';
+
+const CACHE_POINT: Tool.CachePointMember = {
+  cachePoint: { type: 'default' },
+};
+
+const BEDROCK_TOOL_CACHE_MARKER = '__lc_bedrock_cache_point_after';
+const BEDROCK_TOOL_CACHE_DISABLED_MARKER = '__lc_bedrock_skip_tool_cache';
+
+type BedrockToolWithCacheMarker = Tool & {
+  [BEDROCK_TOOL_CACHE_MARKER]?: true;
+  [BEDROCK_TOOL_CACHE_DISABLED_MARKER]?: true;
+};
+
+type OpenAIFunctionTool = Extract<
+  OpenAIClient.ChatCompletionTool,
+  { type: 'function' }
+>;
+
+type ToolNameCandidate = {
+  name?: unknown;
+  function?: {
+    name?: unknown;
+  };
+  toolSpec?: {
+    name?: unknown;
+  };
+};
+
+function isBedrockToolSpec(tool: unknown): tool is Tool.ToolSpecMember {
+  return (
+    typeof tool === 'object' &&
+    tool != null &&
+    'toolSpec' in tool &&
+    typeof (tool as ToolNameCandidate).toolSpec?.name === 'string'
+  );
+}
+
+function isBedrockCachePoint(tool: Tool): tool is Tool.CachePointMember {
+  return 'cachePoint' in tool && tool.cachePoint != null;
+}
+
+function getToolName(tool: unknown): string | undefined {
+  const candidate = tool as ToolNameCandidate;
+  if (typeof candidate.toolSpec?.name === 'string') {
+    return candidate.toolSpec.name;
+  }
+  if (typeof candidate.name === 'string') {
+    return candidate.name;
+  }
+  if (typeof candidate.function?.name === 'string') {
+    return candidate.function.name;
+  }
+  return undefined;
+}
+
+function openAIToBedrockTool(tool: OpenAIFunctionTool): Tool.ToolSpecMember {
+  return {
+    toolSpec: {
+      name: tool.function.name,
+      description: tool.function.description,
+      inputSchema: { json: tool.function.parameters as DocumentType },
+    },
+  };
+}
+
+function toBedrockTool(tool: unknown): BedrockToolWithCacheMarker {
+  if (isBedrockToolSpec(tool)) {
+    return { ...tool };
+  }
+
+  return openAIToBedrockTool(
+    _convertToOpenAITool(tool as BindToolsInput) as OpenAIFunctionTool
+  ) as BedrockToolWithCacheMarker;
+}
+
+function markCachePointAfter(
+  tool: BedrockToolWithCacheMarker
+): BedrockToolWithCacheMarker {
+  return {
+    ...tool,
+    [BEDROCK_TOOL_CACHE_MARKER]: true,
+  };
+}
+
+function markToolCacheDisabled(
+  tool: BedrockToolWithCacheMarker
+): BedrockToolWithCacheMarker {
+  return {
+    ...tool,
+    [BEDROCK_TOOL_CACHE_DISABLED_MARKER]: true,
+  };
+}
+
+function stripCachePointMarker(tool: BedrockToolWithCacheMarker): Tool {
+  const {
+    [BEDROCK_TOOL_CACHE_MARKER]: _marker,
+    [BEDROCK_TOOL_CACHE_DISABLED_MARKER]: _disabled,
+    ...rest
+  } = tool;
+  return rest as Tool;
+}
+
+export function partitionAndMarkBedrockToolCache(
+  tools: GraphTools | undefined,
+  isDeferred: (toolName: string) => boolean
+): GraphTools | undefined {
+  if (tools == null || tools.length === 0) {
+    return tools;
+  }
+
+  const staticTools: BedrockToolWithCacheMarker[] = [];
+  const deferredTools: BedrockToolWithCacheMarker[] = [];
+
+  for (const tool of tools as readonly unknown[]) {
+    const converted = toBedrockTool(tool);
+    const name = getToolName(converted) ?? getToolName(tool);
+
+    if (name != null && isDeferred(name)) {
+      deferredTools.push(converted);
+      continue;
+    }
+
+    staticTools.push(converted);
+  }
+
+  if (staticTools.length === 0) {
+    deferredTools[0] = markToolCacheDisabled(deferredTools[0]);
+    return [...deferredTools] as GraphTools;
+  }
+
+  staticTools[staticTools.length - 1] = markCachePointAfter(
+    staticTools[staticTools.length - 1]
+  );
+
+  return [...staticTools, ...deferredTools] as GraphTools;
+}
+
+export function insertBedrockToolCachePoint(
+  toolConfig: ToolConfiguration | undefined,
+  fallbackToEnd: boolean
+): ToolConfiguration | undefined {
+  const tools = toolConfig?.tools as BedrockToolWithCacheMarker[] | undefined;
+  if (tools == null || tools.length === 0) {
+    return toolConfig;
+  }
+
+  let markerIndex = -1;
+  let hasCachePoint = false;
+  let hasDisabledMarker = false;
+  const cleanedTools: Tool[] = [];
+
+  for (let i = 0; i < tools.length; i++) {
+    const tool = tools[i];
+    if (isBedrockCachePoint(tool)) {
+      hasCachePoint = true;
+      cleanedTools.push(tool);
+      continue;
+    }
+    if (tool[BEDROCK_TOOL_CACHE_MARKER] === true) {
+      markerIndex = cleanedTools.length;
+    }
+    if (tool[BEDROCK_TOOL_CACHE_DISABLED_MARKER] === true) {
+      hasDisabledMarker = true;
+    }
+    cleanedTools.push(stripCachePointMarker(tool));
+  }
+
+  if (hasCachePoint || hasDisabledMarker) {
+    return { ...toolConfig, tools: cleanedTools };
+  }
+
+  const insertionIndex = markerIndex >= 0 ? markerIndex : tools.length - 1;
+  if (markerIndex < 0 && !fallbackToEnd) {
+    return { ...toolConfig, tools: cleanedTools };
+  }
+
+  return {
+    ...toolConfig,
+    tools: [
+      ...cleanedTools.slice(0, insertionIndex + 1),
+      CACHE_POINT,
+      ...cleanedTools.slice(insertionIndex + 1),
+    ],
+  };
+}

--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -287,23 +287,28 @@ type TestMsg = {
 };
 
 describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
-  it('returns input when not enough messages', () => {
+  it('returns empty input unchanged and caches a single user message', () => {
     const empty: TestMsg[] = [];
     expect(addBedrockCacheControl(empty)).toEqual(empty);
     const single: TestMsg[] = [{ role: 'user', content: 'only' }];
-    expect(addBedrockCacheControl(single)).toEqual(single);
+    expect(addBedrockCacheControl(single)[0].content).toEqual([
+      { type: ContentTypes.TEXT, text: 'only' },
+      { cachePoint: { type: 'default' } },
+    ]);
   });
 
-  it('wraps string content and appends separate cachePoint block', () => {
+  it('wraps latest user string content and appends separate cachePoint block', () => {
     const messages: TestMsg[] = [
       { role: 'user', content: 'Hello' },
       { role: 'assistant', content: [{ type: ContentTypes.TEXT, text: 'Hi' }] },
     ];
     const result = addBedrockCacheControl(messages);
-    const last = result[1].content as MessageContentComplex[];
-    expect(Array.isArray(last)).toBe(true);
-    expect(last[0]).toEqual({ type: ContentTypes.TEXT, text: 'Hi' });
-    expect(last[1]).toEqual({ cachePoint: { type: 'default' } });
+    const user = result[0].content as MessageContentComplex[];
+    const assistant = result[1].content as MessageContentComplex[];
+    expect(Array.isArray(user)).toBe(true);
+    expect(user[0]).toEqual({ type: ContentTypes.TEXT, text: 'Hello' });
+    expect(user[1]).toEqual({ cachePoint: { type: 'default' } });
+    expect(assistant).toEqual([{ type: ContentTypes.TEXT, text: 'Hi' }]);
   });
 
   it('inserts cachePoint after the last text when multiple text blocks exist', () => {
@@ -345,20 +350,21 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
 
     expect(second[0]).toEqual({ type: ContentTypes.TEXT, text: 'Reply A' });
     expect(second[1]).toEqual({ type: ContentTypes.TEXT, text: 'Reply B' });
-    expect(second[2]).toEqual({ cachePoint: { type: 'default' } });
+    expect(second).toHaveLength(2);
   });
 
-  it('skips adding cachePoint when content is an empty array', () => {
+  it('skips empty arrays and caches the latest non-empty user message', () => {
     const messages: TestMsg[] = [
       { role: 'user', content: [] },
       { role: 'assistant', content: [] },
-      { role: 'user', content: 'ignored because only last two are modified' },
+      { role: 'user', content: 'latest cacheable user message' },
     ];
 
     const result = addBedrockCacheControl(messages);
 
     const first = result[0].content as MessageContentComplex[];
     const second = result[1].content as MessageContentComplex[];
+    const third = result[2].content as MessageContentComplex[];
 
     expect(Array.isArray(first)).toBe(true);
     expect(first.length).toBe(0);
@@ -366,39 +372,51 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     expect(Array.isArray(second)).toBe(true);
     expect(second.length).toBe(0);
     expect(second[0]).not.toEqual({ cachePoint: { type: 'default' } });
+
+    expect(third).toEqual([
+      { type: ContentTypes.TEXT, text: 'latest cacheable user message' },
+      { cachePoint: { type: 'default' } },
+    ]);
   });
 
-  it('skips adding cachePoint when content is an empty string', () => {
+  it('skips empty strings and caches the latest non-empty user message', () => {
     const messages: TestMsg[] = [
       { role: 'user', content: '' },
       { role: 'assistant', content: '' },
-      { role: 'user', content: 'ignored because only last two are modified' },
+      { role: 'user', content: 'latest cacheable user message' },
     ];
 
     const result = addBedrockCacheControl(messages);
 
     expect(result[0].content).toBe('');
     expect(result[1].content).toBe('');
+    expect(result[2].content).toEqual([
+      { type: ContentTypes.TEXT, text: 'latest cacheable user message' },
+      { cachePoint: { type: 'default' } },
+    ]);
   });
 
   /** (I don't think this will ever occur in actual use, but its the only branch left uncovered so I'm covering it */
-  it('skips messages with non-string, non-array content and still modifies the previous to reach two edits', () => {
+  it('skips messages with non-string, non-array content', () => {
     const messages: TestMsg[] = [
       {
         role: 'user',
-        content: [{ type: ContentTypes.TEXT, text: 'Will be modified' }],
+        content: [{ type: ContentTypes.TEXT, text: 'Older user message' }],
       },
       { role: 'assistant', content: undefined },
       {
         role: 'user',
-        content: [{ type: ContentTypes.TEXT, text: 'Also modified' }],
+        content: [{ type: ContentTypes.TEXT, text: 'Latest user message' }],
       },
     ];
 
     const result = addBedrockCacheControl(messages);
 
     const last = result[2].content as MessageContentComplex[];
-    expect(last[0]).toEqual({ type: ContentTypes.TEXT, text: 'Also modified' });
+    expect(last[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Latest user message',
+    });
     expect(last[1]).toEqual({ cachePoint: { type: 'default' } });
 
     expect(result[1].content).toBeUndefined();
@@ -406,7 +424,7 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     const first = result[0].content as MessageContentComplex[];
     expect(first[0]).toEqual({
       type: ContentTypes.TEXT,
-      text: 'Will be modified',
+      text: 'Older user message',
     });
     expect(first[1]).toEqual({ cachePoint: { type: 'default' } });
   });
@@ -511,7 +529,7 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     expect(systemContent[2]).toHaveProperty('cache_control');
   });
 
-  it('skips serialized system messages while adding cache points to non-system turns', () => {
+  it('skips serialized system messages while adding a cache point to the latest user turn', () => {
     const messages: TestMsg[] = [
       {
         role: 'system',
@@ -575,7 +593,7 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
       type: ContentTypes.TEXT,
       text: 'Sure! The capital of France is Paris.',
     });
-    expect(assistant[1]).toEqual({ cachePoint: { type: 'default' } });
+    expect(assistant).toHaveLength(1);
   });
 
   it('is idempotent - calling multiple times does not add duplicate cache points', () => {
@@ -601,12 +619,11 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     });
     expect(firstContent[1]).toEqual({ cachePoint: { type: 'default' } });
 
-    expect(secondContent.length).toBe(2);
+    expect(secondContent.length).toBe(1);
     expect(secondContent[0]).toEqual({
       type: ContentTypes.TEXT,
       text: 'First response',
     });
-    expect(secondContent[1]).toEqual({ cachePoint: { type: 'default' } });
 
     const result2 = addBedrockCacheControl(result1);
     const firstContentAfter = result2[0].content as MessageContentComplex[];
@@ -619,15 +636,14 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     });
     expect(firstContentAfter[1]).toEqual({ cachePoint: { type: 'default' } });
 
-    expect(secondContentAfter.length).toBe(2);
+    expect(secondContentAfter.length).toBe(1);
     expect(secondContentAfter[0]).toEqual({
       type: ContentTypes.TEXT,
       text: 'First response',
     });
-    expect(secondContentAfter[1]).toEqual({ cachePoint: { type: 'default' } });
   });
 
-  it('skips messages that already have cache points in multi-agent scenarios', () => {
+  it('strips stale cache points and caches the latest user messages in multi-agent scenarios', () => {
     const messages: TestMsg[] = [
       {
         role: 'user',
@@ -647,8 +663,16 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     ];
 
     const result = addBedrockCacheControl(messages);
+    const firstContent = result[0].content as MessageContentComplex[];
     const lastContent = result[2].content as MessageContentComplex[];
     const secondLastContent = result[1].content as MessageContentComplex[];
+
+    expect(firstContent.length).toBe(2);
+    expect(firstContent[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'Hello',
+    });
+    expect(firstContent[1]).toEqual({ cachePoint: { type: 'default' } });
 
     expect(lastContent.length).toBe(2);
     expect(lastContent[0]).toEqual({
@@ -657,12 +681,11 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     });
     expect(lastContent[1]).toEqual({ cachePoint: { type: 'default' } });
 
-    expect(secondLastContent.length).toBe(2);
+    expect(secondLastContent.length).toBe(1);
     expect(secondLastContent[0]).toEqual({
       type: ContentTypes.TEXT,
       text: 'Response from agent 1',
     });
-    expect(secondLastContent[1]).toEqual({ cachePoint: { type: 'default' } });
   });
 
   it('skips cachePoint on AI messages with only whitespace text and reasoning (tool-call scenario)', () => {
@@ -704,6 +727,42 @@ describe('addBedrockCacheControl (Bedrock cache checkpoints)', () => {
     expect(userContent[userContent.length - 1]).toEqual({
       cachePoint: { type: 'default' },
     });
+  });
+
+  it('keeps cachePoint on the stable user boundary through tool loops', () => {
+    const messages: BaseMessage[] = [
+      new HumanMessage('Use the stable prompt context.'),
+      new AIMessage({
+        content: 'I will call the first tool.',
+        tool_calls: [{ id: 'call_1', name: 'lookup', args: { step: 1 } }],
+      }),
+      new ToolMessage({
+        content: 'volatile tool result 1',
+        tool_call_id: 'call_1',
+      }),
+      new AIMessage({
+        content: 'I will call the second tool.',
+        tool_calls: [{ id: 'call_2', name: 'lookup', args: { step: 2 } }],
+      }),
+      new ToolMessage({
+        content: 'volatile tool result 2',
+        tool_call_id: 'call_2',
+      }),
+    ];
+
+    const result = addBedrockCacheControl(messages);
+
+    const userContent = result[0].content as MessageContentComplex[];
+    expect(userContent[userContent.length - 1]).toEqual({
+      cachePoint: { type: 'default' },
+    });
+
+    for (const message of result.slice(1)) {
+      const content = message.content;
+      expect(
+        Array.isArray(content) && content.some((block) => 'cachePoint' in block)
+      ).toBe(false);
+    }
   });
 });
 
@@ -947,7 +1006,7 @@ describe('Multi-agent provider interoperability', () => {
     expect('cache_control' in secondContent[0]).toBe(false);
 
     expect(firstContent.some((b) => 'cachePoint' in b)).toBe(true);
-    expect(secondContent.some((b) => 'cachePoint' in b)).toBe(true);
+    expect(secondContent.some((b) => 'cachePoint' in b)).toBe(false);
   });
 
   it('strips Bedrock cache using separate function (backwards compat)', () => {
@@ -1142,7 +1201,7 @@ describe('Immutability - addBedrockCacheControl does not mutate original message
     expect(typeof originalMessages[1].content).toBe('string');
 
     expect(Array.isArray(result[0].content)).toBe(true);
-    expect(Array.isArray(result[1].content)).toBe(true);
+    expect(result[1].content).toBe('Hi there');
   });
 
   it('should not mutate original messages when adding cache points to array content', () => {
@@ -1178,9 +1237,9 @@ describe('Immutability - addBedrockCacheControl does not mutate original message
     const resultFirstContent = result[0].content as MessageContentComplex[];
     const resultSecondContent = result[1].content as MessageContentComplex[];
     expect(resultFirstContent.length).toBe(originalFirstContentLength + 1);
-    expect(resultSecondContent.length).toBe(originalSecondContentLength + 1);
+    expect(resultSecondContent.length).toBe(originalSecondContentLength);
     expect(resultFirstContent.some((b) => 'cachePoint' in b)).toBe(true);
-    expect(resultSecondContent.some((b) => 'cachePoint' in b)).toBe(true);
+    expect(resultSecondContent.some((b) => 'cachePoint' in b)).toBe(false);
   });
 
   it('should not mutate original messages when stripping existing cache control', () => {
@@ -1339,13 +1398,13 @@ describe('Multi-turn cache cleanup', () => {
     const lastContent = result[3].content as MessageContentComplex[];
     const secondLastContent = result[2].content as MessageContentComplex[];
 
-    expect(lastContent.some((b) => 'cachePoint' in b)).toBe(true);
+    expect(lastContent.some((b) => 'cachePoint' in b)).toBe(false);
     expect(secondLastContent.some((b) => 'cachePoint' in b)).toBe(true);
 
     const firstContent = result[0].content as MessageContentComplex[];
     const secondContent = result[1].content as MessageContentComplex[];
 
-    expect(firstContent.some((b) => 'cachePoint' in b)).toBe(false);
+    expect(firstContent.some((b) => 'cachePoint' in b)).toBe(true);
     expect(secondContent.some((b) => 'cachePoint' in b)).toBe(false);
   });
 
@@ -1561,14 +1620,14 @@ describe('OpenRouter prompt caching (reuses addCacheControl)', () => {
     const lastUser = converted[2];
 
     expect(Array.isArray(firstUser.content)).toBe(true);
-    expect(
-      (firstUser.content as CacheControlBlock[])[0]
-    ).toHaveProperty('cache_control');
+    expect((firstUser.content as CacheControlBlock[])[0]).toHaveProperty(
+      'cache_control'
+    );
 
     expect(Array.isArray(lastUser.content)).toBe(true);
-    expect(
-      (lastUser.content as CacheControlBlock[])[0]
-    ).toHaveProperty('cache_control');
+    expect((lastUser.content as CacheControlBlock[])[0]).toHaveProperty(
+      'cache_control'
+    );
   });
 
   it('strips Bedrock cache before applying OpenRouter/Anthropic cache', () => {

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -470,11 +470,11 @@ export function stripBedrockCacheControl<T extends MessageWithContent>(
 }
 
 /**
- * Adds Bedrock Converse API cache points to the last two messages.
+ * Adds Bedrock Converse API cache points to the latest two user messages.
  * Inserts `{ cachePoint: { type: 'default' } }` as a separate content block
  * immediately after the last text block in each targeted message.
  * Strips ALL existing cache control (both Bedrock and Anthropic formats) from all messages,
- * then adds fresh cache points to the last 2 messages in a single backward pass.
+ * then adds fresh cache points to the latest two non-tool user messages in a single backward pass.
  * This ensures we don't accumulate stale cache points across multiple turns.
  * Returns a new array - only clones messages that require modification.
  * @param messages - The array of message objects.
@@ -483,12 +483,12 @@ export function stripBedrockCacheControl<T extends MessageWithContent>(
 export function addBedrockCacheControl<
   T extends MessageWithContent & { getType?: () => string; role?: string },
 >(messages: T[]): T[] {
-  if (!Array.isArray(messages) || messages.length < 2) {
+  if (!Array.isArray(messages) || messages.length === 0) {
     return messages;
   }
 
   const updatedMessages: T[] = [...messages];
-  let messagesModified = 0;
+  let cachePointsAdded = 0;
 
   for (let i = updatedMessages.length - 1; i >= 0; i--) {
     const originalMessage = updatedMessages[i];
@@ -510,21 +510,27 @@ export function addBedrockCacheControl<
     }
 
     const isToolMessage = messageType === 'tool' || messageRole === 'tool';
+    const isUserMessage = messageType === 'human' || messageRole === 'user';
     const content = originalMessage.content;
+    const hasSerializationProps =
+      'lc_kwargs' in originalMessage ||
+      'lc_serializable' in originalMessage ||
+      'lc_namespace' in originalMessage;
     const hasArrayContent = Array.isArray(content);
     const isEmptyString = typeof content === 'string' && content === '';
     const needsCacheAdd =
-      messagesModified < 2 &&
+      cachePointsAdded < 2 &&
+      isUserMessage &&
       !isToolMessage &&
       !isEmptyString &&
       (typeof content === 'string' || hasArrayContent);
 
-    if (!needsCacheAdd && !hasArrayContent) {
+    if (!needsCacheAdd && !hasArrayContent && !hasSerializationProps) {
       continue;
     }
 
-    let workingContent: MessageContentComplex[];
-    let modified = false;
+    let workingContent: string | MessageContentComplex[];
+    let modified = hasSerializationProps;
 
     if (hasArrayContent) {
       // Single pass: clone blocks, strip cache markers, find last
@@ -563,14 +569,16 @@ export function addBedrockCacheControl<
         workingContent.splice(lastNonEmptyTextIndex + 1, 0, {
           cachePoint: { type: 'default' },
         } as MessageContentComplex);
-        messagesModified++;
+        cachePointsAdded++;
       }
     } else if (typeof content === 'string' && needsCacheAdd) {
       workingContent = [
         { type: ContentTypes.TEXT, text: content },
         { cachePoint: { type: 'default' } } as MessageContentComplex,
       ];
-      messagesModified++;
+      cachePointsAdded++;
+    } else if (typeof content === 'string' && hasSerializationProps) {
+      workingContent = content;
     } else {
       continue;
     }

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -87,7 +87,7 @@ export type BedrockAnthropicInput = ChatBedrockConverseInput & {
     AnthropicReasoning;
   promptCache?: boolean;
 };
-export type BedrockConverseClientOptions = ChatBedrockConverseInput;
+export type BedrockConverseClientOptions = BedrockAnthropicInput;
 export type BedrockAnthropicClientOptions = BedrockAnthropicInput;
 export type GoogleClientOptions = GoogleGenerativeAIChatInput & {
   customHeaders?: RequestOptions['customHeaders'];
@@ -128,7 +128,7 @@ export type ProviderOptionsMap = {
   [Providers.MISTRALAI]: MistralAIClientOptions;
   [Providers.MISTRAL]: MistralAIClientOptions;
   [Providers.OPENROUTER]: ChatOpenRouterCallOptions;
-  [Providers.BEDROCK]: BedrockConverseClientOptions;
+  [Providers.BEDROCK]: BedrockAnthropicClientOptions;
   [Providers.XAI]: XAIClientOptions;
   [Providers.MOONSHOT]: OpenAIClientOptions;
 };


### PR DESCRIPTION
## Summary

I fixed Bedrock prompt-cache placement so stable message and tool prefixes are cached instead of repeatedly cache-writing volatile assistant/tool-loop tails.

- Changed Bedrock cache marking to place `cachePoint` blocks on the latest two non-tool user messages, matching the useful multi-breakpoint behavior Anthropic already uses.
- Added Bedrock tool-definition caching by partitioning tools into static and deferred groups, placing a native Bedrock `cachePoint` after the last static tool, and stripping SDK-internal markers before the AWS request is sent.
- Preserved direct Bedrock model usage by caching all directly-bound tools when `promptCache` is enabled outside Graph partitioning.
- Prevented all-deferred tool sets from falling back to tool caching, so dynamically discovered tools do not become the cached prefix by accident.
- Made `promptCache` a first-class Bedrock client option in the exported provider types.
- Added focused unit coverage for Bedrock tool cache insertion, LangChain tool conversion, deferred-tool ordering, all-deferred skip behavior, and marker stripping.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx eslint src/graphs/Graph.ts src/llm/bedrock/toolCache.ts src/llm/bedrock/toolCache.test.ts src/llm/bedrock/index.ts src/types/llm.ts`.
- Ran `npx tsc --noEmit`.
- Ran `npx jest src/llm/bedrock/toolCache.test.ts src/llm/bedrock/llm.spec.ts --runInBand`.
- Ran `npm test -- src/messages/cache.test.ts src/agents/__tests__/AgentContext.bedrock.live.test.ts src/agents/__tests__/AgentContext.anthropic.live.test.ts --runInBand`.
- Ran live Bedrock tool-loop benchmark with real credentials. Previous moving-tail second call wrote `16522` cache tokens and read `0`; new user-boundary second call wrote `0` and read `8017`.
- Ran live Bedrock multi-turn benchmark with real credentials. Current two-user policy wrote `864` and read `9150`; latest-user-only wrote `10432` and read `0`.
- Ran live Anthropic prompt-cache benchmark with real credentials. Current two-user policy wrote `792` and read `8384`; latest-user-only wrote `9594` and read `0`, confirming Anthropic should remain unchanged.
- Ran live Bedrock tool-definition cache probe with real credentials. Call 1 wrote `28170` tool-prefix cache tokens and read `0`; call 2 wrote `0` and read `28170`. The observed tool order was `stable_cache_probe_tool`, `cachePoint`, with a separate lower-threshold probe confirming deferred ordering as `stable_cache_probe_tool`, `cachePoint`, `deferred_probe_tool`.

### **Test Configuration**:

- Node `20.19.5`
- Bedrock model `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
- Anthropic model `claude-sonnet-4-5`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
