### PR TITLE
feat(hooks): add executingAgentId to attribute tool batches to their agent

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1218,6 +1218,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         sessions: this.sessions,
         toolDefinitions: toolDefMap,
         agentId: agentContext?.agentId,
+        executingAgentId: agentContext?.agentId,
         toolCallStepIds: this.toolCallStepIds,
         toolRegistry: agentContext?.toolRegistry,
         hookRegistry: this.hookRegistry,
@@ -1262,6 +1263,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       trace: traceToolNode,
       runLangfuse: this.langfuse,
       agentLangfuse: agentContext?.langfuse,
+      // `agentId` is intentionally left unset on this path (it is the
+      // subagent-scope marker); `executingAgentId` always identifies the owning
+      // agent so hooks can attribute the batch even at the top level.
+      executingAgentId: agentContext?.agentId,
       toolCallStepIds: this.toolCallStepIds,
       errorHandler: (data, metadata): Promise<void> =>
         StandardGraph.handleToolCallErrorStatic(this, data, metadata),

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -39,11 +39,16 @@ export type StopDecision = 'continue' | 'block';
  * - `runId` identifies the current agent run and is always present.
  * - `threadId` identifies the conversation thread when the host has one.
  * - `agentId` is only set when the hook fires inside a subagent scope.
+ * - `executingAgentId` identifies the agent that owns the node emitting the hook,
+ *   whenever the graph knows it — including top-level agents in a multi-agent
+ *   graph (where `agentId` is intentionally undefined). Use this to attribute a
+ *   hook to a specific agent regardless of subagent scope.
  */
 export interface BaseHookInput {
   runId: string;
   threadId?: string;
   agentId?: string;
+  executingAgentId?: string;
 }
 
 export interface RunStartHookInput extends BaseHookInput {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -534,7 +534,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.eagerEventToolExecutions = eagerEventToolExecutions;
     this.eagerEventToolUsageCount = eagerEventToolUsageCount;
     this.agentId = agentId;
-    this.executingAgentId = executingAgentId;
+    // Default to agentId so callers constructing ToolNode directly (who pass the
+    // existing agentId option) still get attribution without knowing the new option.
+    this.executingAgentId = executingAgentId ?? agentId;
     this.directToolNames = directToolNames;
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
@@ -934,6 +936,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             runId: (config.configurable?.run_id as string | undefined) ?? '',
             threadId: config.configurable?.thread_id as string | undefined,
             agentId: this.agentId,
+            executingAgentId: this.executingAgentId,
           },
         };
       } else if (call.name === Constants.TOOL_SEARCH) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -431,6 +431,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private eagerEventToolUsageCount?: Map<string, number>;
   /** Agent ID for event-driven mode */
   private agentId?: string;
+  /**
+   * ID of the agent that owns this tool node, whenever the graph knows it
+   * (including top-level agents in a multi-agent graph). Surfaced to hooks as
+   * `executingAgentId` so they can attribute a tool batch to a specific agent
+   * even where `agentId` (the subagent-scope marker) is undefined.
+   */
+  private executingAgentId?: string;
   /** Tool names that bypass event dispatch and execute directly (e.g., graph-managed handoff tools) */
   private directToolNames?: Set<string>;
   /**
@@ -492,6 +499,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     eagerEventToolExecutions,
     eagerEventToolUsageCount,
     agentId,
+    executingAgentId,
     directToolNames,
     maxContextTokens,
     maxToolResultChars,
@@ -526,6 +534,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.eagerEventToolExecutions = eagerEventToolExecutions;
     this.eagerEventToolUsageCount = eagerEventToolUsageCount;
     this.agentId = agentId;
+    this.executingAgentId = executingAgentId;
     this.directToolNames = directToolNames;
     this.maxToolResultChars =
       maxToolResultChars ?? calculateMaxToolResultChars(maxContextTokens);
@@ -1260,6 +1269,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executingAgentId: this.executingAgentId,
           toolName: call.name,
           toolInput: resolvedArgs,
           toolUseId: call.id ?? '',
@@ -1467,6 +1477,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executingAgentId: this.executingAgentId,
           toolName: call.name,
           toolInput: effectiveCall.args as Record<string, unknown>,
           toolUseId: call.id ?? '',
@@ -1500,6 +1511,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executingAgentId: this.executingAgentId,
           toolName: call.name,
           toolInput: effectiveCall.args as Record<string, unknown>,
           toolOutput: output.content,
@@ -1606,6 +1618,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executingAgentId: this.executingAgentId,
           toolName: call.name,
           toolInput: resolvedArgs,
           toolUseId: call.id ?? '',
@@ -1950,6 +1963,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               runId,
               threadId,
               agentId: this.agentId,
+              executingAgentId: this.executingAgentId,
               toolName: entry.call.name,
               toolInput: entry.args,
               toolUseId: entry.call.id!,
@@ -2041,6 +2055,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 runId,
                 threadId,
                 agentId: this.agentId,
+                executingAgentId: this.executingAgentId,
                 toolName: item.toolName,
                 toolInput: item.args,
                 toolUseId: item.callId,
@@ -2609,6 +2624,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 runId,
                 threadId,
                 agentId: this.agentId,
+                executingAgentId: this.executingAgentId,
                 toolName,
                 toolInput: request?.args ?? {},
                 toolUseId: result.toolCallId,
@@ -2652,6 +2668,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 runId,
                 threadId,
                 agentId: this.agentId,
+                executingAgentId: this.executingAgentId,
                 toolName,
                 toolInput: request?.args ?? {},
                 toolOutput: result.content,
@@ -2889,6 +2906,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executingAgentId: this.executingAgentId,
           entries: orderedBatchEntries,
         },
         sessionId: runId,

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1464,6 +1464,30 @@ for member in team:
       expect(gate.denyReason).toContain('no writes from bridge');
     });
 
+    it('threads executingAgentId from the hook context to bridge PreToolUse hooks', async () => {
+      const { HookRegistry } = await import('@/hooks');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const ptcMod = require('../local/LocalProgrammaticToolCalling');
+      const registry = new HookRegistry();
+      let seen: string | undefined = 'UNSET';
+      registry.register('PreToolUse', {
+        hooks: [
+          // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+          async (input) => {
+            seen = input.executingAgentId;
+            return { decision: 'allow' };
+          },
+        ],
+      });
+      await ptcMod.applyPreToolUseHooksForBridge(
+        { registry, runId: 'r1', executingAgentId: 'repo_investigator' },
+        'write_file',
+        'call_1',
+        { path: '/tmp/x' }
+      );
+      expect(seen).toBe('repo_investigator');
+    });
+
     it('passes through when no hook denies (allow path)', async () => {
       const { HookRegistry } = await import('@/hooks');
       // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/src/tools/__tests__/directToolHooks.test.ts
+++ b/src/tools/__tests__/directToolHooks.test.ts
@@ -147,6 +147,47 @@ describe('Direct-path lifecycle hooks (in-process tools)', () => {
     expect(String(message.content)).toBe('ran:ls');
   });
 
+  it('executingAgentId defaults to agentId for direct callers, and an explicit value wins', async () => {
+    const echo = createDirectTool('echo', (args) => `ran:${args.command}`);
+    const captured: Array<string | undefined> = [];
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> => {
+          captured.push(input.executingAgentId);
+          return { decision: 'allow' };
+        },
+      ],
+    });
+
+    // Only the existing `agentId` option is passed → executingAgentId defaults to it.
+    const defaulted = new ToolNode({
+      tools: [echo],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['echo']),
+      agentId: 'solo-agent',
+    });
+    await defaulted.invoke({
+      messages: [aiCall('call_def', 'echo', { command: 'a' })],
+    });
+
+    // An explicit executingAgentId overrides the agentId default.
+    const explicit = new ToolNode({
+      tools: [echo],
+      eventDrivenMode: true,
+      hookRegistry: registry,
+      directToolNames: new Set(['echo']),
+      agentId: 'solo-agent',
+      executingAgentId: 'owner-agent',
+    });
+    await explicit.invoke({
+      messages: [aiCall('call_exp', 'echo', { command: 'b' })],
+    });
+
+    expect(captured).toEqual(['solo-agent', 'owner-agent']);
+  });
+
   it('PreToolUse updatedInput rewrites the args before runTool sees them', async () => {
     const seen: Record<string, unknown>[] = [];
     const echo = createDirectTool('echo', (args) => {

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -292,11 +292,16 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     const registry = new HookRegistry();
     const preToolEvents: string[] = [];
     const postToolEvents: string[] = [];
+    // `executingAgentId` is always the owning agent (incl. top-level), unlike
+    // `agentId` which stays undefined outside a subagent scope.
+    const preExecEvents: string[] = [];
+    const postExecEvents: string[] = [];
 
     const preHook: HookCallback<'PreToolUse'> = async (
       input
     ): Promise<PreToolUseHookOutput> => {
       preToolEvents.push(`${input.agentId ?? '-'}:${input.toolName}`);
+      preExecEvents.push(`${input.executingAgentId ?? '-'}:${input.toolName}`);
       return { decision: 'allow' };
     };
     registry.register('PreToolUse', { hooks: [preHook] });
@@ -305,6 +310,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       input
     ): Promise<PostToolUseHookOutput> => {
       postToolEvents.push(`${input.agentId ?? '-'}:${input.toolName}`);
+      postExecEvents.push(`${input.executingAgentId ?? '-'}:${input.toolName}`);
       return {};
     };
     registry.register('PostToolUse', { hooks: [postHook] });
@@ -351,6 +357,14 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     expect(preToolEvents).toContain('researcher-child:calculator');
     expect(postToolEvents).toContain('-:subagent');
     expect(postToolEvents).toContain('researcher-child:calculator');
+
+    // `agentId` stays the subagent-scope marker (undefined at the top level),
+    // but `executingAgentId` attributes every batch to its owning agent — incl.
+    // the top-level parent, which a multi-agent host needs and `agentId` can't give.
+    expect(preExecEvents).toContain('hook-parent:subagent');
+    expect(preExecEvents).toContain('researcher-child:calculator');
+    expect(postExecEvents).toContain('hook-parent:subagent');
+    expect(postExecEvents).toContain('researcher-child:calculator');
   });
 
   it('child subagent tool ask hooks fail closed instead of starting unsupported nested HITL', async () => {

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -219,6 +219,7 @@ export async function applyPreToolUseHooksForBridge(
       runId: hookContext.runId,
       threadId: hookContext.threadId,
       agentId: hookContext.agentId,
+      executingAgentId: hookContext.executingAgentId,
       toolName,
       toolInput,
       toolUseId,

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -970,6 +970,7 @@ export type ProgrammaticHookContext = {
   runId: string;
   threadId?: string;
   agentId?: string;
+  executingAgentId?: string;
 };
 
 /** Search mode: code_interpreter uses external sandbox, local uses safe substring matching */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -93,6 +93,9 @@ export type ToolNodeOptions = {
   toolDefinitions?: Map<string, LCTool>;
   /** Agent ID for event-driven mode (used to identify which agent's context to use) */
   agentId?: string;
+  /** ID of the agent that owns this tool node, surfaced to hooks as `executingAgentId`
+   * so a batch can be attributed to a specific agent even where `agentId` is undefined. */
+  executingAgentId?: string;
   /** Tool names that must be executed directly (via runTool) even in event-driven mode (e.g., graph-managed handoff tools) */
   directToolNames?: Set<string>;
   /** Opt-in eager execution for event-driven tool calls. */


### PR DESCRIPTION
## Problem

The hook `agentId` is a **subagent-scope marker** — it's `undefined` for top-level agents (documented on `BaseHookInput`, asserted in `subagentHooks.test.ts`). In a **multi-agent graph**, an agent whose tools run via the **traditional `ToolNode` path** (engine/runtime tools, i.e. no `toolDefinitions`) emits `PostToolBatch` / `PreToolUse` / `PostToolUse` / `PermissionDenied` with **no way to attribute the batch to the owning agent**.

Root inconsistency in `Graph.initializeTools`: the **event-driven** path passes `agentId: agentContext?.agentId`, but the **traditional** path **omits it**. So the same agent reports its id when using event-driven tools and `undefined` when using engine/runtime tools. "Fixing" that by populating `agentId` on the traditional path would change the documented subagent-scope semantics and break `subagentHooks.test.ts`.

## Fix (additive, non-breaking)

Introduce **`executingAgentId`** on `BaseHookInput`, always set to the owning agent's id — including top-level agents in a multi-agent graph. `agentId` is left **completely unchanged**, so the subagent-scope contract and all existing hosts are untouched.

- `BaseHookInput.executingAgentId` + `ToolNodeOptions.executingAgentId` (types)
- `ToolNode`: new field + ctor param (defaults to `executingAgentId ?? agentId` so direct callers get it for free), surfaced at all 9 hook-emission sites
- `Graph.initializeTools`: pass `executingAgentId: agentContext?.agentId` on **both** ToolNode paths
- Programmatic bridge: threaded through `ProgrammaticHookContext` → `applyPreToolUseHooksForBridge` so inner programmatic tool calls (`write_file`/`edit_file`) are attributed too

## Verification

- `tsc --noEmit` clean; full `npm run build` clean; `eslint` clean.
- Tool/hook suites pass, incl. new tests: top-level agent has `agentId: undefined` **but** `executingAgentId` set (through the real `Run` pipeline); direct-ToolNode default + override; programmatic-bridge threading.

## Motivation

Found while auditing hook agent-attribution for a multi-agent triage graph. Per-agent hook logic (budgeting/inspecting one agent's tool batches) wasn't reliable for agents on the traditional/engine-tool path, where `agentId` arrives `undefined`. `executingAgentId` gives hosts a dependable "which agent ran this" signal without disturbing the subagent-scope meaning of `agentId`.
