### PR TITLE
feat: optional deterministic Langfuse trace IDs (seed from runId)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -12,7 +12,10 @@ import {
   getContextLangfuseConfig,
 } from '@/langfuseToolOutputTracing';
 import { isPresent } from '@/utils/misc';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createHash, randomBytes } from 'node:crypto';
 import type {
+  IdGenerator,
   ReadableSpan,
   Span,
   SpanProcessor,
@@ -20,6 +23,43 @@ import type {
 import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
+
+/**
+ * Per-run seed for deterministic Langfuse trace ids. When a run opts in
+ * (`LangfuseConfig.deterministicTraceId`), it executes its stream inside
+ * `runWithTraceIdSeed(runId, …)` and the IdGenerator below derives the root
+ * trace id from that seed instead of a random one. This lets external systems
+ * (e.g. a host app recording user feedback after the fact) attach scores or
+ * observations to the trace by regenerating the same id from the run/message
+ * id — no trace lookup required. With no active seed it falls back to random
+ * ids, so default behavior is unchanged.
+ */
+const traceIdSeedStore = new AsyncLocalStorage<string>();
+
+export function runWithTraceIdSeed<T>(
+  seed: string | undefined,
+  fn: () => T
+): T {
+  return isPresent(seed) ? traceIdSeedStore.run(seed, fn) : fn();
+}
+
+/** sha256(seed) → first 32 hex chars; matches `@langfuse/tracing` `createTraceId`. */
+function traceIdFromSeed(seed: string): string {
+  return createHash('sha256').update(seed, 'utf8').digest('hex').slice(0, 32);
+}
+
+class SeededTraceIdGenerator implements IdGenerator {
+  generateTraceId(): string {
+    const seed = traceIdSeedStore.getStore();
+    return isPresent(seed)
+      ? traceIdFromSeed(seed)
+      : randomBytes(16).toString('hex');
+  }
+
+  generateSpanId(): string {
+    return randomBytes(8).toString('hex');
+  }
+}
 
 let langfuseTracerProvider: BasicTracerProvider | undefined;
 let langfuseRoutingSpanProcessor: RoutingLangfuseSpanProcessor | undefined;
@@ -163,6 +203,7 @@ export function initializeLangfuseTracing(
   langfuseRoutingSpanProcessor.ensureProcessor(langfuse);
   langfuseTracerProvider = new BasicTracerProvider({
     spanProcessors: [langfuseRoutingSpanProcessor],
+    idGenerator: new SeededTraceIdGenerator(),
   });
 
   setLangfuseTracerProvider(langfuseTracerProvider);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,8 @@
 // src/run.ts
-import { initializeLangfuseTracing } from './instrumentation';
+import {
+  initializeLangfuseTracing,
+  runWithTraceIdSeed,
+} from './instrumentation';
 import { PromptTemplate } from '@langchain/core/prompts';
 import { RunnableLambda } from '@langchain/core/runnables';
 import { AzureChatOpenAI, ChatOpenAI } from '@langchain/openai';
@@ -552,9 +555,7 @@ export class Run<_T extends t.BaseGraphState> {
   }
 
   private shouldClearHookSession(streamThrew: boolean): boolean {
-    return (
-      this._interrupt == null || this._haltedReason != null || streamThrew
-    );
+    return this._interrupt == null || this._haltedReason != null || streamThrew;
   }
 
   private isAwaitingResume(streamThrew: boolean): boolean {
@@ -584,9 +585,7 @@ export class Run<_T extends t.BaseGraphState> {
   private getStreamToolOutputTracingLangfuseConfig(
     graph: StandardGraph | MultiAgentGraph
   ): t.LangfuseConfig | undefined {
-    const toolOutputTracingConfigs = Array.from(
-      graph.agentContexts.values()
-    )
+    const toolOutputTracingConfigs = Array.from(graph.agentContexts.values())
       .map((context) => {
         return resolveLangfuseConfig(this.langfuse, context.langfuse)
           ?.toolOutputTracing;
@@ -906,10 +905,19 @@ export class Run<_T extends t.BaseGraphState> {
     };
 
     try {
-      await withLangfuseToolOutputTracingConfig(
-        streamLangfuseConfig,
-        consumeStream,
-        this.getStreamToolOutputTracingLangfuseConfig(graph)
+      // When opted in, seed the root trace id from this run's id so feedback /
+      // other external signals can be attached to the trace later without a
+      // lookup (see SeededTraceIdGenerator in ./instrumentation).
+      await runWithTraceIdSeed(
+        streamLangfuseConfig?.deterministicTraceId === true
+          ? this.id
+          : undefined,
+        () =>
+          withLangfuseToolOutputTracingConfig(
+            streamLangfuseConfig,
+            consumeStream,
+            this.getStreamToolOutputTracingLangfuseConfig(graph)
+          )
       );
     } catch (err) {
       streamThrew = true;

--- a/src/specs/deterministic-trace-id.test.ts
+++ b/src/specs/deterministic-trace-id.test.ts
@@ -1,0 +1,50 @@
+import { createHash } from 'node:crypto';
+import {
+  initializeLangfuseTracing,
+  runWithTraceIdSeed,
+} from '@/instrumentation';
+
+const langfuse = {
+  publicKey: 'pk-lf-test',
+  secretKey: 'sk-lf-test',
+  baseUrl: 'http://localhost:3999',
+};
+
+/** sha256(seed) → first 32 hex chars; what `@langfuse/tracing` `createTraceId` produces. */
+const expectedTraceId = (seed: string): string =>
+  createHash('sha256').update(seed, 'utf8').digest('hex').slice(0, 32);
+
+describe('deterministic Langfuse trace ids', () => {
+  it('derives the root trace id from the seed when run inside runWithTraceIdSeed', () => {
+    const provider = initializeLangfuseTracing(langfuse);
+    expect(provider).toBeDefined();
+    const tracer = provider!.getTracer('deterministic-trace-id-test');
+
+    const seed = 'response-message-id-1234';
+    let traceId: string | undefined;
+    runWithTraceIdSeed(seed, () => {
+      const span = tracer.startSpan('AgentRun');
+      traceId = span.spanContext().traceId;
+      span.end();
+    });
+
+    expect(traceId).toBe(expectedTraceId(seed));
+  });
+
+  it('falls back to a random trace id when no seed is active', () => {
+    const provider = initializeLangfuseTracing(langfuse);
+    const tracer = provider!.getTracer('deterministic-trace-id-test');
+
+    const span = tracer.startSpan('AgentRun');
+    const traceId = span.spanContext().traceId;
+    span.end();
+
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(traceId).not.toBe(expectedTraceId('response-message-id-1234'));
+  });
+
+  it('runWithTraceIdSeed is a passthrough when the seed is undefined', () => {
+    const sentinel = {};
+    expect(runWithTraceIdSeed(undefined, () => sentinel)).toBe(sentinel);
+  });
+});

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -445,6 +445,14 @@ export interface LangfuseConfig {
   baseUrl?: string;
   toolNodeTracing?: LangfuseToolNodeTracingConfig;
   toolOutputTracing?: LangfuseToolOutputTracingConfig;
+  /**
+   * When true, derive the run's root Langfuse trace id deterministically from
+   * its `runId` (`sha256(runId)` → 32 hex chars, matching `@langfuse/tracing`
+   * `createTraceId`) instead of a random id. This lets external systems attach
+   * scores or observations to the trace afterwards by regenerating the same id
+   * from the run/message id, without a trace lookup. Default: random ids.
+   */
+  deterministicTraceId?: boolean;
 }
 
 export interface AgentInputs {


### PR DESCRIPTION
## What

Adds an opt-in `LangfuseConfig.deterministicTraceId`. When enabled, a run's
**root** Langfuse trace id is derived from its `runId` as `sha256(runId)` → first
32 hex chars (matching `@langfuse/tracing`'s `createTraceId`), instead of a
random id. Off by default — fully backwards compatible.

## Why

External systems can't attach a Langfuse **score** or observation to a run's
trace after the fact (e.g. user 👍/👎 feedback submitted later from the host
app) because the trace id is random — they'd need a lookup. With this flag, the
host regenerates the same id from the run/message id and attaches scores with
zero lookups.

This can't be done cleanly from the app layer: injecting a parent span context
from outside makes the run's span a *child*, so it stops being the trace root
and the trace ingests **unnamed**. The trace id must be set where the
OpenTelemetry SDK is configured — here.

## How

- A custom OTEL `IdGenerator` on the Langfuse `BasicTracerProvider` returns the
  seeded id when a per-run seed is present in an `AsyncLocalStorage`, otherwise a
  random id.
- `Run.processStream` wraps stream execution in `runWithTraceIdSeed(runId, …)`
  only when `deterministicTraceId` is set. Title-generation tracing is left
  untouched.

## Tests

New `src/specs/deterministic-trace-id.test.ts` (seeded → deterministic, unseeded
→ random, undefined-seed passthrough). Existing Langfuse specs unchanged and
green; `npm run build` + eslint clean.

## Context

Companion to danny-avila/LibreChat#13537 — surfacing message feedback as Langfuse
scores, which sets this flag and scores by `createTraceId(messageId)`.

---

### Companion feature working end-to-end

The LibreChat change (danny-avila/LibreChat#13537) sets `deterministicTraceId`
and scores by `createTraceId(messageId)`. A 👍/👎 in the chat UI lands as a
Langfuse **score attached to that message's trace** — no lookup:

![Langfuse Scores UI showing a user-feedback BOOLEAN score (thumbsUp / clear_well_written)](https://raw.githubusercontent.com/graphaelli/agents/pr-assets/.pr-assets/langfuse-feedback-scores.png)
