### PR TITLE
🪢 fix: Preserve Anthropic Vertex Search Pairs

### DIFF
--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -372,6 +372,22 @@ function getToolUseId(part: MessageContentComplex): string | undefined {
   return part.tool_use_id;
 }
 
+function getToolCallId(part: MessageContentComplex): string | undefined {
+  if (part.type !== ContentTypes.TOOL_CALL) {
+    return undefined;
+  }
+  const id = part.tool_call?.id;
+  return typeof id === 'string' && id !== '' ? id : undefined;
+}
+
+function hasToolCallOutput(part: MessageContentComplex): boolean {
+  if (part.type !== ContentTypes.TOOL_CALL) {
+    return false;
+  }
+  const output = part.tool_call?.output;
+  return output != null && output !== '';
+}
+
 /**
  * Helper function to format an assistant message
  * @param message The message to format
@@ -392,6 +408,7 @@ function formatAssistantMessage(
   const shouldPreserveReasoningContent =
     options?.preserveReasoningContent === true;
   const serverToolResultIds = new Set<string>();
+  const preferredToolCallParts = new Map<string, MessageContentComplex>();
 
   const takePendingReasoningContent = (): string | undefined => {
     if (!shouldPreserveReasoningContent || !pendingReasoningContent) {
@@ -449,6 +466,19 @@ function formatAssistantMessage(
       ) {
         serverToolResultIds.add(toolUseId);
       }
+      if (options?.provider === Providers.ANTHROPIC) {
+        const toolCallId = getToolCallId(part);
+        if (toolCallId == null) {
+          continue;
+        }
+        const preferredPart = preferredToolCallParts.get(toolCallId);
+        if (
+          preferredPart == null ||
+          (!hasToolCallOutput(preferredPart) && hasToolCallOutput(part))
+        ) {
+          preferredToolCallParts.set(toolCallId, part);
+        }
+      }
     }
 
     for (const part of contentParts) {
@@ -489,6 +519,14 @@ function formatAssistantMessage(
       } else if (part.type === ContentTypes.TOOL_CALL) {
         // Skip malformed tool call entries without tool_call property
         if (part.tool_call == null) {
+          continue;
+        }
+        const toolCallId = getToolCallId(part);
+        if (
+          options?.provider === Providers.ANTHROPIC &&
+          toolCallId != null &&
+          preferredToolCallParts.get(toolCallId) !== part
+        ) {
           continue;
         }
 

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -284,6 +284,7 @@ export const formatFromLangChain = (
 };
 
 interface FormatAssistantMessageOptions {
+  preserveUnpairedServerToolUses?: boolean;
   preserveReasoningContent?: boolean;
   provider?: Providers;
 }
@@ -390,6 +391,7 @@ function formatAssistantMessage(
   const pendingServerToolUses = new Map<string, MessageContentComplex>();
   const shouldPreserveReasoningContent =
     options?.preserveReasoningContent === true;
+  const serverToolResultIds = new Set<string>();
 
   const takePendingReasoningContent = (): string | undefined => {
     if (!shouldPreserveReasoningContent || !pendingReasoningContent) {
@@ -442,10 +444,26 @@ function formatAssistantMessage(
         continue;
       }
       const toolUseId = getToolUseId(part);
+      if (
+        toolUseId?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) === true
+      ) {
+        serverToolResultIds.add(toolUseId);
+      }
+    }
+
+    for (const part of contentParts) {
+      if (part == null) {
+        continue;
+      }
+      const toolUseId = getToolUseId(part);
       if (toolUseId != null) {
         flushPendingServerToolUse(toolUseId);
       } else if (hasMeaningfulAssistantContent(part)) {
-        pendingServerToolUses.clear();
+        for (const id of pendingServerToolUses.keys()) {
+          if (!serverToolResultIds.has(id)) {
+            pendingServerToolUses.delete(id);
+          }
+        }
       }
       if (part.type === ContentTypes.TEXT && part.tool_call_ids) {
         /*
@@ -494,6 +512,12 @@ function formatAssistantMessage(
           typeof _tool_call.id === 'string' &&
           _tool_call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
         ) {
+          if (
+            !serverToolResultIds.has(_tool_call.id) &&
+            options.preserveUnpairedServerToolUses !== true
+          ) {
+            continue;
+          }
           if (
             emittedServerToolUseIds.has(_tool_call.id) ||
             pendingServerToolUses.has(_tool_call.id)
@@ -1254,6 +1278,7 @@ export const formatAgentMessages = (
     }
 
     const formattedMessages = formatAssistantMessage(processedMessage, {
+      preserveUnpairedServerToolUses: i === payload.length - 1,
       preserveReasoningContent: options?.provider === Providers.DEEPSEEK,
       provider: options?.provider,
     });

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -29,6 +29,7 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import { emitAgentLog } from '@/utils/events';
 import { Providers, ContentTypes, Constants } from '@/common';
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
+import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
 
 interface MediaMessageParams {
   message: {
@@ -376,7 +377,6 @@ function isValidServerToolResult(part: MessageContentComplex): boolean {
   const toolUseId = getToolUseId(part);
   if (
     toolUseId?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) !== true ||
-    part.type !== 'web_search_tool_result' ||
     !('content' in part)
   ) {
     return false;
@@ -503,13 +503,18 @@ function formatAssistantMessage(
       }
       const toolUseId = getToolUseId(part);
       if (toolUseId != null) {
+        const isServerToolResult = isValidServerToolResult(part);
         if (
           toolUseId.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) &&
-          !isValidServerToolResult(part)
+          !isServerToolResult
         ) {
           continue;
         }
         flushPendingServerToolUse(toolUseId);
+        if (isServerToolResult) {
+          currentContent.push(part);
+          continue;
+        }
       } else if (hasMeaningfulAssistantContent(part)) {
         for (const id of pendingServerToolUses.keys()) {
           if (!serverToolResultIds.has(id)) {
@@ -624,11 +629,14 @@ function formatAssistantMessage(
         }
 
         tool_call.args = args;
-        if (Array.isArray(lastAIMessage.content)) {
+        if (
+          options?.provider === Providers.ANTHROPIC &&
+          Array.isArray(lastAIMessage.content)
+        ) {
           const content = lastAIMessage.content as MessageContentComplex[];
           content.push({
             type: 'tool_use',
-            id: tool_call.id,
+            id: normalizeAnthropicToolCallId(tool_call.id ?? ''),
             name: tool_call.name,
             input: args,
           } as MessageContentComplex);

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -372,6 +372,25 @@ function getToolUseId(part: MessageContentComplex): string | undefined {
   return part.tool_use_id;
 }
 
+function isValidServerToolResult(part: MessageContentComplex): boolean {
+  const toolUseId = getToolUseId(part);
+  if (
+    toolUseId?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) !== true ||
+    part.type !== 'web_search_tool_result' ||
+    !('content' in part)
+  ) {
+    return false;
+  }
+  const { content } = part as { content?: unknown };
+  return (
+    Array.isArray(content) ||
+    (content != null &&
+      typeof content === 'object' &&
+      'type' in content &&
+      (content as { type?: unknown }).type === 'web_search_tool_result_error')
+  );
+}
+
 function getToolCallId(part: MessageContentComplex): string | undefined {
   if (part.type !== ContentTypes.TOOL_CALL) {
     return undefined;
@@ -460,11 +479,8 @@ function formatAssistantMessage(
       if (part == null) {
         continue;
       }
-      const toolUseId = getToolUseId(part);
-      if (
-        toolUseId?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) === true
-      ) {
-        serverToolResultIds.add(toolUseId);
+      if (isValidServerToolResult(part)) {
+        serverToolResultIds.add(getToolUseId(part) ?? '');
       }
       if (options?.provider === Providers.ANTHROPIC) {
         const toolCallId = getToolCallId(part);
@@ -487,6 +503,12 @@ function formatAssistantMessage(
       }
       const toolUseId = getToolUseId(part);
       if (toolUseId != null) {
+        if (
+          toolUseId.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) &&
+          !isValidServerToolResult(part)
+        ) {
+          continue;
+        }
         flushPendingServerToolUse(toolUseId);
       } else if (hasMeaningfulAssistantContent(part)) {
         for (const id of pendingServerToolUses.keys()) {
@@ -501,6 +523,15 @@ function formatAssistantMessage(
         For Anthropic models, the "tool_calls" field on a message is only respected if content is a string.
         */
         if (currentContent.length > 0) {
+          if (
+            currentContent.some((content) => content.type !== ContentTypes.TEXT)
+          ) {
+            currentContent.push(part);
+            lastAIMessage = createAIMessage(toLangChainContent(currentContent));
+            formattedMessages.push(lastAIMessage);
+            currentContent = [];
+            continue;
+          }
           let content = currentContent.reduce((acc, curr) => {
             if (curr.type === ContentTypes.TEXT) {
               return `${acc}${getTextContent(curr)}\n`;
@@ -593,10 +624,21 @@ function formatAssistantMessage(
         }
 
         tool_call.args = args;
-        if (!lastAIMessage.tool_calls) {
-          lastAIMessage.tool_calls = [];
+        if (Array.isArray(lastAIMessage.content)) {
+          const content = lastAIMessage.content as MessageContentComplex[];
+          content.push({
+            type: 'tool_use',
+            id: tool_call.id,
+            name: tool_call.name,
+            input: args,
+          } as MessageContentComplex);
+          lastAIMessage.content = content as MessageContent;
+        } else {
+          if (!lastAIMessage.tool_calls) {
+            lastAIMessage.tool_calls = [];
+          }
+          lastAIMessage.tool_calls.push(tool_call as ToolCall);
         }
-        lastAIMessage.tool_calls.push(tool_call as ToolCall);
 
         formattedMessages.push(
           new ToolMessage({

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -14,6 +14,23 @@ import {
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
 
+type AnthropicPayloadBlock = {
+  content?: unknown;
+  id?: string;
+  input?: unknown;
+  name?: string;
+  text?: string;
+  tool_use_id?: string;
+  type: string;
+};
+
+const getAnthropicPayloadBlocks = (
+  content: unknown
+): AnthropicPayloadBlock[] => {
+  expect(Array.isArray(content)).toBe(true);
+  return content as AnthropicPayloadBlock[];
+};
+
 describe('formatAgentMessages', () => {
   it('should format simple user and AI messages', () => {
     const payload: TPayload = [
@@ -271,8 +288,9 @@ describe('formatAgentMessages', () => {
 
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
-    expect(result.messages.some((message) => message instanceof ToolMessage))
-      .toBe(false);
+    expect(
+      result.messages.some((message) => message instanceof ToolMessage)
+    ).toBe(false);
     expect((result.messages[0] as AIMessage).tool_calls).toHaveLength(0);
     expect(result.messages[0].content).toEqual([
       {
@@ -387,6 +405,205 @@ describe('formatAgentMessages', () => {
         }
       }
     }
+  });
+
+  it('preserves Anthropic Vertex web search pair when mixed with regular tool calls', () => {
+    const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}vrtx_search_1`;
+    const calculatorToolId = 'toolu_calc_1';
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content: 'Search current Claude Vertex docs and calculate 6 * 7.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: serverToolId,
+              name: 'web_search',
+              args: '{"query":"Claude Vertex web search"}',
+            },
+          },
+          {
+            type: ContentTypes.TEXT,
+            text: 'I will calculate the number too.',
+            tool_call_ids: [calculatorToolId],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: calculatorToolId,
+              name: 'calculator',
+              args: '{"expression":"6*7"}',
+              output: '42',
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: serverToolId,
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com/claude-vertex',
+                title: 'Claude on Vertex',
+                encrypted_content: 'opaque',
+                page_age: '1d',
+              },
+            ],
+          } as MessageContentComplex,
+          {
+            type: ContentTypes.TEXT,
+            text: ' \n\t ',
+          },
+          {
+            type: ContentTypes.TEXT,
+            text: 'The calculation result is 42.',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Follow up on that.',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search', 'calculator']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const allBlocks = anthropicPayload.messages.flatMap((message) =>
+      typeof message.content === 'string'
+        ? []
+        : getAnthropicPayloadBlocks(message.content)
+    );
+    const serverToolMessageBlocks = anthropicPayload.messages
+      .map((message) =>
+        typeof message.content === 'string'
+          ? []
+          : getAnthropicPayloadBlocks(message.content)
+      )
+      .find((blocks) => blocks.some((block) => block.id === serverToolId));
+    const serverToolUseBlocks = allBlocks.filter(
+      (block) => block.type === 'server_tool_use'
+    );
+    const webSearchResultBlocks = allBlocks.filter(
+      (block) => block.type === 'web_search_tool_result'
+    );
+    const regularToolUseBlocks = allBlocks.filter(
+      (block) => block.type === 'tool_use' && block.id === calculatorToolId
+    );
+    const whitespaceTextBlocks = allBlocks.filter(
+      (block) =>
+        block.type === ContentTypes.TEXT &&
+        typeof block.text === 'string' &&
+        block.text.trim().length === 0
+    );
+
+    expect(messages.some((message) => message instanceof ToolMessage)).toBe(
+      true
+    );
+    expect(
+      messages.some(
+        (message) =>
+          message instanceof ToolMessage &&
+          message.tool_call_id === serverToolId
+      )
+    ).toBe(false);
+    expect(serverToolUseBlocks).toEqual([
+      {
+        type: 'server_tool_use',
+        id: serverToolId,
+        name: 'web_search',
+        input: { query: 'Claude Vertex web search' },
+      },
+    ]);
+    expect(webSearchResultBlocks).toHaveLength(1);
+    expect(webSearchResultBlocks[0].tool_use_id).toBe(serverToolId);
+    expect(serverToolMessageBlocks).toBeDefined();
+    expect(
+      serverToolMessageBlocks?.findIndex((block) => block.id === serverToolId)
+    ).toBeLessThan(
+      serverToolMessageBlocks?.findIndex(
+        (block) => block.tool_use_id === serverToolId
+      ) ?? -1
+    );
+    expect(regularToolUseBlocks).toHaveLength(1);
+    expect(whitespaceTextBlocks).toHaveLength(0);
+  });
+
+  it('drops unpaired historical Anthropic Vertex web search calls from mixed turns', () => {
+    const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}vrtx_missing_result`;
+    const calculatorToolId = 'toolu_calc_1';
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content: 'Search for current Claude info and calculate 6 * 7.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: serverToolId,
+              name: 'web_search',
+              args: '{"query":"Claude Vertex web search"}',
+              output: 'Search results were formatted for the assistant.',
+            },
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: calculatorToolId,
+              name: 'calculator',
+              args: '{"expression":"6*7"}',
+              output: '42',
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Follow up on that.',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search', 'calculator']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const allBlocks = anthropicPayload.messages.flatMap((message) =>
+      typeof message.content === 'string'
+        ? []
+        : getAnthropicPayloadBlocks(message.content)
+    );
+
+    expect(
+      messages.some(
+        (message) =>
+          message instanceof ToolMessage &&
+          message.tool_call_id === serverToolId
+      )
+    ).toBe(false);
+    expect(allBlocks.some((block) => block.id === serverToolId)).toBe(false);
+    expect(allBlocks.some((block) => block.tool_use_id === serverToolId)).toBe(
+      false
+    );
+    expect(
+      allBlocks.some(
+        (block) => block.type === 'tool_use' && block.id === calculatorToolId
+      )
+    ).toBe(true);
   });
 
   it('should handle malformed tool call entries with missing tool_call property', () => {
@@ -695,13 +912,9 @@ describe('formatAgentMessages', () => {
     expect(result.messages[1]).toBeInstanceOf(ToolMessage);
     expect(result.messages[2]).toBeInstanceOf(AIMessage);
     expect(result.messages[3]).toBeInstanceOf(ToolMessage);
-    expect((result.messages[0] as AIMessage).tool_calls?.[0].id).toBe(
-      'call_1'
-    );
+    expect((result.messages[0] as AIMessage).tool_calls?.[0].id).toBe('call_1');
     expect((result.messages[1] as ToolMessage).tool_call_id).toBe('call_1');
-    expect((result.messages[2] as AIMessage).tool_calls?.[0].id).toBe(
-      'call_2'
-    );
+    expect((result.messages[2] as AIMessage).tool_calls?.[0].id).toBe('call_2');
     expect((result.messages[3] as ToolMessage).tool_call_id).toBe('call_2');
   });
 

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -606,6 +606,78 @@ describe('formatAgentMessages', () => {
     ).toBe(true);
   });
 
+  it('deduplicates repeated Anthropic Vertex client tool calls in replay payloads', () => {
+    const calculatorToolId = 'toolu_vrtx_calc_1';
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content: 'Calculate 19 * 23.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: calculatorToolId,
+              name: 'calculator',
+              args: '{"input":"19 * 23"}',
+              output: '437',
+            },
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: calculatorToolId,
+              name: 'calculator',
+              args: '',
+            },
+          },
+          {
+            type: ContentTypes.TEXT,
+            text: '437437',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'What was the result?',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['calculator']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const allBlocks = anthropicPayload.messages.flatMap((message) =>
+      typeof message.content === 'string'
+        ? []
+        : getAnthropicPayloadBlocks(message.content)
+    );
+    const toolUseBlocks = allBlocks.filter(
+      (block) => block.type === 'tool_use' && block.id === calculatorToolId
+    );
+    const toolResultBlocks = allBlocks.filter(
+      (block) =>
+        block.type === 'tool_result' && block.tool_use_id === calculatorToolId
+    );
+
+    expect(toolUseBlocks).toEqual([
+      {
+        type: 'tool_use',
+        id: calculatorToolId,
+        name: 'calculator',
+        input: { input: '19 * 23' },
+      },
+    ]);
+    expect(toolResultBlocks).toHaveLength(1);
+    expect(toolResultBlocks[0].content).toBe('437');
+  });
+
   it('should handle malformed tool call entries with missing tool_call property', () => {
     const tools = new Set(['search']);
     const payload = [

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -537,6 +537,166 @@ describe('formatAgentMessages', () => {
     expect(whitespaceTextBlocks).toHaveLength(0);
   });
 
+  it('preserves multiple Anthropic server tool pairs from one persisted turn', () => {
+    const firstSearchId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}search_1`;
+    const secondSearchId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}search_2`;
+    const calculatorToolId = 'toolu_calc_duplicate';
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content:
+          'Use native web search twice for current docs and calculate 19 * 23.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: 'I will check the docs and calculate.',
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: firstSearchId,
+              name: 'web_search',
+              args: '{"query":"Anthropic web search docs"}',
+            },
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: calculatorToolId,
+              name: 'calculator',
+              args: '{"input":"19 * 23"}',
+              output: '437',
+            },
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: calculatorToolId,
+              name: 'calculator',
+              args: '',
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: firstSearchId,
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com/anthropic-web-search',
+                title: 'Anthropic web search',
+                encrypted_content: 'opaque-1',
+                page_age: '1d',
+              },
+            ],
+          } as MessageContentComplex,
+          {
+            type: ContentTypes.TEXT,
+            text: 'I found the first result and will check one more.',
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: secondSearchId,
+              name: 'web_search',
+              args: '{"query":"Anthropic web_search_20260209 docs"}',
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: secondSearchId,
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com/anthropic-web-search-20260209',
+                title: 'Anthropic web_search_20260209',
+                encrypted_content: 'opaque-2',
+                page_age: '1d',
+              },
+            ],
+          } as MessageContentComplex,
+          {
+            type: ContentTypes.TEXT,
+            text: 'The calculation result is 437.',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Summarize the prior results.',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search', 'calculator']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const allBlocks = anthropicPayload.messages.flatMap((message) =>
+      typeof message.content === 'string'
+        ? []
+        : getAnthropicPayloadBlocks(message.content)
+    );
+    const serverToolUseBlocks = allBlocks.filter(
+      (block) => block.type === 'server_tool_use'
+    );
+    const webSearchResultBlocks = allBlocks.filter(
+      (block) => block.type === 'web_search_tool_result'
+    );
+    const calculatorUseBlocks = allBlocks.filter(
+      (block) => block.type === 'tool_use' && block.id === calculatorToolId
+    );
+    const serverBlocksByMessage = anthropicPayload.messages
+      .map((message) =>
+        typeof message.content === 'string'
+          ? []
+          : getAnthropicPayloadBlocks(message.content)
+      )
+      .filter((blocks) =>
+        blocks.some(
+          (block) =>
+            block.id === firstSearchId ||
+            block.id === secondSearchId ||
+            block.tool_use_id === firstSearchId ||
+            block.tool_use_id === secondSearchId
+        )
+      );
+
+    expect(serverToolUseBlocks.map((block) => block.id)).toEqual([
+      firstSearchId,
+      secondSearchId,
+    ]);
+    expect(webSearchResultBlocks.map((block) => block.tool_use_id)).toEqual([
+      firstSearchId,
+      secondSearchId,
+    ]);
+    expect(calculatorUseBlocks).toHaveLength(1);
+    for (const blocks of serverBlocksByMessage) {
+      const serverUseIndexes = new Map<string, number>();
+      blocks.forEach((block, index) => {
+        if (block.type === 'server_tool_use' && typeof block.id === 'string') {
+          serverUseIndexes.set(block.id, index);
+        }
+      });
+      for (const block of blocks) {
+        if (
+          block.type !== 'web_search_tool_result' ||
+          typeof block.tool_use_id !== 'string'
+        ) {
+          continue;
+        }
+        expect(serverUseIndexes.get(block.tool_use_id)).toBeLessThan(
+          blocks.indexOf(block)
+        );
+      }
+    }
+  });
+
   it('drops unpaired historical Anthropic Vertex web search calls from mixed turns', () => {
     const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}vrtx_missing_result`;
     const calculatorToolId = 'toolu_calc_1';

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -798,6 +798,223 @@ describe('formatAgentMessages', () => {
     ).toBe(true);
   });
 
+  it('keeps non-Anthropic array-content tool calls on AIMessage.tool_calls', () => {
+    const toolId = 'toolu_openai_after_image';
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.IMAGE_URL,
+            image_url: { url: 'https://example.com/chart.png' },
+          },
+          {
+            type: ContentTypes.TEXT,
+            text: 'I will inspect the image.',
+            tool_call_ids: [toolId],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: toolId,
+              name: 'describe_image',
+              args: '{"focus":"colors"}',
+              output: 'Blue and gray.',
+            },
+          },
+        ],
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['describe_image']),
+      undefined,
+      { provider: Providers.OPENAI }
+    );
+    const aiMessage = messages.find(
+      (message) => message instanceof AIMessage
+    ) as AIMessage;
+
+    expect(Array.isArray(aiMessage.content)).toBe(true);
+    expect(aiMessage.tool_calls).toEqual([
+      {
+        id: toolId,
+        name: 'describe_image',
+        args: { focus: 'colors' },
+      },
+    ]);
+    expect(
+      (aiMessage.content as MessageContentComplex[]).some(
+        (block) => block.type === 'tool_use'
+      )
+    ).toBe(false);
+    expect(
+      messages.some(
+        (message) =>
+          message instanceof ToolMessage && message.tool_call_id === toolId
+      )
+    ).toBe(true);
+  });
+
+  it('normalizes Anthropic inlined tool use ids before tool results', () => {
+    const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}search_before_invalid_calc`;
+    const rawCalculatorToolId = 'toolu|responses|calculator|invalid';
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content: 'Search first, then calculate 21 * 2.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: serverToolId,
+              name: 'web_search',
+              args: '{"query":"Anthropic web search docs"}',
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: serverToolId,
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com/anthropic-web-search',
+                title: 'Anthropic web search',
+                encrypted_content: 'opaque',
+                page_age: '1d',
+              },
+            ],
+          } as MessageContentComplex,
+          {
+            type: ContentTypes.TEXT,
+            text: 'Now I will calculate.',
+            tool_call_ids: [rawCalculatorToolId],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: rawCalculatorToolId,
+              name: 'calculator',
+              args: '{"input":"21 * 2"}',
+              output: '42',
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Summarize the result.',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search', 'calculator']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const allBlocks = anthropicPayload.messages.flatMap((message) =>
+      typeof message.content === 'string'
+        ? []
+        : getAnthropicPayloadBlocks(message.content)
+    );
+    const toolUseBlock = allBlocks.find(
+      (block) => block.type === 'tool_use' && block.name === 'calculator'
+    );
+    const toolResultBlock = allBlocks.find(
+      (block) => block.type === 'tool_result'
+    );
+
+    expect(toolUseBlock?.id).not.toBe(rawCalculatorToolId);
+    expect(toolUseBlock?.id).toMatch(/^[a-zA-Z0-9_-]+$/);
+    expect(toolUseBlock?.id).toBe(toolResultBlock?.tool_use_id);
+  });
+
+  it('preserves repairable Anthropic server search results with drifted types', () => {
+    const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}repairable_result`;
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content: 'Search current Anthropic web search docs.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: serverToolId,
+              name: 'web_search',
+              args: '{"query":"Anthropic web search docs"}',
+            },
+          },
+          {
+            type: ContentTypes.TEXT,
+            tool_use_id: serverToolId,
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com/anthropic-web-search',
+                title: 'Anthropic web search',
+                encrypted_content: 'opaque',
+                page_age: '1d',
+              },
+            ],
+          } as MessageContentComplex,
+          {
+            type: ContentTypes.TEXT,
+            text: 'I found the docs.',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Follow up.',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const assistantBlocks = anthropicPayload.messages
+      .filter((message) => message.role === 'assistant')
+      .flatMap((message) =>
+        typeof message.content === 'string'
+          ? []
+          : getAnthropicPayloadBlocks(message.content)
+      );
+    const serverToolUseIndex = assistantBlocks.findIndex(
+      (block) => block.type === 'server_tool_use' && block.id === serverToolId
+    );
+    const serverResultIndex = assistantBlocks.findIndex(
+      (block) =>
+        block.type === 'web_search_tool_result' &&
+        block.tool_use_id === serverToolId
+    );
+
+    expect(serverToolUseIndex).toBeGreaterThanOrEqual(0);
+    expect(serverResultIndex).toBeGreaterThan(serverToolUseIndex);
+    expect(
+      messages.some(
+        (message) =>
+          message instanceof ToolMessage &&
+          message.tool_call_id === serverToolId
+      )
+    ).toBe(false);
+  });
+
   it('does not pair malformed Anthropic server tool result blocks', () => {
     const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}malformed_result`;
     const payload: TPayload = [

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -697,6 +697,162 @@ describe('formatAgentMessages', () => {
     }
   });
 
+  it('preserves Anthropic server tool pairs before regular tool boundaries', () => {
+    const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}search_before_calc`;
+    const calculatorToolId = 'toolu_calc_after_search';
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content: 'Search first, then calculate 19 * 23.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TEXT,
+            text: 'I will search first.',
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: serverToolId,
+              name: 'web_search',
+              args: '{"query":"Anthropic web search docs"}',
+            },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: serverToolId,
+            content: [
+              {
+                type: 'web_search_result',
+                url: 'https://example.com/anthropic-web-search',
+                title: 'Anthropic web search',
+                encrypted_content: 'opaque',
+                page_age: '1d',
+              },
+            ],
+          } as MessageContentComplex,
+          {
+            type: ContentTypes.TEXT,
+            text: 'Now I will calculate.',
+            tool_call_ids: [calculatorToolId],
+          },
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: calculatorToolId,
+              name: 'calculator',
+              args: '{"input":"19 * 23"}',
+              output: '437',
+            },
+          },
+          {
+            type: ContentTypes.TEXT,
+            text: 'The calculation result is 437.',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Summarize the prior results.',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search', 'calculator']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const assistantBlocks = anthropicPayload.messages
+      .filter((message) => message.role === 'assistant')
+      .flatMap((message) =>
+        typeof message.content === 'string'
+          ? []
+          : getAnthropicPayloadBlocks(message.content)
+      );
+    const serverToolUseIndex = assistantBlocks.findIndex(
+      (block) => block.type === 'server_tool_use' && block.id === serverToolId
+    );
+    const serverResultIndex = assistantBlocks.findIndex(
+      (block) =>
+        block.type === 'web_search_tool_result' &&
+        block.tool_use_id === serverToolId
+    );
+    const calculatorToolUseIndex = assistantBlocks.findIndex(
+      (block) => block.type === 'tool_use' && block.id === calculatorToolId
+    );
+
+    expect(serverToolUseIndex).toBeGreaterThanOrEqual(0);
+    expect(serverResultIndex).toBeGreaterThan(serverToolUseIndex);
+    expect(calculatorToolUseIndex).toBeGreaterThan(serverResultIndex);
+    expect(
+      messages.some(
+        (message) =>
+          message instanceof ToolMessage &&
+          message.tool_call_id === calculatorToolId
+      )
+    ).toBe(true);
+  });
+
+  it('does not pair malformed Anthropic server tool result blocks', () => {
+    const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}malformed_result`;
+    const payload: TPayload = [
+      {
+        role: 'user',
+        content: 'Search current docs.',
+      },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: ContentTypes.TOOL_CALL,
+            tool_call: {
+              id: serverToolId,
+              name: 'web_search',
+              args: '{"query":"Anthropic web search docs"}',
+            },
+          },
+          {
+            type: ContentTypes.TEXT,
+            text: 'Malformed result should not pair this server tool.',
+            tool_use_id: serverToolId,
+          } as MessageContentComplex,
+          {
+            type: ContentTypes.TEXT,
+            text: 'Here is the final answer.',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: 'Follow up.',
+      },
+    ];
+
+    const { messages } = formatAgentMessages(
+      payload,
+      undefined,
+      new Set(['web_search']),
+      undefined,
+      { provider: Providers.ANTHROPIC }
+    );
+    const anthropicPayload = _convertMessagesToAnthropicPayload(messages);
+    const allBlocks = anthropicPayload.messages.flatMap((message) =>
+      typeof message.content === 'string'
+        ? []
+        : getAnthropicPayloadBlocks(message.content)
+    );
+
+    expect(allBlocks.some((block) => block.id === serverToolId)).toBe(false);
+    expect(allBlocks.some((block) => block.tool_use_id === serverToolId)).toBe(
+      false
+    );
+  });
+
   it('drops unpaired historical Anthropic Vertex web search calls from mixed turns', () => {
     const serverToolId = `${Constants.ANTHROPIC_SERVER_TOOL_PREFIX}vrtx_missing_result`;
     const calculatorToolId = 'toolu_calc_1';


### PR DESCRIPTION
## Summary

I fixed Anthropic/Vertex replay formatting for mixed native `web_search` and regular tool-call turns, related to danny-avila/LibreChat#13474.

- Preserve `srvtoolu_...` server tool uses only when a matching `web_search_tool_result` exists, except for the current tail assistant message where the server tool may still be in flight.
- Keep paired server web-search use/result blocks together even when normal text or client tool calls appear between them.
- Drop stale historical Anthropic server search calls before Anthropic payload conversion so follow-up turns do not include dangling `server_tool_use` blocks.
- Added regressions for Vertex-style `srvtoolu_vrtx_...` IDs mixed with calculator tool calls and for historical persisted output without raw web-search result blocks.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/messages/formatAgentMessages.test.ts --runInBand`
- `npx jest src/llm/anthropic/utils/server-tool-inputs.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx eslint src/messages/format.ts src/messages/formatAgentMessages.test.ts`
- `npm run build`

### **Test Configuration**:

- Package: `@librechat/agents@3.2.01`
- Node dependencies installed with `npm ci`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
