### PR TITLE
🪨 fix: Omit Empty Bedrock Tool Descriptions

### DIFF
--- a/src/llm/bedrock/toolCache.test.ts
+++ b/src/llm/bedrock/toolCache.test.ts
@@ -15,17 +15,30 @@ type OpenAITool = {
   };
 };
 
-function createOpenAITool(name: string): OpenAITool {
+type CreateOpenAIToolOptions = {
+  description?: string;
+  omitDescription?: boolean;
+};
+
+function createOpenAITool(
+  name: string,
+  options: CreateOpenAIToolOptions = {}
+): OpenAITool {
+  const functionDefinition: OpenAITool['function'] = {
+    name,
+    parameters: {
+      type: 'object',
+      properties: {},
+    },
+  };
+  const description = options.description ?? `${name} description`;
+  if (options.omitDescription !== true) {
+    functionDefinition.description = description;
+  }
+
   return {
     type: 'function',
-    function: {
-      name,
-      description: `${name} description`,
-      parameters: {
-        type: 'object',
-        properties: {},
-      },
-    },
+    function: functionDefinition,
   };
 }
 
@@ -38,6 +51,11 @@ function toolName(entry: Tool): string {
 
 function toolNames(tools: Tool[] | undefined): string[] {
   return (tools ?? []).map(toolName);
+}
+
+function getToolSpec(entry: Tool): Tool.ToolSpecMember['toolSpec'] {
+  expect(entry).toHaveProperty('toolSpec');
+  return (entry as Tool.ToolSpecMember).toolSpec;
 }
 
 describe('partitionAndMarkBedrockToolCache', () => {
@@ -127,5 +145,26 @@ describe('partitionAndMarkBedrockToolCache', () => {
     );
 
     expect(toolNames(result?.tools)).toEqual(['direct_tool', 'cachePoint']);
+  });
+
+  it('omits empty OpenAI tool descriptions when converting for Bedrock', () => {
+    const tools = [
+      createOpenAITool('missing_description', { omitDescription: true }),
+      createOpenAITool('empty_description', { description: '' }),
+      createOpenAITool('described_tool'),
+    ] as GraphTools;
+
+    const marked = partitionAndMarkBedrockToolCache(
+      tools,
+      () => false
+    ) as Tool[];
+    const result = insertBedrockToolCachePoint({ tools: marked }, false);
+    const convertedTools = result?.tools ?? [];
+
+    expect(getToolSpec(convertedTools[0])).not.toHaveProperty('description');
+    expect(getToolSpec(convertedTools[1])).not.toHaveProperty('description');
+    expect(getToolSpec(convertedTools[2]).description).toBe(
+      'described_tool description'
+    );
   });
 });

--- a/src/llm/bedrock/toolCache.ts
+++ b/src/llm/bedrock/toolCache.ts
@@ -60,12 +60,17 @@ function getToolName(tool: unknown): string | undefined {
 }
 
 function openAIToBedrockTool(tool: OpenAIFunctionTool): Tool.ToolSpecMember {
+  const toolSpec: NonNullable<Tool.ToolSpecMember['toolSpec']> = {
+    name: tool.function.name,
+    inputSchema: { json: tool.function.parameters as DocumentType },
+  };
+
+  if (tool.function.description != null && tool.function.description !== '') {
+    toolSpec.description = tool.function.description;
+  }
+
   return {
-    toolSpec: {
-      name: tool.function.name,
-      description: tool.function.description,
-      inputSchema: { json: tool.function.parameters as DocumentType },
-    },
+    toolSpec,
   };
 }
 


### PR DESCRIPTION
I fixed Bedrock tool conversion so OpenAI-style tools with empty or missing descriptions no longer send an invalid empty `toolSpec.description` value to Bedrock. Fixes #215.

- Omitted the Bedrock `description` key unless the converted OpenAI tool description is non-empty.
- Preserved valid tool descriptions and the existing input schema conversion behavior.
- Added regression coverage for missing, empty, and populated descriptions through the Bedrock tool-cache path.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I ran the focused Bedrock tool-cache regression test, TypeScript type-checking, linting on the touched files, and a production build.

### **Test Configuration**:

- Node.js via local project tooling
- `@librechat/agents` v3.2.21 worktree

```sh
npx jest src/llm/bedrock/toolCache.test.ts --runInBand
npx tsc --noEmit
npx eslint src/llm/bedrock/toolCache.ts src/llm/bedrock/toolCache.test.ts --fix
npm run build
```

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes