### PR TITLE
fix: Prevent Late OpenRouter Reasoning Replay

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -1611,6 +1611,104 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     );
   });
 
+  it('defers disableStreaming mixed hidden reasoning and visible text chunks', async () => {
+    const dispatchMessageDelta = jest.fn<StandardGraph['dispatchMessageDelta']>(
+      async () => undefined
+    );
+    const dispatchReasoningDelta = jest.fn<
+      StandardGraph['dispatchReasoningDelta']
+    >(async () => undefined);
+    const agentContext: Partial<AgentContext> = {
+      provider: Providers.OPENAI,
+      reasoningKey: 'reasoning_content',
+      clientOptions: { disableStreaming: true } as t.OpenAIClientOptions,
+      currentTokenType: ContentTypes.TEXT,
+      toolDefinitions: [],
+      graphTools: [],
+      agentId: 'agent_1',
+    };
+    const graph = createGraph({
+      dispatchMessageDelta,
+      dispatchReasoningDelta,
+      getAgentContext: jest.fn(
+        () => agentContext
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const mixedChunk = {
+      content: 'final answer',
+      additional_kwargs: {
+        reasoning_content: 'hidden reasoning',
+      },
+    } as unknown as t.StreamChunk;
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: mixedChunk },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      { chunk: mixedChunk },
+      metadata,
+      graph
+    );
+
+    expect(dispatchReasoningDelta).not.toHaveBeenCalled();
+    expect(dispatchMessageDelta).not.toHaveBeenCalled();
+    expect(graph.dispatchRunStep).not.toHaveBeenCalled();
+  });
+
+  it('leaves mixed hidden reasoning and visible text chunks on the streaming path', async () => {
+    const dispatchMessageDelta = jest.fn<StandardGraph['dispatchMessageDelta']>(
+      async () => undefined
+    );
+    const dispatchReasoningDelta = jest.fn<
+      StandardGraph['dispatchReasoningDelta']
+    >(async () => undefined);
+    const graph = createGraph({
+      dispatchMessageDelta,
+      dispatchReasoningDelta,
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          currentTokenType: ContentTypes.TEXT,
+          toolDefinitions: [],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const metadata = { langgraph_node: 'agent' };
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: 'streamed answer',
+          additional_kwargs: {
+            reasoning_content: 'hidden reasoning',
+          },
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(dispatchReasoningDelta).not.toHaveBeenCalled();
+    expect(dispatchMessageDelta).toHaveBeenCalledTimes(1);
+    expect(dispatchMessageDelta).toHaveBeenCalledWith(
+      expect.stringMatching(/^step_/),
+      {
+        content: [{ type: ContentTypes.TEXT, text: 'streamed answer' }],
+      },
+      metadata
+    );
+  });
+
   it('processes a reused chunk object when its streamed payload changes', async () => {
     const graph = createGraph();
     const handler = new ChatModelStreamHandler();

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -252,6 +252,8 @@ export class AgentContext {
   /** Current token type being processed */
   currentTokenType: ContentTypes.TEXT | ContentTypes.THINK | 'think_and_text' =
     ContentTypes.TEXT;
+  /** Visible text dispatched through stream deltas in the current run */
+  streamedTextContent = '';
   /** Whether tools should end the workflow */
   toolEnd: boolean = false;
   /** Cached system runnable (created lazily) */
@@ -904,6 +906,7 @@ export class AgentContext {
     this.tokenTypeSwitch = undefined;
     this.reasoningTransitionCount = 0;
     this.currentTokenType = ContentTypes.TEXT;
+    this.streamedTextContent = '';
     this.discoveredToolNames.clear();
     this.handoffContext = undefined;
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -252,8 +252,8 @@ export class AgentContext {
   /** Current token type being processed */
   currentTokenType: ContentTypes.TEXT | ContentTypes.THINK | 'think_and_text' =
     ContentTypes.TEXT;
-  /** Visible text dispatched through stream deltas in the current run */
-  streamedTextContent = '';
+  /** Visible text deltas dispatched during the current model invocation */
+  streamedTextDeltaCount = 0;
   /** Whether tools should end the workflow */
   toolEnd: boolean = false;
   /** Cached system runnable (created lazily) */
@@ -906,7 +906,7 @@ export class AgentContext {
     this.tokenTypeSwitch = undefined;
     this.reasoningTransitionCount = 0;
     this.currentTokenType = ContentTypes.TEXT;
-    this.streamedTextContent = '';
+    this.streamedTextDeltaCount = 0;
     this.discoveredToolNames.clear();
     this.handoffContext = undefined;
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -252,8 +252,6 @@ export class AgentContext {
   /** Current token type being processed */
   currentTokenType: ContentTypes.TEXT | ContentTypes.THINK | 'think_and_text' =
     ContentTypes.TEXT;
-  /** Visible text deltas dispatched during the current model invocation */
-  streamedTextDeltaCount = 0;
   /** Whether tools should end the workflow */
   toolEnd: boolean = false;
   /** Cached system runnable (created lazily) */
@@ -906,7 +904,6 @@ export class AgentContext {
     this.tokenTypeSwitch = undefined;
     this.reasoningTransitionCount = 0;
     this.currentTokenType = ContentTypes.TEXT;
-    this.streamedTextDeltaCount = 0;
     this.discoveredToolNames.clear();
     this.handoffContext = undefined;
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -217,16 +217,23 @@ function hasTextDeltaContent(
   );
 }
 
-function shouldSkipFinalTextFallback({
-  agentContext,
-  content,
+function hasCurrentTextDeltaStep({
+  graph,
+  metadata,
 }: {
-  agentContext: AgentContext;
-  content: t.MessageDelta['content'] | undefined;
+  graph: Graph<t.BaseGraphState>;
+  metadata: Record<string, unknown>;
 }): boolean {
-  return (
-    agentContext.streamedTextDeltaCount > 0 && hasTextDeltaContent(content)
-  );
+  const baseStepKey = graph.getStepBaseKey(metadata);
+  for (const [stepKey, stepIds] of graph.stepKeyIds) {
+    if (stepKey !== baseStepKey && !stepKey.startsWith(`${baseStepKey}_`)) {
+      continue;
+    }
+    if (stepIds.some((stepId) => graph.messageStepHasTextDeltas.has(stepId))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function dispatchTextMessageContent({
@@ -333,6 +340,9 @@ export abstract class Graph<
   abstract getKeyList(
     metadata: Record<string, unknown> | undefined
   ): (string | number | undefined)[];
+  abstract getStepBaseKey(
+    metadata: Record<string, unknown> | undefined
+  ): string;
   abstract getStepKey(metadata: Record<string, unknown> | undefined): string;
   abstract checkKeyList(keyList: (string | number | undefined)[]): boolean;
   abstract getStepIdByKey(stepKey: string, index?: number): string;
@@ -364,6 +374,7 @@ export abstract class Graph<
     state: t.AgentSubgraphState,
     config?: RunnableConfig
   ) => Promise<Partial<t.AgentSubgraphState>>;
+  messageStepHasTextDeltas: Set<string> = new Set();
   messageStepHasToolCalls: Map<string, boolean> = new Map();
   messageIdsByStepKey: Map<string, string> = new Map();
   prelimMessageIdsByStepKey: Map<string, string> = new Map();
@@ -453,6 +464,7 @@ export abstract class Graph<
     this.stepKeyIds = new Map();
     this.toolCallStepIds.clear();
     this.messageIdsByStepKey = new Map();
+    this.messageStepHasTextDeltas = new Set();
     this.messageStepHasToolCalls = new Map();
     this.prelimMessageIdsByStepKey = new Map();
     this.invokedToolIds = undefined;
@@ -729,6 +741,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       this.messageStepHasToolCalls,
       new Map()
     );
+    this.messageStepHasTextDeltas = resetIfNotEmpty(
+      this.messageStepHasTextDeltas,
+      new Set()
+    );
     this.prelimMessageIdsByStepKey = resetIfNotEmpty(
       this.prelimMessageIdsByStepKey,
       new Map()
@@ -788,6 +804,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     return agentContext;
   }
 
+  getStepBaseKey(metadata: Record<string, unknown> | undefined): string {
+    if (!metadata) return '';
+
+    const keyList = this.getBaseKeyList(metadata);
+    if (this.checkKeyList(keyList)) {
+      throw new Error('Missing metadata');
+    }
+
+    return joinKeys(keyList);
+  }
+
   getStepKey(metadata: Record<string, unknown> | undefined): string {
     if (!metadata) return '';
 
@@ -834,6 +861,27 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   ): (string | number | undefined)[] {
     if (!metadata) return [];
 
+    const keyList = this.getBaseKeyList(metadata);
+    const agentContext = this.getAgentContext(metadata);
+    if (
+      agentContext.currentTokenType === ContentTypes.THINK ||
+      agentContext.currentTokenType === 'think_and_text'
+    ) {
+      keyList.push('reasoning');
+    } else if (agentContext.tokenTypeSwitch === 'content') {
+      keyList.push(`post-reasoning-${agentContext.reasoningTransitionCount}`);
+    }
+
+    if (this.invokedToolIds != null && this.invokedToolIds.size > 0) {
+      keyList.push(this.invokedToolIds.size + '');
+    }
+
+    return keyList;
+  }
+
+  private getBaseKeyList(
+    metadata: Record<string, unknown>
+  ): (string | number | undefined)[] {
     const configurable = this.config?.configurable;
     const runId =
       (metadata.run_id as string | undefined) ??
@@ -854,20 +902,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       metadata.langgraph_step as number,
       checkpointNs,
     ];
-
-    const agentContext = this.getAgentContext(metadata);
-    if (
-      agentContext.currentTokenType === ContentTypes.THINK ||
-      agentContext.currentTokenType === 'think_and_text'
-    ) {
-      keyList.push('reasoning');
-    } else if (agentContext.tokenTypeSwitch === 'content') {
-      keyList.push(`post-reasoning-${agentContext.reasoningTransitionCount}`);
-    }
-
-    if (this.invokedToolIds != null && this.invokedToolIds.size > 0) {
-      keyList.push(this.invokedToolIds.size + '');
-    }
 
     return keyList;
   }
@@ -1636,7 +1670,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       try {
-        agentContext.streamedTextDeltaCount = 0;
         result = await withLangfuseToolOutputTracingConfig(
           this.langfuse,
           () =>
@@ -1652,7 +1685,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.langfuse
         );
       } catch (primaryError) {
-        agentContext.streamedTextDeltaCount = 0;
         result = await withLangfuseToolOutputTracingConfig(
           this.langfuse,
           () =>
@@ -1701,6 +1733,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const textMessageContent = getTextMessageDeltaContent(
         responseMessage?.content as MessageContent | undefined
       );
+      const hasStreamedTextDeltaStep = hasCurrentTextDeltaStep({
+        graph: this,
+        metadata,
+      });
 
       if (hasToolCalls) {
         const dispatchedReasoning =
@@ -1714,13 +1750,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         if (dispatchedReasoning) {
           markPostReasoningContent(agentContext);
         }
-        if (
-          textMessageContent != null &&
-          !shouldSkipFinalTextFallback({
-            agentContext,
-            content: textMessageContent,
-          })
-        ) {
+        if (textMessageContent != null && !hasStreamedTextDeltaStep) {
           const stepKey = this.getStepKey(metadata);
           const dispatchedText = await dispatchTextMessageContent({
             graph: this,
@@ -1753,13 +1783,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         if (dispatchedReasoning && textMessageContent != null) {
           markPostReasoningContent(agentContext);
         }
-        if (
-          textMessageContent != null &&
-          !shouldSkipFinalTextFallback({
-            agentContext,
-            content: textMessageContent,
-          })
-        ) {
+        if (textMessageContent != null && !hasStreamedTextDeltaStep) {
           const stepKey = this.getStepKey(metadata);
           await dispatchTextMessageContent({
             graph: this,
@@ -2332,6 +2356,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       id,
       delta,
     };
+    if (hasTextDeltaContent(delta.content)) {
+      this.messageStepHasTextDeltas.add(id);
+    }
     const handler = this.handlerRegistry?.getHandler(
       GraphEvents.ON_MESSAGE_DELTA
     );

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -205,31 +205,28 @@ function getTextMessageDeltaContent(
   return content as t.MessageDelta['content'];
 }
 
-function getTextDeltaValue(
+function hasTextDeltaContent(
   content: t.MessageDelta['content'] | undefined
-): string | undefined {
+): boolean {
   if (content == null) {
-    return undefined;
+    return false;
   }
-  const text = content
-    .map((contentPart) =>
-      contentPart.type === ContentTypes.TEXT ? contentPart.text : ''
-    )
-    .join('');
-  return text !== '' ? text : undefined;
+  return content.some(
+    (contentPart) =>
+      contentPart.type === ContentTypes.TEXT && contentPart.text !== ''
+  );
 }
 
-function isFinalTextReplay({
+function shouldSkipFinalTextFallback({
   agentContext,
   content,
 }: {
   agentContext: AgentContext;
   content: t.MessageDelta['content'] | undefined;
 }): boolean {
-  const text = getTextDeltaValue(content);
-  // Keep this exact: the reported replay stores byte-identical answer text.
-  // Prefix/suffix guessing risks suppressing legitimate final content.
-  return text != null && text === agentContext.streamedTextContent;
+  return (
+    agentContext.streamedTextDeltaCount > 0 && hasTextDeltaContent(content)
+  );
 }
 
 async function dispatchTextMessageContent({
@@ -1639,6 +1636,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       try {
+        agentContext.streamedTextDeltaCount = 0;
         result = await withLangfuseToolOutputTracingConfig(
           this.langfuse,
           () =>
@@ -1654,6 +1652,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.langfuse
         );
       } catch (primaryError) {
+        agentContext.streamedTextDeltaCount = 0;
         result = await withLangfuseToolOutputTracingConfig(
           this.langfuse,
           () =>
@@ -1717,7 +1716,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }
         if (
           textMessageContent != null &&
-          !isFinalTextReplay({ agentContext, content: textMessageContent })
+          !shouldSkipFinalTextFallback({
+            agentContext,
+            content: textMessageContent,
+          })
         ) {
           const stepKey = this.getStepKey(metadata);
           const dispatchedText = await dispatchTextMessageContent({
@@ -1753,7 +1755,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }
         if (
           textMessageContent != null &&
-          !isFinalTextReplay({ agentContext, content: textMessageContent })
+          !shouldSkipFinalTextFallback({
+            agentContext,
+            content: textMessageContent,
+          })
         ) {
           const stepKey = this.getStepKey(metadata);
           await dispatchTextMessageContent({

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -807,7 +807,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   getStepBaseKey(metadata: Record<string, unknown> | undefined): string {
     if (!metadata) return '';
 
-    const keyList = this.getBaseKeyList(metadata);
+    const keyList = this.getInvocationKeyList(metadata);
     if (this.checkKeyList(keyList)) {
       throw new Error('Missing metadata');
     }
@@ -861,7 +861,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   ): (string | number | undefined)[] {
     if (!metadata) return [];
 
-    const keyList = this.getBaseKeyList(metadata);
+    const keyList = this.getInvocationKeyList(metadata);
     const agentContext = this.getAgentContext(metadata);
     if (
       agentContext.currentTokenType === ContentTypes.THINK ||
@@ -872,10 +872,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       keyList.push(`post-reasoning-${agentContext.reasoningTransitionCount}`);
     }
 
+    return keyList;
+  }
+
+  private getInvocationKeyList(
+    metadata: Record<string, unknown>
+  ): (string | number | undefined)[] {
+    const keyList = this.getBaseKeyList(metadata);
     if (this.invokedToolIds != null && this.invokedToolIds.size > 0) {
       keyList.push(this.invokedToolIds.size + '');
     }
-
     return keyList;
   }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -211,10 +211,43 @@ function hasTextDeltaContent(
   if (content == null) {
     return false;
   }
+  return content.some((contentPart) => {
+    if (contentPart.type?.startsWith(ContentTypes.TEXT) !== true) {
+      return false;
+    }
+    const text = (contentPart as Partial<{ text: string }>).text;
+    return typeof text === 'string' && text !== '';
+  });
+}
+
+function hasReasoningDeltaContent(
+  content: t.ReasoningDelta['content'] | undefined
+): boolean {
+  if (content == null) {
+    return false;
+  }
   return content.some(
     (contentPart) =>
-      contentPart.type === ContentTypes.TEXT && contentPart.text !== ''
+      contentPart.type === ContentTypes.THINK && contentPart.think !== ''
   );
+}
+
+function getCurrentStepIds({
+  graph,
+  metadata,
+}: {
+  graph: Graph<t.BaseGraphState>;
+  metadata: Record<string, unknown>;
+}): string[] {
+  const baseStepKey = graph.getStepBaseKey(metadata);
+  const currentStepIds: string[] = [];
+  for (const [stepKey, stepIds] of graph.stepKeyIds) {
+    if (stepKey !== baseStepKey && !stepKey.startsWith(`${baseStepKey}_`)) {
+      continue;
+    }
+    currentStepIds.push(...stepIds);
+  }
+  return currentStepIds;
 }
 
 function hasCurrentTextDeltaStep({
@@ -224,16 +257,34 @@ function hasCurrentTextDeltaStep({
   graph: Graph<t.BaseGraphState>;
   metadata: Record<string, unknown>;
 }): boolean {
-  const baseStepKey = graph.getStepBaseKey(metadata);
-  for (const [stepKey, stepIds] of graph.stepKeyIds) {
-    if (stepKey !== baseStepKey && !stepKey.startsWith(`${baseStepKey}_`)) {
-      continue;
-    }
-    if (stepIds.some((stepId) => graph.messageStepHasTextDeltas.has(stepId))) {
-      return true;
-    }
+  return getCurrentStepIds({ graph, metadata }).some((stepId) =>
+    graph.messageStepHasTextDeltas.has(stepId)
+  );
+}
+
+function hasCurrentReasoningDeltaStep({
+  graph,
+  metadata,
+}: {
+  graph: Graph<t.BaseGraphState>;
+  metadata: Record<string, unknown>;
+}): boolean {
+  return getCurrentStepIds({ graph, metadata }).some((stepId) =>
+    graph.reasoningStepHasDeltas.has(stepId)
+  );
+}
+
+function clearCurrentDeltaStepMarkers({
+  graph,
+  metadata,
+}: {
+  graph: Graph<t.BaseGraphState>;
+  metadata: Record<string, unknown>;
+}): void {
+  for (const stepId of getCurrentStepIds({ graph, metadata })) {
+    graph.messageStepHasTextDeltas.delete(stepId);
+    graph.reasoningStepHasDeltas.delete(stepId);
   }
-  return false;
 }
 
 async function dispatchTextMessageContent({
@@ -389,6 +440,7 @@ export abstract class Graph<
    * the same step are scoped to the active custom event dispatch.
    */
   handlerDispatchedStepIds: Set<string> = new Set();
+  reasoningStepHasDeltas: Set<string> = new Set();
   protected handlerDispatchedEventCounts: Map<string, number> = new Map();
   signal?: AbortSignal;
   /** Set of invoked tool call IDs from non-message run steps completed mid-run, if any */
@@ -465,6 +517,7 @@ export abstract class Graph<
     this.toolCallStepIds.clear();
     this.messageIdsByStepKey = new Map();
     this.messageStepHasTextDeltas = new Set();
+    this.reasoningStepHasDeltas = new Set();
     this.messageStepHasToolCalls = new Map();
     this.prelimMessageIdsByStepKey = new Map();
     this.invokedToolIds = undefined;
@@ -743,6 +796,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     );
     this.messageStepHasTextDeltas = resetIfNotEmpty(
       this.messageStepHasTextDeltas,
+      new Set()
+    );
+    this.reasoningStepHasDeltas = resetIfNotEmpty(
+      this.reasoningStepHasDeltas,
       new Set()
     );
     this.prelimMessageIdsByStepKey = resetIfNotEmpty(
@@ -1674,6 +1731,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           };
         }
       }
+      const metadata = config.metadata as Record<string, unknown>;
 
       try {
         result = await withLangfuseToolOutputTracingConfig(
@@ -1691,6 +1749,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.langfuse
         );
       } catch (primaryError) {
+        clearCurrentDeltaStepMarkers({
+          graph: this,
+          metadata,
+        });
         result = await withLangfuseToolOutputTracingConfig(
           this.langfuse,
           () =>
@@ -1731,7 +1793,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       const toolCalls = (responseMessage as AIMessageChunk | undefined)
         ?.tool_calls;
       const hasToolCalls = Array.isArray(toolCalls) && toolCalls.length > 0;
-      const metadata = config.metadata as Record<string, unknown>;
       const responseReasoningContent = getResponseReasoningContent({
         responseMessage: responseMessage as Partial<AIMessageChunk> | undefined,
         reasoningKey: agentContext.reasoningKey,
@@ -1743,10 +1804,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         graph: this,
         metadata,
       });
+      const hasStreamedReasoningDeltaStep = hasCurrentReasoningDeltaStep({
+        graph: this,
+        metadata,
+      });
 
       if (hasToolCalls) {
         const dispatchedReasoning =
           responseReasoningContent != null &&
+          !hasStreamedReasoningDeltaStep &&
           (await dispatchReasoningContent({
             graph: this,
             agentContext,
@@ -1780,6 +1846,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       if (!hasToolCalls && responseMessage != null) {
         const dispatchedReasoning =
           responseReasoningContent != null &&
+          !hasStreamedReasoningDeltaStep &&
           (await dispatchReasoningContent({
             graph: this,
             agentContext,
@@ -2403,6 +2470,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       id: stepId,
       delta,
     };
+    if (hasReasoningDeltaContent(delta.content)) {
+      this.reasoningStepHasDeltas.add(stepId);
+    }
     const handler = this.handlerRegistry?.getHandler(
       GraphEvents.ON_REASONING_DELTA
     );

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -373,6 +373,28 @@ function markPostReasoningContent(agentContext: AgentContext): void {
   agentContext.reasoningTransitionCount++;
 }
 
+function getDispatchableFinalReasoningContent({
+  agentContext,
+  responseReasoningContent,
+  hasStreamedTextDeltaStep,
+  hasStreamedReasoningDeltaStep,
+}: {
+  agentContext: AgentContext;
+  responseReasoningContent: string | undefined;
+  hasStreamedTextDeltaStep: boolean;
+  hasStreamedReasoningDeltaStep: boolean;
+}): string | undefined {
+  if (responseReasoningContent == null || hasStreamedReasoningDeltaStep) {
+    return undefined;
+  }
+  if (
+    agentContext.provider === Providers.OPENROUTER && hasStreamedTextDeltaStep
+  ) {
+    return undefined;
+  }
+  return responseReasoningContent;
+}
+
 export abstract class Graph<
   T extends t.BaseGraphState = t.BaseGraphState,
   _TNodeName extends string = string,
@@ -1808,15 +1830,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         graph: this,
         metadata,
       });
+      const dispatchableFinalReasoningContent =
+        getDispatchableFinalReasoningContent({
+          agentContext,
+          responseReasoningContent,
+          hasStreamedTextDeltaStep,
+          hasStreamedReasoningDeltaStep,
+        });
 
       if (hasToolCalls) {
         const dispatchedReasoning =
-          responseReasoningContent != null &&
-          !hasStreamedReasoningDeltaStep &&
+          dispatchableFinalReasoningContent != null &&
           (await dispatchReasoningContent({
             graph: this,
             agentContext,
-            reasoningContent: responseReasoningContent,
+            reasoningContent: dispatchableFinalReasoningContent,
             metadata,
           }));
         if (dispatchedReasoning) {
@@ -1845,12 +1873,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        */
       if (!hasToolCalls && responseMessage != null) {
         const dispatchedReasoning =
-          responseReasoningContent != null &&
-          !hasStreamedReasoningDeltaStep &&
+          dispatchableFinalReasoningContent != null &&
           (await dispatchReasoningContent({
             graph: this,
             agentContext,
-            reasoningContent: responseReasoningContent,
+            reasoningContent: dispatchableFinalReasoningContent,
             metadata,
           }));
         if (dispatchedReasoning && textMessageContent != null) {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -205,6 +205,33 @@ function getTextMessageDeltaContent(
   return content as t.MessageDelta['content'];
 }
 
+function getTextDeltaValue(
+  content: t.MessageDelta['content'] | undefined
+): string | undefined {
+  if (content == null) {
+    return undefined;
+  }
+  const text = content
+    .map((contentPart) =>
+      contentPart.type === ContentTypes.TEXT ? contentPart.text : ''
+    )
+    .join('');
+  return text !== '' ? text : undefined;
+}
+
+function isFinalTextReplay({
+  agentContext,
+  content,
+}: {
+  agentContext: AgentContext;
+  content: t.MessageDelta['content'] | undefined;
+}): boolean {
+  const text = getTextDeltaValue(content);
+  // Keep this exact: the reported replay stores byte-identical answer text.
+  // Prefix/suffix guessing risks suppressing legitimate final content.
+  return text != null && text === agentContext.streamedTextContent;
+}
+
 async function dispatchTextMessageContent({
   graph,
   stepKey,
@@ -1688,7 +1715,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         if (dispatchedReasoning) {
           markPostReasoningContent(agentContext);
         }
-        if (textMessageContent != null) {
+        if (
+          textMessageContent != null &&
+          !isFinalTextReplay({ agentContext, content: textMessageContent })
+        ) {
           const stepKey = this.getStepKey(metadata);
           const dispatchedText = await dispatchTextMessageContent({
             graph: this,
@@ -1721,7 +1751,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         if (dispatchedReasoning && textMessageContent != null) {
           markPostReasoningContent(agentContext);
         }
-        if (textMessageContent != null) {
+        if (
+          textMessageContent != null &&
+          !isFinalTextReplay({ agentContext, content: textMessageContent })
+        ) {
           const stepKey = this.getStepKey(metadata);
           await dispatchTextMessageContent({
             graph: this,

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -640,6 +640,58 @@ describe('StandardGraph final response reasoning fallback', () => {
     }
   );
 
+  it('streams OpenRouter reasoning_content before visible text', async () => {
+    const text = '391.';
+    const reasoningText = 'Use the difference of squares.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-reasoning-content-stream',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      createReasoningChunk('reasoning_content', reasoningText),
+      new AIMessageChunk({ content: text }),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('stream OpenRouter reasoning_content')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openrouter-reasoning-content-stream',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+  });
+
   it('does not replay streamed OpenRouter text when the final chunk has reasoning_details', async () => {
     const text = '391.';
     const reasoningText = '17 times 23 equals 391.';
@@ -749,12 +801,64 @@ describe('StandardGraph final response reasoning fallback', () => {
       }
     );
 
-    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas).toHaveLength(0);
     expect(messageDeltas).toHaveLength(1);
-    expect(contentParts).toEqual([
-      { type: ContentTypes.TEXT, text },
+    expect(contentParts).toEqual([{ type: ContentTypes.TEXT, text }]);
+    expect(finalContentParts).toEqual([
       { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
     ]);
+    expect(run.getRunMessages()?.[0]?.content).toBe(text);
+  });
+
+  it('does not replay streamed text when late OpenRouter reasoning_content arrives', async () => {
+    const text = '391.';
+    const reasoningText = 'Confirm the arithmetic after visible text.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-text-before-reasoning-content',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({ content: text }),
+      createReasoningChunk('reasoning_content', reasoningText),
+    ]);
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('think briefly, what is 17 x 23?')] },
+      {
+        ...config,
+        configurable: {
+          thread_id:
+            'reasoning-fallback-openrouter-text-before-reasoning-content',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(0);
+    expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([{ type: ContentTypes.TEXT, text }]);
     expect(finalContentParts).toEqual([
       { type: ContentTypes.THINK, think: reasoningText },
       { type: ContentTypes.TEXT, text },
@@ -807,12 +911,9 @@ describe('StandardGraph final response reasoning fallback', () => {
       }
     );
 
-    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas).toHaveLength(0);
     expect(messageDeltas).toHaveLength(1);
-    expect(contentParts).toEqual([
-      { type: ContentTypes.TEXT, text },
-      { type: ContentTypes.THINK, think: reasoningText },
-    ]);
+    expect(contentParts).toEqual([{ type: ContentTypes.TEXT, text }]);
     expect(finalContentParts).toEqual([
       { type: ContentTypes.THINK, think: reasoningText },
       { type: ContentTypes.TEXT, text },
@@ -872,7 +973,7 @@ describe('StandardGraph final response reasoning fallback', () => {
       }
     );
 
-    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas).toHaveLength(0);
     expect(messageDeltas).toHaveLength(2);
     expect(messageDeltas[1].delta.content?.[0]).toEqual({
       type: ContentTypes.TEXT,
@@ -880,7 +981,6 @@ describe('StandardGraph final response reasoning fallback', () => {
     });
     expect(contentParts).toEqual([
       { type: ContentTypes.TEXT, text: replayWithSuffix },
-      { type: ContentTypes.THINK, think: reasoningText },
     ]);
     expect(finalContentParts).toEqual([
       { type: ContentTypes.THINK, think: reasoningText },
@@ -1109,7 +1209,7 @@ describe('StandardGraph final response reasoning fallback', () => {
       }
     );
 
-    expect(reasoningDeltas).toHaveLength(1);
+    expect(reasoningDeltas).toHaveLength(0);
     expect(messageDeltas.map((delta) => delta.delta.content?.[0])).toEqual([
       { type: ContentTypes.TEXT, text: 'world' },
     ]);

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -6,7 +6,7 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
 import type { OpenAIClient } from '@langchain/openai';
 import type * as t from '@/types';
-import { ContentTypes, GraphEvents, Providers } from '@/common';
+import { ContentTypes, GraphEvents, Providers, StepTypes } from '@/common';
 import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
 import { ChatOpenRouter } from '@/llm/openrouter';
 import { ModelEndHandler, ToolEndHandler } from '@/events';
@@ -818,6 +818,242 @@ describe('StandardGraph final response reasoning fallback', () => {
       { type: ContentTypes.TEXT, text },
     ]);
     expect(run.getRunMessages()?.[0]?.content).toBe(text);
+  });
+
+  it('keeps new OpenRouter final text suffixes that carry reasoning_details', async () => {
+    const firstText = 'Hello ';
+    const replayWithSuffix = 'Hello world';
+    const reasoningText = 'The greeting needs one more word.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-final-suffix-details',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({ content: firstText }),
+      new AIMessageChunk({
+        content: replayWithSuffix,
+        additional_kwargs: {
+          reasoning_details: [
+            { type: 'reasoning.text', text: reasoningText },
+          ],
+        },
+      }),
+    ]);
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('finish the greeting')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openrouter-final-suffix-details',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(messageDeltas).toHaveLength(2);
+    expect(messageDeltas[1].delta.content?.[0]).toEqual({
+      type: ContentTypes.TEXT,
+      text: 'world',
+    });
+    expect(contentParts).toEqual([
+      { type: ContentTypes.TEXT, text: replayWithSuffix },
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text: replayWithSuffix },
+    ]);
+    expect(run.getRunMessages()?.[0]?.content).toBe(replayWithSuffix);
+  });
+
+  it('keeps post-tool final text when an earlier invocation streamed text', async () => {
+    const streamedBeforeTool = 'I will check that. ';
+    const finalAfterTool = 'The answer is 391.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-post-tool-final-text',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENAI,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const graph = run.Graph;
+    const metadata = {
+      thread_id: 'reasoning-fallback-post-tool-final-text',
+      langgraph_node: 'agent=default',
+      langgraph_step: 1,
+      checkpoint_ns: '',
+    };
+    const runConfig = {
+      ...config,
+      configurable: {
+        thread_id: 'reasoning-fallback-post-tool-final-text',
+      },
+      metadata,
+    };
+    graph.config = runConfig;
+    const streamedStepKey = graph.getStepKey(metadata);
+    await graph.dispatchRunStep(
+      streamedStepKey,
+      {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'msg-before-tool' },
+      },
+      metadata
+    );
+    await graph.dispatchMessageDelta(
+      graph.getStepIdByKey(streamedStepKey),
+      {
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: streamedBeforeTool,
+          },
+        ],
+      },
+      metadata
+    );
+
+    graph.invokedToolIds = new Set(['call_calculator']);
+    graph.overrideModel = new InvokeOnlyMessageModel(
+      new AIMessageChunk({ content: finalAfterTool })
+    );
+
+    await graph.createCallModel('default')(
+      { messages: [new HumanMessage('continue after tool')] },
+      runConfig
+    );
+
+    expect(messageDeltas.map((delta) => delta.delta.content?.[0])).toEqual([
+      {
+        type: ContentTypes.TEXT,
+        text: streamedBeforeTool,
+      },
+      {
+        type: ContentTypes.TEXT,
+        text: finalAfterTool,
+      },
+    ]);
+  });
+
+  it('composes observer chat stream handlers with default graph dispatch', async () => {
+    const firstText = 'Vis';
+    const secondText = 'ible answer.';
+    const observedTextChunks: string[] = [];
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-observer-stream',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.CHAT_MODEL_STREAM]: {
+          handle: (
+            _event: string,
+            data: t.StreamEventData
+          ): void => {
+            const content = (data.chunk as AIMessageChunk | undefined)
+              ?.content;
+            if (typeof content === 'string' && content !== '') {
+              observedTextChunks.push(content);
+            }
+          },
+        },
+        ...createReasoningHandlers(
+          aggregateContent,
+          reasoningDeltas,
+          messageDeltas
+        ),
+      },
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const model = new ChatOpenRouter({
+      model: 'google/gemini-test',
+      apiKey: 'test-key',
+    });
+    const completions = (model as unknown as StreamingCompletionBackedModel)
+      .completions;
+
+    async function* streamChunks(): AsyncGenerator<OpenAIClient.Chat.Completions.ChatCompletionChunk> {
+      yield createOpenRouterStreamChunk(firstText);
+      yield createOpenRouterStreamChunk(secondText, 'stop');
+    }
+
+    completions.completionWithRetry = async (): Promise<
+      AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
+    > => streamChunks();
+    run.Graph.overrideModel = model as t.ChatModel;
+
+    await run.processStream(
+      { messages: [new HumanMessage('stream OpenRouter text to observer')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openrouter-observer-stream',
+        },
+      }
+    );
+
+    expect(observedTextChunks).toEqual([firstText, secondText]);
+    expect(reasoningDeltas).toHaveLength(0);
+    expect(messageDeltas).toHaveLength(2);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.TEXT, text: `${firstText}${secondText}` },
+    ]);
   });
 
   it('does not handle OpenRouter callback-emitted chunks twice inside graph streaming', async () => {

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -4,13 +4,22 @@ import { FakeListChatModel } from '@langchain/core/utils/testing';
 import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
+import type { OpenAIClient } from '@langchain/openai';
 import type * as t from '@/types';
 import { ContentTypes, GraphEvents, Providers } from '@/common';
-import { createContentAggregator } from '@/stream';
+import { ChatModelStreamHandler, createContentAggregator } from '@/stream';
+import { ChatOpenRouter } from '@/llm/openrouter';
 import { ModelEndHandler, ToolEndHandler } from '@/events';
 import { Run } from '@/run';
 
 type ReasoningKey = 'reasoning_content' | 'reasoning';
+type StreamingCompletionBackedModel = {
+  completions: {
+    completionWithRetry: () => Promise<
+      AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
+    >;
+  };
+};
 
 class InvokeOnlyReasoningModel implements t.ChatModel {
   constructor(
@@ -91,6 +100,25 @@ class CallbackStreamingReasoningModel extends FakeListChatModel {
       void runManager?.handleLLMNewToken(text);
     }
   }
+}
+
+function createOpenRouterStreamChunk(
+  content: string,
+  finishReason: OpenAIClient.Chat.Completions.ChatCompletionChunk.Choice['finish_reason'] = null
+): OpenAIClient.Chat.Completions.ChatCompletionChunk {
+  return {
+    id: 'chatcmpl-openrouter-test',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'google/gemini-test',
+    choices: [
+      {
+        index: 0,
+        delta: { content },
+        finish_reason: finishReason,
+      },
+    ],
+  };
 }
 
 function createReasoningChunk(
@@ -611,6 +639,186 @@ describe('StandardGraph final response reasoning fallback', () => {
       ]);
     }
   );
+
+  it('does not replay streamed OpenRouter text when the final chunk has reasoning_details', async () => {
+    const text = '391.';
+    const reasoningText = '17 times 23 equals 391.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-final-details-stream',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({
+        content: text,
+        additional_kwargs: {
+          reasoning_details: [
+            { type: 'reasoning.text', text: reasoningText },
+          ],
+        },
+      }),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('think briefly, what is 17 x 23?')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openrouter-final-details-stream',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+  });
+
+  it('does not keep an OpenRouter streamed text replay before final reasoning_details fallback', async () => {
+    const text = '391.';
+    const reasoningText = '17 times 23 equals 391.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-streamed-text-final-details',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({ content: text }),
+      new AIMessageChunk({
+        content: text,
+        additional_kwargs: {
+          reasoning_details: [
+            { type: 'reasoning.text', text: reasoningText },
+          ],
+        },
+      }),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('think briefly, what is 17 x 23?')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openrouter-streamed-text-final-details',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.TEXT, text },
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
+  });
+
+  it('does not handle OpenRouter callback-emitted chunks twice inside graph streaming', async () => {
+    const text = 'Visible answer.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const streamHandler = new ChatModelStreamHandler();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-callback-yield-stream',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.CHAT_MODEL_STREAM]: streamHandler,
+        ...createReasoningHandlers(
+          aggregateContent,
+          reasoningDeltas,
+          messageDeltas
+        ),
+      },
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const model = new ChatOpenRouter({
+      model: 'google/gemini-test',
+      apiKey: 'test-key',
+    });
+    const completions = (model as unknown as StreamingCompletionBackedModel)
+      .completions;
+
+    async function* streamChunks(): AsyncGenerator<OpenAIClient.Chat.Completions.ChatCompletionChunk> {
+      yield createOpenRouterStreamChunk(text, 'stop');
+    }
+
+    completions.completionWithRetry = async (): Promise<
+      AsyncIterable<OpenAIClient.Chat.Completions.ChatCompletionChunk>
+    > => streamChunks();
+    run.Graph.overrideModel = model as t.ChatModel;
+
+    await run.processStream(
+      { messages: [new HumanMessage('stream OpenRouter text once')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-openrouter-callback-yield-stream',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(0);
+    expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([{ type: ContentTypes.TEXT, text }]);
+  });
 
   it.each([
     {

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -977,6 +977,149 @@ describe('StandardGraph final response reasoning fallback', () => {
     ]);
   });
 
+  it('does not replay streamed text block variants from the final fallback', async () => {
+    const text = 'Variant text.';
+    const textDeltaContent: t.MessageDelta['content'] = [
+      { type: 'text_delta', text },
+    ];
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-text-delta-block',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENAI,
+          disableStreaming: true,
+          streamUsage: false,
+        },
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    const graph = run.Graph;
+    const metadata = {
+      thread_id: 'reasoning-fallback-text-delta-block',
+      langgraph_node: 'agent=default',
+      langgraph_step: 1,
+      checkpoint_ns: '',
+    };
+    const runConfig = {
+      ...config,
+      configurable: {
+        thread_id: 'reasoning-fallback-text-delta-block',
+      },
+      metadata,
+    };
+    graph.config = runConfig;
+    const stepKey = graph.getStepKey(metadata);
+    await graph.dispatchRunStep(
+      stepKey,
+      {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'msg-text-delta-block' },
+      },
+      metadata
+    );
+    await graph.dispatchMessageDelta(
+      graph.getStepIdByKey(stepKey),
+      { content: textDeltaContent },
+      metadata
+    );
+
+    graph.overrideModel = new InvokeOnlyMessageModel(
+      new AIMessageChunk({ content: textDeltaContent as never })
+    );
+
+    await graph.createCallModel('default')(
+      { messages: [new HumanMessage('finish text delta block')] },
+      runConfig
+    );
+
+    expect(messageDeltas.map((delta) => delta.delta.content?.[0])).toEqual([
+      { type: 'text_delta', text },
+    ]);
+  });
+
+  it('sanitizes OpenRouter final reasoning chunks for registered stream handlers', async () => {
+    const firstText = 'Hello ';
+    const replayWithSuffix = 'Hello world';
+    const reasoningText = 'The greeting needs one more word.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { aggregateContent } = createContentAggregator();
+    const streamHandler = new ChatModelStreamHandler();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-registered-handler-suffix',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.CHAT_MODEL_STREAM]: streamHandler,
+        ...createReasoningHandlers(
+          aggregateContent,
+          reasoningDeltas,
+          messageDeltas
+        ),
+      },
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({ content: firstText }),
+      new AIMessageChunk({
+        content: replayWithSuffix,
+        additional_kwargs: {
+          reasoning_details: [
+            { type: 'reasoning.text', text: reasoningText },
+          ],
+        },
+      }),
+    ]);
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('stream OpenRouter suffix once')] },
+      {
+        ...config,
+        configurable: {
+          thread_id:
+            'reasoning-fallback-openrouter-registered-handler-suffix',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(messageDeltas.map((delta) => delta.delta.content?.[0])).toEqual([
+      { type: ContentTypes.TEXT, text: 'world' },
+    ]);
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text: replayWithSuffix },
+    ]);
+    expect(run.getRunMessages()?.[0]?.content).toBe(replayWithSuffix);
+  });
+
   it('composes observer chat stream handlers with default graph dispatch', async () => {
     const firstText = 'Vis';
     const secondText = 'ible answer.';

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -105,7 +105,9 @@ function createReasoningChunk(
   });
 }
 
-function createOpenAIReasoningSummaryChunk(reasoningText: string): AIMessageChunk {
+function createOpenAIReasoningSummaryChunk(
+  reasoningText: string
+): AIMessageChunk {
   return new AIMessageChunk({
     content: '',
     additional_kwargs: {
@@ -123,7 +125,10 @@ function createReasoningHandlers(
 ): Record<string | GraphEvents, t.EventHandler> {
   return {
     [GraphEvents.ON_RUN_STEP]: {
-      handle: (event: GraphEvents.ON_RUN_STEP, data: t.StreamEventData): void => {
+      handle: (
+        event: GraphEvents.ON_RUN_STEP,
+        data: t.StreamEventData
+      ): void => {
         aggregateContent({ event, data: data as t.RunStep });
       },
     },
@@ -320,6 +325,58 @@ describe('StandardGraph final response reasoning fallback', () => {
       config
     );
 
+    expect(contentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+  });
+
+  it('uses the final fallback for one-shot disableStreaming mixed chunks', async () => {
+    const text = 'Cloudflare content check.';
+    const reasoningText = 'Plan the exact final wording.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-disable-streaming-mixed-final-chunk',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({
+        content: text,
+        additional_kwargs: {
+          reasoning_content: reasoningText,
+        },
+      }),
+    ]);
+
+    await run.processStream(
+      { messages: [new HumanMessage('return mixed final chunk')] },
+      {
+        ...config,
+        configurable: {
+          thread_id: 'reasoning-fallback-disable-streaming-mixed-final-chunk',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(messageDeltas).toHaveLength(1);
     expect(contentParts).toEqual([
       { type: ContentTypes.THINK, think: reasoningText },
       { type: ContentTypes.TEXT, text },

--- a/src/graphs/__tests__/Graph.reasoning.test.ts
+++ b/src/graphs/__tests__/Graph.reasoning.test.ts
@@ -739,7 +739,7 @@ describe('StandardGraph final response reasoning fallback', () => {
       }),
     ]);
 
-    await run.processStream(
+    const finalContentParts = await run.processStream(
       { messages: [new HumanMessage('think briefly, what is 17 x 23?')] },
       {
         ...config,
@@ -755,6 +755,69 @@ describe('StandardGraph final response reasoning fallback', () => {
       { type: ContentTypes.TEXT, text },
       { type: ContentTypes.THINK, think: reasoningText },
     ]);
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+    expect(run.getRunMessages()?.[0]?.content).toBe(text);
+  });
+
+  it('does not replay streamed text when the final fallback is on the reasoning key', async () => {
+    const text = '391.';
+    const reasoningText = 'Confirm the arithmetic after visible text.';
+    const reasoningDeltas: t.ReasoningDeltaEvent[] = [];
+    const messageDeltas: t.MessageDeltaEvent[] = [];
+    const { contentParts, aggregateContent } = createContentAggregator();
+    const run = await Run.create<t.IState>({
+      runId: 'reasoning-fallback-openrouter-text-before-reasoning-key',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.OPENROUTER,
+          streamUsage: false,
+        },
+        reasoningKey: 'reasoning',
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: createReasoningHandlers(
+        aggregateContent,
+        reasoningDeltas,
+        messageDeltas
+      ),
+    });
+
+    if (!run.Graph) {
+      throw new Error('Expected graph to be initialized');
+    }
+
+    run.Graph.overrideModel = new StreamingReasoningModel([
+      new AIMessageChunk({ content: text }),
+      createReasoningChunk('reasoning', reasoningText),
+    ]);
+
+    const finalContentParts = await run.processStream(
+      { messages: [new HumanMessage('think briefly, what is 17 x 23?')] },
+      {
+        ...config,
+        configurable: {
+          thread_id:
+            'reasoning-fallback-openrouter-text-before-reasoning-key',
+        },
+      }
+    );
+
+    expect(reasoningDeltas).toHaveLength(1);
+    expect(messageDeltas).toHaveLength(1);
+    expect(contentParts).toEqual([
+      { type: ContentTypes.TEXT, text },
+      { type: ContentTypes.THINK, think: reasoningText },
+    ]);
+    expect(finalContentParts).toEqual([
+      { type: ContentTypes.THINK, think: reasoningText },
+      { type: ContentTypes.TEXT, text },
+    ]);
+    expect(run.getRunMessages()?.[0]?.content).toBe(text);
   });
 
   it('does not handle OpenRouter callback-emitted chunks twice inside graph streaming', async () => {

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -62,7 +62,7 @@ function hasReasoningDetails(chunk: AIMessageChunk): boolean {
   return Array.isArray(reasoningDetails) && reasoningDetails.length > 0;
 }
 
-function removeOpenRouterFinalReplayContent({
+function removeOpenRouterFinalReasoningReplayContent({
   current,
   next,
   provider,
@@ -83,13 +83,9 @@ function removeOpenRouterFinalReplayContent({
     return next;
   }
 
-  if (!next.content.startsWith(current.content)) {
-    return next;
-  }
-
   return new AIMessageChunk(
     Object.assign({}, next, {
-      content: next.content.slice(current.content.length),
+      content: '',
     })
   );
 }
@@ -108,7 +104,7 @@ function appendStreamChunk({
   }
   return concat(
     current,
-    removeOpenRouterFinalReplayContent({ current, next, provider })
+    removeOpenRouterFinalReasoningReplayContent({ current, next, provider })
   );
 }
 

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -51,9 +51,12 @@ export type InvokeContext = NonNullable<
  */
 export type OnChunk = (chunk: AIMessageChunk) => void | Promise<void>;
 
-function hasRegisteredChatStreamHandler(context?: InvokeContext): boolean {
+function hasRegisteredDefaultChatStreamHandler(
+  context?: InvokeContext
+): boolean {
   return (
-    context?.handlerRegistry?.getHandler(GraphEvents.CHAT_MODEL_STREAM) != null
+    context?.handlerRegistry?.getHandler(GraphEvents.CHAT_MODEL_STREAM) instanceof
+    ChatModelStreamHandler
   );
 }
 
@@ -71,6 +74,31 @@ function removeOpenRouterFinalReasoningReplayContent({
   next: AIMessageChunk;
   provider: Providers;
 }): AIMessageChunk {
+  const content = getOpenRouterFinalReasoningContent({
+    current,
+    next,
+    provider,
+  });
+  if (content == null || content === next.content) {
+    return next;
+  }
+
+  return new AIMessageChunk(
+    Object.assign({}, next, {
+      content,
+    })
+  );
+}
+
+function getOpenRouterFinalReasoningContent({
+  current,
+  next,
+  provider,
+}: {
+  current?: AIMessageChunk;
+  next: AIMessageChunk;
+  provider: Providers;
+}): string | undefined {
   if (
     provider !== Providers.OPENROUTER ||
     current == null ||
@@ -80,12 +108,48 @@ function removeOpenRouterFinalReasoningReplayContent({
     typeof next.content !== 'string' ||
     next.content === ''
   ) {
+    return undefined;
+  }
+  if (!next.content.startsWith(current.content)) {
+    return next.content;
+  }
+  return next.content.slice(current.content.length);
+}
+
+function removeReasoningDetails(
+  additionalKwargs: AIMessageChunk['additional_kwargs']
+): AIMessageChunk['additional_kwargs'] {
+  return Object.fromEntries(
+    Object.entries(additionalKwargs).filter(
+      ([key]) => key !== 'reasoning_details'
+    )
+  );
+}
+
+function getStreamHandlingChunk({
+  current,
+  next,
+  provider,
+}: {
+  current?: AIMessageChunk;
+  next: AIMessageChunk;
+  provider: Providers;
+}): AIMessageChunk | undefined {
+  const content = getOpenRouterFinalReasoningContent({
+    current,
+    next,
+    provider,
+  });
+  if (content == null) {
     return next;
   }
-
+  if (content === '') {
+    return undefined;
+  }
   return new AIMessageChunk(
     Object.assign({}, next, {
-      content: '',
+      content,
+      additional_kwargs: removeReasoningDetails(next.additional_kwargs),
     })
   );
 }
@@ -157,16 +221,23 @@ export async function attemptInvoke(
           provider,
         });
       }
-    } else if (!hasRegisteredChatStreamHandler(context)) {
+    } else if (!hasRegisteredDefaultChatStreamHandler(context)) {
       const metadata = config?.metadata as Record<string, unknown> | undefined;
       const streamHandler = new ChatModelStreamHandler();
       for await (const chunk of stream) {
-        await streamHandler.handle(
-          GraphEvents.CHAT_MODEL_STREAM,
-          { chunk },
-          metadata,
-          context
-        );
+        const handlingChunk = getStreamHandlingChunk({
+          current: finalChunk,
+          next: chunk,
+          provider,
+        });
+        if (handlingChunk != null) {
+          await streamHandler.handle(
+            GraphEvents.CHAT_MODEL_STREAM,
+            { chunk: handlingChunk },
+            metadata,
+            context
+          );
+        }
         finalChunk = appendStreamChunk({
           current: finalChunk,
           next: chunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -51,13 +51,13 @@ export type InvokeContext = NonNullable<
  */
 export type OnChunk = (chunk: AIMessageChunk) => void | Promise<void>;
 
-function hasRegisteredDefaultChatStreamHandler(
+function getRegisteredDefaultChatStreamHandler(
   context?: InvokeContext
-): boolean {
-  return (
-    context?.handlerRegistry?.getHandler(GraphEvents.CHAT_MODEL_STREAM) instanceof
-    ChatModelStreamHandler
+): ChatModelStreamHandler | undefined {
+  const handler = context?.handlerRegistry?.getHandler(
+    GraphEvents.CHAT_MODEL_STREAM
   );
+  return handler instanceof ChatModelStreamHandler ? handler : undefined;
 }
 
 function hasReasoningDetails(chunk: AIMessageChunk): boolean {
@@ -211,6 +211,8 @@ export async function attemptInvoke(
   if (model.stream) {
     const stream = await model.stream(messagesForProvider, config);
     let finalChunk: AIMessageChunk | undefined;
+    const registeredStreamHandler =
+      getRegisteredDefaultChatStreamHandler(context);
 
     if (onChunk) {
       for await (const chunk of stream) {
@@ -221,7 +223,7 @@ export async function attemptInvoke(
           provider,
         });
       }
-    } else if (!hasRegisteredDefaultChatStreamHandler(context)) {
+    } else if (registeredStreamHandler == null) {
       const metadata = config?.metadata as Record<string, unknown> | undefined;
       const streamHandler = new ChatModelStreamHandler();
       for await (const chunk of stream) {
@@ -245,7 +247,21 @@ export async function attemptInvoke(
         });
       }
     } else {
+      const metadata = config?.metadata as Record<string, unknown> | undefined;
       for await (const chunk of stream) {
+        const handlingChunk = getStreamHandlingChunk({
+          current: finalChunk,
+          next: chunk,
+          provider,
+        });
+        if (handlingChunk != null && handlingChunk !== chunk) {
+          await registeredStreamHandler.handle(
+            GraphEvents.CHAT_MODEL_STREAM,
+            { chunk: handlingChunk },
+            metadata,
+            context
+          );
+        }
         finalChunk = appendStreamChunk({
           current: finalChunk,
           next: chunk,

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -51,6 +51,67 @@ export type InvokeContext = NonNullable<
  */
 export type OnChunk = (chunk: AIMessageChunk) => void | Promise<void>;
 
+function hasRegisteredChatStreamHandler(context?: InvokeContext): boolean {
+  return (
+    context?.handlerRegistry?.getHandler(GraphEvents.CHAT_MODEL_STREAM) != null
+  );
+}
+
+function hasReasoningDetails(chunk: AIMessageChunk): boolean {
+  const reasoningDetails = chunk.additional_kwargs.reasoning_details;
+  return Array.isArray(reasoningDetails) && reasoningDetails.length > 0;
+}
+
+function removeOpenRouterFinalReplayContent({
+  current,
+  next,
+  provider,
+}: {
+  current?: AIMessageChunk;
+  next: AIMessageChunk;
+  provider: Providers;
+}): AIMessageChunk {
+  if (
+    provider !== Providers.OPENROUTER ||
+    current == null ||
+    !hasReasoningDetails(next) ||
+    typeof current.content !== 'string' ||
+    current.content === '' ||
+    typeof next.content !== 'string' ||
+    next.content === ''
+  ) {
+    return next;
+  }
+
+  if (!next.content.startsWith(current.content)) {
+    return next;
+  }
+
+  return new AIMessageChunk(
+    Object.assign({}, next, {
+      content: next.content.slice(current.content.length),
+    })
+  );
+}
+
+function appendStreamChunk({
+  current,
+  next,
+  provider,
+}: {
+  current?: AIMessageChunk;
+  next: AIMessageChunk;
+  provider: Providers;
+}): AIMessageChunk {
+  if (current == null) {
+    return next;
+  }
+  return concat(
+    current,
+    removeOpenRouterFinalReplayContent({ current, next, provider })
+  );
+}
+
 /**
  * Invokes a chat model with the given messages, handling both streaming and
  * non-streaming paths.
@@ -94,9 +155,13 @@ export async function attemptInvoke(
     if (onChunk) {
       for await (const chunk of stream) {
         await onChunk(chunk);
-        finalChunk = finalChunk ? concat(finalChunk, chunk) : chunk;
+        finalChunk = appendStreamChunk({
+          current: finalChunk,
+          next: chunk,
+          provider,
+        });
       }
-    } else {
+    } else if (!hasRegisteredChatStreamHandler(context)) {
       const metadata = config?.metadata as Record<string, unknown> | undefined;
       const streamHandler = new ChatModelStreamHandler();
       for await (const chunk of stream) {
@@ -106,7 +171,19 @@ export async function attemptInvoke(
           metadata,
           context
         );
-        finalChunk = finalChunk ? concat(finalChunk, chunk) : chunk;
+        finalChunk = appendStreamChunk({
+          current: finalChunk,
+          next: chunk,
+          provider,
+        });
+      }
+    } else {
+      for await (const chunk of stream) {
+        finalChunk = appendStreamChunk({
+          current: finalChunk,
+          next: chunk,
+          provider,
+        });
       }
     }
 

--- a/src/stream.test.ts
+++ b/src/stream.test.ts
@@ -39,6 +39,23 @@ describe('getChunkContent', () => {
     expect(result).toBe('Reasoning from key');
   });
 
+  it('should use OpenRouter reasoning_content when no visible content is present', () => {
+    const chunk: Partial<AIMessageChunk> = {
+      content: '',
+      additional_kwargs: {
+        reasoning_content: 'OpenRouter reasoning delta',
+      },
+    };
+
+    const result = getChunkContent({
+      chunk,
+      provider: Providers.OPENROUTER,
+      reasoningKey: 'reasoning',
+    });
+
+    expect(result).toBe('OpenRouter reasoning delta');
+  });
+
   it('should prefer visible content when hidden reasoning is present on the same chunk', () => {
     const chunk: Partial<AIMessageChunk> = {
       content: 'Regular content',
@@ -50,6 +67,23 @@ describe('getChunkContent', () => {
     const result = getChunkContent({
       chunk,
       reasoningKey: 'reasoning_content',
+    });
+
+    expect(result).toBe('Regular content');
+  });
+
+  it('should prefer visible OpenRouter content over reasoning_content on the same chunk', () => {
+    const chunk: Partial<AIMessageChunk> = {
+      content: 'Regular content',
+      additional_kwargs: {
+        reasoning_content: 'OpenRouter reasoning delta',
+      },
+    };
+
+    const result = getChunkContent({
+      chunk,
+      provider: Providers.OPENROUTER,
+      reasoningKey: 'reasoning',
     });
 
     expect(result).toBe('Regular content');

--- a/src/stream.test.ts
+++ b/src/stream.test.ts
@@ -23,7 +23,23 @@ describe('getChunkContent', () => {
     expect(result).toBe('Reasoning summary text');
   });
 
-  it('should fallback to reasoningKey when no OpenAI reasoning summary', () => {
+  it('should fallback to reasoningKey when no visible content is present', () => {
+    const chunk: Partial<AIMessageChunk> = {
+      content: '',
+      additional_kwargs: {
+        reasoning_content: 'Reasoning from key',
+      },
+    };
+
+    const result = getChunkContent({
+      chunk,
+      reasoningKey: 'reasoning_content',
+    });
+
+    expect(result).toBe('Reasoning from key');
+  });
+
+  it('should prefer visible content when hidden reasoning is present on the same chunk', () => {
     const chunk: Partial<AIMessageChunk> = {
       content: 'Regular content',
       additional_kwargs: {
@@ -36,7 +52,7 @@ describe('getChunkContent', () => {
       reasoningKey: 'reasoning_content',
     });
 
-    expect(result).toBe('Reasoning from key');
+    expect(result).toBe('Regular content');
   });
 
   it('should fallback to chunk.content when reasoningKey value is null or undefined', () => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -913,16 +913,6 @@ export function getChunkContent({
         | undefined
     )?.summary?.[0]?.text;
   }
-  /**
-   * For OpenRouter, reasoning is stored in additional_kwargs.reasoning (not reasoning_content).
-   * NOTE: We intentionally do NOT extract text from reasoning_details here.
-   * The reasoning_details array contains the FULL accumulated reasoning text (set only on final chunk),
-   * but individual reasoning tokens are already streamed via additional_kwargs.reasoning.
-   * Extracting from reasoning_details would cause duplication.
-   * The reasoning_details is only used for:
-   * 1. Detecting reasoning mode in handleReasoning()
-   * 2. Final message storage (for thought signatures)
-   */
   if (provider === Providers.OPENROUTER) {
     // Content presence signals end of reasoning phase - prefer content over reasoning
     // This handles transitional chunks that may have both reasoning and content
@@ -932,6 +922,12 @@ export function getChunkContent({
     const reasoning = chunk?.additional_kwargs?.reasoning as string | undefined;
     if (reasoning != null && reasoning !== '') {
       return reasoning;
+    }
+    const reasoningContent = chunk?.additional_kwargs?.reasoning_content as
+      | string
+      | undefined;
+    if (reasoningContent != null && reasoningContent !== '') {
+      return reasoningContent;
     }
     return chunk?.content;
   }
@@ -1029,6 +1025,59 @@ function shouldDeferMixedFinalReasoningChunk({
   );
 }
 
+function hasCurrentTextDeltaStep({
+  graph,
+  metadata,
+}: {
+  graph: StandardGraph;
+  metadata?: Record<string, unknown>;
+}): boolean {
+  if (metadata == null) {
+    return false;
+  }
+  const baseStepKey = graph.getStepBaseKey(metadata);
+  for (const [stepKey, stepIds] of graph.stepKeyIds) {
+    if (stepKey !== baseStepKey && !stepKey.startsWith(`${baseStepKey}_`)) {
+      continue;
+    }
+    if (stepIds.some((stepId) => graph.messageStepHasTextDeltas.has(stepId))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldSkipLateOpenRouterReasoningChunk({
+  chunk,
+  agentContext,
+  graph,
+  metadata,
+}: {
+  chunk: Partial<AIMessageChunk>;
+  agentContext: AgentContext;
+  graph: StandardGraph;
+  metadata?: Record<string, unknown>;
+}): boolean {
+  if (
+    agentContext.provider !== Providers.OPENROUTER ||
+    (chunk.tool_calls?.length ?? 0) > 0 ||
+    (chunk.tool_call_chunks?.length ?? 0) > 0 ||
+    (chunk.content != null && chunk.content !== '')
+  ) {
+    return false;
+  }
+  return (
+    (hasReasoningContent(chunk.additional_kwargs?.reasoning as string) ||
+      hasReasoningContent(
+        chunk.additional_kwargs?.reasoning_content as string
+      ) ||
+      hasReasoningContent(
+        chunk.additional_kwargs?.reasoning_details as object[]
+      )) &&
+    hasCurrentTextDeltaStep({ graph, metadata })
+  );
+}
+
 export class ChatModelStreamHandler implements t.EventHandler {
   async handle(
     event: string,
@@ -1067,6 +1116,16 @@ export class ChatModelStreamHandler implements t.EventHandler {
       return;
     }
     if (shouldDeferMixedFinalReasoningChunk({ chunk, agentContext })) {
+      return;
+    }
+    if (
+      shouldSkipLateOpenRouterReasoningChunk({
+        chunk,
+        agentContext,
+        graph,
+        metadata,
+      })
+    ) {
       return;
     }
     this.handleReasoning(chunk, agentContext);
@@ -1350,7 +1409,9 @@ hasToolCallChunks: ${hasToolCallChunks}
         Array.isArray(chunk.additional_kwargs.reasoning_details) &&
         chunk.additional_kwargs.reasoning_details.length > 0) ||
         (typeof chunk.additional_kwargs?.reasoning === 'string' &&
-          chunk.additional_kwargs.reasoning !== ''))
+          chunk.additional_kwargs.reasoning !== '') ||
+        (typeof chunk.additional_kwargs?.reasoning_content === 'string' &&
+          chunk.additional_kwargs.reasoning_content !== ''))
     ) {
       reasoning_content = 'valid';
     }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -978,20 +978,8 @@ function hasReasoningContent(
   );
 }
 
-function recordStreamedTextContent(
-  agentContext: AgentContext,
-  content: string | t.MessageDelta['content'] | undefined
-): void {
-  if (content == null) {
-    return;
-  }
-  if (typeof content === 'string') {
-    agentContext.streamedTextContent += content;
-    return;
-  }
-  agentContext.streamedTextContent += content
-    .map((part) => (part.type === ContentTypes.TEXT ? part.text : ''))
-    .join('');
+function recordStreamedTextDelta(agentContext: AgentContext): void {
+  agentContext.streamedTextDeltaCount++;
 }
 
 function shouldDeferMixedFinalReasoningChunk({
@@ -1225,7 +1213,7 @@ hasToolCallChunks: ${hasToolCallChunks}
       return;
     } else if (typeof content === 'string') {
       if (agentContext.currentTokenType === ContentTypes.TEXT) {
-        recordStreamedTextContent(agentContext, content);
+        recordStreamedTextDelta(agentContext);
         await graph.dispatchMessageDelta(
           stepId,
           {
@@ -1271,7 +1259,7 @@ hasToolCallChunks: ${hasToolCallChunks}
           );
 
           const newStepId = graph.getStepIdByKey(newStepKey);
-          recordStreamedTextContent(agentContext, text);
+          recordStreamedTextDelta(agentContext);
           await graph.dispatchMessageDelta(
             newStepId,
             {
@@ -1302,7 +1290,7 @@ hasToolCallChunks: ${hasToolCallChunks}
     } else if (
       content.every((c) => c.type?.startsWith(ContentTypes.TEXT) ?? false)
     ) {
-      recordStreamedTextContent(agentContext, content);
+      recordStreamedTextDelta(agentContext);
       await graph.dispatchMessageDelta(
         stepId,
         {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -978,16 +978,29 @@ function hasReasoningContent(
   );
 }
 
-function shouldDeferDisableStreamingMixedFinalChunk({
+function recordStreamedTextContent(
+  agentContext: AgentContext,
+  content: string | t.MessageDelta['content'] | undefined
+): void {
+  if (content == null) {
+    return;
+  }
+  if (typeof content === 'string') {
+    agentContext.streamedTextContent += content;
+    return;
+  }
+  agentContext.streamedTextContent += content
+    .map((part) => (part.type === ContentTypes.TEXT ? part.text : ''))
+    .join('');
+}
+
+function shouldDeferMixedFinalReasoningChunk({
   chunk,
   agentContext,
 }: {
   chunk: Partial<AIMessageChunk>;
   agentContext: AgentContext;
 }): boolean {
-  if (!isDisableStreamingEnabled(agentContext.clientOptions)) {
-    return false;
-  }
   if (
     (chunk.tool_calls?.length ?? 0) > 0 ||
     (chunk.tool_call_chunks?.length ?? 0) > 0 ||
@@ -997,6 +1010,15 @@ function shouldDeferDisableStreamingMixedFinalChunk({
     return false;
   }
   const additionalKwargs = chunk.additional_kwargs;
+  if (
+    agentContext.provider === Providers.OPENROUTER &&
+    hasReasoningContent(additionalKwargs?.reasoning_details as object[])
+  ) {
+    return true;
+  }
+  if (!isDisableStreamingEnabled(agentContext.clientOptions)) {
+    return false;
+  }
   return (
     hasReasoningContent(
       additionalKwargs?.[agentContext.reasoningKey] as
@@ -1060,7 +1082,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
     if (skipHandling) {
       return;
     }
-    if (shouldDeferDisableStreamingMixedFinalChunk({ chunk, agentContext })) {
+    if (shouldDeferMixedFinalReasoningChunk({ chunk, agentContext })) {
       return;
     }
     this.handleReasoning(chunk, agentContext);
@@ -1203,6 +1225,7 @@ hasToolCallChunks: ${hasToolCallChunks}
       return;
     } else if (typeof content === 'string') {
       if (agentContext.currentTokenType === ContentTypes.TEXT) {
+        recordStreamedTextContent(agentContext, content);
         await graph.dispatchMessageDelta(
           stepId,
           {
@@ -1248,6 +1271,7 @@ hasToolCallChunks: ${hasToolCallChunks}
           );
 
           const newStepId = graph.getStepIdByKey(newStepKey);
+          recordStreamedTextContent(agentContext, text);
           await graph.dispatchMessageDelta(
             newStepId,
             {
@@ -1278,6 +1302,7 @@ hasToolCallChunks: ${hasToolCallChunks}
     } else if (
       content.every((c) => c.type?.startsWith(ContentTypes.TEXT) ?? false)
     ) {
+      recordStreamedTextContent(agentContext, content);
       await graph.dispatchMessageDelta(
         stepId,
         {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -978,10 +978,6 @@ function hasReasoningContent(
   );
 }
 
-function recordStreamedTextDelta(agentContext: AgentContext): void {
-  agentContext.streamedTextDeltaCount++;
-}
-
 function shouldDeferMixedFinalReasoningChunk({
   chunk,
   agentContext,
@@ -1213,7 +1209,6 @@ hasToolCallChunks: ${hasToolCallChunks}
       return;
     } else if (typeof content === 'string') {
       if (agentContext.currentTokenType === ContentTypes.TEXT) {
-        recordStreamedTextDelta(agentContext);
         await graph.dispatchMessageDelta(
           stepId,
           {
@@ -1259,7 +1254,6 @@ hasToolCallChunks: ${hasToolCallChunks}
           );
 
           const newStepId = graph.getStepIdByKey(newStepKey);
-          recordStreamedTextDelta(agentContext);
           await graph.dispatchMessageDelta(
             newStepId,
             {
@@ -1290,7 +1284,6 @@ hasToolCallChunks: ${hasToolCallChunks}
     } else if (
       content.every((c) => c.type?.startsWith(ContentTypes.TEXT) ?? false)
     ) {
-      recordStreamedTextDelta(agentContext);
       await graph.dispatchMessageDelta(
         stepId,
         {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -42,6 +42,10 @@ const LOCAL_CODING_BUNDLE_NAME_SET: ReadonlySet<string> = new Set(
   LOCAL_CODING_BUNDLE_NAMES
 );
 
+type ReasoningSummaryLike = {
+  summary?: Array<{ text?: string }>;
+};
+
 /**
  * Parses content to extract thinking sections enclosed in <think> tags using string operations
  * @param content The content to parse
@@ -931,9 +935,91 @@ export function getChunkContent({
     }
     return chunk?.content;
   }
+  const keyedReasoning = chunk?.additional_kwargs?.[reasoningKey] as
+    | string
+    | undefined;
+  if (
+    typeof chunk?.content === 'string' &&
+    chunk.content !== '' &&
+    keyedReasoning != null &&
+    keyedReasoning !== ''
+  ) {
+    return chunk.content;
+  }
+  return ((keyedReasoning as string | undefined) ?? '') || chunk?.content;
+}
+
+function isDisableStreamingEnabled(
+  clientOptions: t.ClientOptions | undefined
+): boolean {
   return (
-    ((chunk?.additional_kwargs?.[reasoningKey] as string | undefined) ?? '') ||
-    chunk?.content
+    clientOptions != null &&
+    'disableStreaming' in clientOptions &&
+    clientOptions.disableStreaming === true
+  );
+}
+
+function hasReasoningContent(
+  value: string | ReasoningSummaryLike | object[] | null | undefined
+): boolean {
+  if (typeof value === 'string') {
+    return value !== '';
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (value == null) {
+    return false;
+  }
+  return (
+    value.summary?.some(
+      (summary) => summary.text != null && summary.text.length > 0
+    ) === true
+  );
+}
+
+function shouldDeferDisableStreamingMixedFinalChunk({
+  chunk,
+  agentContext,
+}: {
+  chunk: Partial<AIMessageChunk>;
+  agentContext: AgentContext;
+}): boolean {
+  if (!isDisableStreamingEnabled(agentContext.clientOptions)) {
+    return false;
+  }
+  if (
+    (chunk.tool_calls?.length ?? 0) > 0 ||
+    (chunk.tool_call_chunks?.length ?? 0) > 0 ||
+    typeof chunk.content !== 'string' ||
+    chunk.content === ''
+  ) {
+    return false;
+  }
+  const additionalKwargs = chunk.additional_kwargs;
+  return (
+    hasReasoningContent(
+      additionalKwargs?.[agentContext.reasoningKey] as
+        | string
+        | ReasoningSummaryLike
+        | null
+        | undefined
+    ) ||
+    hasReasoningContent(
+      additionalKwargs?.reasoning_content as
+        | string
+        | ReasoningSummaryLike
+        | null
+        | undefined
+    ) ||
+    hasReasoningContent(
+      additionalKwargs?.reasoning as
+        | string
+        | ReasoningSummaryLike
+        | null
+        | undefined
+    ) ||
+    hasReasoningContent(additionalKwargs?.reasoning_details as object[])
   );
 }
 
@@ -972,6 +1058,9 @@ export class ChatModelStreamHandler implements t.EventHandler {
       agentContext,
     });
     if (skipHandling) {
+      return;
+    }
+    if (shouldDeferDisableStreamingMixedFinalChunk({ chunk, agentContext })) {
       return;
     }
     this.handleReasoning(chunk, agentContext);


### PR DESCRIPTION
## Summary

I fixed a mixed reasoning/text ordering regression where OpenRouter can emit visible answer text before late reasoning metadata, which could surface as a live `text` block followed by a `think` block for the same assistant response. This also addresses the streamed final-fallback replay behind duplicate assistant responses after tool/web-search cycles.

Fixes #214.

- Preserved the existing step-based approach instead of aggregating streamed text strings or adding long-lived local content buffers.
- Added run-step checks that suppress late OpenRouter reasoning-only chunks after the current invocation has already emitted visible text.
- Gated final reasoning fallback dispatch for OpenRouter when text already streamed, while keeping non-stream and pre-text reasoning fallback behavior intact.
- Recognized OpenRouter `reasoning_content` as a valid pre-text reasoning field, in addition to `reasoning` and `reasoning_details`.
- Kept canonical final content ordered as reasoning before answer text when final metadata is available, without replaying that metadata as a late live reasoning delta.
- Added regression coverage for late OpenRouter `reasoning_details`, late OpenRouter `reasoning_content`, normal pre-text reasoning, registered stream handlers, and fallback replay behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### **Test Configuration**:

- OpenRouter raw API and framework path with `google/gemini-3.5-flash`
- Cloudflare Workers AI Gateway with `@cf/moonshotai/kimi-k2.6`
- Local Ollama OpenAI-compatible endpoint with `qwen3:14b`
- Calculator tool attached for tool-call regression rows

Commands run:

```sh
npm test -- --runInBand src/stream.test.ts src/graphs/__tests__/Graph.reasoning.test.ts src/__tests__/stream.eagerEventExecution.test.ts src/session/__tests__/handlers.test.ts src/splitStream.test.ts
npx eslint src/stream.ts src/stream.test.ts src/graphs/Graph.ts src/graphs/__tests__/Graph.reasoning.test.ts
npm run build
git diff --check
gh pr checks 213 --repo danny-avila/agents
```

I ran an 11-case live matrix across OpenRouter, Workers AI Kimi, and Ollama Qwen3 covering streaming, non-streaming, reasoning enabled, reasoning disabled where supported, no-tool runs, and calculator tool runs. Every case passed the per-step/per-message ordering check: no `think` block appeared after `text` within the same assistant step/message.

Raw OpenRouter checks confirmed the edge case: `google/gemini-3.5-flash` can report `reasoning_tokens` and emit late `reasoning_details` after visible text, while not always streaming readable `delta.reasoning` text. The fix treats that late metadata as final metadata, not as a live post-text reasoning delta.

CI is green for install, lint, typecheck, and test on commit `7033e59`.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
