### PR TITLE
🏷️ fix: Expose LangChain Message Roles

### DIFF
--- a/src/messages/cache.test.ts
+++ b/src/messages/cache.test.ts
@@ -14,6 +14,7 @@ import {
   addBedrockCacheControl,
   addCacheControl,
 } from './cache';
+import { formatAgentMessages } from './format';
 import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
 import { toLangChainContent } from './langchain';
 import { ContentTypes } from '@/common/enum';
@@ -1474,6 +1475,27 @@ describe('Multi-turn cache cleanup', () => {
 });
 
 describe('LangChain message type preservation', () => {
+  it('preserves direct roles for formatted LangChain messages after addCacheControl', () => {
+    const { messages } = formatAgentMessages([
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+      { role: 'user', content: 'Thanks' },
+    ]);
+
+    const result = addCacheControl(messages);
+
+    expect(result.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+    ]);
+    expect(result[0]).toBeInstanceOf(HumanMessage);
+    expect(result[0]).not.toBe(messages[0]);
+    expect(Object.keys(result[0])).not.toContain('role');
+    expect(result[1]).toBe(messages[1]);
+    expect(result[2]).not.toBe(messages[2]);
+  });
+
   it('should preserve instanceof for LangChain messages after addCacheControl', () => {
     const messages: BaseMessage[] = [
       new HumanMessage({ content: [{ type: 'text', text: 'Hello' }] }),

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -9,6 +9,7 @@ import {
 import type { AnthropicMessage } from '@/types/messages';
 import type Anthropic from '@anthropic-ai/sdk';
 import { ContentTypes } from '@/common/enum';
+import { withMessageRole } from './format';
 import { toLangChainContent } from './langchain';
 
 type MessageWithContent = {
@@ -56,19 +57,31 @@ function cloneMessage<T extends MessageWithContent>(
     const msgType = message.getType();
     switch (msgType) {
     case 'ai':
-      return new AIMessage({
-        ...baseParams,
-        tool_calls: (message as unknown as AIMessage).tool_calls,
-      }) as unknown as T;
+      return withMessageRole(
+        new AIMessage({
+          ...baseParams,
+          tool_calls: (message as unknown as AIMessage).tool_calls,
+        }),
+        'assistant'
+      ) as unknown as T;
     case 'human':
-      return new HumanMessage(baseParams) as unknown as T;
+      return withMessageRole(
+        new HumanMessage(baseParams),
+        'user'
+      ) as unknown as T;
     case 'system':
-      return new SystemMessage(baseParams) as unknown as T;
+      return withMessageRole(
+        new SystemMessage(baseParams),
+        'system'
+      ) as unknown as T;
     case 'tool':
-      return new ToolMessage({
-        ...baseParams,
-        tool_call_id: (message as unknown as ToolMessage).tool_call_id,
-      }) as unknown as T;
+      return withMessageRole(
+        new ToolMessage({
+          ...baseParams,
+          tool_call_id: (message as unknown as ToolMessage).tool_call_id,
+        }),
+        'tool'
+      ) as unknown as T;
     default:
       break;
     }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -106,15 +106,19 @@ interface FormatMessageParams {
   langChain?: boolean;
 }
 
-type LangChainMessageRole = 'system' | 'user' | 'assistant' | 'tool';
+export type LangChainMessageRole = 'system' | 'user' | 'assistant' | 'tool';
 
-function withMessageRole<T extends BaseMessage>(
+export type RoleBearingMessage<T extends BaseMessage = BaseMessage> = T & {
+  role: LangChainMessageRole;
+};
+
+export function withMessageRole<T extends BaseMessage>(
   message: T,
   role: LangChainMessageRole
-): T {
+): RoleBearingMessage<T> {
   const roleMessage = message as T & { role?: LangChainMessageRole };
   if (roleMessage.role === role) {
-    return message;
+    return roleMessage as RoleBearingMessage<T>;
   }
   Object.defineProperty(roleMessage, 'role', {
     value: role,
@@ -122,7 +126,7 @@ function withMessageRole<T extends BaseMessage>(
     enumerable: false,
     configurable: true,
   });
-  return message;
+  return roleMessage as RoleBearingMessage<T>;
 }
 
 interface FormattedMessage {
@@ -146,9 +150,9 @@ export const formatMessage = ({
   langChain = false,
 }: FormatMessageParams):
   | FormattedMessage
-  | HumanMessage
-  | AIMessage
-  | SystemMessage => {
+  | RoleBearingMessage<HumanMessage>
+  | RoleBearingMessage<AIMessage>
+  | RoleBearingMessage<SystemMessage> => {
   // eslint-disable-next-line prefer-const
   let { role: _role, _name, sender, text, content: _content, lc_id } = message;
   if (lc_id && lc_id[2] && !langChain) {
@@ -274,14 +278,21 @@ export const formatMessage = ({
 export const formatLangChainMessages = (
   messages: Array<MessageInput>,
   formatOptions: Omit<FormatMessageParams, 'message' | 'langChain'>
-): Array<HumanMessage | AIMessage | SystemMessage> => {
+): Array<
+  | RoleBearingMessage<HumanMessage>
+  | RoleBearingMessage<AIMessage>
+  | RoleBearingMessage<SystemMessage>
+> => {
   return messages.map((msg) => {
     const formatted = formatMessage({
       ...formatOptions,
       message: msg,
       langChain: true,
     });
-    return formatted as HumanMessage | AIMessage | SystemMessage;
+    return formatted as
+      | RoleBearingMessage<HumanMessage>
+      | RoleBearingMessage<AIMessage>
+      | RoleBearingMessage<SystemMessage>;
   });
 };
 
@@ -411,10 +422,12 @@ function getToolUseId(part: MessageContentComplex): string | undefined {
 function formatAssistantMessage(
   message: Partial<TMessage>,
   options?: FormatAssistantMessageOptions
-): Array<AIMessage | ToolMessage> {
-  const formattedMessages: Array<AIMessage | ToolMessage> = [];
+): Array<RoleBearingMessage<AIMessage> | RoleBearingMessage<ToolMessage>> {
+  const formattedMessages: Array<
+    RoleBearingMessage<AIMessage> | RoleBearingMessage<ToolMessage>
+  > = [];
   let currentContent: MessageContentComplex[] = [];
-  let lastAIMessage: AIMessage | null = null;
+  let lastAIMessage: RoleBearingMessage<AIMessage> | null = null;
   let hasReasoning = false;
   let pendingReasoningContent = '';
   const emittedServerToolUseIds = new Set<string>();
@@ -431,7 +444,9 @@ function formatAssistantMessage(
     return reasoningContent;
   };
 
-  const createAIMessage = (content: MessageContent): AIMessage => {
+  const createAIMessage = (
+    content: MessageContent
+  ): RoleBearingMessage<AIMessage> => {
     const reasoningContent = takePendingReasoningContent();
     return withMessageRole(
       new AIMessage({
@@ -1044,7 +1059,12 @@ export const formatAgentMessages = (
   skills?: Map<string, string>,
   options?: FormatAgentMessagesOptions
 ): {
-  messages: Array<HumanMessage | AIMessage | SystemMessage | ToolMessage>;
+  messages: Array<
+    | RoleBearingMessage<HumanMessage>
+    | RoleBearingMessage<AIMessage>
+    | RoleBearingMessage<SystemMessage>
+    | RoleBearingMessage<ToolMessage>
+  >;
   indexTokenCountMap?: Record<number, number>;
   /** Cross-run summary extracted from the payload. Should be forwarded to the
    *  agent run so it can be included in the system message via AgentContext. */
@@ -1059,7 +1079,10 @@ export const formatAgentMessages = (
   };
 } => {
   const messages: Array<
-    HumanMessage | AIMessage | SystemMessage | ToolMessage
+    | RoleBearingMessage<HumanMessage>
+    | RoleBearingMessage<AIMessage>
+    | RoleBearingMessage<SystemMessage>
+    | RoleBearingMessage<ToolMessage>
   > = [];
   // If indexTokenCountMap is provided, create a new map to track the updated indices
   const updatedIndexTokenCountMap: Record<number, number> = {};
@@ -1115,7 +1138,10 @@ export const formatAgentMessages = (
       const formattedMessage = formatMessage({
         message: message as MessageInput,
         langChain: true,
-      }) as HumanMessage | AIMessage | SystemMessage;
+      }) as
+        | RoleBearingMessage<HumanMessage>
+        | RoleBearingMessage<AIMessage>
+        | RoleBearingMessage<SystemMessage>;
       if (sourceMessageId != null && sourceMessageId !== '') {
         formattedMessage.id = sourceMessageId;
       }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -106,6 +106,25 @@ interface FormatMessageParams {
   langChain?: boolean;
 }
 
+type LangChainMessageRole = 'system' | 'user' | 'assistant' | 'tool';
+
+function withMessageRole<T extends BaseMessage>(
+  message: T,
+  role: LangChainMessageRole
+): T {
+  const roleMessage = message as T & { role?: LangChainMessageRole };
+  if (roleMessage.role === role) {
+    return message;
+  }
+  Object.defineProperty(roleMessage, 'role', {
+    value: role,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return message;
+}
+
 interface FormattedMessage {
   role: string;
   content: string | MessageContentComplex[];
@@ -217,7 +236,10 @@ export const formatMessage = ({
       return mediaMessage;
     }
 
-    return new HumanMessage(toLangChainMessageFields(mediaMessage));
+    return withMessageRole(
+      new HumanMessage(toLangChainMessageFields(mediaMessage)),
+      'user'
+    );
   }
 
   if (!langChain) {
@@ -225,11 +247,20 @@ export const formatMessage = ({
   }
 
   if (role === 'user') {
-    return new HumanMessage(toLangChainMessageFields(formattedMessage));
+    return withMessageRole(
+      new HumanMessage(toLangChainMessageFields(formattedMessage)),
+      'user'
+    );
   } else if (role === 'assistant') {
-    return new AIMessage(toLangChainMessageFields(formattedMessage));
+    return withMessageRole(
+      new AIMessage(toLangChainMessageFields(formattedMessage)),
+      'assistant'
+    );
   } else {
-    return new SystemMessage(toLangChainMessageFields(formattedMessage));
+    return withMessageRole(
+      new SystemMessage(toLangChainMessageFields(formattedMessage)),
+      'system'
+    );
   }
 };
 
@@ -402,12 +433,15 @@ function formatAssistantMessage(
 
   const createAIMessage = (content: MessageContent): AIMessage => {
     const reasoningContent = takePendingReasoningContent();
-    return new AIMessage({
-      content,
-      ...(reasoningContent != null && {
-        additional_kwargs: { reasoning_content: reasoningContent },
+    return withMessageRole(
+      new AIMessage({
+        content,
+        ...(reasoningContent != null && {
+          additional_kwargs: { reasoning_content: reasoningContent },
+        }),
       }),
-    });
+      'assistant'
+    );
   };
 
   const attachPendingReasoningContent = (aiMessage: AIMessage): void => {
@@ -537,11 +571,14 @@ function formatAssistantMessage(
         lastAIMessage.tool_calls.push(tool_call as ToolCall);
 
         formattedMessages.push(
-          new ToolMessage({
-            tool_call_id: tool_call.id ?? '',
-            name: tool_call.name,
-            content: output != null ? output : '',
-          })
+          withMessageRole(
+            new ToolMessage({
+              tool_call_id: tool_call.id ?? '',
+              name: tool_call.name,
+              content: output != null ? output : '',
+            }),
+            'tool'
+          )
         );
       } else if (
         part.type === ContentTypes.THINK ||
@@ -1273,15 +1310,18 @@ export const formatAgentMessages = (
         const body = skills?.get(skillName) ?? '';
         if (body) {
           messages.push(
-            new HumanMessage({
-              content: body,
-              additional_kwargs: {
-                role: 'user',
-                isMeta: true,
-                source: 'skill',
-                skillName,
-              },
-            })
+            withMessageRole(
+              new HumanMessage({
+                content: body,
+                additional_kwargs: {
+                  role: 'user',
+                  isMeta: true,
+                  source: 'skill',
+                  skillName,
+                },
+              }),
+              'user'
+            )
           );
         }
       }
@@ -1721,7 +1761,12 @@ export function ensureThinkingBlockInMessages(
         'ensureThinkingBlockInMessages: injecting [Previous agent context] HumanMessage' +
           ` (${parts.length} msgs at index ${i}, no thinking block in chain)`
       );
-      result.push(new HumanMessage({ content: toLangChainContent(parts) }));
+      result.push(
+        withMessageRole(
+          new HumanMessage({ content: toLangChainContent(parts) }),
+          'user'
+        )
+      );
       i = j;
     } else {
       // Keep the message as is

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -14,8 +14,6 @@ import {
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
 
-type RoleBearingMessage = { role?: string };
-
 describe('formatAgentMessages', () => {
   it('should format simple user and AI messages', () => {
     const payload: TPayload = [
@@ -26,9 +24,10 @@ describe('formatAgentMessages', () => {
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0]).toBeInstanceOf(HumanMessage);
     expect(result.messages[1]).toBeInstanceOf(AIMessage);
-    expect(
-      result.messages.map((message) => (message as RoleBearingMessage).role)
-    ).toEqual(['user', 'assistant']);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+    ]);
     expect(Object.keys(result.messages[0])).not.toContain('role');
     expect(Object.keys(result.messages[1])).not.toContain('role');
   });
@@ -63,9 +62,11 @@ describe('formatAgentMessages', () => {
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
     expect(result.messages[1]).toBeInstanceOf(ToolMessage);
     expect(result.messages[2]).toBeInstanceOf(HumanMessage);
-    expect(
-      result.messages.map((message) => (message as RoleBearingMessage).role)
-    ).toEqual(['assistant', 'tool', 'user']);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      'assistant',
+      'tool',
+      'user',
+    ]);
     expect(result.messages[0].id).toBe('msg_assistant_1');
     expect(result.messages[1].id).toBe('msg_assistant_1');
     expect(result.messages[2].id).toBe('msg_user_1');
@@ -78,7 +79,7 @@ describe('formatAgentMessages', () => {
     const result = formatAgentMessages(payload);
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(SystemMessage);
-    expect((result.messages[0] as RoleBearingMessage).role).toBe('system');
+    expect(result.messages[0].role).toBe('system');
     expect(Object.keys(result.messages[0])).not.toContain('role');
   });
 

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -14,6 +14,8 @@ import {
 import { _convertMessagesToAnthropicPayload } from '@/llm/anthropic/utils/message_inputs';
 import { Constants, ContentTypes, Providers } from '@/common';
 
+type RoleBearingMessage = { role?: string };
+
 describe('formatAgentMessages', () => {
   it('should format simple user and AI messages', () => {
     const payload: TPayload = [
@@ -24,6 +26,11 @@ describe('formatAgentMessages', () => {
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0]).toBeInstanceOf(HumanMessage);
     expect(result.messages[1]).toBeInstanceOf(AIMessage);
+    expect(
+      result.messages.map((message) => (message as RoleBearingMessage).role)
+    ).toEqual(['user', 'assistant']);
+    expect(Object.keys(result.messages[0])).not.toContain('role');
+    expect(Object.keys(result.messages[1])).not.toContain('role');
   });
 
   it('preserves source messageId on formatted messages', () => {
@@ -56,6 +63,9 @@ describe('formatAgentMessages', () => {
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
     expect(result.messages[1]).toBeInstanceOf(ToolMessage);
     expect(result.messages[2]).toBeInstanceOf(HumanMessage);
+    expect(
+      result.messages.map((message) => (message as RoleBearingMessage).role)
+    ).toEqual(['assistant', 'tool', 'user']);
     expect(result.messages[0].id).toBe('msg_assistant_1');
     expect(result.messages[1].id).toBe('msg_assistant_1');
     expect(result.messages[2].id).toBe('msg_user_1');
@@ -68,6 +78,8 @@ describe('formatAgentMessages', () => {
     const result = formatAgentMessages(payload);
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(SystemMessage);
+    expect((result.messages[0] as RoleBearingMessage).role).toBe('system');
+    expect(Object.keys(result.messages[0])).not.toContain('role');
   });
 
   it('should prepend the latest summary and trim context before its boundary', () => {
@@ -271,8 +283,9 @@ describe('formatAgentMessages', () => {
 
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]).toBeInstanceOf(AIMessage);
-    expect(result.messages.some((message) => message instanceof ToolMessage))
-      .toBe(false);
+    expect(
+      result.messages.some((message) => message instanceof ToolMessage)
+    ).toBe(false);
     expect((result.messages[0] as AIMessage).tool_calls).toHaveLength(0);
     expect(result.messages[0].content).toEqual([
       {
@@ -695,13 +708,9 @@ describe('formatAgentMessages', () => {
     expect(result.messages[1]).toBeInstanceOf(ToolMessage);
     expect(result.messages[2]).toBeInstanceOf(AIMessage);
     expect(result.messages[3]).toBeInstanceOf(ToolMessage);
-    expect((result.messages[0] as AIMessage).tool_calls?.[0].id).toBe(
-      'call_1'
-    );
+    expect((result.messages[0] as AIMessage).tool_calls?.[0].id).toBe('call_1');
     expect((result.messages[1] as ToolMessage).tool_call_id).toBe('call_1');
-    expect((result.messages[2] as AIMessage).tool_calls?.[0].id).toBe(
-      'call_2'
-    );
+    expect((result.messages[2] as AIMessage).tool_calls?.[0].id).toBe('call_2');
     expect((result.messages[3] as ToolMessage).tool_call_id).toBe('call_2');
   });
 


### PR DESCRIPTION
I added a compatibility role property to formatted LangChain messages so host code can safely inspect message roles without changing LangChain serialization behavior.

- Added a shared helper that defines writable, non-enumerable `role` properties on formatted `HumanMessage`, `AIMessage`, `SystemMessage`, and `ToolMessage` instances.
- Applied the helper across `formatMessage`, assistant/tool message formatting, injected skill-prime messages, and previous-agent-context conversion.
- Expanded `formatAgentMessages` coverage to assert direct roles for user, assistant, system, and tool messages while confirming the compatibility role remains non-enumerable.
- Addressed the likely root cause from https://github.com/danny-avila/LibreChat/discussions/13549, where downstream LibreChat code may inspect `.role` on LangChain messages during later conversation turns.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/messages/formatAgentMessages.test.ts src/messages/formatMessage.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx eslint src/messages/format.ts src/messages/formatAgentMessages.test.ts`

### **Test Configuration**:

- Node.js: local workspace runtime
- Package manager: npm via `package-lock.json`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes