### PR TITLE
fix: Handle Empty Deltas And Final Reasoning

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -91,6 +91,7 @@ const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
 
 type ReasoningKey = 'reasoning_content' | 'reasoning';
 type ReasoningSummary = { summary?: Array<{ text?: string }> };
+type ReasoningDetail = { type?: string; text?: string };
 
 function getHandlerDispatchedEventKey(
   eventName: string,
@@ -105,10 +106,25 @@ function getReasoningText(
   if (typeof value === 'string') {
     return value !== '' ? value : undefined;
   }
-  const summaryText = value?.summary?.[0]?.text;
-  return summaryText != null && summaryText !== ''
-    ? summaryText
-    : undefined;
+  const summaryText = value?.summary
+    ?.map((summary) => summary.text ?? '')
+    .filter((text) => text !== '')
+    .join('');
+  return summaryText != null && summaryText !== '' ? summaryText : undefined;
+}
+
+function getReasoningDetailsText(
+  value: ReasoningDetail[] | null | undefined
+): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const reasoningText = value
+    .filter((detail) => detail.type === 'reasoning.text')
+    .map((detail) => detail.text ?? '')
+    .filter((text) => text !== '')
+    .join('');
+  return reasoningText !== '' ? reasoningText : undefined;
 }
 
 function getResponseReasoningContent({
@@ -145,12 +161,19 @@ function getResponseReasoningContent({
     return reasoningContent;
   }
 
-  return getReasoningText(
+  const reasoning = getReasoningText(
     additionalKwargs.reasoning as
       | string
       | Partial<ReasoningSummary>
       | null
       | undefined
+  );
+  if (reasoning != null) {
+    return reasoning;
+  }
+
+  return getReasoningDetailsText(
+    additionalKwargs.reasoning_details as ReasoningDetail[] | null | undefined
   );
 }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -89,11 +89,183 @@ const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 /** Minimum relative variance before calibrated toolSchemaTokens overrides current value. */
 const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
 
+type ReasoningKey = 'reasoning_content' | 'reasoning';
+type ReasoningSummary = { summary?: Array<{ text?: string }> };
+
 function getHandlerDispatchedEventKey(
   eventName: string,
   stepId: string
 ): string {
   return `${eventName}:${stepId}`;
+}
+
+function getReasoningText(
+  value: string | Partial<ReasoningSummary> | null | undefined
+): string | undefined {
+  if (typeof value === 'string') {
+    return value !== '' ? value : undefined;
+  }
+  const summaryText = value?.summary?.[0]?.text;
+  return summaryText != null && summaryText !== ''
+    ? summaryText
+    : undefined;
+}
+
+function getResponseReasoningContent({
+  responseMessage,
+  reasoningKey,
+}: {
+  responseMessage?: Partial<AIMessageChunk>;
+  reasoningKey: ReasoningKey;
+}): string | undefined {
+  const additionalKwargs = responseMessage?.additional_kwargs;
+  if (additionalKwargs == null) {
+    return undefined;
+  }
+
+  const keyedReasoning = getReasoningText(
+    additionalKwargs[reasoningKey] as
+      | string
+      | Partial<ReasoningSummary>
+      | null
+      | undefined
+  );
+  if (keyedReasoning != null) {
+    return keyedReasoning;
+  }
+
+  const reasoningContent = getReasoningText(
+    additionalKwargs.reasoning_content as
+      | string
+      | Partial<ReasoningSummary>
+      | null
+      | undefined
+  );
+  if (reasoningContent != null) {
+    return reasoningContent;
+  }
+
+  return getReasoningText(
+    additionalKwargs.reasoning as
+      | string
+      | Partial<ReasoningSummary>
+      | null
+      | undefined
+  );
+}
+
+function getTextMessageDeltaContent(
+  content: MessageContent | undefined
+): t.MessageDelta['content'] | undefined {
+  if (content == null) {
+    return undefined;
+  }
+  if (typeof content === 'string') {
+    return content !== ''
+      ? [{ type: ContentTypes.TEXT, text: content }]
+      : undefined;
+  }
+  if (content.length === 0) {
+    return undefined;
+  }
+  if (
+    !content.every(
+      (contentPart) =>
+        typeof contentPart === 'object' &&
+        'type' in contentPart &&
+        typeof contentPart.type === 'string' &&
+        contentPart.type.startsWith('text')
+    )
+  ) {
+    return undefined;
+  }
+  return content as t.MessageDelta['content'];
+}
+
+async function dispatchTextMessageContent({
+  graph,
+  stepKey,
+  content,
+  metadata,
+}: {
+  graph: Graph<t.BaseGraphState>;
+  stepKey: string;
+  content: t.MessageDelta['content'];
+  metadata: Record<string, unknown>;
+}): Promise<boolean> {
+  const messageId = getMessageId(stepKey, graph) ?? '';
+  if (!messageId) {
+    return false;
+  }
+  await graph.dispatchRunStep(
+    stepKey,
+    {
+      type: StepTypes.MESSAGE_CREATION,
+      message_creation: { message_id: messageId },
+    },
+    metadata
+  );
+  const stepId = graph.getStepIdByKey(stepKey);
+  await graph.dispatchMessageDelta(stepId, { content }, metadata);
+  return true;
+}
+
+async function dispatchReasoningContent({
+  graph,
+  agentContext,
+  reasoningContent,
+  metadata,
+}: {
+  graph: Graph<t.BaseGraphState>;
+  agentContext: AgentContext;
+  reasoningContent: string;
+  metadata: Record<string, unknown>;
+}): Promise<boolean> {
+  const previousTokenType = agentContext.currentTokenType;
+  const previousTokenTypeSwitch = agentContext.tokenTypeSwitch;
+  const previousTransitionCount = agentContext.reasoningTransitionCount;
+
+  agentContext.currentTokenType = ContentTypes.THINK;
+  agentContext.tokenTypeSwitch = 'reasoning';
+
+  const stepKey = graph.getStepKey(metadata);
+  const messageId = getMessageId(stepKey, graph) ?? '';
+  if (!messageId) {
+    agentContext.currentTokenType = previousTokenType;
+    agentContext.tokenTypeSwitch = previousTokenTypeSwitch;
+    agentContext.reasoningTransitionCount = previousTransitionCount;
+    return false;
+  }
+
+  await graph.dispatchRunStep(
+    stepKey,
+    {
+      type: StepTypes.MESSAGE_CREATION,
+      message_creation: { message_id: messageId },
+    },
+    metadata
+  );
+  const stepId = graph.getStepIdByKey(stepKey);
+  await graph.dispatchReasoningDelta(
+    stepId,
+    {
+      content: [{ type: ContentTypes.THINK, think: reasoningContent }],
+    },
+    metadata
+  );
+  return true;
+}
+
+function markPostReasoningContent(agentContext: AgentContext): void {
+  if (
+    agentContext.tokenTypeSwitch !== 'reasoning' ||
+    agentContext.currentTokenType === ContentTypes.TEXT
+  ) {
+    return;
+  }
+  agentContext.currentTokenType = ContentTypes.TEXT;
+  agentContext.tokenTypeSwitch = 'content';
+  agentContext.reasoningTransitionCount++;
 }
 
 export abstract class Graph<
@@ -1472,60 +1644,37 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const toolCalls = (responseMessage as AIMessageChunk | undefined)
         ?.tool_calls;
       const hasToolCalls = Array.isArray(toolCalls) && toolCalls.length > 0;
+      const metadata = config.metadata as Record<string, unknown>;
+      const responseReasoningContent = getResponseReasoningContent({
+        responseMessage: responseMessage as Partial<AIMessageChunk> | undefined,
+        reasoningKey: agentContext.reasoningKey,
+      });
+      const textMessageContent = getTextMessageDeltaContent(
+        responseMessage?.content as MessageContent | undefined
+      );
 
       if (hasToolCalls) {
-        const metadata = config.metadata as Record<string, unknown>;
-        const stepKey = this.getStepKey(metadata);
-        const content = responseMessage?.content as MessageContent | undefined;
-        const hasTextContent =
-          content != null &&
-          (typeof content === 'string'
-            ? content !== ''
-            : Array.isArray(content) && content.length > 0);
-
-        /**
-         * Dispatch text content BEFORE creating TOOL_CALLS steps.
-         * getMessageId returns a new ID only on the first call for a step key;
-         * if the for-await consumer already claimed it, this is a no-op.
-         */
-        if (hasTextContent) {
-          const messageId = getMessageId(stepKey, this) ?? '';
-          if (messageId) {
-            await this.dispatchRunStep(
-              stepKey,
-              {
-                type: StepTypes.MESSAGE_CREATION,
-                message_creation: { message_id: messageId },
-              },
-              metadata
-            );
-            const stepId = this.getStepIdByKey(stepKey);
-            if (typeof content === 'string') {
-              await this.dispatchMessageDelta(
-                stepId,
-                {
-                  content: [{ type: ContentTypes.TEXT, text: content }],
-                },
-                metadata
-              );
-            } else if (
-              Array.isArray(content) &&
-              content.every(
-                (c) =>
-                  typeof c === 'object' &&
-                  'type' in c &&
-                  typeof c.type === 'string' &&
-                  c.type.startsWith('text')
-              )
-            ) {
-              await this.dispatchMessageDelta(
-                stepId,
-                {
-                  content: content as t.MessageDelta['content'],
-                },
-                metadata
-              );
-            }
+        const dispatchedReasoning =
+          responseReasoningContent != null &&
+          (await dispatchReasoningContent({
+            graph: this,
+            agentContext,
+            reasoningContent: responseReasoningContent,
+            metadata,
+          }));
+        if (dispatchedReasoning) {
+          markPostReasoningContent(agentContext);
+        }
+        if (textMessageContent != null) {
+          const stepKey = this.getStepKey(metadata);
+          const dispatchedText = await dispatchTextMessageContent({
+            graph: this,
+            stepKey,
+            content: textMessageContent,
+            metadata,
+          });
+          if (dispatchedText) {
+            markPostReasoningContent(agentContext);
           }
         }
 
@@ -1533,60 +1682,30 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       /**
-       * When streaming is disabled, on_chat_model_stream events are never
-       * emitted so ChatModelStreamHandler never fires. Dispatch the text
-       * content as MESSAGE_CREATION + MESSAGE_DELTA here.
+       * When streaming events are unavailable, ChatModelStreamHandler never
+       * fires. Dispatch final reasoning/text content here. getMessageId makes
+       * this a no-op when the streaming path already handled the same step.
        */
-      const disableStreaming =
-        (agentContext.clientOptions as t.OpenAIClientOptions | undefined)
-          ?.disableStreaming === true;
-
-      if (
-        disableStreaming &&
-        !hasToolCalls &&
-        responseMessage != null &&
-        (responseMessage.content as MessageContent | undefined) != null
-      ) {
-        const metadata = config.metadata as Record<string, unknown>;
-        const stepKey = this.getStepKey(metadata);
-        const messageId = getMessageId(stepKey, this) ?? '';
-        if (messageId) {
-          await this.dispatchRunStep(
+      if (!hasToolCalls && responseMessage != null) {
+        const dispatchedReasoning =
+          responseReasoningContent != null &&
+          (await dispatchReasoningContent({
+            graph: this,
+            agentContext,
+            reasoningContent: responseReasoningContent,
+            metadata,
+          }));
+        if (dispatchedReasoning && textMessageContent != null) {
+          markPostReasoningContent(agentContext);
+        }
+        if (textMessageContent != null) {
+          const stepKey = this.getStepKey(metadata);
+          await dispatchTextMessageContent({
+            graph: this,
             stepKey,
-            {
-              type: StepTypes.MESSAGE_CREATION,
-              message_creation: { message_id: messageId },
-            },
-            metadata
-          );
-          const stepId = this.getStepIdByKey(stepKey);
-          const content = responseMessage.content;
-          if (typeof content === 'string') {
-            await this.dispatchMessageDelta(
-              stepId,
-              {
-                content: [{ type: ContentTypes.TEXT, text: content }],
-              },
-              metadata
-            );
-          } else if (
-            Array.isArray(content) &&
-            content.every(
-              (c) =>
-                typeof c === 'object' &&
-                'type' in c &&
-                typeof c.type === 'string' &&
-                c.type.startsWith('text')
-            )
-          ) {
-            await this.dispatchMessageDelta(
-              stepId,
-              {
-                content: content as t.MessageDelta['content'],
-              },
-              metadata
-            );
-          }
+            content: textMessageContent,
+            metadata,
+          });
         }
       }
 

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -6,6 +6,8 @@ import { ContentTypes, GraphEvents, Providers } from '@/common';
 import { createContentAggregator } from '@/stream';
 import { Run } from '@/run';
 
+type ReasoningKey = 'reasoning_content' | 'reasoning';
+
 class InvokeOnlyReasoningModel implements t.ChatModel {
   constructor(
     private readonly response: {
@@ -27,9 +29,45 @@ class InvokeOnlyReasoningModel implements t.ChatModel {
   }
 }
 
+class StreamingReasoningModel implements t.ChatModel {
+  constructor(private readonly chunks: AIMessageChunk[]) {}
+
+  async invoke(
+    _messages: BaseMessage[],
+    _config?: RunnableConfig
+  ): Promise<AIMessageChunk> {
+    return this.chunks[this.chunks.length - 1] ?? new AIMessageChunk('');
+  }
+
+  async stream(
+    _messages: BaseMessage[],
+    _config?: RunnableConfig
+  ): Promise<AsyncIterable<AIMessageChunk>> {
+    const chunks = this.chunks;
+    return (async function* streamChunks(): AsyncGenerator<AIMessageChunk> {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    })();
+  }
+}
+
+function createReasoningChunk(
+  reasoningKey: ReasoningKey,
+  reasoningText: string
+): AIMessageChunk {
+  return new AIMessageChunk({
+    content: '',
+    additional_kwargs: {
+      [reasoningKey]: reasoningText,
+    },
+  });
+}
+
 function createReasoningHandlers(
   aggregateContent: t.ContentAggregator,
-  reasoningDeltas: t.ReasoningDeltaEvent[]
+  reasoningDeltas: t.ReasoningDeltaEvent[],
+  messageDeltas?: t.MessageDeltaEvent[]
 ): Record<string | GraphEvents, t.EventHandler> {
   return {
     [GraphEvents.ON_RUN_STEP]: {
@@ -42,7 +80,9 @@ function createReasoningHandlers(
         event: GraphEvents.ON_MESSAGE_DELTA,
         data: t.StreamEventData
       ): void => {
-        aggregateContent({ event, data: data as t.MessageDeltaEvent });
+        const messageDelta = data as t.MessageDeltaEvent;
+        messageDeltas?.push(messageDelta);
+        aggregateContent({ event, data: messageDelta });
       },
     },
     [GraphEvents.ON_REASONING_DELTA]: {
@@ -154,4 +194,139 @@ describe('StandardGraph final response reasoning fallback', () => {
       { type: ContentTypes.TEXT, text },
     ]);
   });
+
+  it.each([
+    {
+      providerName: 'DeepSeek',
+      provider: Providers.DEEPSEEK,
+      reasoningKey: 'reasoning_content' as const,
+    },
+    {
+      providerName: 'OpenRouter',
+      provider: Providers.OPENROUTER,
+      reasoningKey: 'reasoning' as const,
+    },
+  ])(
+    'does not replay streamed $providerName reasoning from the final fallback',
+    async ({ provider, providerName, reasoningKey }) => {
+      const text = 'Done.';
+      const reasoningText = 'Check the provider reasoning stream first.';
+      const firstReasoningChunk = reasoningText.slice(0, 19);
+      const secondReasoningChunk = reasoningText.slice(19);
+      const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+      const messageDeltas: t.MessageDeltaEvent[] = [];
+      const { contentParts, aggregateContent } = createContentAggregator();
+      const run = await Run.create<t.IState>({
+        runId: `reasoning-fallback-${providerName.toLowerCase()}-stream`,
+        graphConfig: {
+          type: 'standard',
+          llmConfig: {
+            provider,
+            streamUsage: false,
+          },
+          reasoningKey,
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: createReasoningHandlers(
+          aggregateContent,
+          reasoningDeltas,
+          messageDeltas
+        ),
+      });
+
+      if (!run.Graph) {
+        throw new Error('Expected graph to be initialized');
+      }
+
+      run.Graph.overrideModel = new StreamingReasoningModel([
+        createReasoningChunk(reasoningKey, firstReasoningChunk),
+        createReasoningChunk(reasoningKey, secondReasoningChunk),
+        new AIMessageChunk({ content: text }),
+      ]);
+
+      await run.processStream(
+        { messages: [new HumanMessage('stream provider reasoning')] },
+        {
+          ...config,
+          configurable: {
+            thread_id: `reasoning-fallback-${providerName.toLowerCase()}-stream`,
+          },
+        }
+      );
+
+      expect(reasoningDeltas).toHaveLength(2);
+      expect(messageDeltas).toHaveLength(1);
+      expect(contentParts).toEqual([
+        { type: ContentTypes.THINK, think: reasoningText },
+        { type: ContentTypes.TEXT, text },
+      ]);
+    }
+  );
+
+  it.each([
+    {
+      providerName: 'DeepSeek',
+      provider: Providers.DEEPSEEK,
+      reasoningKey: 'reasoning_content' as const,
+    },
+    {
+      providerName: 'OpenRouter',
+      provider: Providers.OPENROUTER,
+      reasoningKey: 'reasoning' as const,
+    },
+  ])(
+    'does not replay streamed reasoning-only $providerName output',
+    async ({ provider, providerName, reasoningKey }) => {
+      const reasoningText = 'The answer is still being considered.';
+      const firstReasoningChunk = reasoningText.slice(0, 14);
+      const secondReasoningChunk = reasoningText.slice(14);
+      const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+      const messageDeltas: t.MessageDeltaEvent[] = [];
+      const { contentParts, aggregateContent } = createContentAggregator();
+      const run = await Run.create<t.IState>({
+        runId: `reasoning-only-${providerName.toLowerCase()}-stream`,
+        graphConfig: {
+          type: 'standard',
+          llmConfig: {
+            provider,
+            streamUsage: false,
+          },
+          reasoningKey,
+        },
+        returnContent: true,
+        skipCleanup: true,
+        customHandlers: createReasoningHandlers(
+          aggregateContent,
+          reasoningDeltas,
+          messageDeltas
+        ),
+      });
+
+      if (!run.Graph) {
+        throw new Error('Expected graph to be initialized');
+      }
+
+      run.Graph.overrideModel = new StreamingReasoningModel([
+        createReasoningChunk(reasoningKey, firstReasoningChunk),
+        createReasoningChunk(reasoningKey, secondReasoningChunk),
+      ]);
+
+      await run.processStream(
+        { messages: [new HumanMessage('stream provider reasoning only')] },
+        {
+          ...config,
+          configurable: {
+            thread_id: `reasoning-only-${providerName.toLowerCase()}-stream`,
+          },
+        }
+      );
+
+      expect(reasoningDeltas).toHaveLength(2);
+      expect(messageDeltas).toHaveLength(0);
+      expect(contentParts).toEqual([
+        { type: ContentTypes.THINK, think: reasoningText },
+      ]);
+    }
+  );
 });

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -1,0 +1,157 @@
+import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { ContentTypes, GraphEvents, Providers } from '@/common';
+import { createContentAggregator } from '@/stream';
+import { Run } from '@/run';
+
+class InvokeOnlyReasoningModel implements t.ChatModel {
+  constructor(
+    private readonly response: {
+      content: string;
+      reasoningContent: string;
+    }
+  ) {}
+
+  async invoke(
+    _messages: BaseMessage[],
+    _config?: RunnableConfig
+  ): Promise<AIMessageChunk> {
+    return new AIMessageChunk({
+      content: this.response.content,
+      additional_kwargs: {
+        reasoning_content: this.response.reasoningContent,
+      },
+    });
+  }
+}
+
+function createReasoningHandlers(
+  aggregateContent: t.ContentAggregator,
+  reasoningDeltas: t.ReasoningDeltaEvent[]
+): Record<string | GraphEvents, t.EventHandler> {
+  return {
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event: GraphEvents.ON_RUN_STEP, data: t.StreamEventData): void => {
+        aggregateContent({ event, data: data as t.RunStep });
+      },
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_MESSAGE_DELTA,
+        data: t.StreamEventData
+      ): void => {
+        aggregateContent({ event, data: data as t.MessageDeltaEvent });
+      },
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: t.StreamEventData
+      ): void => {
+        const reasoningDelta = data as t.ReasoningDeltaEvent;
+        reasoningDeltas.push(reasoningDelta);
+        aggregateContent({ event, data: reasoningDelta });
+      },
+    },
+  };
+}
+
+describe('StandardGraph final response reasoning fallback', () => {
+  const config = {
+    configurable: {
+      thread_id: 'reasoning-fallback-thread',
+    },
+    streamMode: 'values' as const,
+    version: 'v2' as const,
+  };
+  const llmConfig: t.LLMConfig = {
+    provider: Providers.OPENAI,
+    disableStreaming: true,
+    streamUsage: false,
+  };
+
+  it('emits reasoning_content from invoke-only final responses', async () => {
+    const reasoningText = 'Need to inspect the Home Assistant tool state.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-empty-content',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new InvokeOnlyReasoningModel({
+      content: '',
+      reasoningContent: reasoningText,
+    });
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('turn on the bedroom light')] },
+      config
+    );
+
+    expect(finalContentParts).toBeDefined();
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas[0].delta.content?.[0]).toEqual({
+      type: ContentTypes.THINK,
+      think: reasoningText,
+    });
+    expect(contentParts).toContainEqual({
+      type: ContentTypes.THINK,
+      think: reasoningText,
+    });
+  });
+
+  it('keeps final reasoning before final text when both are present', async () => {
+    const text = 'Done.';
+    const reasoningText = 'Decide whether a tool is needed first.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-with-text',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new InvokeOnlyReasoningModel({
+      content: text,
+      reasoningContent: reasoningText,
+    });
+
+    await run.processStream(
+      { messages: [new HumanMessage('say done')] },
+      config
+    );
+
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+  });
+});

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -64,6 +64,17 @@ function createReasoningChunk(
   });
 }
 
+function createOpenAIReasoningSummaryChunk(reasoningText: string): AIMessageChunk {
+  return new AIMessageChunk({
+    content: '',
+    additional_kwargs: {
+      reasoning: {
+        summary: [{ text: reasoningText }],
+      },
+    },
+  });
+}
+
 function createReasoningHandlers(
   aggregateContent: t.ContentAggregator,
   reasoningDeltas: t.ReasoningDeltaEvent[],
@@ -329,4 +340,59 @@ describe('StandardGraph final response reasoning fallback', () => {
       ]);
     }
   );
+
+  it('does not replay streamed OpenAI reasoning summaries from the final fallback', async () => {
+    const text = 'Done.';
+    const reasoningText = 'Use the summary reasoning channel.';
+    const firstReasoningChunk = reasoningText.slice(0, 15);
+    const secondReasoningChunk = reasoningText.slice(15);
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openai-summary-stream',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENAI,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      createOpenAIReasoningSummaryChunk(firstReasoningChunk),
+      createOpenAIReasoningSummaryChunk(secondReasoningChunk),
+      new AIMessageChunk({ content: text }),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('stream OpenAI summary reasoning')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openai-summary-stream',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(2);
+    expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+  });
 });

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -33,6 +33,17 @@ class InvokeOnlyReasoningModel implements t.ChatModel {
   }
 }
 
+class InvokeOnlyMessageModel implements t.ChatModel {
+  constructor(private readonly message: AIMessageChunk) {}
+
+  async invoke(
+    _messages: BaseMessage[],
+    _config?: RunnableConfig
+  ): Promise<AIMessageChunk> {
+    return this.message;
+  }
+}
+
 class StreamingReasoningModel implements t.ChatModel {
   constructor(private readonly chunks: AIMessageChunk[]) {}
 
@@ -262,7 +273,9 @@ describe('StandardGraph final response reasoning fallback', () => {
       config
     );
 
-    expect(finalContentParts).toBeDefined();
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
     expect(reasoningDeltas).toHaveLength(1);
     expect(reasoningDeltas[0].delta.content?.[0]).toEqual({
       type: ContentTypes.THINK,
@@ -310,6 +323,166 @@ describe('StandardGraph final response reasoning fallback', () => {
     expect(contentParts).toEqual([
       { type: ContentTypes.THINK, think: reasoningText },
       { type: ContentTypes.TEXT, text },
+    ]);
+  });
+
+  it('returns reasoning content without a custom aggregator', async () => {
+    const reasoningText = 'Reasoning should persist for returnContent.';
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-return-content',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      returnContent: true,
+      skipCleanup: true,
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new InvokeOnlyReasoningModel({
+      content: '',
+      reasoningContent: reasoningText,
+    });
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('return reasoning content')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-return-content',
+        },
+      }
+    );
+
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
+  });
+
+  it('emits every OpenAI reasoning summary segment in invoke-only fallback', async () => {
+    const reasoningText = 'First summary. Second summary.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openai-multi-summary',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENAI,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new InvokeOnlyMessageModel(
+      new AIMessageChunk({
+        content: '',
+        additional_kwargs: {
+          reasoning: {
+            summary: [{ text: 'First summary. ' }, { text: 'Second summary.' }],
+          },
+        },
+      })
+    );
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('return multi summary reasoning')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openai-multi-summary',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas[0].delta.content?.[0]).toEqual({
+      type: ContentTypes.THINK,
+      think: reasoningText,
+    });
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
+  });
+
+  it('emits OpenRouter reasoning_details in invoke-only fallback', async () => {
+    const reasoningText = 'OpenRouter detail reasoning.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-details',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new InvokeOnlyMessageModel(
+      new AIMessageChunk({
+        content: '',
+        additional_kwargs: {
+          reasoning_details: [
+            { type: 'reasoning.text', text: 'OpenRouter detail ' },
+            { type: 'reasoning.encrypted', id: 'encrypted' },
+            { type: 'reasoning.text', text: 'reasoning.' },
+          ],
+        },
+      })
+    );
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('return OpenRouter reasoning details')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openrouter-details',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas[0].delta.content?.[0]).toEqual({
+      type: ContentTypes.THINK,
+      think: reasoningText,
+    });
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
     ]);
   });
 

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -1,9 +1,13 @@
 import { AIMessageChunk, HumanMessage } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import { FakeListChatModel } from '@langchain/core/utils/testing';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { RunnableConfig } from '@langchain/core/runnables';
-import type { BaseMessage } from '@langchain/core/messages';
+import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { ContentTypes, GraphEvents, Providers } from '@/common';
 import { createContentAggregator } from '@/stream';
+import { ModelEndHandler, ToolEndHandler } from '@/events';
 import { Run } from '@/run';
 
 type ReasoningKey = 'reasoning_content' | 'reasoning';
@@ -49,6 +53,32 @@ class StreamingReasoningModel implements t.ChatModel {
         yield chunk;
       }
     })();
+  }
+}
+
+class CallbackStreamingReasoningModel extends FakeListChatModel {
+  constructor(private readonly chunks: AIMessageChunk[]) {
+    super({ responses: [''] });
+  }
+
+  _llmType(): string {
+    return 'callback-streaming-reasoning';
+  }
+
+  async *_streamResponseChunks(
+    _messages: BaseMessage[],
+    _options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    for (const chunk of this.chunks) {
+      const text = typeof chunk.content === 'string' ? chunk.content : '';
+      yield new ChatGenerationChunk({
+        text,
+        generationInfo: {},
+        message: chunk,
+      });
+      void runManager?.handleLLMNewToken(text);
+    }
   }
 }
 
@@ -105,6 +135,83 @@ function createReasoningHandlers(
         reasoningDeltas.push(reasoningDelta);
         aggregateContent({ event, data: reasoningDelta });
       },
+    },
+  };
+}
+
+function createLibreChatLikeHandlers({
+  aggregateContent,
+  collectedUsage,
+  emittedEvents,
+}: {
+  aggregateContent: t.ContentAggregator;
+  collectedUsage: UsageMetadata[];
+  emittedEvents: Array<{ event: string; data: unknown }>;
+}): Record<string | GraphEvents, t.EventHandler> {
+  const modelEndHandler = new ModelEndHandler(collectedUsage);
+  const toolEndHandler = new ToolEndHandler();
+  const aggregateAndEmit = (
+    event: GraphEvents,
+    data: t.StreamEventData
+  ): void => {
+    aggregateContent({
+      event,
+      data: data as
+        | t.RunStep
+        | t.MessageDeltaEvent
+        | t.ReasoningDeltaEvent
+        | t.RunStepDeltaEvent
+        | { result: t.ToolEndEvent },
+    });
+    emittedEvents.push({
+      event,
+      data,
+    });
+  };
+
+  return {
+    [GraphEvents.CHAT_MODEL_END]: {
+      handle: async (event, data, metadata, graph): Promise<void> => {
+        await modelEndHandler.handle(
+          event,
+          data as t.ModelEndData,
+          metadata,
+          graph
+        );
+        emittedEvents.push({
+          event,
+          data,
+        });
+      },
+    },
+    [GraphEvents.TOOL_END]: toolEndHandler,
+    [GraphEvents.ON_RUN_STEP]: {
+      handle: (event: GraphEvents.ON_RUN_STEP, data: t.StreamEventData): void =>
+        aggregateAndEmit(event, data),
+    },
+    [GraphEvents.ON_RUN_STEP_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP_DELTA,
+        data: t.StreamEventData
+      ): void => aggregateAndEmit(event, data),
+    },
+    [GraphEvents.ON_RUN_STEP_COMPLETED]: {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP_COMPLETED,
+        data: t.StreamEventData
+      ): void => aggregateAndEmit(event, data),
+    },
+    [GraphEvents.ON_MESSAGE_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_MESSAGE_DELTA,
+        data: t.StreamEventData
+      ): void => aggregateAndEmit(event, data),
+    },
+    [GraphEvents.ON_REASONING_DELTA]: {
+      handle: (
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: t.StreamEventData
+      ): void => aggregateAndEmit(event, data),
     },
   };
 }
@@ -390,6 +497,75 @@ describe('StandardGraph final response reasoning fallback', () => {
 
     expect(reasoningDeltas).toHaveLength(2);
     expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+  });
+
+  it('preserves LibreChat-like callbacks including model_end usage collection', async () => {
+    const text = 'Visible answer.';
+    const reasoningText = 'Visible reasoning.';
+    const usage: UsageMetadata = {
+      input_tokens: 7,
+      output_tokens: 5,
+      total_tokens: 12,
+      output_token_details: {
+        reasoning: 3,
+      },
+    };
+    const collectedUsage: UsageMetadata[] = [];
+    const emittedEvents: Array<{ event: string; data: unknown }> = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-librechat-callbacks',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.DEEPSEEK,
+          streamUsage: false,
+        },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createLibreChatLikeHandlers({
+        aggregateContent,
+        collectedUsage,
+        emittedEvents,
+      }),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new CallbackStreamingReasoningModel([
+      createReasoningChunk('reasoning_content', reasoningText.slice(0, 8)),
+      createReasoningChunk('reasoning_content', reasoningText.slice(8)),
+      new AIMessageChunk({
+        content: text,
+        usage_metadata: usage,
+      }),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('stream with LibreChat handlers')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-librechat-callbacks',
+        },
+      }
+    );
+
+    const countEvents = (event: GraphEvents): number =>
+      emittedEvents.filter((entry) => entry.event === event).length;
+
+    expect(countEvents(GraphEvents.ON_REASONING_DELTA)).toBe(2);
+    expect(countEvents(GraphEvents.ON_MESSAGE_DELTA)).toBe(1);
+    expect(countEvents(GraphEvents.CHAT_MODEL_END)).toBe(1);
+    expect(collectedUsage).toHaveLength(1);
+    expect(collectedUsage[0]).toMatchObject(usage);
     expect(contentParts).toEqual([
       { type: ContentTypes.THINK, think: reasoningText },
       { type: ContentTypes.TEXT, text },

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -8,8 +8,16 @@ import {
 } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
-import { Providers } from '@/common';
+import { ContentTypes, Providers } from '@/common';
 import { toLangChainContent } from './langchain';
+
+type ReasoningSummary = { summary?: Array<{ text?: string }> };
+type ReasoningDetail = { type?: string; text?: string };
+type ReasoningAdditionalKwargs = {
+  reasoning_content?: string | Partial<ReasoningSummary> | null;
+  reasoning?: string | Partial<ReasoningSummary> | null;
+  reasoning_details?: ReasoningDetail[] | null;
+};
 
 export function getConverseOverrideMessage({
   userMessage,
@@ -141,6 +149,75 @@ function reduceBlocks(blocks: ContentBlock[]): ContentBlock[] {
   }
 
   return reduced;
+}
+
+function getReasoningText(
+  value: string | Partial<ReasoningSummary> | null | undefined
+): string | undefined {
+  if (typeof value === 'string') {
+    return value !== '' ? value : undefined;
+  }
+  const summaryText = value?.summary
+    ?.map((summary) => summary.text ?? '')
+    .filter((text) => text !== '')
+    .join('');
+  return summaryText != null && summaryText !== '' ? summaryText : undefined;
+}
+
+function getReasoningDetailsText(
+  value: ReasoningDetail[] | null | undefined
+): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const reasoningText = value
+    .filter((detail) => detail.type === 'reasoning.text')
+    .map((detail) => detail.text ?? '')
+    .filter((text) => text !== '')
+    .join('');
+  return reasoningText !== '' ? reasoningText : undefined;
+}
+
+function getAdditionalReasoningContent(
+  message: BaseMessage
+): string | undefined {
+  const additionalKwargs =
+    message.additional_kwargs as ReasoningAdditionalKwargs | undefined;
+  if (additionalKwargs == null) {
+    return undefined;
+  }
+
+  const reasoningContent = getReasoningText(
+    additionalKwargs.reasoning_content
+  );
+  if (reasoningContent != null) {
+    return reasoningContent;
+  }
+
+  const reasoning = getReasoningText(additionalKwargs.reasoning);
+  if (reasoning != null) {
+    return reasoning;
+  }
+
+  return getReasoningDetailsText(additionalKwargs.reasoning_details);
+}
+
+function hasReasoningContent(content: BaseMessage['content']): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((item) => {
+    if (typeof item !== 'object' || !('type' in item)) {
+      return false;
+    }
+    return (
+      item.type === ContentTypes.THINK ||
+      item.type === ContentTypes.THINKING ||
+      item.type === ContentTypes.REASONING ||
+      item.type === ContentTypes.REASONING_CONTENT ||
+      item.type === 'redacted_thinking'
+    );
+  });
 }
 
 export function modifyDeltaProperties(
@@ -295,7 +372,20 @@ export function convertMessagesToContent(
     if (content === undefined) {
       return;
     }
+    const reasoningContent =
+      message?._getType() === 'ai' && !hasReasoningContent(content)
+        ? getAdditionalReasoningContent(message)
+        : undefined;
+    if (reasoningContent != null) {
+      processedContent.push({
+        type: ContentTypes.THINK,
+        think: reasoningContent,
+      });
+    }
     if (typeof content === 'string') {
+      if (content === '') {
+        return;
+      }
       processedContent.push({
         type: 'text',
         text: content,
@@ -398,7 +488,7 @@ export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
     ) {
       const base = Array.isArray(msg.content)
         ? msg.content
-        : [{ type: 'text' as const, text: String(msg.content ?? '') }];
+        : [{ type: 'text' as const, text: String(msg.content) }];
       msg.content = base.concat(msg.artifact.content);
     }
   }

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -364,13 +364,18 @@ export function convertMessagesToContent(
 ): t.MessageContentComplex[] {
   const processedContent: t.MessageContentComplex[] = [];
 
-  const addContentPart = (message: BaseMessage | null): void => {
+  const addToolCallBoundary = (): number => {
+    processedContent.push({ type: ContentTypes.TEXT, text: '' });
+    return processedContent.length - 1;
+  };
+
+  const addContentPart = (message: BaseMessage | null): number | undefined => {
     const content =
       message?.lc_kwargs.content != null
         ? message.lc_kwargs.content
         : message?.content;
     if (content === undefined) {
-      return;
+      return undefined;
     }
     const reasoningContent =
       message?._getType() === 'ai' && !hasReasoningContent(content)
@@ -384,18 +389,27 @@ export function convertMessagesToContent(
     }
     if (typeof content === 'string') {
       if (content === '') {
-        return;
+        return undefined;
       }
       processedContent.push({
-        type: 'text',
+        type: ContentTypes.TEXT,
         text: content,
       });
+      return processedContent.length - 1;
     } else if (Array.isArray(content)) {
-      const filteredContent = content.filter(
-        (item) => item != null && item.type !== 'tool_use'
-      );
-      processedContent.push(...filteredContent);
+      let textContentIndex: number | undefined;
+      for (const item of content) {
+        if (item == null || item.type === 'tool_use') {
+          continue;
+        }
+        processedContent.push(item);
+        if (item.type === ContentTypes.TEXT) {
+          textContentIndex = processedContent.length - 1;
+        }
+      }
+      return textContentIndex;
     }
+    return undefined;
   };
 
   let currentAIMessageIndex = -1;
@@ -418,8 +432,8 @@ export function convertMessagesToContent(
         toolCallMap.set(tool_call.id, tool_call);
       }
 
-      addContentPart(message);
-      currentAIMessageIndex = processedContent.length - 1;
+      currentAIMessageIndex =
+        addContentPart(message) ?? addToolCallBoundary();
       continue;
     } else if (
       messageType === 'tool' &&
@@ -449,6 +463,12 @@ export function convertMessagesToContent(
   }
 
   return processedContent;
+}
+
+function stringifyToolMessageContent(
+  content: ToolMessage['content'] | null | undefined
+): string {
+  return content == null ? '' : String(content);
 }
 
 export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
@@ -488,7 +508,12 @@ export function formatAnthropicArtifactContent(messages: BaseMessage[]): void {
     ) {
       const base = Array.isArray(msg.content)
         ? msg.content
-        : [{ type: 'text' as const, text: String(msg.content) }];
+        : [
+          {
+            type: ContentTypes.TEXT,
+            text: stringifyToolMessageContent(msg.content),
+          },
+        ];
       msg.content = base.concat(msg.artifact.content);
     }
   }

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -1,11 +1,16 @@
 import {
   HumanMessage,
   AIMessage,
+  AIMessageChunk,
   SystemMessage,
   ToolMessage,
 } from '@langchain/core/messages';
 import type { MessageContentComplex, TPayload } from '@/types';
 import { formatAgentMessages } from './format';
+import {
+  convertMessagesToContent,
+  formatAnthropicArtifactContent,
+} from './core';
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
 
@@ -616,6 +621,123 @@ describe('formatAgentMessages', () => {
     // Check final AIMessage
     expect(result.messages[4].content).toStrictEqual([
       { [ContentTypes.TEXT]: 'Here\'s your answer.', type: ContentTypes.TEXT },
+    ]);
+  });
+
+  it('preserves tool-only assistant turn boundaries when converting messages to content', () => {
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            name: 'lookup',
+            args: { step: 1 },
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'first result',
+        tool_call_id: 'call_1',
+        name: 'lookup',
+      }),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_2',
+            name: 'lookup',
+            args: { step: 2 },
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      new ToolMessage({
+        content: 'second result',
+        tool_call_id: 'call_2',
+        name: 'lookup',
+      }),
+    ];
+
+    const content = convertMessagesToContent(messages);
+    expect(content).toHaveLength(4);
+    expect(content[0]).toMatchObject({
+      type: ContentTypes.TEXT,
+      text: '',
+      tool_call_ids: ['call_1'],
+    });
+    expect(content[1]).toMatchObject({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: {
+        id: 'call_1',
+        name: 'lookup',
+        output: 'first result',
+      },
+    });
+    expect(content[2]).toMatchObject({
+      type: ContentTypes.TEXT,
+      text: '',
+      tool_call_ids: ['call_2'],
+    });
+    expect(content[3]).toMatchObject({
+      type: ContentTypes.TOOL_CALL,
+      tool_call: {
+        id: 'call_2',
+        name: 'lookup',
+        output: 'second result',
+      },
+    });
+
+    const result = formatAgentMessages([{ role: 'assistant', content }]);
+    expect(result.messages).toHaveLength(4);
+    expect(result.messages[0]).toBeInstanceOf(AIMessage);
+    expect(result.messages[1]).toBeInstanceOf(ToolMessage);
+    expect(result.messages[2]).toBeInstanceOf(AIMessage);
+    expect(result.messages[3]).toBeInstanceOf(ToolMessage);
+    expect((result.messages[0] as AIMessage).tool_calls?.[0].id).toBe(
+      'call_1'
+    );
+    expect((result.messages[1] as ToolMessage).tool_call_id).toBe('call_1');
+    expect((result.messages[2] as AIMessage).tool_calls?.[0].id).toBe(
+      'call_2'
+    );
+    expect((result.messages[3] as ToolMessage).tool_call_id).toBe('call_2');
+  });
+
+  it('keeps absent tool content empty when merging Anthropic artifacts', () => {
+    const toolMessage = new ToolMessage({
+      content: '',
+      tool_call_id: 'call_artifact',
+      name: 'render',
+      artifact: {
+        content: [{ type: ContentTypes.TEXT, text: 'artifact text' }],
+      },
+    });
+    Object.defineProperty(toolMessage, 'content', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    formatAnthropicArtifactContent([
+      new AIMessageChunk({
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_artifact',
+            name: 'render',
+            args: {},
+            type: 'tool_call' as const,
+          },
+        ],
+      }),
+      toolMessage,
+    ]);
+
+    expect(toolMessage.content).toEqual([
+      { type: ContentTypes.TEXT, text: '' },
+      { type: ContentTypes.TEXT, text: 'artifact text' },
     ]);
   });
 

--- a/src/specs/deepseek.simple.test.ts
+++ b/src/specs/deepseek.simple.test.ts
@@ -265,10 +265,15 @@ const skipTests = process.env.DEEPSEEK_API_KEY == null;
       const finalContentParts = await run.processStream(inputs, testConfig);
       expect(finalContentParts).toBeDefined();
 
-      const allTextParts = finalContentParts?.every(
-        (part) => part.type === ContentTypes.TEXT
+      const supportedContentParts = finalContentParts?.every(
+        (part) =>
+          part.type === ContentTypes.TEXT || part.type === ContentTypes.THINK
       );
-      expect(allTextParts).toBe(true);
+      expect(supportedContentParts).toBe(true);
+      const textParts =
+        finalContentParts?.filter((part) => part.type === ContentTypes.TEXT) ??
+        [];
+      expect(textParts.length).toBeGreaterThan(0);
 
       expect(collectedUsage.length).toBeGreaterThan(0);
       expect(collectedUsage[0].input_tokens).toBeGreaterThan(0);

--- a/src/specs/moonshot.simple.test.ts
+++ b/src/specs/moonshot.simple.test.ts
@@ -283,10 +283,15 @@ const skipTests = process.env.MOONSHOT_API_KEY == null;
       const finalContentParts = await run.processStream(inputs, testConfig);
       expect(finalContentParts).toBeDefined();
 
-      const allTextParts = finalContentParts?.every(
-        (part) => part.type === ContentTypes.TEXT
+      const supportedContentParts = finalContentParts?.every(
+        (part) =>
+          part.type === ContentTypes.TEXT || part.type === ContentTypes.THINK
       );
-      expect(allTextParts).toBe(true);
+      expect(supportedContentParts).toBe(true);
+      const textParts =
+        finalContentParts?.filter((part) => part.type === ContentTypes.TEXT) ??
+        [];
+      expect(textParts.length).toBeGreaterThan(0);
 
       expect(collectedUsage.length).toBeGreaterThan(0);
       expect(collectedUsage[0].input_tokens).toBeGreaterThan(0);

--- a/src/splitStream.test.ts
+++ b/src/splitStream.test.ts
@@ -11,6 +11,18 @@ jest.mock('@/utils', () => ({
   sleep: (): Promise<void> => Promise.resolve(),
 }));
 
+const createRunStep = (id: string): t.RunStep => ({
+  id,
+  stepIndex: 0,
+  type: StepTypes.MESSAGE_CREATION,
+  index: 0,
+  stepDetails: {
+    type: StepTypes.MESSAGE_CREATION,
+    message_creation: { message_id: id },
+  },
+  usage: null,
+});
+
 describe('Stream Generation and Handling', () => {
   let mockHandlers: {
     [GraphEvents.ON_RUN_STEP]: jest.Mock;
@@ -158,6 +170,58 @@ End code.`;
 
     expect(tokens).toContain(' ');
     expect(tokens.join('')).toBe('Hello  world');
+  });
+});
+
+describe('ContentAggregator empty deltas', () => {
+  it('should ignore empty message delta content arrays', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { contentParts, aggregateContent } = createContentAggregator();
+
+    try {
+      aggregateContent({
+        event: GraphEvents.ON_RUN_STEP,
+        data: createRunStep('step_empty_message'),
+      });
+
+      aggregateContent({
+        event: GraphEvents.ON_MESSAGE_DELTA,
+        data: {
+          id: 'step_empty_message',
+          delta: { content: [] },
+        },
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(contentParts).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('should ignore empty reasoning delta content arrays', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { contentParts, aggregateContent } = createContentAggregator();
+
+    try {
+      aggregateContent({
+        event: GraphEvents.ON_RUN_STEP,
+        data: createRunStep('step_empty_reasoning'),
+      });
+
+      aggregateContent({
+        event: GraphEvents.ON_REASONING_DELTA,
+        data: {
+          id: 'step_empty_reasoning',
+          delta: { content: [] },
+        },
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(contentParts).toEqual([]);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1317,6 +1317,14 @@ export function createContentAggregator(): t.ContentAggregatorResult {
     number,
     { agentId?: string; groupId?: number }
   >();
+  const getFirstContentPart = (
+    content?: t.MessageDelta['content'] | t.MessageContentComplex
+  ): t.MessageContentComplex | undefined => {
+    if (content == null) {
+      return undefined;
+    }
+    return Array.isArray(content) ? content[0] : content;
+  };
 
   const updateContent = (
     index: number,
@@ -1588,11 +1596,8 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         return;
       }
 
-      if (messageDelta.delta.content) {
-        const contentPart = Array.isArray(messageDelta.delta.content)
-          ? messageDelta.delta.content[0]
-          : messageDelta.delta.content;
-
+      const contentPart = getFirstContentPart(messageDelta.delta.content);
+      if (contentPart != null) {
         updateContent(runStep.index, contentPart);
       }
     } else if (
@@ -1612,11 +1617,8 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         return;
       }
 
-      if (reasoningDelta.delta.content) {
-        const contentPart = Array.isArray(reasoningDelta.delta.content)
-          ? reasoningDelta.delta.content[0]
-          : reasoningDelta.delta.content;
-
+      const contentPart = getFirstContentPart(reasoningDelta.delta.content);
+      if (contentPart != null) {
         updateContent(runStep.index, contentPart);
       }
     } else if (event === GraphEvents.ON_RUN_STEP_DELTA) {


### PR DESCRIPTION
## Summary

I fixed content aggregation for empty deltas and added a final-response reasoning fallback so OpenAI-compatible providers like Ollama do not appear blank when reasoning is returned outside normal stream events.

- Ignored empty message and reasoning delta content arrays before calling `updateContent`, avoiding misleading `No content part found in 'updateContent'` warnings.
- Added final response extraction for `reasoning_content`, `reasoning`, OpenAI reasoning summary text, and OpenRouter `reasoning_details` in the graph fallback path.
- Dispatched final reasoning as `ON_REASONING_DELTA` before final text or tool-call handling, while preserving `getMessageId` deduplication for normal streaming runs.
- Materialized AI-message `additional_kwargs` reasoning into returned content parts when `returnContent` callers do not provide a custom aggregator.
- Preserved empty text boundaries for tool-only assistant turns so sequential tool calls replay in the original AI/tool order.
- Kept artifact-only tool results from fabricating `null` or `undefined` text when Anthropic artifact content is appended.
- Added regression coverage for invoke-only final responses that return reasoning-only output, reasoning plus text, multi-part OpenAI summaries, and OpenRouter reasoning details.
- Added DeepSeek/Ollama/Moonshot-shaped `reasoning_content`, OpenRouter-shaped `reasoning`, and OpenAI/Azure-shaped reasoning summary streaming regressions to prove final fallback does not double-send streamed reasoning or text, including reasoning-only output.
- Mirrored LibreChat's callback surface with a regression that includes `ModelEndHandler`, `ToolEndHandler`, aggregation, emitted stream events, and model-end usage collection.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] `npx jest src/stream.test.ts src/splitStream.test.ts src/graphs/__tests__/Graph.reasoning.test.ts --runInBand`
- [x] `npx jest src/specs/custom-event-await.test.ts --runInBand`
- [x] `npx jest src/graphs/__tests__/Graph.reasoning.test.ts src/stream.test.ts src/splitStream.test.ts src/llm/openrouter/reasoning.test.ts src/llm/openai/deepseek.test.ts src/llm/custom-chat-models.smoke.test.ts --runInBand`
- [x] `npx jest src/messages/formatAgentMessages.test.ts src/messages/ensureThinkingBlock.test.ts --runInBand`
- [x] `npx jest src/messages/formatAgentMessages.test.ts src/messages/formatAgentMessages.tools.test.ts src/messages/ensureThinkingBlock.test.ts src/messages/cache.test.ts --runInBand`
- [x] `npx jest src/specs/deepseek.simple.test.ts src/specs/openrouter.simple.test.ts --runInBand` (skipped locally because `DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` are unset)
- [x] `npx tsc --noEmit --pretty false`
- [x] `npx eslint src/graphs/Graph.ts src/graphs/__tests__/Graph.reasoning.test.ts src/messages/core.ts`
- [x] `npx eslint src/messages/core.ts src/messages/formatAgentMessages.test.ts`
- [x] `git diff --check`
- [x] Live Ollama sanity check with local `qwen3:14b` through `Run`, confirming `ON_REASONING_DELTA` emitted reasoning while final text was empty due to token cap.

### **Test Configuration**:

- macOS arm64
- Ollama `0.24.0`
- Local model: `qwen3:14b`
- `DEEPSEEK_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, and `ANTHROPIC_API_KEY` were unset in this workspace

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
