### PR TITLE
🧠 fix: Recognize non-Anthropic reasoning blocks in pruner

### DIFF
--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -609,21 +609,20 @@ export type PruningResult = {
 };
 
 /**
- * Reasoning blocks carry provider-specific `type` tags: Anthropic emits
- * `thinking`, while Bedrock and OpenAI-compatible reasoning providers
- * (DeepSeek-R1, DashScope/Qwen-thinking) emit `reasoning_content`. Only
- * Anthropic and Bedrock have their blocks normalized upstream, so a reasoning
- * provider routed through an OpenAI-compatible surface reaches the pruner with
- * its native `reasoning_content` tag intact — regardless of the `reasoningType`
- * inferred from the provider name. Matching the full set lets the pruner locate
- * the block by whichever shape is actually present, so an unexpected tag cannot
- * hide it and trip the malformed-payload guards. See issue #191.
+ * Locates a reasoning block in assistant content. Reasoning blocks carry
+ * provider-specific `type` tags: Anthropic emits `thinking`, while Bedrock and
+ * OpenAI-compatible reasoning providers (DeepSeek-R1, DashScope/Qwen-thinking)
+ * emit `reasoning_content`. DeepSeek/Qwen route through the `THINKING` default
+ * even though their blocks are `reasoning_content` and aren't normalized
+ * upstream, so for the `THINKING` case we also accept `reasoning_content` — this
+ * is what fixes issue #191.
+ *
+ * The broadening is intentionally one-directional. A Bedrock run
+ * (`REASONING_CONTENT`) must NOT match an Anthropic `thinking` block: the
+ * Bedrock input converter rejects `thinking` blocks outright
+ * (`src/llm/bedrock/utils/message_inputs.ts`), so reattaching one to a
+ * surviving message would make the request fail before it is sent.
  */
-const reasoningBlockTypes = new Set<string>([
-  ContentTypes.THINKING,
-  ContentTypes.REASONING_CONTENT,
-]);
-
 function findReasoningBlock(
   content: MessageContentComplex[],
   reasoningType: ContentTypes
@@ -631,7 +630,8 @@ function findReasoningBlock(
   return content.find(
     (part) =>
       part.type === reasoningType ||
-      (part.type != null && reasoningBlockTypes.has(part.type))
+      (reasoningType === ContentTypes.THINKING &&
+        part.type === ContentTypes.REASONING_CONTENT)
   ) as ThinkingContentText | ReasoningContentText | undefined;
 }
 
@@ -848,6 +848,15 @@ export function getMessagesWithinTokenLimit({
    * one to make the failure fatal.
    */
   if ((thinkingEndIndex > -1 && thinkingStartIndex < 0) || !thinkingBlock) {
+    /**
+     * No block was located, so any `thinkingStartIndex` set above came from a
+     * stale carried-over index pointing at a block-less message. Drop it:
+     * `createPruneMessages` persists the returned index as
+     * `runThinkingStartIndex`, and a stale value would suppress the trailing
+     * scan (`thinkingStartIndex < 0`) on later turns, causing a real reasoning
+     * block to be missed and never reattached.
+     */
+    delete result.thinkingStartIndex;
     result.context = context.reverse() as BaseMessage[];
     return result;
   }

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -563,7 +563,7 @@ function addThinkingBlock(
       },
     ];
   /** Edge case, the message already has the thinking block */
-  if (content[0].type === thinkingBlock.type) {
+  if (content[0]?.type === thinkingBlock.type) {
     return message;
   }
   content.unshift(thinkingBlock);
@@ -607,6 +607,33 @@ export type PruningResult = {
   messagesToRefine: BaseMessage[];
   thinkingStartIndex?: number;
 };
+
+/**
+ * Reasoning blocks carry provider-specific `type` tags: Anthropic emits
+ * `thinking`, while Bedrock and OpenAI-compatible reasoning providers
+ * (DeepSeek-R1, DashScope/Qwen-thinking) emit `reasoning_content`. Only
+ * Anthropic and Bedrock have their blocks normalized upstream, so a reasoning
+ * provider routed through an OpenAI-compatible surface reaches the pruner with
+ * its native `reasoning_content` tag intact — regardless of the `reasoningType`
+ * inferred from the provider name. Matching the full set lets the pruner locate
+ * the block by whichever shape is actually present, so an unexpected tag cannot
+ * hide it and trip the malformed-payload guards. See issue #191.
+ */
+const reasoningBlockTypes = new Set<string>([
+  ContentTypes.THINKING,
+  ContentTypes.REASONING_CONTENT,
+]);
+
+function findReasoningBlock(
+  content: MessageContentComplex[],
+  reasoningType: ContentTypes
+): ThinkingContentText | ReasoningContentText | undefined {
+  return content.find(
+    (part) =>
+      part.type === reasoningType ||
+      (part.type != null && reasoningBlockTypes.has(part.type))
+  ) as ThinkingContentText | ReasoningContentText | undefined;
+}
 
 /**
  * Processes an array of messages and returns a context of messages that fit within a specified token limit.
@@ -670,9 +697,7 @@ export function getMessagesWithinTokenLimit({
   if (_thinkingStartIndex > -1) {
     const thinkingMessageContent = messages[_thinkingStartIndex]?.content;
     if (Array.isArray(thinkingMessageContent)) {
-      thinkingBlock = thinkingMessageContent.find(
-        (content) => content.type === reasoningType
-      ) as ThinkingContentText | undefined;
+      thinkingBlock = findReasoningBlock(thinkingMessageContent, reasoningType);
     }
   }
 
@@ -705,9 +730,10 @@ export function getMessagesWithinTokenLimit({
         messageType === 'ai' &&
         Array.isArray(poppedMessage.content)
       ) {
-        thinkingBlock = poppedMessage.content.find(
-          (content) => content.type === reasoningType
-        ) as ThinkingContentText | undefined;
+        thinkingBlock = findReasoningBlock(
+          poppedMessage.content,
+          reasoningType
+        );
         thinkingStartIndex = thinkingBlock != null ? currentIndex : -1;
       }
       /**
@@ -811,16 +837,19 @@ export function getMessagesWithinTokenLimit({
     return result;
   }
 
-  if (thinkingEndIndex > -1 && thinkingStartIndex < 0) {
-    throw new Error(
-      'The payload is malformed. There is a thinking sequence but no "AI" messages with thinking blocks.'
-    );
-  }
-
-  if (!thinkingBlock) {
-    throw new Error(
-      'The payload is malformed. There is a thinking sequence but no thinking block found.'
-    );
+  /**
+   * A trailing reasoning sequence was detected but its block could not be
+   * located in the surviving context. Rather than throw — which permanently
+   * bricks the conversation, re-firing on every retry of the same thread (see
+   * issue #191) — return the partially-pruned context and let the provider
+   * surface a real, recoverable error if the payload is genuinely malformed.
+   * Strict providers (Anthropic) reject it cleanly; lenient ones (DeepSeek,
+   * Qwen) proceed. The pruner cannot know which applies, so it must not be the
+   * one to make the failure fatal.
+   */
+  if ((thinkingEndIndex > -1 && thinkingStartIndex < 0) || !thinkingBlock) {
+    result.context = context.reverse() as BaseMessage[];
+    return result;
   }
 
   let assistantIndex = -1;

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -2510,5 +2510,68 @@ describe('thinking enabled — non-Anthropic reasoning_content blocks (issue #19
 
     expect(result!.context.length).toBeGreaterThan(0);
     expect(result!.messagesToRefine.length).toBeGreaterThan(0);
+    // The stale carried-over index must NOT be propagated: createPruneMessages
+    // persists it as runThinkingStartIndex, and a stale value would suppress
+    // the trailing scan on later turns and miss a real reasoning block.
+    expect(result!.thinkingStartIndex).toBeUndefined();
+  });
+
+  it('does not match an Anthropic thinking block for a Bedrock (reasoning_content) run', () => {
+    // The cross-type fallback is one-directional: REASONING_CONTENT (Bedrock)
+    // must not match a `thinking` block, since the Bedrock input converter
+    // rejects `thinking` blocks and reattaching one would break the request.
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new SystemMessage('you are a helpful assistant'),
+      new AIMessage({
+        content: [
+          {
+            type: ContentTypes.THINKING,
+            thinking: 'inherited Anthropic-style reasoning',
+            signature: 'sig-anthropic',
+          },
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'c'.repeat(6000),
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    let result: ReturnType<typeof realGetMessagesWithinTokenLimit> | undefined;
+    expect(() => {
+      result = realGetMessagesWithinTokenLimit({
+        messages,
+        maxContextTokens: 200,
+        indexTokenCountMap,
+        thinkingEnabled: true,
+        tokenCounter,
+        reasoningType: ContentTypes.REASONING_CONTENT,
+      });
+    }).not.toThrow();
+
+    // The thinking block is intentionally not located for a Bedrock run, so no
+    // index is reported and nothing gets reattached.
+    expect(result!.thinkingStartIndex).toBeUndefined();
   });
 });

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -2382,3 +2382,133 @@ describe('thinking enabled — tail tool_use without a thinking block (issue #11
     expect(result.thinkingStartIndex).toBeGreaterThanOrEqual(0);
   });
 });
+
+describe('thinking enabled — non-Anthropic reasoning_content blocks (issue #191)', () => {
+  it('locates a trailing reasoning_content block even when reasoningType defaults to THINKING (DeepSeek/Qwen)', () => {
+    // DeepSeek-R1 and DashScope/Qwen-thinking route through the non-Bedrock
+    // branch, so the caller passes reasoningType: THINKING — but their blocks
+    // are tagged `reasoning_content` and are not normalized upstream. With a
+    // system prompt at index 0 and an all-AI/tool tail, the consume loop never
+    // pops a human to clear thinkingEndIndex (the issue #116 escape hatch), so
+    // searching only for `thinking` missed the present block and threw a fatal
+    // that permanently bricked the thread. The pruner must find the block by
+    // its actual shape instead.
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new SystemMessage('you are a helpful assistant'),
+      new AIMessage({
+        content: [
+          {
+            type: ContentTypes.REASONING_CONTENT,
+            reasoningText: {
+              text: 'I will fetch the doc',
+              signature: 'sig-new',
+            },
+          },
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'c'.repeat(6000),
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    let result: ReturnType<typeof realGetMessagesWithinTokenLimit> | undefined;
+    expect(() => {
+      result = realGetMessagesWithinTokenLimit({
+        messages,
+        maxContextTokens: 200,
+        indexTokenCountMap,
+        thinkingEnabled: true,
+        tokenCounter,
+        reasoningType: ContentTypes.THINKING,
+      });
+    }).not.toThrow();
+
+    // thinkingStartIndex is only set when the reasoning block is actually
+    // located — isolating the find fix (B) from the graceful-degradation
+    // safety net (C), which would swallow the throw without finding anything.
+    expect(result!.thinkingStartIndex).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not throw when a carried-over thinking sequence has no locatable block', () => {
+    // Models a stale runThinkingStartIndex carry-over pointing at an assistant
+    // message that has no reasoning block. The pruner cannot find a block, but
+    // a trailing AI/tool sequence keeps thinkingEndIndex set, so it used to
+    // reach the fatal "no thinking block found" throw. Defense in depth: a
+    // misconfiguration upstream of the pruner must not be able to brick the
+    // thread — degrade to the partially-pruned context instead.
+    const tokenCounter = createTestTokenCounter();
+    const messages: BaseMessage[] = [
+      new HumanMessage('h'.repeat(100)),
+      new AIMessage({
+        content: [{ type: 'text', text: 'a reply with no reasoning block' }],
+      }),
+      new HumanMessage('please read the doc'),
+      new AIMessage({
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            input: { docId: 'abc' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'tc_get_doc',
+            name: 'get_doc_content',
+            args: { docId: 'abc' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'x'.repeat(150),
+        tool_call_id: 'tc_get_doc',
+        name: 'get_doc_content',
+      }),
+    ];
+
+    const indexTokenCountMap: Record<string, number | undefined> = {};
+    for (let i = 0; i < messages.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(messages[i]);
+    }
+
+    let result: ReturnType<typeof realGetMessagesWithinTokenLimit> | undefined;
+    expect(() => {
+      result = realGetMessagesWithinTokenLimit({
+        messages,
+        maxContextTokens: 200,
+        indexTokenCountMap,
+        thinkingEnabled: true,
+        tokenCounter,
+        thinkingStartIndex: 1,
+        reasoningType: ContentTypes.THINKING,
+      });
+    }).not.toThrow();
+
+    expect(result!.context.length).toBeGreaterThan(0);
+    expect(result!.messagesToRefine.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes fatal 500s in `getMessagesWithinTokenLimit` for reasoning-capable **non-Anthropic / non-Bedrock** providers — **DeepSeek-R1** (`reasoning_content`) and **DashScope/Qwen-thinking** via OpenAI-compat surfaces. Once a long conversation crossed `maxContextTokens` and the pruner ran, it threw and the thread was permanently bricked (every retry re-hit the same throw).

Resolves #191.

## Root cause

The pruner locates the trailing reasoning block by `content.type === reasoningType`, but `reasoningType` resolves to `reasoning_content` **only for Bedrock** — every other provider falls through to `thinking`. DeepSeek/Qwen tag their blocks `reasoning_content`, and those blocks are *not* normalized upstream: `modifyDeltaProperties` (which rewrites content types) runs only for Anthropic and Bedrock (`manualToolStreamProviders`). So the block reaches the pruner with its native `reasoning_content` tag, the strict `find()` for `thinking` misses it, and execution falls through to the malformed-payload throws.

This is a different root cause from #115/#116 (which addressed the *absent*-block case); here the block is **present but tagged differently**, so #116's bailout doesn't catch it.

## Changes (all in `src/messages/prune.ts`)

1. **Provider-agnostic find** — a shared `findReasoningBlock` helper matches any reasoning shape (`thinking` or `reasoning_content`), so the block is found by whichever tag the provider actually emitted. This also covers custom OpenAI-compat endpoints, which a provider-name check structurally cannot.
2. **Graceful degradation** — the two post-loop throws now return the partially-pruned context instead of throwing. A genuinely malformed payload surfaces a *recoverable* provider error (Anthropic rejects cleanly; DeepSeek/Qwen proceed) rather than a fatal that bricks the thread.
3. **Null-guard** `addThinkingBlock` content access for empty content arrays.

The public signature of `getMessagesWithinTokenLimit` is unchanged.

## Testing

- New regression tests in `src/specs/prune.test.ts` for both the find path and the graceful-degradation path. Each was verified to reproduce the corresponding pre-fix throw (temporarily reverting each fix turns the test red).
- `npx jest src/specs/prune.test.ts` → 59 passed; related message suites (ensureThinkingBlock, formatAgentMessages, cache) → 180 passed.
- `npx tsc --noEmit` clean · `npx eslint` clean.
