### PR TITLE
🧯 fix: Sanitize Reranker Axios Error Logs

### DIFF
--- a/src/tools/search/jina-reranker.test.ts
+++ b/src/tools/search/jina-reranker.test.ts
@@ -1,18 +1,72 @@
-import { JinaReranker } from './rerankers';
+import axios from 'axios';
+
+import { createReranker, JinaReranker } from './rerankers';
 import { createDefaultLogger } from './utils';
+
+type AxiosErrorFixture = Error & {
+  isAxiosError: true;
+  code: string;
+  config: {
+    data: string;
+    headers: {
+      Authorization: string;
+    };
+    method: string;
+    url: string;
+  };
+  response: {
+    data: {
+      details?: string;
+      message: string;
+    };
+    status: number;
+  };
+};
+
+const getApiUrl = (reranker: JinaReranker): string => {
+  const descriptor = Object.getOwnPropertyDescriptor(reranker, 'apiUrl');
+  if (typeof descriptor?.value === 'string') {
+    return descriptor.value;
+  }
+  throw new Error('Expected JinaReranker apiUrl to be initialized.');
+};
+
+const createAxiosErrorFixture = (
+  url: string,
+  responseData: AxiosErrorFixture['response']['data']
+): AxiosErrorFixture =>
+  Object.assign(new Error('Request failed with status code 500'), {
+    isAxiosError: true as const,
+    code: 'ERR_BAD_RESPONSE',
+    config: {
+      data: JSON.stringify({ documents: ['document1', 'document2'] }),
+      headers: {
+        Authorization: 'Bearer test-key',
+      },
+      method: 'post',
+      url,
+    },
+    response: {
+      data: responseData,
+      status: 500,
+    },
+  });
 
 describe('JinaReranker', () => {
   const mockLogger = createDefaultLogger();
-  
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('constructor', () => {
     it('should use default API URL when no apiUrl is provided', () => {
       const reranker = new JinaReranker({
         apiKey: 'test-key',
         logger: mockLogger,
       });
-      
-      // Access private property for testing
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = getApiUrl(reranker);
       expect(apiUrl).toBe('https://api.jina.ai/v1/rerank');
     });
 
@@ -23,25 +77,24 @@ describe('JinaReranker', () => {
         apiUrl: customUrl,
         logger: mockLogger,
       });
-      
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = getApiUrl(reranker);
       expect(apiUrl).toBe(customUrl);
     });
 
     it('should use environment variable JINA_API_URL when available', () => {
       const originalEnv = process.env.JINA_API_URL;
       process.env.JINA_API_URL = 'https://env-jina-endpoint.com/v1/rerank';
-      
+
       const reranker = new JinaReranker({
         apiKey: 'test-key',
         logger: mockLogger,
       });
-      
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = getApiUrl(reranker);
       expect(apiUrl).toBe('https://env-jina-endpoint.com/v1/rerank');
-      
-      // Restore original environment
-      if (originalEnv) {
+
+      if (typeof originalEnv === 'string') {
         process.env.JINA_API_URL = originalEnv;
       } else {
         delete process.env.JINA_API_URL;
@@ -51,19 +104,18 @@ describe('JinaReranker', () => {
     it('should prioritize explicit apiUrl over environment variable', () => {
       const originalEnv = process.env.JINA_API_URL;
       process.env.JINA_API_URL = 'https://env-jina-endpoint.com/v1/rerank';
-      
+
       const customUrl = 'https://explicit-jina-endpoint.com/v1/rerank';
       const reranker = new JinaReranker({
         apiKey: 'test-key',
         apiUrl: customUrl,
         logger: mockLogger,
       });
-      
-      const apiUrl = (reranker as any).apiUrl;
+
+      const apiUrl = getApiUrl(reranker);
       expect(apiUrl).toBe(customUrl);
-      
-      // Restore original environment
-      if (originalEnv) {
+
+      if (typeof originalEnv === 'string') {
         process.env.JINA_API_URL = originalEnv;
       } else {
         delete process.env.JINA_API_URL;
@@ -79,27 +131,80 @@ describe('JinaReranker', () => {
         apiUrl: customUrl,
         logger: mockLogger,
       });
-      
-      const logSpy = jest.spyOn(mockLogger, 'debug');
-      
-      try {
-        await reranker.rerank('test query', ['document1', 'document2'], 2);
-      } catch (error) {
-        // Expected to fail due to missing API key, but we can check the log
-      }
-      
+
+      const logSpy = jest
+        .spyOn(mockLogger, 'debug')
+        .mockImplementation(() => mockLogger);
+      jest.spyOn(mockLogger, 'error').mockImplementation(() => mockLogger);
+      jest
+        .spyOn(axios, 'post')
+        .mockRejectedValueOnce(new Error('Network error'));
+
+      await reranker.rerank('test query', ['document1', 'document2'], 2);
+
       expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining(`Reranking 2 chunks with Jina using API URL: ${customUrl}`)
+        expect.stringContaining(
+          `Reranking 2 chunks with Jina using API URL: ${customUrl}`
+        )
       );
-      
-      logSpy.mockRestore();
+    });
+
+    it('should log compact Axios errors without request internals', async () => {
+      const customUrl = 'https://test-jina-endpoint.com/v1/rerank?api_key=hidden';
+      const reranker = new JinaReranker({
+        apiKey: 'test-key',
+        apiUrl: customUrl,
+        logger: mockLogger,
+      });
+      const errorSpy = jest
+        .spyOn(mockLogger, 'error')
+        .mockImplementation(() => mockLogger);
+      jest.spyOn(mockLogger, 'debug').mockImplementation(() => mockLogger);
+      jest.spyOn(axios, 'isAxiosError').mockReturnValue(true);
+      jest.spyOn(axios, 'post').mockRejectedValueOnce(
+        createAxiosErrorFixture(customUrl, {
+          message: 'upstream failed',
+          details: 'x'.repeat(5000),
+        })
+      );
+
+      const result = await reranker.rerank(
+        'test query',
+        ['document1', 'document2'],
+        2
+      );
+
+      expect(result).toEqual([
+        { text: 'document1', score: 0 },
+        { text: 'document2', score: 0 },
+      ]);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Error using Jina reranker',
+        expect.objectContaining({
+          code: 'ERR_BAD_RESPONSE',
+          message: 'Request failed with status code 500',
+          method: 'POST',
+          name: 'Error',
+          responseData: expect.stringContaining('upstream failed'),
+          status: 500,
+          url: 'https://test-jina-endpoint.com/v1/rerank',
+        })
+      );
+
+      const metadata = errorSpy.mock.calls.flat()[1];
+      const serializedMetadata = JSON.stringify(metadata);
+
+      expect(serializedMetadata).toContain('[truncated]');
+      expect(serializedMetadata).not.toContain('Authorization');
+      expect(serializedMetadata).not.toContain('api_key');
+      expect(serializedMetadata).not.toContain('document1');
+      expect(serializedMetadata).not.toContain('test-key');
+      expect(serializedMetadata.length).toBeLessThan(2600);
     });
   });
 });
 
 describe('createReranker', () => {
-  const { createReranker } = require('./rerankers');
-  
   it('should create JinaReranker with jinaApiUrl when provided', () => {
     const customUrl = 'https://custom-jina-endpoint.com/v1/rerank';
     const reranker = createReranker({
@@ -107,9 +212,12 @@ describe('createReranker', () => {
       jinaApiKey: 'test-key',
       jinaApiUrl: customUrl,
     });
-    
+
     expect(reranker).toBeInstanceOf(JinaReranker);
-    const apiUrl = (reranker as any).apiUrl;
+    if (!(reranker instanceof JinaReranker)) {
+      throw new Error('Expected createReranker to return a JinaReranker.');
+    }
+    const apiUrl = getApiUrl(reranker);
     expect(apiUrl).toBe(customUrl);
   });
 
@@ -118,9 +226,12 @@ describe('createReranker', () => {
       rerankerType: 'jina',
       jinaApiKey: 'test-key',
     });
-    
+
     expect(reranker).toBeInstanceOf(JinaReranker);
-    const apiUrl = (reranker as any).apiUrl;
+    if (!(reranker instanceof JinaReranker)) {
+      throw new Error('Expected createReranker to return a JinaReranker.');
+    }
+    const apiUrl = getApiUrl(reranker);
     expect(apiUrl).toBe('https://api.jina.ai/v1/rerank');
   });
 });

--- a/src/tools/search/jina-reranker.test.ts
+++ b/src/tools/search/jina-reranker.test.ts
@@ -185,7 +185,7 @@ describe('JinaReranker', () => {
           message: 'Request failed with status code 500',
           method: 'POST',
           name: 'Error',
-          responseData: expect.stringContaining('upstream failed'),
+          responseDataSummary: 'object(2)',
           status: 500,
           url: 'https://test-jina-endpoint.com/v1/rerank',
         })
@@ -194,12 +194,12 @@ describe('JinaReranker', () => {
       const metadata = errorSpy.mock.calls.flat()[1];
       const serializedMetadata = JSON.stringify(metadata);
 
-      expect(serializedMetadata).toContain('[truncated]');
+      expect(serializedMetadata).not.toContain('upstream failed');
       expect(serializedMetadata).not.toContain('Authorization');
       expect(serializedMetadata).not.toContain('api_key');
       expect(serializedMetadata).not.toContain('document1');
       expect(serializedMetadata).not.toContain('test-key');
-      expect(serializedMetadata.length).toBeLessThan(2600);
+      expect(serializedMetadata.length).toBeLessThan(500);
     });
   });
 });

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -1,6 +1,13 @@
 import axios from 'axios';
 import type * as t from './types';
-import { createDefaultLogger } from './utils';
+import { createDefaultLogger, formatErrorForLog } from './utils';
+
+const DEFAULT_JINA_API_URL = 'https://api.jina.ai/v1/rerank';
+
+const getDefaultJinaApiUrl = (): string =>
+  process.env.JINA_API_URL != null && process.env.JINA_API_URL !== ''
+    ? process.env.JINA_API_URL
+    : DEFAULT_JINA_API_URL;
 
 export abstract class BaseReranker {
   protected apiKey: string | undefined;
@@ -32,7 +39,7 @@ export class JinaReranker extends BaseReranker {
 
   constructor({
     apiKey = process.env.JINA_API_KEY,
-    apiUrl = process.env.JINA_API_URL || 'https://api.jina.ai/v1/rerank',
+    apiUrl = getDefaultJinaApiUrl(),
     logger,
   }: {
     apiKey?: string;
@@ -107,7 +114,7 @@ export class JinaReranker extends BaseReranker {
         return this.getDefaultRanking(documents, topK);
       }
     } catch (error) {
-      this.logger.error('Error using Jina reranker:', error);
+      this.logger.error('Error using Jina reranker', formatErrorForLog(error));
       // Fallback to default ranking on error
       return this.getDefaultRanking(documents, topK);
     }
@@ -174,7 +181,10 @@ export class CohereReranker extends BaseReranker {
         return this.getDefaultRanking(documents, topK);
       }
     } catch (error) {
-      this.logger.error('Error using Cohere reranker:', error);
+      this.logger.error(
+        'Error using Cohere reranker',
+        formatErrorForLog(error)
+      );
       // Fallback to default ranking on error
       return this.getDefaultRanking(documents, topK);
     }

--- a/src/tools/search/tavily-search.ts
+++ b/src/tools/search/tavily-search.ts
@@ -3,7 +3,7 @@ import type * as t from './types';
 
 const DEFAULT_TAVILY_TIMEOUT = 15000;
 
-const TAVILY_COUNTRY_ALIASES: Record<string, string> = {
+const TAVILY_COUNTRY_ALIASES: Partial<Record<string, string>> = {
   ba: 'bosnia and herzegovina',
   cg: 'congo',
   cz: 'czech republic',
@@ -319,7 +319,7 @@ export const createTavilyAPI = (
       if (tavilyCountry != null) {
         payload.country = tavilyCountry;
       }
-      if (type === 'images' || options?.includeImages) {
+      if (type === 'images' || options?.includeImages === true) {
         payload.include_images = true;
       }
       if (options?.includeAnswer != null) {

--- a/src/tools/search/utils.ts
+++ b/src/tools/search/utils.ts
@@ -1,6 +1,22 @@
 /* eslint-disable no-console */
 
+import { isAxiosError } from 'axios';
+
+import type { AxiosError } from 'axios';
 import type * as t from './types';
+
+const LOG_VALUE_MAX_LENGTH = 2048;
+
+export interface SafeErrorLog {
+  message: string;
+  name?: string;
+  code?: string;
+  status?: number;
+  method?: string;
+  url?: string;
+  responseData?: string;
+  value?: string;
+}
 
 /**
  * Singleton instance of the default logger
@@ -24,6 +40,86 @@ export const createDefaultLogger = (): t.Logger => {
   return defaultLoggerInstance;
 };
 
+const truncateLogValue = (value: string): string =>
+  value.length <= LOG_VALUE_MAX_LENGTH
+    ? value
+    : `${value.slice(0, LOG_VALUE_MAX_LENGTH)}... [truncated]`;
+
+const stringifyLogValue = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return truncateLogValue(value);
+  }
+  if (
+    typeof value === 'undefined' ||
+    typeof value === 'function' ||
+    typeof value === 'symbol'
+  ) {
+    return truncateLogValue(String(value));
+  }
+
+  try {
+    return truncateLogValue(JSON.stringify(value));
+  } catch {
+    return truncateLogValue(String(value));
+  }
+};
+
+const sanitizeUrlForLog = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    return truncateLogValue(`${parsed.origin}${parsed.pathname}`);
+  } catch {
+    return truncateLogValue(url.split('?')[0].split('#')[0]);
+  }
+};
+
+const formatAxiosErrorForLog = (
+  error: AxiosError<unknown, unknown>
+): SafeErrorLog => {
+  const log: SafeErrorLog = {
+    message: error.message,
+    name: error.name,
+  };
+  const { code, config, response, status } = error;
+  const responseStatus = response?.status ?? status;
+  const method = config?.method;
+  const url = config?.url;
+
+  if (typeof code === 'string' && code !== '') {
+    log.code = code;
+  }
+  if (responseStatus != null) {
+    log.status = responseStatus;
+  }
+  if (typeof method === 'string' && method !== '') {
+    log.method = method.toUpperCase();
+  }
+  if (typeof url === 'string' && url !== '') {
+    log.url = sanitizeUrlForLog(url);
+  }
+  if (typeof response?.data !== 'undefined') {
+    log.responseData = stringifyLogValue(response.data);
+  }
+
+  return log;
+};
+
+export const formatErrorForLog = (error: unknown): SafeErrorLog => {
+  if (isAxiosError<unknown, unknown>(error)) {
+    return formatAxiosErrorForLog(error);
+  }
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+    };
+  }
+  return {
+    message: String(error),
+    value: stringifyLogValue(error),
+  };
+};
+
 export const fileExtRegex =
   /\.(pdf|jpe?g|png|gif|svg|webp|bmp|ico|tiff?|avif|heic|doc[xm]?|xls[xm]?|ppt[xm]?|zip|rar|mp[34]|mov|avi|wav)(?:\?.*)?$/i;
 
@@ -33,16 +129,13 @@ export const getDomainName = (
   logger?: t.Logger
 ): string | undefined => {
   try {
-    const sourceUrl = metadata?.sourceURL;
-    const metadataUrl = metadata?.url;
-    const url =
-      typeof sourceUrl === 'string'
-        ? sourceUrl
-        : typeof metadataUrl === 'string'
-          ? metadataUrl
-          : link || '';
+    const sourceUrl =
+      typeof metadata?.sourceURL === 'string' ? metadata.sourceURL : undefined;
+    const metadataUrl =
+      typeof metadata?.url === 'string' ? metadata.url : undefined;
+    const url = sourceUrl ?? metadataUrl ?? link;
     const domain = new URL(url).hostname.replace(/^www\./, '');
-    if (domain) {
+    if (domain !== '') {
       return domain;
     }
   } catch (e) {

--- a/src/tools/search/utils.ts
+++ b/src/tools/search/utils.ts
@@ -14,7 +14,7 @@ export interface SafeErrorLog {
   status?: number;
   method?: string;
   url?: string;
-  responseData?: string;
+  responseDataSummary?: string;
   value?: string;
 }
 
@@ -45,23 +45,20 @@ const truncateLogValue = (value: string): string =>
     ? value
     : `${value.slice(0, LOG_VALUE_MAX_LENGTH)}... [truncated]`;
 
-const stringifyLogValue = (value: unknown): string => {
+const summarizeLogValue = (value: unknown): string => {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return `array(${value.length})`;
+  }
   if (typeof value === 'string') {
-    return truncateLogValue(value);
+    return `string(${value.length})`;
   }
-  if (
-    typeof value === 'undefined' ||
-    typeof value === 'function' ||
-    typeof value === 'symbol'
-  ) {
-    return truncateLogValue(String(value));
+  if (typeof value === 'object') {
+    return `object(${Object.keys(value).length})`;
   }
-
-  try {
-    return truncateLogValue(JSON.stringify(value));
-  } catch {
-    return truncateLogValue(String(value));
-  }
+  return typeof value;
 };
 
 const sanitizeUrlForLog = (url: string): string => {
@@ -98,7 +95,7 @@ const formatAxiosErrorForLog = (
     log.url = sanitizeUrlForLog(url);
   }
   if (typeof response?.data !== 'undefined') {
-    log.responseData = stringifyLogValue(response.data);
+    log.responseDataSummary = summarizeLogValue(response.data);
   }
 
   return log;
@@ -116,7 +113,7 @@ export const formatErrorForLog = (error: unknown): SafeErrorLog => {
   }
   return {
     message: String(error),
-    value: stringifyLogValue(error),
+    value: summarizeLogValue(error),
   };
 };
 


### PR DESCRIPTION
## Summary

I fixed the reranker error logging path so failed Axios calls no longer serialize request internals, auth headers, socket state, submitted payloads, or response body contents into production logs.

- Added a compact `formatErrorForLog` helper for search tools that detects Axios errors, preserves useful fields, strips URL query strings, and summarizes response body shape without logging contents.
- Updated Jina and Cohere reranker catch blocks to log safe structured metadata while preserving default-ranking fallback behavior.
- Added Jina reranker regression coverage to verify compact Axios metadata and ensure auth headers, query secrets, submitted documents, and echoed upstream response text are not logged.
- Cleaned nearby Tavily search lint warnings with behavior-preserving type and boolean checks.

Closes #219.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/tools/search/jina-reranker.test.ts --runInBand`
- `npx jest src/tools/search/tavily.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx eslint src/tools/search`
- `git diff --check`

### **Test Configuration**:

- Node dependencies installed with `npm ci --ignore-scripts`
- Local checkout: `/Users/danny/.codex/worktrees/1fe7/agents`

Note: `npx eslint src/` still reports unrelated existing errors/warnings outside this change set, primarily in local/tool tests and OpenAI utilities.

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes