### PR TITLE
🪝 feat: updatedPrompt on UserPromptSubmit + Message-Content Redaction Primitive

### DIFF
--- a/src/hooks/__tests__/updatedPrompt.test.ts
+++ b/src/hooks/__tests__/updatedPrompt.test.ts
@@ -1,11 +1,9 @@
-import { HumanMessage } from '@langchain/core/messages';
 import type {
   HookCallback,
   UserPromptSubmitHookInput,
   UserPromptSubmitHookOutput,
 } from '../types';
 import {
-  filterMessageContent,
   redactSensitiveText,
   type SensitivePattern,
 } from '@/messageContentRedaction';
@@ -96,25 +94,6 @@ describe('executeHooks — updatedPrompt fold', () => {
     });
 
     expect(result.updatedPrompt).toBe('second rewrite');
-  });
-
-  it('skips non-string updatedPrompt values', async () => {
-    const registry = new HookRegistry();
-    registry.register(
-      'UserPromptSubmit',
-      userPromptMatcher(
-        async (): Promise<UserPromptSubmitHookOutput> => ({
-          updatedPrompt: 42 as unknown as string,
-        })
-      )
-    );
-
-    const result = await executeHooks({
-      registry,
-      input: promptSubmitInput('original'),
-    });
-
-    expect(result.updatedPrompt).toBeUndefined();
   });
 
   it('leaves updatedPrompt unset when no hook supplies one', async () => {
@@ -225,21 +204,5 @@ describe('messageContentRedaction as a UserPromptSubmit hook', () => {
     expect(result.updatedPrompt).toBe(
       'jwt eyJ[REDACTED] and key sk-ant-FAKE1234567890'
     );
-  });
-});
-
-describe('filterMessageContent helper alongside updatedPrompt', () => {
-  it('scrubs a HumanMessage array — useful when a hook wants to inspect full message history', () => {
-    const messages = [
-      new HumanMessage('first sk-proj-FAKE1234567890'),
-      new HumanMessage('second clean prompt'),
-    ];
-    const { messages: filtered, matches } = filterMessageContent(messages, {
-      patterns: TEST_PATTERNS,
-    });
-
-    expect(filtered[0].content).toBe('first sk-proj-[REDACTED]');
-    expect(filtered[1]).toBe(messages[1]);
-    expect(matches.map((m) => m.patternId)).toEqual(['openai_key']);
   });
 });

--- a/src/hooks/__tests__/updatedPrompt.test.ts
+++ b/src/hooks/__tests__/updatedPrompt.test.ts
@@ -1,0 +1,245 @@
+import { HumanMessage } from '@langchain/core/messages';
+import type {
+  HookCallback,
+  UserPromptSubmitHookInput,
+  UserPromptSubmitHookOutput,
+} from '../types';
+import {
+  filterMessageContent,
+  redactSensitiveText,
+  type SensitivePattern,
+} from '@/messageContentRedaction';
+import { clearMatcherCache } from '../matchers';
+import { HookRegistry } from '../HookRegistry';
+import { executeHooks } from '../executeHooks';
+
+const TEST_PATTERNS: SensitivePattern[] = [
+  {
+    id: 'anthropic_key',
+    label: 'Anthropic key',
+    pattern: /\b(sk-ant-)[A-Za-z0-9_-]{10,}/g,
+  },
+  {
+    id: 'openai_key',
+    label: 'OpenAI key',
+    pattern: /\b(sk-proj-)[A-Za-z0-9_-]{10,}/g,
+  },
+  {
+    id: 'jwt',
+    label: 'JWT',
+    pattern: /\b(eyJ)[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+  },
+];
+
+function promptSubmitInput(prompt: string): UserPromptSubmitHookInput {
+  return {
+    hook_event_name: 'UserPromptSubmit',
+    runId: 'run-1',
+    threadId: 'thread-1',
+    agentId: 'agent-1',
+    prompt,
+  };
+}
+
+function userPromptMatcher(callback: HookCallback<'UserPromptSubmit'>): {
+  hooks: HookCallback<'UserPromptSubmit'>[];
+} {
+  return { hooks: [callback] };
+}
+
+beforeEach(() => {
+  clearMatcherCache();
+});
+
+describe('executeHooks — updatedPrompt fold', () => {
+  it('aggregates a single hook updatedPrompt', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(
+        async (): Promise<UserPromptSubmitHookOutput> => ({
+          updatedPrompt: 'scrubbed prompt',
+        })
+      )
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput('original prompt with sk-ant-secret'),
+    });
+
+    expect(result.updatedPrompt).toBe('scrubbed prompt');
+  });
+
+  it('lets the last writer win in registration order', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(
+        async (): Promise<UserPromptSubmitHookOutput> => ({
+          updatedPrompt: 'first rewrite',
+        })
+      )
+    );
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(
+        async (): Promise<UserPromptSubmitHookOutput> => ({
+          updatedPrompt: 'second rewrite',
+        })
+      )
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput('original'),
+    });
+
+    expect(result.updatedPrompt).toBe('second rewrite');
+  });
+
+  it('skips non-string updatedPrompt values', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(
+        async (): Promise<UserPromptSubmitHookOutput> => ({
+          updatedPrompt: 42 as unknown as string,
+        })
+      )
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput('original'),
+    });
+
+    expect(result.updatedPrompt).toBeUndefined();
+  });
+
+  it('leaves updatedPrompt unset when no hook supplies one', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(
+        async (): Promise<UserPromptSubmitHookOutput> => ({
+          additionalContext: 'noted',
+        })
+      )
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput('original'),
+    });
+
+    expect(result.updatedPrompt).toBeUndefined();
+    expect(result.additionalContexts).toEqual(['noted']);
+  });
+
+  it('does not collide with decision or preventContinuation', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(
+        async (): Promise<UserPromptSubmitHookOutput> => ({
+          updatedPrompt: 'rewritten',
+          decision: 'allow',
+        })
+      )
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput('original'),
+    });
+
+    expect(result.updatedPrompt).toBe('rewritten');
+    expect(result.decision).toBe('allow');
+  });
+});
+
+describe('messageContentRedaction as a UserPromptSubmit hook', () => {
+  it('produces an updatedPrompt with credentials redacted using caller-supplied patterns', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(async (input): Promise<UserPromptSubmitHookOutput> => {
+        const { text, matches } = redactSensitiveText(input.prompt, {
+          patterns: TEST_PATTERNS,
+        });
+        return matches.length > 0 ? { updatedPrompt: text } : {};
+      })
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput('my key is sk-ant-FAKE1234567890 please debug'),
+    });
+
+    expect(result.updatedPrompt).toBe(
+      'my key is sk-ant-[REDACTED] please debug'
+    );
+  });
+
+  it('is a no-op (no updatedPrompt) when nothing matches', async () => {
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(async (input): Promise<UserPromptSubmitHookOutput> => {
+        const { text, matches } = redactSensitiveText(input.prompt, {
+          patterns: TEST_PATTERNS,
+        });
+        return matches.length > 0 ? { updatedPrompt: text } : {};
+      })
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput('plain conversational text'),
+    });
+
+    expect(result.updatedPrompt).toBeUndefined();
+  });
+
+  it('honors a configured pattern subset', async () => {
+    const onlyJwt = [TEST_PATTERNS[2]];
+    const registry = new HookRegistry();
+    registry.register(
+      'UserPromptSubmit',
+      userPromptMatcher(async (input): Promise<UserPromptSubmitHookOutput> => {
+        const { text, matches } = redactSensitiveText(input.prompt, {
+          patterns: onlyJwt,
+        });
+        return matches.length > 0 ? { updatedPrompt: text } : {};
+      })
+    );
+
+    const result = await executeHooks({
+      registry,
+      input: promptSubmitInput(
+        'jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.sig and key sk-ant-FAKE1234567890'
+      ),
+    });
+
+    expect(result.updatedPrompt).toBe(
+      'jwt eyJ[REDACTED] and key sk-ant-FAKE1234567890'
+    );
+  });
+});
+
+describe('filterMessageContent helper alongside updatedPrompt', () => {
+  it('scrubs a HumanMessage array — useful when a hook wants to inspect full message history', () => {
+    const messages = [
+      new HumanMessage('first sk-proj-FAKE1234567890'),
+      new HumanMessage('second clean prompt'),
+    ];
+    const { messages: filtered, matches } = filterMessageContent(messages, {
+      patterns: TEST_PATTERNS,
+    });
+
+    expect(filtered[0].content).toBe('first sk-proj-[REDACTED]');
+    expect(filtered[1]).toBe(messages[1]);
+    expect(matches.map((m) => m.patternId)).toEqual(['openai_key']);
+  });
+});

--- a/src/hooks/executeHooks.ts
+++ b/src/hooks/executeHooks.ts
@@ -274,6 +274,19 @@ function applyUpdatedOutput(
   agg.updatedOutput = output.updatedOutput;
 }
 
+function applyUpdatedPrompt(
+  agg: AggregatedHookResult,
+  output: HookOutput
+): void {
+  if (
+    !('updatedPrompt' in output) ||
+    typeof output.updatedPrompt !== 'string'
+  ) {
+    return;
+  }
+  agg.updatedPrompt = output.updatedPrompt;
+}
+
 function applyAllowedDecisions(
   agg: AggregatedHookResult,
   output: HookOutput
@@ -314,6 +327,7 @@ function fold(outcomes: readonly HookOutcome[]): AggregatedHookResult {
     applyDecision(agg, output);
     applyUpdatedInput(agg, output);
     applyUpdatedOutput(agg, output);
+    applyUpdatedPrompt(agg, output);
     applyAllowedDecisions(agg, output);
   }
   return agg;

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -307,6 +307,25 @@ export type RunStartHookOutput = BaseHookOutput;
 export interface UserPromptSubmitHookOutput extends BaseHookOutput {
   decision?: ToolDecision;
   reason?: string;
+  /**
+   * Replacement prompt text. When set, the SDK rewrites the last
+   * human message's text content with this value before the model
+   * turn runs. Use this to surface a guardrail-scrubbed version of
+   * the user's prompt (PII redaction, jailbreak filtering, etc.).
+   *
+   * Multimodal handling: if the message's content is a string, it's
+   * replaced wholesale. If it's a content-block array, the first
+   * text block's text is replaced with this value and any other text
+   * blocks are dropped; non-text blocks (images, files) are
+   * preserved in their original order.
+   *
+   * When multiple hooks set `updatedPrompt` within a single
+   * `executeHooks` call, the last writer in registration order wins
+   * (same precedence as `PreToolUseHookOutput.updatedInput`).
+   * Consumers that need a single authoritative rewrite should still
+   * scope `updatedPrompt` to one hook per matcher.
+   */
+  updatedPrompt?: string;
 }
 
 export interface PreToolUseHookOutput extends BaseHookOutput {
@@ -506,6 +525,13 @@ export interface AggregatedHookResult {
    * means "use the original tool output".
    */
   updatedOutput?: unknown;
+  /**
+   * Replacement prompt text from a `UserPromptSubmit` hook. Same
+   * last-writer-wins-in-registration-order semantics as
+   * `updatedInput`. Present only when at least one hook set it;
+   * `undefined` means "use the original user prompt unchanged".
+   */
+  updatedPrompt?: string;
   /** Accumulated `additionalContext` strings from every hook, in order. */
   additionalContexts: string[];
   /** True if any hook returned `preventContinuation`. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,9 +82,7 @@ export { isThinkingEnabled, getMaxOutputTokensKey } from './llm/request';
 /* Message Content Redaction (PII filter primitive) */
 export {
   DEFAULT_REDACTION_TEXT,
-  filterMessageContent,
   redactSensitiveText,
-  redactSensitiveValue,
 } from './messageContentRedaction';
 export type {
   MessageContentRedactionConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,3 +78,16 @@ export { FakeChatModel, createFakeStreamingLLM } from './llm/fake';
 export { initializeModel } from './llm/init';
 export { attemptInvoke, tryFallbackProviders } from './llm/invoke';
 export { isThinkingEnabled, getMaxOutputTokensKey } from './llm/request';
+
+/* Message Content Redaction (PII filter primitive) */
+export {
+  DEFAULT_REDACTION_TEXT,
+  filterMessageContent,
+  redactSensitiveText,
+  redactSensitiveValue,
+} from './messageContentRedaction';
+export type {
+  MessageContentRedactionConfig,
+  PatternMatch,
+  SensitivePattern,
+} from './messageContentRedaction';

--- a/src/messageContentRedaction.ts
+++ b/src/messageContentRedaction.ts
@@ -1,0 +1,206 @@
+import type { BaseMessage, MessageContent } from '@langchain/core/messages';
+
+export const DEFAULT_REDACTION_TEXT = '[REDACTED]';
+
+export type SensitivePattern = {
+  id: string;
+  label: string;
+  pattern: RegExp;
+};
+
+export type PatternMatch = {
+  patternId: string;
+  patternLabel: string;
+  count: number;
+};
+
+export type MessageContentRedactionConfig = {
+  patterns: SensitivePattern[];
+  redactionText?: string;
+};
+
+type ResolvedConfig = {
+  patterns: SensitivePattern[];
+  redactionText: string;
+};
+
+function resolveConfig(config: MessageContentRedactionConfig): ResolvedConfig {
+  return {
+    patterns: config.patterns,
+    redactionText: config.redactionText ?? DEFAULT_REDACTION_TEXT,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function recordMatch(
+  aggregate: Map<string, PatternMatch>,
+  pattern: SensitivePattern,
+  count: number
+): void {
+  if (count === 0) {
+    return;
+  }
+  const existing = aggregate.get(pattern.id);
+  if (existing != null) {
+    existing.count += count;
+    return;
+  }
+  aggregate.set(pattern.id, {
+    patternId: pattern.id,
+    patternLabel: pattern.label,
+    count,
+  });
+}
+
+function redactStringInto(
+  text: string,
+  resolved: ResolvedConfig,
+  aggregate: Map<string, PatternMatch>
+): string {
+  let next = text;
+  for (const pattern of resolved.patterns) {
+    pattern.pattern.lastIndex = 0;
+    let count = 0;
+    const replaced = next.replace(pattern.pattern, (...args: unknown[]) => {
+      count += 1;
+      const groups = args.slice(1, -2);
+      const prefix = typeof groups[0] === 'string' ? groups[0] : '';
+      return `${prefix}${resolved.redactionText}`;
+    });
+    if (count > 0) {
+      next = replaced;
+      recordMatch(aggregate, pattern, count);
+    }
+  }
+  return next;
+}
+
+/**
+ * Scrubs credential-shaped substrings from a single string using the
+ * caller-supplied patterns. Each match is replaced with the configured
+ * redaction text (default `[REDACTED]`) while the leading prefix capture
+ * group is preserved so reviewers can still identify which family of
+ * secret was matched.
+ *
+ * This is a primitive: the caller owns the pattern catalog. The agents
+ * library ships no built-in patterns by design — consumers like LibreChat
+ * define and maintain the patterns they care about.
+ */
+export function redactSensitiveText(
+  text: string,
+  config: MessageContentRedactionConfig
+): { text: string; matches: PatternMatch[] } {
+  const resolved = resolveConfig(config);
+  const aggregate = new Map<string, PatternMatch>();
+  const next = redactStringInto(text, resolved, aggregate);
+  return { text: next, matches: Array.from(aggregate.values()) };
+}
+
+function redactValueInto(
+  value: unknown,
+  resolved: ResolvedConfig,
+  aggregate: Map<string, PatternMatch>
+): { value: unknown; changed: boolean } {
+  if (typeof value === 'string') {
+    const next = redactStringInto(value, resolved, aggregate);
+    return { value: next, changed: next !== value };
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next: unknown[] = [];
+    for (const item of value) {
+      const result = redactValueInto(item, resolved, aggregate);
+      next.push(result.value);
+      if (result.changed) {
+        changed = true;
+      }
+    }
+    return changed ? { value: next, changed } : { value, changed: false };
+  }
+
+  if (!isRecord(value)) {
+    return { value, changed: false };
+  }
+
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    const result = redactValueInto(child, resolved, aggregate);
+    next[key] = result.value;
+    if (result.changed) {
+      changed = true;
+    }
+  }
+  return changed ? { value: next, changed } : { value, changed: false };
+}
+
+/**
+ * Recursively walks an arbitrary value, scrubbing every string it
+ * encounters. Returns the rewritten value (reference-equal to the original
+ * when no matches fired) and the aggregated match summary.
+ */
+export function redactSensitiveValue(
+  value: unknown,
+  config: MessageContentRedactionConfig
+): { value: unknown; matches: PatternMatch[] } {
+  const resolved = resolveConfig(config);
+  const aggregate = new Map<string, PatternMatch>();
+  const { value: next } = redactValueInto(value, resolved, aggregate);
+  return { value: next, matches: Array.from(aggregate.values()) };
+}
+
+function cloneMessageWithContent(
+  message: BaseMessage,
+  content: MessageContent
+): BaseMessage {
+  const clone = Object.assign(
+    Object.create(Object.getPrototypeOf(message)),
+    message
+  );
+  clone.content = content;
+  return clone as BaseMessage;
+}
+
+function redactMessageContent(
+  content: MessageContent,
+  resolved: ResolvedConfig,
+  aggregate: Map<string, PatternMatch>
+): { content: MessageContent; changed: boolean } {
+  if (typeof content === 'string') {
+    const next = redactStringInto(content, resolved, aggregate);
+    return { content: next, changed: next !== content };
+  }
+
+  const result = redactValueInto(content, resolved, aggregate);
+  return {
+    content: result.value as MessageContent,
+    changed: result.changed,
+  };
+}
+
+/**
+ * Returns a new array of LangChain messages with credential-shaped
+ * substrings scrubbed from each message's content. Messages with no
+ * matches keep reference equality; only the affected messages are cloned
+ * (prototype-preserving so `instanceof` checks still hold).
+ */
+export function filterMessageContent(
+  messages: BaseMessage[],
+  config: MessageContentRedactionConfig
+): { messages: BaseMessage[]; matches: PatternMatch[] } {
+  const resolved = resolveConfig(config);
+  const aggregate = new Map<string, PatternMatch>();
+  const next = messages.map((message) => {
+    const { content, changed } = redactMessageContent(
+      message.content,
+      resolved,
+      aggregate
+    );
+    return changed ? cloneMessageWithContent(message, content) : message;
+  });
+  return { messages: next, matches: Array.from(aggregate.values()) };
+}

--- a/src/messageContentRedaction.ts
+++ b/src/messageContentRedaction.ts
@@ -1,5 +1,3 @@
-import type { BaseMessage, MessageContent } from '@langchain/core/messages';
-
 export const DEFAULT_REDACTION_TEXT = '[REDACTED]';
 
 /**
@@ -15,6 +13,8 @@ export const DEFAULT_REDACTION_TEXT = '[REDACTED]';
  *     and the capture group are also dropped.
  *   - Use a zero-width empty group `()` at the start if you want no
  *     visible prefix preserved.
+ *   - `id` must be unique across the supplied pattern list (match
+ *     aggregation keys by id; duplicates throw at config-resolve time).
  */
 export type SensitivePattern = {
   id: string;
@@ -39,7 +39,15 @@ type ResolvedConfig = {
 };
 
 function resolveConfig(config: MessageContentRedactionConfig): ResolvedConfig {
+  const seenIds = new Set<string>();
   for (const { id, pattern } of config.patterns) {
+    if (seenIds.has(id)) {
+      throw new TypeError(
+        `[messageContentRedaction] duplicate pattern id "${id}"; ` +
+          'each pattern must have a unique id (match aggregation keys by id).'
+      );
+    }
+    seenIds.add(id);
     if (!pattern.global) {
       throw new TypeError(
         `[messageContentRedaction] pattern "${id}" must use the global (g) flag; ` +
@@ -54,18 +62,11 @@ function resolveConfig(config: MessageContentRedactionConfig): ResolvedConfig {
   };
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value != null && typeof value === 'object' && !Array.isArray(value);
-}
-
 function recordMatch(
   aggregate: Map<string, PatternMatch>,
   pattern: SensitivePattern,
   count: number
 ): void {
-  if (count === 0) {
-    return;
-  }
   const existing = aggregate.get(pattern.id);
   if (existing != null) {
     existing.count += count;
@@ -104,13 +105,12 @@ function redactStringInto(
 /**
  * Scrubs credential-shaped substrings from a single string using the
  * caller-supplied patterns. Each match is replaced with the configured
- * redaction text (default `[REDACTED]`) while the leading prefix capture
- * group is preserved so reviewers can still identify which family of
- * secret was matched.
+ * redaction text (default `[REDACTED]`) while the leading prefix
+ * capture group is preserved so reviewers can still identify which
+ * family of secret was matched.
  *
- * This is a primitive: the caller owns the pattern catalog. The agents
- * library ships no built-in patterns by design — consumers like LibreChat
- * define and maintain the patterns they care about.
+ * The library ships no built-in patterns by design — consumers like
+ * LibreChat define and maintain the patterns they care about.
  */
 export function redactSensitiveText(
   text: string,
@@ -120,110 +120,4 @@ export function redactSensitiveText(
   const aggregate = new Map<string, PatternMatch>();
   const next = redactStringInto(text, resolved, aggregate);
   return { text: next, matches: Array.from(aggregate.values()) };
-}
-
-function redactValueInto(
-  value: unknown,
-  resolved: ResolvedConfig,
-  aggregate: Map<string, PatternMatch>
-): { value: unknown; changed: boolean } {
-  if (typeof value === 'string') {
-    const next = redactStringInto(value, resolved, aggregate);
-    return { value: next, changed: next !== value };
-  }
-
-  if (Array.isArray(value)) {
-    let changed = false;
-    const next: unknown[] = [];
-    for (const item of value) {
-      const result = redactValueInto(item, resolved, aggregate);
-      next.push(result.value);
-      if (result.changed) {
-        changed = true;
-      }
-    }
-    return changed ? { value: next, changed } : { value, changed: false };
-  }
-
-  if (!isRecord(value)) {
-    return { value, changed: false };
-  }
-
-  let changed = false;
-  const next: Record<string, unknown> = {};
-  for (const [key, child] of Object.entries(value)) {
-    const result = redactValueInto(child, resolved, aggregate);
-    next[key] = result.value;
-    if (result.changed) {
-      changed = true;
-    }
-  }
-  return changed ? { value: next, changed } : { value, changed: false };
-}
-
-/**
- * Recursively walks an arbitrary value, scrubbing every string it
- * encounters. Returns the rewritten value (reference-equal to the original
- * when no matches fired) and the aggregated match summary.
- */
-export function redactSensitiveValue(
-  value: unknown,
-  config: MessageContentRedactionConfig
-): { value: unknown; matches: PatternMatch[] } {
-  const resolved = resolveConfig(config);
-  const aggregate = new Map<string, PatternMatch>();
-  const { value: next } = redactValueInto(value, resolved, aggregate);
-  return { value: next, matches: Array.from(aggregate.values()) };
-}
-
-function cloneMessageWithContent(
-  message: BaseMessage,
-  content: MessageContent
-): BaseMessage {
-  const clone = Object.assign(
-    Object.create(Object.getPrototypeOf(message)),
-    message
-  );
-  clone.content = content;
-  return clone as BaseMessage;
-}
-
-function redactMessageContent(
-  content: MessageContent,
-  resolved: ResolvedConfig,
-  aggregate: Map<string, PatternMatch>
-): { content: MessageContent; changed: boolean } {
-  if (typeof content === 'string') {
-    const next = redactStringInto(content, resolved, aggregate);
-    return { content: next, changed: next !== content };
-  }
-
-  const result = redactValueInto(content, resolved, aggregate);
-  return {
-    content: result.value as MessageContent,
-    changed: result.changed,
-  };
-}
-
-/**
- * Returns a new array of LangChain messages with credential-shaped
- * substrings scrubbed from each message's content. Messages with no
- * matches keep reference equality; only the affected messages are cloned
- * (prototype-preserving so `instanceof` checks still hold).
- */
-export function filterMessageContent(
-  messages: BaseMessage[],
-  config: MessageContentRedactionConfig
-): { messages: BaseMessage[]; matches: PatternMatch[] } {
-  const resolved = resolveConfig(config);
-  const aggregate = new Map<string, PatternMatch>();
-  const next = messages.map((message) => {
-    const { content, changed } = redactMessageContent(
-      message.content,
-      resolved,
-      aggregate
-    );
-    return changed ? cloneMessageWithContent(message, content) : message;
-  });
-  return { messages: next, matches: Array.from(aggregate.values()) };
 }

--- a/src/messageContentRedaction.ts
+++ b/src/messageContentRedaction.ts
@@ -2,6 +2,20 @@ import type { BaseMessage, MessageContent } from '@langchain/core/messages';
 
 export const DEFAULT_REDACTION_TEXT = '[REDACTED]';
 
+/**
+ * Regex shape contract:
+ *   - `pattern` must be `/g`-flagged (validated at call time; throws
+ *     otherwise — see resolveConfig).
+ *   - The first capture group is treated as the visible prefix that
+ *     survives redaction. Replacement is always `$1<redactionText>`,
+ *     so the regex must place the prefix at the start of the match
+ *     (e.g. `/\b(sk-)[A-Za-z0-9_-]+/g`). A pattern whose first group
+ *     is somewhere in the middle (e.g. `/secret=([a-z]+)/g`) will
+ *     produce broken output because the bytes between the match start
+ *     and the capture group are also dropped.
+ *   - Use a zero-width empty group `()` at the start if you want no
+ *     visible prefix preserved.
+ */
 export type SensitivePattern = {
   id: string;
   label: string;
@@ -25,6 +39,15 @@ type ResolvedConfig = {
 };
 
 function resolveConfig(config: MessageContentRedactionConfig): ResolvedConfig {
+  for (const { id, pattern } of config.patterns) {
+    if (!pattern.global) {
+      throw new TypeError(
+        `[messageContentRedaction] pattern "${id}" must use the global (g) flag; ` +
+          'without it, only the first match in a string is scrubbed and ' +
+          'subsequent matches silently leak.'
+      );
+    }
+  }
   return {
     patterns: config.patterns,
     redactionText: config.redactionText ?? DEFAULT_REDACTION_TEXT,

--- a/src/run.ts
+++ b/src/run.ts
@@ -1471,19 +1471,34 @@ function extractPromptText(message: BaseMessage): string {
   return parts.join('\n');
 }
 
+/**
+ * Replaces the message's content with `updatedPrompt` while preserving
+ * the original message's prototype (so `instanceof` checks still hold
+ * on subclasses) and every own property other than `content`.
+ *
+ * Multimodal note: when the content is a content-block array, the
+ * `extractPromptText` helper concatenates all text blocks into one
+ * string for the hook (with `\n` separators). The hook can only
+ * return a single replacement string, so we collapse the text blocks
+ * into one block carrying that string. Non-text blocks (images,
+ * files, tool-result blocks, etc.) are preserved in their original
+ * order. This is lossy if a host depended on per-text-block layout —
+ * use the underlying message directly in that case rather than the
+ * hook-rewrite path.
+ */
 function applyPromptOverride(
   message: BaseMessage,
   updatedPrompt: string
 ): BaseMessage {
   const content = message.content;
-  const baseFields = {
-    additional_kwargs: message.additional_kwargs,
-    response_metadata: message.response_metadata,
-    name: message.name,
-    id: message.id,
-  };
+  const clone = Object.assign(
+    Object.create(Object.getPrototypeOf(message)),
+    message
+  ) as BaseMessage;
+
   if (typeof content === 'string' || !Array.isArray(content)) {
-    return new HumanMessage({ ...baseFields, content: updatedPrompt });
+    clone.content = updatedPrompt;
+    return clone;
   }
 
   const next: typeof content = [];
@@ -1501,5 +1516,6 @@ function applyPromptOverride(
   if (!textInserted) {
     next.unshift({ type: 'text', text: updatedPrompt });
   }
-  return new HumanMessage({ ...baseFields, content: next });
+  clone.content = next;
+  return clone;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -442,6 +442,15 @@ export class Run<_T extends t.BaseGraphState> {
         config.callbacks = undefined;
         return true;
       }
+      if (typeof promptResult.updatedPrompt === 'string') {
+        const idx = stateInputs.messages.lastIndexOf(lastHuman);
+        if (idx >= 0) {
+          stateInputs.messages[idx] = applyPromptOverride(
+            lastHuman,
+            promptResult.updatedPrompt
+          );
+        }
+      }
       for (const ctx of promptResult.additionalContexts) {
         preStreamContexts.push(ctx);
       }
@@ -1460,4 +1469,37 @@ function extractPromptText(message: BaseMessage): string {
     }
   }
   return parts.join('\n');
+}
+
+function applyPromptOverride(
+  message: BaseMessage,
+  updatedPrompt: string
+): BaseMessage {
+  const content = message.content;
+  const baseFields = {
+    additional_kwargs: message.additional_kwargs,
+    response_metadata: message.response_metadata,
+    name: message.name,
+    id: message.id,
+  };
+  if (typeof content === 'string' || !Array.isArray(content)) {
+    return new HumanMessage({ ...baseFields, content: updatedPrompt });
+  }
+
+  const next: typeof content = [];
+  let textInserted = false;
+  for (const block of content) {
+    if (typeof block === 'object' && 'type' in block && block.type === 'text') {
+      if (!textInserted) {
+        next.push({ type: 'text', text: updatedPrompt });
+        textInserted = true;
+      }
+      continue;
+    }
+    next.push(block);
+  }
+  if (!textInserted) {
+    next.unshift({ type: 'text', text: updatedPrompt });
+  }
+  return new HumanMessage({ ...baseFields, content: next });
 }

--- a/src/specs/message-content-redaction.test.ts
+++ b/src/specs/message-content-redaction.test.ts
@@ -1,0 +1,246 @@
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+} from '@langchain/core/messages';
+import {
+  DEFAULT_REDACTION_TEXT,
+  filterMessageContent,
+  redactSensitiveText,
+  redactSensitiveValue,
+  type MessageContentRedactionConfig,
+  type PatternMatch,
+  type SensitivePattern,
+} from '@/messageContentRedaction';
+
+const TEST_PATTERNS: SensitivePattern[] = [
+  {
+    id: 'anthropic_key',
+    label: 'Anthropic key',
+    pattern: /\b(sk-ant-)[A-Za-z0-9_-]{10,}/g,
+  },
+  {
+    id: 'github_token',
+    label: 'GitHub token',
+    pattern: /\b(ghp_)[A-Za-z0-9]{20,}/g,
+  },
+  {
+    id: 'aws_key',
+    label: 'AWS key',
+    pattern: /\b(AKIA)[A-Z0-9]{12,16}\b/g,
+  },
+  {
+    id: 'jwt',
+    label: 'JWT',
+    pattern: /\b(eyJ)[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+  },
+];
+
+const ALL: MessageContentRedactionConfig = { patterns: TEST_PATTERNS };
+
+function findMatch(
+  matches: PatternMatch[],
+  patternId: string
+): PatternMatch | undefined {
+  return matches.find((match) => match.patternId === patternId);
+}
+
+describe('redactSensitiveText', () => {
+  it('redacts a single match and reports it', () => {
+    const { text, matches } = redactSensitiveText(
+      'token sk-ant-abcdefghijklmn please',
+      ALL
+    );
+    expect(text).toBe('token sk-ant-[REDACTED] please');
+    expect(matches).toHaveLength(1);
+    expect(findMatch(matches, 'anthropic_key')).toEqual({
+      patternId: 'anthropic_key',
+      patternLabel: 'Anthropic key',
+      count: 1,
+    });
+  });
+
+  it('counts multiple matches of the same pattern', () => {
+    const { text, matches } = redactSensitiveText(
+      'first sk-ant-aaaaaaaaaa second sk-ant-bbbbbbbbbb',
+      ALL
+    );
+    expect(text).toBe('first sk-ant-[REDACTED] second sk-ant-[REDACTED]');
+    expect(findMatch(matches, 'anthropic_key')?.count).toBe(2);
+  });
+
+  it('aggregates matches across different patterns', () => {
+    const { text, matches } = redactSensitiveText(
+      'anthropic sk-ant-abcdefghijklmn and github ghp_abcdefghijklmnopqrstuvwxyz0123',
+      ALL
+    );
+    expect(text).toBe('anthropic sk-ant-[REDACTED] and github ghp_[REDACTED]');
+    expect(matches).toHaveLength(2);
+    expect(findMatch(matches, 'anthropic_key')?.count).toBe(1);
+    expect(findMatch(matches, 'github_token')?.count).toBe(1);
+  });
+
+  it('returns empty matches when nothing fires', () => {
+    const { text, matches } = redactSensitiveText('plain words only', ALL);
+    expect(text).toBe('plain words only');
+    expect(matches).toEqual([]);
+  });
+
+  it('honors a custom redaction text', () => {
+    const { text } = redactSensitiveText('token sk-ant-abcdefghijklmn', {
+      patterns: TEST_PATTERNS,
+      redactionText: '[scrubbed]',
+    });
+    expect(text).toBe('token sk-ant-[scrubbed]');
+  });
+
+  it('limits scanning to the caller-supplied pattern subset', () => {
+    const onlyJwt: SensitivePattern[] = [TEST_PATTERNS[3]];
+    const { text, matches } = redactSensitiveText(
+      'jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.signature and key sk-ant-abcdefghijklmn',
+      { patterns: onlyJwt }
+    );
+    expect(text).toBe('jwt eyJ[REDACTED] and key sk-ant-abcdefghijklmn');
+    expect(matches.map((m) => m.patternId)).toEqual(['jwt']);
+  });
+
+  it('exposes the default redaction text constant', () => {
+    expect(DEFAULT_REDACTION_TEXT).toBe('[REDACTED]');
+  });
+
+  it('returns no matches when patterns array is empty', () => {
+    const { text, matches } = redactSensitiveText(
+      'token sk-ant-abcdefghijklmn',
+      { patterns: [] }
+    );
+    expect(text).toBe('token sk-ant-abcdefghijklmn');
+    expect(matches).toEqual([]);
+  });
+
+  it.each(['task-runner failed', 'mask-value computed', 'monkey=10 bananas'])(
+    'leaves false-positive %s alone',
+    (input) => {
+      const { text, matches } = redactSensitiveText(input, ALL);
+      expect(text).toBe(input);
+      expect(matches).toEqual([]);
+    }
+  );
+});
+
+describe('redactSensitiveValue', () => {
+  it('walks plain strings', () => {
+    const { value, matches } = redactSensitiveValue(
+      'key sk-ant-abcdefghijklmn',
+      ALL
+    );
+    expect(value).toBe('key sk-ant-[REDACTED]');
+    expect(findMatch(matches, 'anthropic_key')?.count).toBe(1);
+  });
+
+  it('walks nested objects and arrays', () => {
+    const input = {
+      user: {
+        text: 'hi sk-ant-abcdefghijklmn',
+        items: [
+          'plain',
+          'ghp_abcdefghijklmnopqrstuvwxyz0123',
+          { nested: 'AKIAIOSFODNN7EXAMPLE' },
+        ],
+      },
+      meta: 42,
+    };
+
+    const { value, matches } = redactSensitiveValue(input, ALL);
+    expect(value).toEqual({
+      user: {
+        text: 'hi sk-ant-[REDACTED]',
+        items: ['plain', 'ghp_[REDACTED]', { nested: 'AKIA[REDACTED]' }],
+      },
+      meta: 42,
+    });
+    expect(findMatch(matches, 'anthropic_key')?.count).toBe(1);
+    expect(findMatch(matches, 'github_token')?.count).toBe(1);
+    expect(findMatch(matches, 'aws_key')?.count).toBe(1);
+  });
+
+  it('preserves reference equality when nothing matches', () => {
+    const input = { user: { text: 'plain words', items: ['a', 'b'] } };
+    const { value, matches } = redactSensitiveValue(input, ALL);
+    expect(value).toBe(input);
+    expect(matches).toEqual([]);
+  });
+
+  it('returns primitives untouched', () => {
+    expect(redactSensitiveValue(42, ALL).value).toBe(42);
+    expect(redactSensitiveValue(true, ALL).value).toBe(true);
+    expect(redactSensitiveValue(null, ALL).value).toBe(null);
+    expect(redactSensitiveValue(undefined, ALL).value).toBe(undefined);
+  });
+});
+
+describe('filterMessageContent', () => {
+  it('scrubs string content on a HumanMessage and reports matches', () => {
+    const input: HumanMessage[] = [
+      new HumanMessage('key sk-ant-abcdefghijklmn please'),
+    ];
+    const { messages, matches } = filterMessageContent(input, ALL);
+
+    expect(messages[0].content).toBe('key sk-ant-[REDACTED] please');
+    expect(messages[0]).toBeInstanceOf(HumanMessage);
+    expect(messages[0]).not.toBe(input[0]);
+    expect(findMatch(matches, 'anthropic_key')?.count).toBe(1);
+  });
+
+  it('preserves reference equality for messages without matches', () => {
+    const clean = new SystemMessage('be helpful');
+    const dirty = new HumanMessage('hi sk-ant-abcdefghijklmn');
+    const { messages } = filterMessageContent([clean, dirty], ALL);
+
+    expect(messages[0]).toBe(clean);
+    expect(messages[1]).not.toBe(dirty);
+  });
+
+  it('scrubs text parts inside multimodal content arrays and leaves other parts alone', () => {
+    const input = new HumanMessage({
+      content: [
+        { type: 'text', text: 'key ghp_abcdefghijklmnopqrstuvwxyz0123 ok' },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.test/img.png' },
+        },
+      ],
+    });
+    const { messages, matches } = filterMessageContent([input], ALL);
+
+    const parts = messages[0].content as Array<
+      | { type: 'text'; text: string }
+      | { type: 'image_url'; image_url: { url: string } }
+    >;
+    expect(parts[0]).toEqual({ type: 'text', text: 'key ghp_[REDACTED] ok' });
+    expect(parts[1]).toEqual({
+      type: 'image_url',
+      image_url: { url: 'https://example.test/img.png' },
+    });
+    expect(findMatch(matches, 'github_token')?.count).toBe(1);
+  });
+
+  it('aggregates match counts across multiple messages', () => {
+    const input = [
+      new HumanMessage('first sk-ant-aaaaaaaaaa'),
+      new AIMessage('seen sk-ant-bbbbbbbbbb earlier'),
+      new SystemMessage('clean'),
+    ];
+    const { messages, matches } = filterMessageContent(input, ALL);
+
+    expect(messages[0].content).toBe('first sk-ant-[REDACTED]');
+    expect(messages[1].content).toBe('seen sk-ant-[REDACTED] earlier');
+    expect(messages[2]).toBe(input[2]);
+    expect(findMatch(matches, 'anthropic_key')?.count).toBe(2);
+  });
+
+  it('returns an empty result for an empty input', () => {
+    const { messages, matches } = filterMessageContent([], ALL);
+    expect(messages).toEqual([]);
+    expect(matches).toEqual([]);
+  });
+});

--- a/src/specs/message-content-redaction.test.ts
+++ b/src/specs/message-content-redaction.test.ts
@@ -1,13 +1,6 @@
 import {
-  AIMessage,
-  HumanMessage,
-  SystemMessage,
-} from '@langchain/core/messages';
-import {
   DEFAULT_REDACTION_TEXT,
-  filterMessageContent,
   redactSensitiveText,
-  redactSensitiveValue,
   type MessageContentRedactionConfig,
   type PatternMatch,
   type SensitivePattern,
@@ -52,12 +45,9 @@ describe('redactSensitiveText', () => {
       ALL
     );
     expect(text).toBe('token sk-ant-[REDACTED] please');
-    expect(matches).toHaveLength(1);
-    expect(findMatch(matches, 'anthropic_key')).toEqual({
-      patternId: 'anthropic_key',
-      patternLabel: 'Anthropic key',
-      count: 1,
-    });
+    expect(matches).toEqual([
+      { patternId: 'anthropic_key', patternLabel: 'Anthropic key', count: 1 },
+    ]);
   });
 
   it('counts multiple matches of the same pattern', () => {
@@ -104,10 +94,6 @@ describe('redactSensitiveText', () => {
     expect(matches.map((m) => m.patternId)).toEqual(['jwt']);
   });
 
-  it('exposes the default redaction text constant', () => {
-    expect(DEFAULT_REDACTION_TEXT).toBe('[REDACTED]');
-  });
-
   it('returns no matches when patterns array is empty', () => {
     const { text, matches } = redactSensitiveText(
       'token sk-ant-abcdefghijklmn',
@@ -115,6 +101,10 @@ describe('redactSensitiveText', () => {
     );
     expect(text).toBe('token sk-ant-abcdefghijklmn');
     expect(matches).toEqual([]);
+  });
+
+  it('exposes the default redaction text constant', () => {
+    expect(DEFAULT_REDACTION_TEXT).toBe('[REDACTED]');
   });
 
   it.each(['task-runner failed', 'mask-value computed', 'monkey=10 bananas'])(
@@ -127,120 +117,29 @@ describe('redactSensitiveText', () => {
   );
 });
 
-describe('redactSensitiveValue', () => {
-  it('walks plain strings', () => {
-    const { value, matches } = redactSensitiveValue(
-      'key sk-ant-abcdefghijklmn',
-      ALL
-    );
-    expect(value).toBe('key sk-ant-[REDACTED]');
-    expect(findMatch(matches, 'anthropic_key')?.count).toBe(1);
-  });
-
-  it('walks nested objects and arrays', () => {
-    const input = {
-      user: {
-        text: 'hi sk-ant-abcdefghijklmn',
-        items: [
-          'plain',
-          'ghp_abcdefghijklmnopqrstuvwxyz0123',
-          { nested: 'AKIAIOSFODNN7EXAMPLE' },
+describe('redactSensitiveText config validation', () => {
+  it('throws when a pattern lacks the global flag', () => {
+    expect(() =>
+      redactSensitiveText('any', {
+        patterns: [
+          {
+            id: 'bad',
+            label: 'missing /g',
+            pattern: /sk-[A-Za-z0-9]+/,
+          },
         ],
-      },
-      meta: 42,
-    };
-
-    const { value, matches } = redactSensitiveValue(input, ALL);
-    expect(value).toEqual({
-      user: {
-        text: 'hi sk-ant-[REDACTED]',
-        items: ['plain', 'ghp_[REDACTED]', { nested: 'AKIA[REDACTED]' }],
-      },
-      meta: 42,
-    });
-    expect(findMatch(matches, 'anthropic_key')?.count).toBe(1);
-    expect(findMatch(matches, 'github_token')?.count).toBe(1);
-    expect(findMatch(matches, 'aws_key')?.count).toBe(1);
+      })
+    ).toThrow(/global \(g\) flag/);
   });
 
-  it('preserves reference equality when nothing matches', () => {
-    const input = { user: { text: 'plain words', items: ['a', 'b'] } };
-    const { value, matches } = redactSensitiveValue(input, ALL);
-    expect(value).toBe(input);
-    expect(matches).toEqual([]);
-  });
-
-  it('returns primitives untouched', () => {
-    expect(redactSensitiveValue(42, ALL).value).toBe(42);
-    expect(redactSensitiveValue(true, ALL).value).toBe(true);
-    expect(redactSensitiveValue(null, ALL).value).toBe(null);
-    expect(redactSensitiveValue(undefined, ALL).value).toBe(undefined);
-  });
-});
-
-describe('filterMessageContent', () => {
-  it('scrubs string content on a HumanMessage and reports matches', () => {
-    const input: HumanMessage[] = [
-      new HumanMessage('key sk-ant-abcdefghijklmn please'),
-    ];
-    const { messages, matches } = filterMessageContent(input, ALL);
-
-    expect(messages[0].content).toBe('key sk-ant-[REDACTED] please');
-    expect(messages[0]).toBeInstanceOf(HumanMessage);
-    expect(messages[0]).not.toBe(input[0]);
-    expect(findMatch(matches, 'anthropic_key')?.count).toBe(1);
-  });
-
-  it('preserves reference equality for messages without matches', () => {
-    const clean = new SystemMessage('be helpful');
-    const dirty = new HumanMessage('hi sk-ant-abcdefghijklmn');
-    const { messages } = filterMessageContent([clean, dirty], ALL);
-
-    expect(messages[0]).toBe(clean);
-    expect(messages[1]).not.toBe(dirty);
-  });
-
-  it('scrubs text parts inside multimodal content arrays and leaves other parts alone', () => {
-    const input = new HumanMessage({
-      content: [
-        { type: 'text', text: 'key ghp_abcdefghijklmnopqrstuvwxyz0123 ok' },
-        {
-          type: 'image_url',
-          image_url: { url: 'https://example.test/img.png' },
-        },
-      ],
-    });
-    const { messages, matches } = filterMessageContent([input], ALL);
-
-    const parts = messages[0].content as Array<
-      | { type: 'text'; text: string }
-      | { type: 'image_url'; image_url: { url: string } }
-    >;
-    expect(parts[0]).toEqual({ type: 'text', text: 'key ghp_[REDACTED] ok' });
-    expect(parts[1]).toEqual({
-      type: 'image_url',
-      image_url: { url: 'https://example.test/img.png' },
-    });
-    expect(findMatch(matches, 'github_token')?.count).toBe(1);
-  });
-
-  it('aggregates match counts across multiple messages', () => {
-    const input = [
-      new HumanMessage('first sk-ant-aaaaaaaaaa'),
-      new AIMessage('seen sk-ant-bbbbbbbbbb earlier'),
-      new SystemMessage('clean'),
-    ];
-    const { messages, matches } = filterMessageContent(input, ALL);
-
-    expect(messages[0].content).toBe('first sk-ant-[REDACTED]');
-    expect(messages[1].content).toBe('seen sk-ant-[REDACTED] earlier');
-    expect(messages[2]).toBe(input[2]);
-    expect(findMatch(matches, 'anthropic_key')?.count).toBe(2);
-  });
-
-  it('returns an empty result for an empty input', () => {
-    const { messages, matches } = filterMessageContent([], ALL);
-    expect(messages).toEqual([]);
-    expect(matches).toEqual([]);
+  it('throws when two patterns share an id', () => {
+    expect(() =>
+      redactSensitiveText('any', {
+        patterns: [
+          { id: 'dup', label: 'first', pattern: /sk-1/g },
+          { id: 'dup', label: 'second', pattern: /sk-2/g },
+        ],
+      })
+    ).toThrow(/duplicate pattern id/);
   });
 });


### PR DESCRIPTION
## Summary

Adds two complementary primitives that together let consumers rewrite the user's prompt before it reaches the model.

**`updatedPrompt` on UserPromptSubmit hook output.** Hooks can now return `{ updatedPrompt: string }` and the value is applied to the prompt that flows into the model. Aggregation follows the existing pattern: parallel hooks fold via last-writer-wins, matching how `updatedInput` is handled. `applyPromptOverride` in `run.ts` performs the swap using a prototype-preserving clone so downstream consumers that check `instanceof HumanMessage` still work, and handles both string and multimodal content-block shapes.

**`redactSensitiveText` primitive** (`src/messageContentRedaction.ts`). Pure helper that scrubs caller-supplied regex patterns from a string, keeping the first capture group as a visible prefix so consumers can still tell which family of secret matched (`sk-[REDACTED]` vs `Bearer [REDACTED]`). No built-in pattern catalog. Validates the `/g` flag, rejects duplicate pattern ids, returns per-pattern match counts.

The two are decoupled. The hook field is useful to any consumer doing prompt rewriting (PII, content policy, translation, normalization). The redaction helper is useful as a standalone scrubbing utility.

## Test plan

- [ ] `npm test -- --testPathPatterns=updatedPrompt` passes
- [ ] `npm test -- --testPathPatterns=message-content-redaction` passes
- [ ] Full test suite green locally
- [ ] CI green on the PR
- [ ] Downstream LibreChat consumer (companion PR) builds and exercises both primitives end-to-end