### PR TITLE
🕶️ feat: Configurable Redaction of Langfuse Message Content

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -130,6 +130,7 @@ function getLangfuseTracerProviderKey(
     baseUrl: params.baseUrl,
     environment: params.environment,
     toolOutputTracing: langfuse?.toolOutputTracing,
+    messageContentRedaction: langfuse?.messageContentRedaction,
   });
 }
 

--- a/src/langfuseContentRedaction.ts
+++ b/src/langfuseContentRedaction.ts
@@ -1,0 +1,348 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createContextKey } from '@opentelemetry/api';
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import type { Context } from '@opentelemetry/api';
+import type * as t from '@/types';
+
+export const LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT = '[REDACTED]';
+
+export type SensitivePattern = {
+  id: string;
+  label: string;
+  pattern: RegExp;
+};
+
+export type ResolvedLangfuseMessageContentRedactionConfig = {
+  enabled: boolean;
+  patterns: SensitivePattern[];
+  redactionText: string;
+};
+
+const messageContentRedactionConfigKey = createContextKey(
+  'librechat.langfuse.message-content-redaction'
+);
+const messageContentRedactionStorage =
+  new AsyncLocalStorage<ResolvedLangfuseMessageContentRedactionConfig>();
+
+const SCANNED_SPAN_ATTRIBUTE_KEYS = [
+  LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+  LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT,
+  LangfuseOtelSpanAttributes.TRACE_INPUT,
+  LangfuseOtelSpanAttributes.TRACE_OUTPUT,
+];
+
+/**
+ * Built-in credential-shaped patterns. Each pattern's first capture group is
+ * the visible prefix that survives redaction (so reviewers can still tell
+ * what kind of secret was scrubbed). Order matters: more specific `sk-`
+ * variants (Anthropic, Langfuse) precede the generic OpenAI pattern, which
+ * uses a negative lookahead to avoid double-matching them.
+ */
+export const SENSITIVE_VALUE_PATTERNS: SensitivePattern[] = [
+  {
+    id: 'aws_access_key',
+    label: 'AWS access key',
+    pattern: /\b(AKIA|ASIA|ABIA|ACCA|A3T[A-Z0-9])[A-Z0-9]{12,16}\b/g,
+  },
+  {
+    id: 'github_token',
+    label: 'GitHub token',
+    pattern: /\b(gh[poshru]_)[A-Za-z0-9]{36,255}\b/g,
+  },
+  {
+    id: 'slack_token',
+    label: 'Slack token',
+    pattern: /\b(xox[bpasr]-)[A-Za-z0-9-]{10,200}/g,
+  },
+  {
+    id: 'google_api_key',
+    label: 'Google API key',
+    pattern: /\b(AIza)[A-Za-z0-9_-]{35}\b/g,
+  },
+  {
+    id: 'stripe_key',
+    label: 'Stripe key',
+    pattern: /\b((?:sk|pk|rk)_(?:live|test|prod)_)[A-Za-z0-9]{10,99}\b/g,
+  },
+  {
+    id: 'anthropic_api_key',
+    label: 'Anthropic API key',
+    pattern: /\b(sk-ant-)[A-Za-z0-9_-]{20,}/g,
+  },
+  {
+    id: 'langfuse_key',
+    label: 'Langfuse key',
+    pattern: /\b((?:pk|sk)-lf-)[A-Za-z0-9-]{20,}/g,
+  },
+  {
+    id: 'openai_api_key',
+    label: 'OpenAI API key',
+    pattern: /\b(sk-(?!ant-|lf-))[A-Za-z0-9_-]{20,}/g,
+  },
+  {
+    id: 'jwt',
+    label: 'JWT',
+    pattern: /\b(eyJ)[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+  },
+  {
+    id: 'bearer_token',
+    label: 'Bearer token',
+    pattern: /\b(Bearer )[A-Za-z0-9._\-=]+/g,
+  },
+  {
+    id: 'api_key_header',
+    label: 'api-key header',
+    pattern: /\b(api-key:\s*)[A-Za-z0-9._\-=]+/gi,
+  },
+  {
+    id: 'api_key_query',
+    label: 'api_key query param',
+    pattern: /\b(api_key=)[^\s"'&]+/gi,
+  },
+];
+
+const PATTERNS_BY_ID = new Map<string, SensitivePattern>(
+  SENSITIVE_VALUE_PATTERNS.map((entry) => [entry.id, entry])
+);
+
+function isPresent(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value == null) {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+  return undefined;
+}
+
+function parsePatternIds(value: string | undefined): string[] | undefined {
+  if (!isPresent(value)) {
+    return undefined;
+  }
+  return value
+    .split(',')
+    .map((id) => id.trim())
+    .filter((id) => id !== '');
+}
+
+function getEnvEnabled(): boolean | undefined {
+  return parseBoolean(process.env.LANGFUSE_REDACT_MESSAGE_CONTENT);
+}
+
+function getEnvPatternIds(): string[] | undefined {
+  return parsePatternIds(process.env.LANGFUSE_REDACT_MESSAGE_CONTENT_PATTERNS);
+}
+
+function getEnvRedactionText(): string | undefined {
+  return isPresent(process.env.LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT)
+    ? process.env.LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT
+    : undefined;
+}
+
+function selectPatterns(ids: string[] | undefined): SensitivePattern[] {
+  if (ids == null) {
+    return SENSITIVE_VALUE_PATTERNS;
+  }
+  const selected: SensitivePattern[] = [];
+  for (const id of ids) {
+    const entry = PATTERNS_BY_ID.get(id);
+    if (entry != null) {
+      selected.push(entry);
+    }
+  }
+  return selected;
+}
+
+export function resolveMessageContentRedactionConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): ResolvedLangfuseMessageContentRedactionConfig {
+  const runConfig = runLangfuse?.messageContentRedaction;
+  const agentConfig = agentLangfuse?.messageContentRedaction;
+
+  const enabled =
+    agentConfig?.enabled ?? runConfig?.enabled ?? getEnvEnabled() ?? false;
+
+  const patternIds =
+    agentConfig?.patternIds ?? runConfig?.patternIds ?? getEnvPatternIds();
+
+  const redactionText =
+    agentConfig?.redactionText ??
+    runConfig?.redactionText ??
+    getEnvRedactionText() ??
+    LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT;
+
+  return {
+    enabled,
+    patterns: selectPatterns(patternIds),
+    redactionText,
+  };
+}
+
+export function shouldApplyMessageContentRedaction(
+  config: ResolvedLangfuseMessageContentRedactionConfig
+): boolean {
+  return config.enabled && config.patterns.length > 0;
+}
+
+function redactString(
+  value: string,
+  config: ResolvedLangfuseMessageContentRedactionConfig
+): { value: string; changed: boolean } {
+  let next = value;
+  let changed = false;
+  for (const { pattern } of config.patterns) {
+    pattern.lastIndex = 0;
+    const replaced = next.replace(pattern, `$1${config.redactionText}`);
+    if (replaced !== next) {
+      next = replaced;
+      changed = true;
+    }
+  }
+  return { value: next, changed };
+}
+
+function redactValue(
+  value: unknown,
+  config: ResolvedLangfuseMessageContentRedactionConfig
+): { value: unknown; changed: boolean } {
+  if (typeof value === 'string') {
+    return redactString(value, config);
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next: unknown[] = [];
+    for (const item of value) {
+      const result = redactValue(item, config);
+      next.push(result.value);
+      if (result.changed) {
+        changed = true;
+      }
+    }
+    return changed ? { value: next, changed } : { value, changed: false };
+  }
+
+  if (!isRecord(value)) {
+    return { value, changed: false };
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const result = redactValue(child, config);
+    next[key] = result.value;
+    if (result.changed) {
+      changed = true;
+    }
+  }
+  return changed ? { value: next, changed } : { value, changed: false };
+}
+
+function redactSpanAttribute(
+  attributes: Record<string, unknown>,
+  key: string,
+  config: ResolvedLangfuseMessageContentRedactionConfig
+): void {
+  if (!(key in attributes)) {
+    return;
+  }
+
+  const value = attributes[key];
+
+  if (typeof value !== 'string') {
+    const result = redactValue(value, config);
+    if (result.changed) {
+      attributes[key] = result.value;
+    }
+    return;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      const result = redactValue(parsed, config);
+      if (result.changed) {
+        attributes[key] = JSON.stringify(result.value);
+        return;
+      }
+    } catch {
+      // fall through to plain-string scrub
+    }
+  }
+
+  const result = redactString(value, config);
+  if (result.changed) {
+    attributes[key] = result.value;
+  }
+}
+
+type SpanWithAttributes = ReadableSpan & {
+  attributes: Record<string, unknown>;
+};
+
+export function redactLangfuseSpanMessageContent(
+  span: ReadableSpan,
+  config: ResolvedLangfuseMessageContentRedactionConfig
+): void {
+  if (!shouldApplyMessageContentRedaction(config)) {
+    return;
+  }
+
+  const attributes = (span as SpanWithAttributes).attributes;
+  for (const key of SCANNED_SPAN_ATTRIBUTE_KEYS) {
+    redactSpanAttribute(attributes, key, config);
+  }
+}
+
+export function getContextMessageContentRedactionConfig(
+  activeContext: Context
+): ResolvedLangfuseMessageContentRedactionConfig | undefined {
+  const asyncConfig = messageContentRedactionStorage.getStore();
+  if (asyncConfig != null) {
+    return asyncConfig;
+  }
+
+  const value = activeContext.getValue(messageContentRedactionConfigKey);
+  return isRecord(value)
+    ? (value as unknown as ResolvedLangfuseMessageContentRedactionConfig)
+    : undefined;
+}
+
+export function setMessageContentRedactionConfigOnContext(
+  activeContext: Context,
+  config: ResolvedLangfuseMessageContentRedactionConfig
+): Context {
+  return activeContext.setValue(messageContentRedactionConfigKey, config);
+}
+
+export function runWithMessageContentRedactionConfig<T>(
+  config: ResolvedLangfuseMessageContentRedactionConfig,
+  action: () => T
+): T {
+  return messageContentRedactionStorage.run(config, action);
+}
+
+export function hasExplicitMessageContentRedactionConfig(
+  runLangfuse?: t.LangfuseConfig,
+  agentLangfuse?: t.LangfuseConfig
+): boolean {
+  return (
+    runLangfuse?.messageContentRedaction != null ||
+    agentLangfuse?.messageContentRedaction != null
+  );
+}

--- a/src/langfuseToolOutputTracing.ts
+++ b/src/langfuseToolOutputTracing.ts
@@ -10,6 +10,15 @@ import type {
 import type { LangfuseSpanProcessorParams } from '@langfuse/otel';
 import type { Context } from '@opentelemetry/api';
 import type * as t from '@/types';
+import {
+  getContextMessageContentRedactionConfig,
+  hasExplicitMessageContentRedactionConfig,
+  redactLangfuseSpanMessageContent,
+  resolveMessageContentRedactionConfig,
+  runWithMessageContentRedactionConfig,
+  setMessageContentRedactionConfigOnContext,
+  type ResolvedLangfuseMessageContentRedactionConfig,
+} from '@/langfuseContentRedaction';
 
 export const LANGFUSE_TOOL_OUTPUT_REDACTION_TEXT = '[tool output redacted]';
 
@@ -535,38 +544,61 @@ export function getContextLangfuseConfig(
   return isRecord(value) ? (value as t.LangfuseConfig) : undefined;
 }
 
-class ToolOutputRedactingLangfuseSpanProcessor implements SpanProcessor {
+class LangfuseRedactingSpanProcessor implements SpanProcessor {
   private readonly processor: LangfuseSpanProcessor;
-  private readonly fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig;
-  private readonly spanConfigs = new WeakMap<
+  private readonly fallbackToolConfig?: ResolvedLangfuseToolOutputTracingConfig;
+  private readonly fallbackContentConfig?: ResolvedLangfuseMessageContentRedactionConfig;
+  private readonly spanToolConfigs = new WeakMap<
     object,
     ResolvedLangfuseToolOutputTracingConfig
+  >();
+  private readonly spanContentConfigs = new WeakMap<
+    object,
+    ResolvedLangfuseMessageContentRedactionConfig
   >();
 
   constructor(
     params?: LangfuseSpanProcessorParams,
-    fallbackConfig?: ResolvedLangfuseToolOutputTracingConfig
+    fallbackToolConfig?: ResolvedLangfuseToolOutputTracingConfig,
+    fallbackContentConfig?: ResolvedLangfuseMessageContentRedactionConfig
   ) {
     this.processor = new LangfuseSpanProcessor(params);
-    this.fallbackConfig = fallbackConfig;
+    this.fallbackToolConfig = fallbackToolConfig;
+    this.fallbackContentConfig = fallbackContentConfig;
   }
 
   onStart(span: Span, parentContext: Context): void {
-    const config =
-      getContextToolOutputTracingConfig(parentContext) ?? this.fallbackConfig;
-    if (config != null) {
-      this.spanConfigs.set(span, config);
+    const toolConfig =
+      getContextToolOutputTracingConfig(parentContext) ??
+      this.fallbackToolConfig;
+    if (toolConfig != null) {
+      this.spanToolConfigs.set(span, toolConfig);
     }
+
+    const contentConfig =
+      getContextMessageContentRedactionConfig(parentContext) ??
+      this.fallbackContentConfig;
+    if (contentConfig != null) {
+      this.spanContentConfigs.set(span, contentConfig);
+    }
+
     this.processor.onStart(span, parentContext);
   }
 
   onEnd(span: ReadableSpan): void {
-    const config =
-      this.spanConfigs.get(span) ??
+    const toolConfig =
+      this.spanToolConfigs.get(span) ??
       toolOutputTracingStorage.getStore() ??
-      this.fallbackConfig ??
+      this.fallbackToolConfig ??
       resolveToolOutputTracingConfig();
-    redactLangfuseSpanToolOutputs(span, config);
+    redactLangfuseSpanToolOutputs(span, toolConfig);
+
+    const contentConfig =
+      this.spanContentConfigs.get(span) ??
+      this.fallbackContentConfig ??
+      resolveMessageContentRedactionConfig();
+    redactLangfuseSpanMessageContent(span, contentConfig);
+
     this.processor.onEnd(span);
   }
 
@@ -584,11 +616,18 @@ export function createLangfuseSpanProcessor(
   runLangfuse?: t.LangfuseConfig,
   agentLangfuse?: t.LangfuseConfig
 ): SpanProcessor {
-  const fallbackConfig =
-    runLangfuse != null || agentLangfuse != null
-      ? resolveToolOutputTracingConfig(runLangfuse, agentLangfuse)
-      : undefined;
-  return new ToolOutputRedactingLangfuseSpanProcessor(params, fallbackConfig);
+  const hasAnyLangfuseConfig = runLangfuse != null || agentLangfuse != null;
+  const fallbackToolConfig = hasAnyLangfuseConfig
+    ? resolveToolOutputTracingConfig(runLangfuse, agentLangfuse)
+    : undefined;
+  const fallbackContentConfig = hasAnyLangfuseConfig
+    ? resolveMessageContentRedactionConfig(runLangfuse, agentLangfuse)
+    : undefined;
+  return new LangfuseRedactingSpanProcessor(
+    params,
+    fallbackToolConfig,
+    fallbackContentConfig
+  );
 }
 
 export function withLangfuseToolOutputTracingConfig<T>(
@@ -600,30 +639,48 @@ export function withLangfuseToolOutputTracingConfig<T>(
   const hasNoToolOutputConfig =
     runLangfuse?.toolOutputTracing == null &&
     agentLangfuse?.toolOutputTracing == null;
+  const hasNoContentConfig = !hasExplicitMessageContentRedactionConfig(
+    runLangfuse,
+    agentLangfuse
+  );
 
-  if (langfuse == null && hasNoToolOutputConfig) {
+  if (langfuse == null && hasNoToolOutputConfig && hasNoContentConfig) {
     return action();
   }
 
-  const config = hasNoToolOutputConfig
+  const toolConfig = hasNoToolOutputConfig
     ? undefined
     : resolveToolOutputTracingConfig(runLangfuse, agentLangfuse);
+  const contentConfig = hasNoContentConfig
+    ? undefined
+    : resolveMessageContentRedactionConfig(runLangfuse, agentLangfuse);
+
   let activeContext = context.active();
   if (langfuse != null) {
     activeContext = activeContext.setValue(langfuseConfigKey, langfuse);
   }
-  if (config != null) {
+  if (toolConfig != null) {
     activeContext = activeContext.setValue(
       langfuseToolOutputTracingConfigKey,
-      config
+      toolConfig
+    );
+  }
+  if (contentConfig != null) {
+    activeContext = setMessageContentRedactionConfigOnContext(
+      activeContext,
+      contentConfig
     );
   }
 
   const runWithContext = (): T => context.with(activeContext, action);
-  const runWithToolOutputConfig = (): T =>
-    config != null
-      ? toolOutputTracingStorage.run(config, runWithContext)
+  const runWithContentConfig = (): T =>
+    contentConfig != null
+      ? runWithMessageContentRedactionConfig(contentConfig, runWithContext)
       : runWithContext();
+  const runWithToolOutputConfig = (): T =>
+    toolConfig != null
+      ? toolOutputTracingStorage.run(toolConfig, runWithContentConfig)
+      : runWithContentConfig();
 
   return langfuse != null
     ? langfuseConfigStorage.run(langfuse, runWithToolOutputConfig)

--- a/src/specs/langfuse-instrumentation.test.ts
+++ b/src/specs/langfuse-instrumentation.test.ts
@@ -33,16 +33,17 @@ type BasicTracerProviderInput = {
     shutdown?: unknown;
   }>;
 };
-type RoutingSpanProcessorForTest = BasicTracerProviderInput['spanProcessors'][0] & {
-  processors: Map<
-    string,
-    {
-      fallbackConfig?: {
-        enabled?: boolean;
-      };
-    }
-  >;
-};
+type RoutingSpanProcessorForTest =
+  BasicTracerProviderInput['spanProcessors'][0] & {
+    processors: Map<
+      string,
+      {
+        fallbackToolConfig?: {
+          enabled?: boolean;
+        };
+      }
+    >;
+  };
 const mockBasicTracerProvider = jest.fn(
   (_input?: BasicTracerProviderInput) => mockTracerProvider
 );
@@ -228,10 +229,10 @@ describe('Langfuse instrumentation', () => {
 
     const providerInput = mockBasicTracerProvider.mock
       .calls[0][0] as BasicTracerProviderInput;
-    const routingProcessor =
-      providerInput.spanProcessors[0] as RoutingSpanProcessorForTest;
+    const routingProcessor = providerInput
+      .spanProcessors[0] as RoutingSpanProcessorForTest;
     const childProcessors = Array.from(routingProcessor.processors.values());
-    expect(childProcessors[0]?.fallbackConfig).toMatchObject({
+    expect(childProcessors[0]?.fallbackToolConfig).toMatchObject({
       enabled: false,
     });
   });

--- a/src/specs/langfuse-message-content-redaction.integration.test.ts
+++ b/src/specs/langfuse-message-content-redaction.integration.test.ts
@@ -1,0 +1,208 @@
+const mockLangfuseSpanProcessorInstance = {
+  onStart: jest.fn(),
+  onEnd: jest.fn(),
+  forceFlush: jest.fn().mockResolvedValue(undefined),
+  shutdown: jest.fn().mockResolvedValue(undefined),
+};
+const mockLangfuseSpanProcessor = jest.fn(
+  () => mockLangfuseSpanProcessorInstance
+);
+
+jest.mock('@langfuse/otel', () => ({
+  LangfuseSpanProcessor: mockLangfuseSpanProcessor,
+  isDefaultExportSpan: jest.fn(() => false),
+}));
+
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import {
+  createLangfuseSpanProcessor,
+  withLangfuseToolOutputTracingConfig,
+} from '@/langfuseToolOutputTracing';
+import type { LangfuseConfig } from '@/types/graph';
+
+function buildPipeline(runLangfuse: LangfuseConfig): {
+  provider: BasicTracerProvider;
+  exporter: InMemorySpanExporter;
+} {
+  const exporter = new InMemorySpanExporter();
+  const redactingProcessor = createLangfuseSpanProcessor(
+    { publicKey: 'pk-test', secretKey: 'sk-test' },
+    runLangfuse
+  );
+  const provider = new BasicTracerProvider({
+    spanProcessors: [redactingProcessor, new SimpleSpanProcessor(exporter)],
+  });
+  return { provider, exporter };
+}
+
+const PROMPT_WITH_CREDENTIAL =
+  'CANARY-XYZ-9876 my key is sk-ant-api03-FAKE1234567890abcdefghij please help';
+
+describe('Langfuse redacting span processor end-to-end', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.LANGFUSE_REDACT_MESSAGE_CONTENT;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('scrubs credentials from generation span input through the full processor pipeline', async () => {
+    const runLangfuse: LangfuseConfig = {
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+      messageContentRedaction: { enabled: true },
+    };
+    const { provider, exporter } = buildPipeline(runLangfuse);
+    const tracer = provider.getTracer('integration-test');
+
+    withLangfuseToolOutputTracingConfig(runLangfuse, () => {
+      const span = tracer.startSpan('chat-generation');
+      span.setAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+        JSON.stringify([{ role: 'user', content: PROMPT_WITH_CREDENTIAL }])
+      );
+      span.end();
+    });
+
+    await provider.forceFlush();
+
+    const captured = exporter.getFinishedSpans();
+    expect(captured).toHaveLength(1);
+
+    const input = captured[0].attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    const parsed = JSON.parse(input) as Array<{ content: string }>;
+
+    expect(parsed[0].content).toContain('CANARY-XYZ-9876');
+    expect(parsed[0].content).toContain('sk-ant-[REDACTED]');
+    expect(parsed[0].content).not.toContain('FAKE1234567890');
+
+    await provider.shutdown();
+  });
+
+  it('preserves tool inputs while scrubbing user-message credentials in the same span', async () => {
+    const runLangfuse: LangfuseConfig = {
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+      messageContentRedaction: { enabled: true },
+    };
+    const { provider, exporter } = buildPipeline(runLangfuse);
+    const tracer = provider.getTracer('integration-test');
+
+    withLangfuseToolOutputTracingConfig(runLangfuse, () => {
+      const span = tracer.startSpan('chat-generation');
+      span.setAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+        JSON.stringify([
+          { role: 'user', content: PROMPT_WITH_CREDENTIAL },
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_sql',
+                name: 'execute_sql',
+                args: { query: 'SELECT 1' },
+              },
+            ],
+          },
+        ])
+      );
+      span.end();
+    });
+
+    await provider.forceFlush();
+
+    const captured = exporter.getFinishedSpans();
+    const input = captured[0].attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    const parsed = JSON.parse(input) as Array<{
+      role: string;
+      content: string;
+      tool_calls?: Array<{ args: { query: string } }>;
+    }>;
+
+    expect(parsed[0].content).toContain('sk-ant-[REDACTED]');
+    expect(parsed[1].tool_calls?.[0].args.query).toBe('SELECT 1');
+
+    await provider.shutdown();
+  });
+
+  it('does not redact when messageContentRedaction is disabled', async () => {
+    const runLangfuse: LangfuseConfig = {
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+      messageContentRedaction: { enabled: false },
+    };
+    const { provider, exporter } = buildPipeline(runLangfuse);
+    const tracer = provider.getTracer('integration-test');
+
+    withLangfuseToolOutputTracingConfig(runLangfuse, () => {
+      const span = tracer.startSpan('chat-generation');
+      span.setAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+        JSON.stringify([{ role: 'user', content: PROMPT_WITH_CREDENTIAL }])
+      );
+      span.end();
+    });
+
+    await provider.forceFlush();
+
+    const captured = exporter.getFinishedSpans();
+    const input = captured[0].attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+
+    expect(input).toContain('FAKE1234567890');
+    expect(input).not.toContain('[REDACTED]');
+
+    await provider.shutdown();
+  });
+
+  it('forwards the same span to the inner LangfuseSpanProcessor so real exports still fire', async () => {
+    const runLangfuse: LangfuseConfig = {
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+      messageContentRedaction: { enabled: true },
+    };
+    const { provider } = buildPipeline(runLangfuse);
+    const tracer = provider.getTracer('integration-test');
+
+    withLangfuseToolOutputTracingConfig(runLangfuse, () => {
+      const span = tracer.startSpan('chat-generation');
+      span.setAttribute(
+        LangfuseOtelSpanAttributes.OBSERVATION_INPUT,
+        JSON.stringify([{ role: 'user', content: PROMPT_WITH_CREDENTIAL }])
+      );
+      span.end();
+    });
+
+    await provider.forceFlush();
+
+    expect(mockLangfuseSpanProcessorInstance.onEnd).toHaveBeenCalledTimes(1);
+    const forwardedSpan =
+      mockLangfuseSpanProcessorInstance.onEnd.mock.calls[0][0];
+    const forwardedInput = forwardedSpan.attributes[
+      LangfuseOtelSpanAttributes.OBSERVATION_INPUT
+    ] as string;
+    expect(forwardedInput).toContain('sk-ant-[REDACTED]');
+    expect(forwardedInput).not.toContain('FAKE1234567890');
+
+    await provider.shutdown();
+  });
+});

--- a/src/specs/langfuse-message-content-redaction.test.ts
+++ b/src/specs/langfuse-message-content-redaction.test.ts
@@ -1,0 +1,380 @@
+import { LangfuseOtelSpanAttributes } from '@langfuse/tracing';
+import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import {
+  LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT,
+  SENSITIVE_VALUE_PATTERNS,
+  redactLangfuseSpanMessageContent,
+  resolveMessageContentRedactionConfig,
+  shouldApplyMessageContentRedaction,
+  type ResolvedLangfuseMessageContentRedactionConfig,
+} from '@/langfuseContentRedaction';
+
+function createSpan(
+  name: string,
+  attributes: Record<string, unknown>
+): ReadableSpan {
+  return { name, attributes } as unknown as ReadableSpan;
+}
+
+function enabledConfig(
+  overrides: Partial<ResolvedLangfuseMessageContentRedactionConfig> = {}
+): ResolvedLangfuseMessageContentRedactionConfig {
+  return {
+    enabled: true,
+    patterns: SENSITIVE_VALUE_PATTERNS,
+    redactionText: LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT,
+    ...overrides,
+  };
+}
+
+describe('Langfuse message content redaction', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('built-in patterns', () => {
+    it.each([
+      [
+        'OpenAI key',
+        'here is sk-proj-AbCdEfGhIjKlMnOpQrStUv09',
+        'here is sk-[REDACTED]',
+      ],
+      [
+        'Anthropic key',
+        'use sk-ant-api03-AbCdEfGhIjKlMnOpQrStUv09_-',
+        'use sk-ant-[REDACTED]',
+      ],
+      [
+        'Langfuse public key',
+        'pk-lf-AbCdEfGhIjKlMnOpQrStUv',
+        'pk-lf-[REDACTED]',
+      ],
+      [
+        'Langfuse secret key',
+        'sk-lf-AbCdEfGhIjKlMnOpQrStUv',
+        'sk-lf-[REDACTED]',
+      ],
+      ['AWS access key', 'AKIAIOSFODNN7EXAMPLE oops', 'AKIA[REDACTED] oops'],
+      ['AWS session key', 'ASIAIOSFODNN7EXAMPLE', 'ASIA[REDACTED]'],
+      [
+        'GitHub PAT',
+        'token ghp_abcdefghijklmnopqrstuvwxyz0123456789',
+        'token ghp_[REDACTED]',
+      ],
+      [
+        'GitHub OAuth',
+        'token gho_abcdefghijklmnopqrstuvwxyz0123456789',
+        'token gho_[REDACTED]',
+      ],
+      ['Slack bot token', 'xoxb-1234567890-abcdefghij', 'xoxb-[REDACTED]'],
+      ['Slack user token', 'xoxp-1234567890-abcdefghij', 'xoxp-[REDACTED]'],
+      [
+        'Google API key',
+        'AIzaSyA-1234567890abcdefghijklmnopqrstu',
+        'AIza[REDACTED]',
+      ],
+      ['Stripe live secret', 'sk_live_1234567890abcdef', 'sk_live_[REDACTED]'],
+      [
+        'Stripe test publishable',
+        'pk_test_1234567890abcdef',
+        'pk_test_[REDACTED]',
+      ],
+      ['Bearer token', 'auth Bearer abc.def-ghi=jkl', 'auth Bearer [REDACTED]'],
+      ['api-key header', 'api-key: abc-def-ghi', 'api-key: [REDACTED]'],
+      [
+        'api_key query',
+        'https://example.test/?api_key=abc123&next=true',
+        'https://example.test/?api_key=[REDACTED]&next=true',
+      ],
+      [
+        'JWT triplet',
+        'jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.abcdefghijk rest',
+        'jwt eyJ[REDACTED] rest',
+      ],
+    ])('redacts %s', (_label, input, expected) => {
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.TRACE_INPUT]: input,
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toBe(
+        expected
+      );
+    });
+  });
+
+  describe('false-positive resistance', () => {
+    it.each([
+      'task-runner failed',
+      'mask-value computed',
+      'monkey=10 bananas',
+      'the secret of comedy is timing',
+      'plain words without prefixes',
+    ])('leaves %s alone', (input) => {
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.TRACE_INPUT]: input,
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toBe(
+        input
+      );
+    });
+  });
+
+  describe('multi-prefix disambiguation', () => {
+    it('does not let the OpenAI pattern eat Anthropic keys', () => {
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.TRACE_INPUT]:
+          'sk-ant-api03-1234567890abcdefghij and sk-proj-1234567890abcdefghij',
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toBe(
+        'sk-ant-[REDACTED] and sk-[REDACTED]'
+      );
+    });
+
+    it('does not let the OpenAI pattern eat Langfuse keys', () => {
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.TRACE_INPUT]: 'sk-lf-1234567890abcdefghij',
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toBe(
+        'sk-lf-[REDACTED]'
+      );
+    });
+  });
+
+  describe('serialized message arrays', () => {
+    it('redacts content inside a JSON-serialized chat history', () => {
+      const messages = [
+        {
+          role: 'user',
+          content: 'my key is sk-proj-1234567890abcdefghij please help',
+        },
+        { role: 'assistant', content: 'never share keys' },
+      ];
+      const span = createSpan('gpt-4o', {
+        [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]:
+          JSON.stringify(messages),
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      const parsed = JSON.parse(
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT] as string
+      ) as Array<{ role: string; content: string }>;
+      expect(parsed[0].content).toBe('my key is sk-[REDACTED] please help');
+      expect(parsed[1].content).toBe('never share keys');
+    });
+
+    it('redacts text parts inside multimodal content arrays', () => {
+      const messages = [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: 'token ghp_abcdefghijklmnopqrstuvwxyz0123456789 ok',
+            },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://example.test/img.png' },
+            },
+          ],
+        },
+      ];
+      const span = createSpan('gpt-4o', {
+        [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]:
+          JSON.stringify(messages),
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      const parsed = JSON.parse(
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT] as string
+      ) as Array<{
+        content: Array<
+          | { type: 'text'; text: string }
+          | { type: 'image_url'; image_url: { url: string } }
+        >;
+      }>;
+      const parts = parsed[0].content;
+      expect(parts[0]).toEqual({
+        type: 'text',
+        text: 'token ghp_[REDACTED] ok',
+      });
+      expect(parts[1]).toEqual({
+        type: 'image_url',
+        image_url: { url: 'https://example.test/img.png' },
+      });
+    });
+
+    it('preserves tool inputs while redacting credentials in user text', () => {
+      const messages = [
+        {
+          role: 'user',
+          content: 'run select 1; my key is sk-ant-api03-1234567890abcdefghij',
+        },
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_sql',
+              name: 'execute_sql',
+              args: { query: 'SELECT 1' },
+            },
+          ],
+        },
+      ];
+      const span = createSpan('gpt-4o', {
+        [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]:
+          JSON.stringify(messages),
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      const parsed = JSON.parse(
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT] as string
+      ) as Array<{
+        role: string;
+        content: string;
+        tool_calls?: Array<{ args: { query: string } }>;
+      }>;
+      expect(parsed[0].content).toBe(
+        'run select 1; my key is sk-ant-[REDACTED]'
+      );
+      expect(parsed[1].tool_calls?.[0].args.query).toBe('SELECT 1');
+    });
+
+    it('leaves non-JSON string attributes alone when no patterns match', () => {
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.TRACE_OUTPUT]: 'plain assistant response',
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT]).toBe(
+        'plain assistant response'
+      );
+    });
+  });
+
+  describe('config resolution', () => {
+    it('is disabled by default', () => {
+      delete process.env.LANGFUSE_REDACT_MESSAGE_CONTENT;
+      const config = resolveMessageContentRedactionConfig();
+      expect(config.enabled).toBe(false);
+      expect(shouldApplyMessageContentRedaction(config)).toBe(false);
+    });
+
+    it('reads LANGFUSE_REDACT_MESSAGE_CONTENT from env', () => {
+      process.env.LANGFUSE_REDACT_MESSAGE_CONTENT = 'true';
+      const config = resolveMessageContentRedactionConfig();
+      expect(config.enabled).toBe(true);
+      expect(shouldApplyMessageContentRedaction(config)).toBe(true);
+    });
+
+    it('limits patterns to the configured allowlist', () => {
+      process.env.LANGFUSE_REDACT_MESSAGE_CONTENT = 'true';
+      process.env.LANGFUSE_REDACT_MESSAGE_CONTENT_PATTERNS =
+        'openai_api_key,unknown_id';
+      const config = resolveMessageContentRedactionConfig();
+      expect(config.patterns.map((p) => p.id)).toEqual(['openai_api_key']);
+    });
+
+    it('honors a custom redaction text', () => {
+      process.env.LANGFUSE_REDACT_MESSAGE_CONTENT = 'true';
+      process.env.LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT = '[scrubbed]';
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.TRACE_INPUT]:
+          'key sk-proj-1234567890abcdefghij ok',
+      });
+
+      redactLangfuseSpanMessageContent(
+        span,
+        resolveMessageContentRedactionConfig()
+      );
+
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toBe(
+        'key sk-[scrubbed] ok'
+      );
+    });
+
+    it('lets agent config override run config', () => {
+      const config = resolveMessageContentRedactionConfig(
+        { messageContentRedaction: { enabled: false } },
+        { messageContentRedaction: { enabled: true } }
+      );
+      expect(config.enabled).toBe(true);
+    });
+
+    it('is a no-op when disabled even if patterns match', () => {
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.TRACE_INPUT]:
+          'sk-proj-1234567890abcdefghij',
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig({ enabled: false }));
+
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toBe(
+        'sk-proj-1234567890abcdefghij'
+      );
+    });
+  });
+
+  describe('span attribute coverage', () => {
+    it('walks all four input/output attribute keys', () => {
+      const span = createSpan('chat', {
+        [LangfuseOtelSpanAttributes.OBSERVATION_INPUT]:
+          'in sk-proj-1234567890abcdefghij',
+        [LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]:
+          'out sk-proj-1234567890abcdefghij',
+        [LangfuseOtelSpanAttributes.TRACE_INPUT]:
+          'trace in sk-proj-1234567890abcdefghij',
+        [LangfuseOtelSpanAttributes.TRACE_OUTPUT]:
+          'trace out sk-proj-1234567890abcdefghij',
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      expect(
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_INPUT]
+      ).toBe('in sk-[REDACTED]');
+      expect(
+        span.attributes[LangfuseOtelSpanAttributes.OBSERVATION_OUTPUT]
+      ).toBe('out sk-[REDACTED]');
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_INPUT]).toBe(
+        'trace in sk-[REDACTED]'
+      );
+      expect(span.attributes[LangfuseOtelSpanAttributes.TRACE_OUTPUT]).toBe(
+        'trace out sk-[REDACTED]'
+      );
+    });
+
+    it('ignores attribute keys that are not configured for scanning', () => {
+      const span = createSpan('chat', {
+        'librechat.unrelated': 'sk-proj-1234567890abcdefghij',
+      });
+
+      redactLangfuseSpanMessageContent(span, enabledConfig());
+
+      expect(span.attributes['librechat.unrelated']).toBe(
+        'sk-proj-1234567890abcdefghij'
+      );
+    });
+  });
+});

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -438,6 +438,24 @@ export type LangfuseToolNodeTracingConfig = {
   enabled?: boolean;
 };
 
+export type LangfuseMessageContentRedactionConfig = {
+  /**
+   * When true, scrub credential-shaped substrings (API keys, tokens, JWTs)
+   * out of chain/generation span input/output attributes before they leave
+   * for Langfuse. Targets the user/assistant message text path that the
+   * `toolOutputTracing` redaction deliberately preserves. Defaults to
+   * `false` (opt-in).
+   */
+  enabled?: boolean;
+  /**
+   * Optional allowlist of built-in pattern ids to apply. When omitted, all
+   * built-in patterns run. Unknown ids are ignored.
+   */
+  patternIds?: string[];
+  /** Replacement text inserted after each matched prefix. */
+  redactionText?: string;
+};
+
 export interface LangfuseConfig {
   enabled?: boolean;
   publicKey?: string;
@@ -445,6 +463,7 @@ export interface LangfuseConfig {
   baseUrl?: string;
   toolNodeTracing?: LangfuseToolNodeTracingConfig;
   toolOutputTracing?: LangfuseToolOutputTracingConfig;
+  messageContentRedaction?: LangfuseMessageContentRedactionConfig;
   /**
    * When true, derive the run's root Langfuse trace id deterministically from
    * its `runId` (`sha256(runId)` → 32 hex chars, matching `@langfuse/tracing`


### PR DESCRIPTION
## Summary

Adds an opt-in span-processor scrubber that strips credential-shaped substrings (API keys, tokens, JWTs) out of chain and generation span input/output attributes before they reach Langfuse. Complements PR #203's tool-output redaction by covering the user/assistant message content path that the tool-output wrapper deliberately preserves; the same path that today carries pasted credentials into otherwise-shareable traces.

- New `src/langfuseContentRedaction.ts` with 12 prefix-anchored regex patterns (OpenAI, Anthropic, Langfuse, AWS, GitHub, Slack, Google, Stripe, JWT, Bearer / api-key / api_key= header forms. Pattern set lifted from `danny-avila/LibreChat#13561`'s hardened winston log redaction).
- Each pattern preserves a leading prefix (`sk-`, `ghp_`, `AKIA`, …) in the redacted output so trace readers can still tell what kind of secret was scrubbed.
- Span processor (`LangfuseRedactingSpanProcessor`, renamed from `ToolOutputRedactingLangfuseSpanProcessor`) now resolves both tool-output and content-redaction configs, stores per-span resolutions on start, and applies them on end. `LangfuseSpanProcessor` is constructed once per processor as before; nothing in the existing redaction path changes when the new feature is disabled.
- `withLangfuseToolOutputTracingConfig` also propagates content-redaction config through async context so run-scoped settings reach spans created inside it.
- Cache key in `instrumentation.ts` includes `messageContentRedaction` so distinct content configs spin up distinct downstream processors.

## Config surface (mirrors the existing `LANGFUSE_REDACT_TOOL_*` knobs)

- `LANGFUSE_REDACT_MESSAGE_CONTENT` - boolean, default `false` (opt-in)
- `LANGFUSE_REDACT_MESSAGE_CONTENT_PATTERNS` - optional comma-separated allowlist of built-in pattern ids (`openai_api_key`, `anthropic_api_key`, `langfuse_key`, `aws_access_key`, `github_token`, `slack_token`, `google_api_key`, `stripe_key`, `jwt`, `bearer_token`, `api_key_header`, `api_key_query`)
- `LANGFUSE_MESSAGE_CONTENT_REDACTION_TEXT` - default `[REDACTED]`
- Per-run and per-agent `langfuse.messageContentRedaction: { enabled, patternIds, redactionText }` config wins over env values; agent over run.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npx jest src/specs/langfuse-message-content-redaction.test.ts --runInBand` - 36/36 pass. 17 prefix patterns exercised (`it.each`) including multi-prefix disambiguation (OpenAI pattern doesn't eat Anthropic or Langfuse keys), serialized chat-history scrubbing, multimodal content-array shape (text parts scrubbed, image_url parts untouched), tool-input preservation alongside user-text redaction, env-var precedence, custom redaction text, agent-over-run config precedence, span-attribute coverage (all four input/output keys), and false-positive resistance for `task-runner`, `mask-value`, `monkey=10`, `the secret of comedy is timing`.
- `npx jest src/specs/langfuse-message-content-redaction.integration.test.ts --runInBand` - 4/4 pass. End-to-end pipeline coverage: real `BasicTracerProvider` + `InMemorySpanExporter` sibling proves the redacted span is what the inner `LangfuseSpanProcessor` would actually export. Negative control with `enabled: false` verifies the kill switch; positive assertion confirms the redacted span is what would ship to Langfuse cloud.
- `npx tsc --noEmit -p tsconfig.json` - no new errors in any touched file.
- `npx eslint src/langfuseContentRedaction.ts src/langfuseToolOutputTracing.ts src/instrumentation.ts src/types/graph.ts src/specs/langfuse-message-content-redaction.test.ts src/specs/langfuse-message-content-redaction.integration.test.ts` - clean.
- Live-verified against Langfuse cloud (`us.cloud.langfuse.com`) by vendoring the packed tarball into a local LibreChat run and pasting a credential into a chat message. The resulting generation span's `input` shows the credential redacted to `sk-ant-[REDACTED]` while the surrounding canary text and tool-call inputs are preserved untouched.

### Leak in LibreChat Convo
<img width="1728" height="958" alt="Screenshot 2026-06-06 at 8 49 00 PM" src="https://github.com/user-attachments/assets/a7573a99-2d4d-467a-8c1f-96bdac3af72f" />

---

### Redaction in Langfuse
<img width="1037" height="958" alt="Screenshot 2026-06-06 at 8 50 03 PM" src="https://github.com/user-attachments/assets/5fba2107-7305-4048-a60f-99e520061685" />

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes