### PR TITLE
🧭 fix: Propagate Langfuse Identity To Observations

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -1,5 +1,6 @@
-import { getLangfuseTracerProvider } from '@langfuse/tracing';
 import { CallbackHandler } from '@langfuse/langchain';
+import { getLangfuseTracerProvider, propagateAttributes } from '@langfuse/tracing';
+import type { PropagateAttributesParams } from '@langfuse/tracing';
 import type * as t from '@/types';
 import { isPresent } from '@/utils/misc';
 
@@ -17,6 +18,10 @@ type LangfuseHandlerParams = {
 
 type AgentLangfuseHandlerParams = LangfuseHandlerParams & {
   langfuse?: t.LangfuseConfig;
+};
+
+type LangfuseAttributeParams = AgentLangfuseHandlerParams & {
+  traceName?: string;
 };
 
 type FlushableTracerProvider = {
@@ -156,6 +161,32 @@ export function createLangfuseHandler({
     traceMetadata,
     tags,
   });
+}
+
+function createPropagateAttributeParams({
+  userId,
+  sessionId,
+  traceMetadata,
+  traceName,
+  tags,
+}: LangfuseAttributeParams): PropagateAttributesParams {
+  return {
+    userId,
+    sessionId,
+    traceName,
+    tags,
+    metadata: traceMetadata,
+  };
+}
+
+export function withLangfuseAttributes<T>(
+  params: LangfuseAttributeParams,
+  action: () => T
+): T {
+  if (!shouldCreateLangfuseHandler(params.langfuse)) {
+    return action();
+  }
+  return propagateAttributes(createPropagateAttributeParams(params), action);
 }
 
 export function hasExplicitLangfuseConfig(

--- a/src/run.ts
+++ b/src/run.ts
@@ -41,6 +41,7 @@ import {
   disposeLangfuseHandler,
   getLangfuseTraceName,
   isLangfuseCallbackHandler,
+  withLangfuseAttributes,
 } from '@/langfuse';
 import {
   resolveLangfuseConfig,
@@ -732,6 +733,7 @@ export class Run<_T extends t.BaseGraphState> {
       agentId: graph.defaultAgentId,
       agentName: primaryContext?.name,
     });
+    const traceName = config.runName ?? getLangfuseTraceName(traceMetadata);
     const streamLangfuseConfig = this.getStreamLangfuseConfig(graph);
     initializeLangfuseTracing(streamLangfuseConfig);
     const langfuseHandler = createLangfuseHandler({
@@ -742,7 +744,7 @@ export class Run<_T extends t.BaseGraphState> {
       tags: ['librechat', 'agent'],
     });
     if (langfuseHandler != null) {
-      config.runName = config.runName ?? getLangfuseTraceName(traceMetadata);
+      config.runName = traceName;
       config.callbacks = appendCallbacks(config.callbacks, [langfuseHandler]);
     }
 
@@ -908,7 +910,18 @@ export class Run<_T extends t.BaseGraphState> {
     try {
       await withLangfuseToolOutputTracingConfig(
         streamLangfuseConfig,
-        consumeStream,
+        () =>
+          withLangfuseAttributes(
+            {
+              langfuse: streamLangfuseConfig,
+              userId,
+              sessionId,
+              traceName,
+              traceMetadata,
+              tags: ['librechat', 'agent'],
+            },
+            consumeStream
+          ),
         this.getStreamToolOutputTracingLangfuseConfig(graph)
       );
     } catch (err) {
@@ -1253,6 +1266,9 @@ export class Run<_T extends t.BaseGraphState> {
     titlePromptTemplate,
   }: t.RunTitleOptions): Promise<{ language?: string; title?: string }> {
     let titleLangfuseHandler: CallbackEntry | undefined;
+    let titleLangfuseConfig: t.LangfuseConfig | undefined;
+    let titleUserId: string | undefined;
+    let titleSessionId: string | undefined;
     const titleContext =
       this.Graph == null
         ? undefined
@@ -1264,23 +1280,23 @@ export class Run<_T extends t.BaseGraphState> {
     const titleRunName = getLangfuseTraceName(traceMetadata, 'LibreChat Title');
 
     if (chainOptions != null) {
-      const userId =
+      titleUserId =
         typeof chainOptions.configurable?.user_id === 'string'
           ? chainOptions.configurable.user_id
           : undefined;
-      const sessionId =
+      titleSessionId =
         typeof chainOptions.configurable?.thread_id === 'string'
           ? chainOptions.configurable.thread_id
           : undefined;
-      const titleLangfuseConfig = resolveLangfuseConfig(
+      titleLangfuseConfig = resolveLangfuseConfig(
         this.langfuse,
         titleContext?.langfuse
       );
       initializeLangfuseTracing(titleLangfuseConfig);
       titleLangfuseHandler = createLangfuseHandler({
         langfuse: titleLangfuseConfig,
-        userId,
-        sessionId,
+        userId: titleUserId,
+        sessionId: titleSessionId,
         traceMetadata,
         tags: ['librechat', 'title'],
       });
@@ -1354,15 +1370,30 @@ export class Run<_T extends t.BaseGraphState> {
       runName: chainOptions?.runName ?? titleRunName,
     });
 
+    const invokeTitleChain = (
+      runtimeConfig: Partial<RunnableConfig>
+    ): Promise<{ language?: string; title?: string }> =>
+      withLangfuseAttributes(
+        {
+          langfuse: titleLangfuseConfig,
+          userId: titleUserId,
+          sessionId: titleSessionId,
+          traceName: runtimeConfig.runName ?? titleRunName,
+          traceMetadata,
+          tags: ['librechat', 'title'],
+        },
+        () =>
+          fullChain.invoke(
+            { input: inputText, output: response },
+            runtimeConfig
+          )
+      );
+
     try {
       try {
         return await withLangfuseToolOutputTracingConfig(
           this.langfuse,
-          () =>
-            fullChain.invoke(
-              { input: inputText, output: response },
-              invokeConfig
-            ),
+          () => invokeTitleChain(invokeConfig),
           titleContext?.langfuse
         );
       } catch (_e) {
@@ -1378,11 +1409,7 @@ export class Run<_T extends t.BaseGraphState> {
         });
         return await withLangfuseToolOutputTracingConfig(
           this.langfuse,
-          () =>
-            fullChain.invoke(
-              { input: inputText, output: response },
-              safeConfig as Partial<RunnableConfig>
-            ),
+          () => invokeTitleChain(safeConfig as Partial<RunnableConfig>),
           titleContext?.langfuse
         );
       }

--- a/src/specs/langfuse-metadata.test.ts
+++ b/src/specs/langfuse-metadata.test.ts
@@ -1,4 +1,5 @@
 import { CallbackHandler } from '@langfuse/langchain';
+import { propagateAttributes } from '@langfuse/tracing';
 import { Providers } from '@/common';
 import { Run } from '@/run';
 
@@ -6,9 +7,16 @@ jest.mock('@langfuse/langchain', () => ({
   CallbackHandler: jest.fn().mockImplementation(() => ({})),
 }));
 
+jest.mock('@langfuse/tracing', () => ({
+  ...jest.requireActual('@langfuse/tracing'),
+  propagateAttributes: jest.fn((_params, action: () => unknown) => action()),
+}));
+
 const MockedCallbackHandler = CallbackHandler as jest.MockedClass<
   typeof CallbackHandler
 >;
+const MockedPropagateAttributes =
+  propagateAttributes as jest.MockedFunction<typeof propagateAttributes>;
 
 async function createTestRun(
   agentName?: string,
@@ -70,6 +78,35 @@ describe('Langfuse trace metadata includes agentName', () => {
     expect(ctorArgs?.traceMetadata).toMatchObject({ agentName: 'DWAINE' });
   });
 
+  it('propagates Langfuse identity around processStream observations', async () => {
+    const run = await createTestRun('DWAINE');
+    await run.processStream(
+      { messages: [] },
+      {
+        configurable: {
+          thread_id: 'thread-123',
+          user_id: 'user-456',
+          requestBody: { parentMessageId: 'parent-789' },
+        },
+        version: 'v2',
+      }
+    );
+
+    expect(MockedPropagateAttributes).toHaveBeenCalledTimes(1);
+    expect(MockedPropagateAttributes.mock.calls[0][0]).toMatchObject({
+      userId: 'user-456',
+      sessionId: 'thread-123',
+      traceName: 'LibreChat Agent: DWAINE',
+      tags: ['librechat', 'agent'],
+      metadata: {
+        messageId: 'test-run-id',
+        parentMessageId: 'parent-789',
+        agentId: 'agent_abc123',
+        agentName: 'DWAINE',
+      },
+    });
+  });
+
   it('falls back to agentId when agent has no explicit name', async () => {
     const run = await createTestRun();
     await run.processStream(
@@ -93,6 +130,7 @@ describe('Langfuse trace metadata includes agentName', () => {
     );
 
     expect(MockedCallbackHandler).not.toHaveBeenCalled();
+    expect(MockedPropagateAttributes).not.toHaveBeenCalled();
   });
 
   it('does not create the legacy CallbackHandler when explicit agent config is supplied', async () => {


### PR DESCRIPTION
## Summary

I propagated Langfuse identity attributes around agent and title execution so child observations inherit the same user/session context as the root trace.

- Added a shared Langfuse helper that calls `propagateAttributes` only when Langfuse tracing is active.
- Wrapped agent `streamEvents` execution so generated spans, tool observations, and model generations inherit `userId`, `sessionId`, trace name, tags, and existing trace metadata such as `messageId`.
- Wrapped title generation with the same propagation path so title model observations also stay attributable.
- Added test coverage for the propagated identity payload used by `processStream`.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx eslint src/langfuse.ts src/run.ts src/specs/langfuse-metadata.test.ts`
- `npx tsc --noEmit`
- `npx jest src/specs/langfuse-config.test.ts src/specs/langfuse-instrumentation.test.ts src/specs/langfuse-tool-output-tracing.test.ts src/specs/langfuse-metadata.test.ts --runInBand`
- Ran a staging Langfuse smoke test with a fake model and verified the emitted trace and observations included the synthetic `userId` and `sessionId`.

### **Test Configuration**:

- Node.js project worktree: `/Users/danny/.codex/worktrees/langfuse-attribute-propagation-agents`
- Langfuse staging credentials sourced locally from `.env.staging` for the smoke test.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
