### PR TITLE
feat: Add additionalHeaders support to Langfuse setup

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -57,6 +57,9 @@ function getLangfuseSpanProcessorParams(
       publicKey: langfuse.publicKey,
       secretKey: langfuse.secretKey,
       ...(isPresent(langfuse.baseUrl) ? { baseUrl: langfuse.baseUrl } : {}),
+      ...(langfuse.additionalHeaders != null
+        ? { additionalHeaders: langfuse.additionalHeaders }
+        : {}),
     };
   }
   if (hasLangfuseEnvConfig()) {

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -524,7 +524,14 @@ class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
     params?: LangfuseSpanProcessorParams,
     fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig
   ) {
-    this.processor = new LangfuseSpanProcessor(params);
+    this.processor = new LangfuseSpanProcessor(
+      params?.baseUrl != null
+        ? {
+          ...params,
+          additionalHeaders: params.additionalHeaders,
+        }
+        : params
+    );
     this.fallbackConfig = fallbackConfig;
   }
 
@@ -618,10 +625,7 @@ function hasLangfuseConfigKeys(langfuse?: t.LangfuseConfig): boolean {
   if (langfuse == null) {
     return false;
   }
-  return (
-    isPresent(langfuse.secretKey) &&
-    isPresent(langfuse.publicKey)
-  );
+  return isPresent(langfuse.secretKey) && isPresent(langfuse.publicKey);
 }
 
 export function shouldTraceToolNodeForLangfuse({
@@ -639,8 +643,7 @@ export function shouldTraceToolNodeForLangfuse({
   const explicit = langfuse?.toolNodeTracing?.enabled;
   if (explicit != null) {
     return (
-      explicit &&
-      (hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys())
+      explicit && (hasLangfuseConfigKeys(langfuse) || hasLangfuseEnvKeys())
     );
   }
 

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -443,6 +443,7 @@ export interface LangfuseConfig {
   publicKey?: string;
   secretKey?: string;
   baseUrl?: string;
+  additionalHeaders?: Record<string, string>;
   toolNodeTracing?: LangfuseToolNodeTracingConfig;
   toolOutputTracing?: LangfuseToolOutputTracingConfig;
 }


### PR DESCRIPTION
## Summary
Add support for passing custom OTLP headers into Langfuse span processor setup.

## Why
Some deployments need arbitrary headers forwarded to the Langfuse OTLP exporter without changing the existing auth flow. This enables me to conditionally apply langfuse tracing for a specific agent that registers for it instead of applying via env vars for the whole app instance.

## Changes
- add `additionalHeaders` support to the Langfuse config
- pass those headers through to the OTLP/Langfuse exporter
- keep existing public/secret key auth intact
- add coverage for header propagation


