### PR TITLE
🚰 fix: Plug Scraped Content Leak & Cap Web Search Payloads

### DIFF
--- a/src/tools/search/highlights.ts
+++ b/src/tools/search/highlights.ts
@@ -240,7 +240,15 @@ export function expandHighlights(
         !result.highlights ||
         result.highlights.length === 0
       ) {
-        return result; // No modification needed
+        if (result.content == null && result.references == null) {
+          return result;
+        }
+        /** Raw scraped content must never leave this function — without
+         * highlights to expand, strip it instead of passing it downstream */
+        const strippedResult = { ...result };
+        delete strippedResult.content;
+        delete strippedResult.references;
+        return strippedResult;
       }
 
       // Create a shallow copy with expanded highlights

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -631,7 +631,20 @@ export const createSourceProcessor = (
           images: [],
           relatedSearches: [],
         };
-      } else if (!result.data.organic) {
+      }
+
+      if (
+        result.data.topStories != null &&
+        result.data.topStories.length > numElements
+      ) {
+        /** Merged news results can far exceed the requested source count;
+         * every entry is formatted into the LLM output, so cap them up
+         * front — before any early return below and before scraping
+         * entries the cap would discard */
+        result.data.topStories = result.data.topStories.slice(0, numElements);
+      }
+
+      if (!result.data.organic) {
         return result.data;
       }
 
@@ -728,14 +741,6 @@ export const createSourceProcessor = (
 
       if (news && topStories.length > 0) {
         updateSourcesWithContent(topStories, sourceMap);
-      }
-
-      if (topStories.length > numElements) {
-        /** Merged news results can far exceed the requested source count;
-         * every entry here is formatted into the LLM output, so cap them
-         * like organic results (sliced after enrichment to keep the
-         * scraped/reranked entries, which come first) */
-        result.data.topStories = topStories.slice(0, numElements);
       }
 
       return result.data;

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -66,6 +66,25 @@ const chunker = {
   },
 };
 
+const DEFAULT_MAX_CONTENT_LENGTH = 50000;
+
+/** Resolves the per-source scraped content cap from config, the
+ * `SEARCH_MAX_CONTENT_LENGTH` env var, or the default (50,000 chars) */
+function resolveMaxContentLength(maxContentLength?: number): number {
+  if (maxContentLength != null && maxContentLength > 0) {
+    return maxContentLength;
+  }
+  const envValue = Number(process.env.SEARCH_MAX_CONTENT_LENGTH);
+  if (Number.isFinite(envValue) && envValue > 0) {
+    return envValue;
+  }
+  return DEFAULT_MAX_CONTENT_LENGTH;
+}
+
+function truncateContent(content: string, maxLength: number): string {
+  return content.length > maxLength ? content.slice(0, maxLength) : content;
+}
+
 function createSourceUpdateCallback(sourceMap: Map<string, t.ValidSource>) {
   return (link: string, update?: Partial<t.ValidSource>): void => {
     const source = sourceMap.get(link);
@@ -83,12 +102,14 @@ const getHighlights = async ({
   content,
   reranker,
   topResults = 5,
+  maxContentLength = DEFAULT_MAX_CONTENT_LENGTH,
   logger,
 }: {
   content: string;
   query: string;
   reranker?: BaseReranker;
   topResults?: number;
+  maxContentLength?: number;
   logger?: t.Logger;
 }): Promise<t.Highlight[] | undefined> => {
   const logger_ = logger || createDefaultLogger();
@@ -103,7 +124,9 @@ const getHighlights = async ({
   }
 
   try {
-    const documents = await chunker.splitText(content);
+    const documents = await chunker.splitText(
+      truncateContent(content, maxContentLength)
+    );
     if (Array.isArray(documents)) {
       return await reranker.rerank(query, documents, topResults);
     } else {
@@ -457,6 +480,7 @@ export const createSourceProcessor = (
     logger,
   } = config;
 
+  const maxContentLength = resolveMaxContentLength(config.maxContentLength);
   const logger_ = logger || createDefaultLogger();
   const scraper = scraperInstance;
 
@@ -475,7 +499,7 @@ export const createSourceProcessor = (
         url,
         references,
         attribution,
-        content: chunker.cleanText(content),
+        content: truncateContent(chunker.cleanText(content), maxContentLength),
       };
     }
 
@@ -498,6 +522,7 @@ export const createSourceProcessor = (
         query,
         reranker,
         content: result.content,
+        maxContentLength,
         logger: logger_,
       });
       if (onGetHighlights) {
@@ -703,6 +728,14 @@ export const createSourceProcessor = (
 
       if (news && topStories.length > 0) {
         updateSourcesWithContent(topStories, sourceMap);
+      }
+
+      if (topStories.length > numElements) {
+        /** Merged news results can far exceed the requested source count;
+         * every entry here is formatted into the LLM output, so cap them
+         * like organic results (sliced after enrichment to keep the
+         * scraped/reranked entries, which come first) */
+        result.data.topStories = topStories.slice(0, numElements);
       }
 
       return result.data;

--- a/src/tools/search/source-processing.test.ts
+++ b/src/tools/search/source-processing.test.ts
@@ -1,0 +1,333 @@
+import type * as t from './types';
+import { executeParallelSearches } from './tool';
+import { createSourceProcessor } from './search';
+import { expandHighlights } from './highlights';
+import { BaseReranker } from './rerankers';
+
+const noopLog = (..._args: unknown[]): void => {};
+const silentLogger = {
+  error: noopLog,
+  warn: noopLog,
+  info: noopLog,
+  debug: noopLog,
+} as t.Logger;
+
+class RecordingReranker extends BaseReranker {
+  public rerankCalls: string[][] = [];
+
+  constructor() {
+    super(silentLogger);
+  }
+
+  async rerank(
+    _query: string,
+    documents: string[],
+    topK: number = 5
+  ): Promise<t.Highlight[]> {
+    this.rerankCalls.push(documents);
+    return this.getDefaultRanking(documents, topK);
+  }
+}
+
+const createFakeScraper = (
+  contentByUrl: Record<string, string>,
+  scrapedUrls: string[] = []
+): t.BaseScraper => ({
+  scrapeUrl: async (url: string): Promise<[string, t.AnyScraperResponse]> => {
+    scrapedUrls.push(url);
+    return [
+      url,
+      { success: true, data: { markdown: contentByUrl[url] ?? '' } },
+    ];
+  },
+  extractContent: (
+    response: t.AnyScraperResponse
+  ): [string, undefined | t.References] => [
+    (response as t.FirecrawlScrapeResponse).data?.markdown ?? '',
+    undefined,
+  ],
+  extractMetadata: (): t.GenericScrapeMetadata => ({}),
+});
+
+const makeOrganic = (link: string): t.ProcessedOrganic => ({
+  link,
+  title: `Title for ${link}`,
+  snippet: `Snippet for ${link}`,
+});
+
+const makeStory = (link: string): t.ProcessedTopStory => ({
+  link,
+  title: `Story for ${link}`,
+});
+
+const makeLongContent = (chars: number): string => {
+  const line =
+    'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod\n';
+  return line.repeat(Math.ceil(chars / line.length)).slice(0, chars);
+};
+
+describe('expandHighlights content stripping', () => {
+  test('strips content and references from sources without highlights', () => {
+    const references: t.References = { links: [], images: [], videos: [] };
+    const data: t.SearchResultData = {
+      organic: [
+        {
+          ...makeOrganic('https://a.com'),
+          content: 'X'.repeat(100000),
+          references,
+        },
+      ],
+      topStories: [
+        { ...makeStory('https://news.com'), content: 'Y'.repeat(100000) },
+      ],
+    };
+
+    const result = expandHighlights(data);
+
+    expect(result.organic?.[0].content).toBeUndefined();
+    expect(result.organic?.[0].references).toBeUndefined();
+    expect(result.organic?.[0].title).toBe('Title for https://a.com');
+    expect(result.organic?.[0].snippet).toBe('Snippet for https://a.com');
+    expect(result.topStories?.[0].content).toBeUndefined();
+    expect(result.topStories?.[0].title).toBe('Story for https://news.com');
+    expect(data.organic?.[0].content).toBeDefined();
+  });
+
+  test('strips content when highlights array is empty', () => {
+    const data: t.SearchResultData = {
+      organic: [
+        {
+          ...makeOrganic('https://a.com'),
+          content: 'X'.repeat(5000),
+          highlights: [],
+        },
+      ],
+    };
+
+    const result = expandHighlights(data);
+
+    expect(result.organic?.[0].content).toBeUndefined();
+    expect(result.organic?.[0].highlights).toEqual([]);
+  });
+
+  test('returns sources without content or references unchanged', () => {
+    const source = makeOrganic('https://a.com');
+    const result = expandHighlights({ organic: [source] });
+
+    expect(result.organic?.[0]).toBe(source);
+  });
+
+  test('still expands highlights and strips content on the normal path', () => {
+    const highlightText = 'THE KEY FACT OF THIS PAGE IS RIGHT HERE.';
+    const content = `${makeLongContent(2000)} ${highlightText} ${makeLongContent(2000)}`;
+    const data: t.SearchResultData = {
+      organic: [
+        {
+          ...makeOrganic('https://a.com'),
+          content,
+          highlights: [{ text: highlightText, score: 0.9 }],
+        },
+      ],
+    };
+
+    const result = expandHighlights(data);
+    const highlight = result.organic?.[0].highlights?.[0];
+
+    expect(highlight?.text).toContain(highlightText);
+    expect(highlight?.text.length).toBeGreaterThan(highlightText.length);
+    expect(highlight?.score).toBe(0.9);
+    expect(result.organic?.[0].content).toBeUndefined();
+    expect(result.organic?.[0].references).toBeUndefined();
+  });
+});
+
+describe('createSourceProcessor content capping', () => {
+  const link = 'https://a.com';
+  const baseFields = {
+    query: 'test query',
+    proMode: true,
+    onGetHighlights: undefined,
+  };
+
+  test('caps stored content and reranker input at maxContentLength', async () => {
+    const reranker = new RecordingReranker();
+    const scraper = createFakeScraper({ [link]: makeLongContent(200000) });
+    const processor = createSourceProcessor(
+      { reranker, maxContentLength: 1000, logger: silentLogger },
+      scraper
+    );
+
+    const data = await processor.processSources({
+      ...baseFields,
+      news: false,
+      numElements: 5,
+      result: { success: true, data: { organic: [makeOrganic(link)] } },
+    });
+
+    expect(data.organic?.[0].content?.length).toBe(1000);
+    const rerankedChars = reranker.rerankCalls
+      .flat()
+      .reduce((sum, doc) => sum + doc.length, 0);
+    expect(rerankedChars).toBeGreaterThan(0);
+    expect(rerankedChars).toBeLessThan(2000);
+  });
+
+  test('respects SEARCH_MAX_CONTENT_LENGTH env var when config is not set', async () => {
+    process.env.SEARCH_MAX_CONTENT_LENGTH = '500';
+    try {
+      const reranker = new RecordingReranker();
+      const scraper = createFakeScraper({ [link]: makeLongContent(10000) });
+      const processor = createSourceProcessor(
+        { reranker, logger: silentLogger },
+        scraper
+      );
+
+      const data = await processor.processSources({
+        ...baseFields,
+        news: false,
+        numElements: 5,
+        result: { success: true, data: { organic: [makeOrganic(link)] } },
+      });
+
+      expect(data.organic?.[0].content?.length).toBe(500);
+    } finally {
+      delete process.env.SEARCH_MAX_CONTENT_LENGTH;
+    }
+  });
+
+  test('caps content at 50,000 chars by default', async () => {
+    const reranker = new RecordingReranker();
+    const scraper = createFakeScraper({ [link]: makeLongContent(60000) });
+    const processor = createSourceProcessor(
+      { reranker, logger: silentLogger },
+      scraper
+    );
+
+    const data = await processor.processSources({
+      ...baseFields,
+      news: false,
+      numElements: 5,
+      result: { success: true, data: { organic: [makeOrganic(link)] } },
+    });
+
+    expect(data.organic?.[0].content?.length).toBe(50000);
+  });
+});
+
+describe('createSourceProcessor topStories capping', () => {
+  const storyLinks = Array.from(
+    { length: 8 },
+    (_, i) => `https://news${i}.com`
+  );
+
+  const createProcessorWithStories = (
+    scrapedUrls: string[]
+  ): ReturnType<typeof createSourceProcessor> => {
+    const contentByUrl = Object.fromEntries(
+      storyLinks.map((storyLink) => [storyLink, makeLongContent(500)])
+    );
+    contentByUrl['https://a.com'] = makeLongContent(500);
+    const scraper = createFakeScraper(contentByUrl, scrapedUrls);
+    return createSourceProcessor(
+      { reranker: new RecordingReranker(), logger: silentLogger },
+      scraper
+    );
+  };
+
+  test('caps topStories to numElements when news is enabled', async () => {
+    const scrapedUrls: string[] = [];
+    const processor = createProcessorWithStories(scrapedUrls);
+
+    const data = await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: true,
+      numElements: 3,
+      result: {
+        success: true,
+        data: { organic: [], topStories: storyLinks.map(makeStory) },
+      },
+    });
+
+    expect(data.topStories?.length).toBe(3);
+    expect(data.topStories?.map((story) => story.link)).toEqual(
+      storyLinks.slice(0, 3)
+    );
+    expect(scrapedUrls).toEqual(storyLinks.slice(0, 3));
+    expect(data.topStories?.[0].content).toBeDefined();
+  });
+
+  test('caps topStories to numElements even when news is disabled', async () => {
+    const scrapedUrls: string[] = [];
+    const processor = createProcessorWithStories(scrapedUrls);
+
+    const data = await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: 3,
+      result: {
+        success: true,
+        data: {
+          organic: [makeOrganic('https://a.com')],
+          topStories: storyLinks.map(makeStory),
+        },
+      },
+    });
+
+    expect(data.topStories?.length).toBe(3);
+    expect(scrapedUrls).toEqual(['https://a.com']);
+  });
+});
+
+describe('executeParallelSearches topStories dedupe', () => {
+  test('dedupes topStories by link across main and news searches', async () => {
+    const mainResult: t.SearchResult = {
+      success: true,
+      data: {
+        organic: [makeOrganic('https://a.com')],
+        topStories: [makeStory('https://n1.com')],
+        news: [
+          { title: 'N1 from main news', link: 'https://n1.com' },
+          { title: 'N2 from main news', link: 'https://n2.com' },
+        ],
+      },
+    };
+    const newsResult: t.SearchResult = {
+      success: true,
+      data: {
+        news: [
+          { title: 'N2 from news search', link: 'https://n2.com' },
+          { title: 'N3 from news search', link: 'https://n3.com' },
+          { title: 'No link' },
+        ],
+      },
+    };
+    const searchAPI = {
+      getSources: async (
+        params: t.GetSourcesParams
+      ): Promise<t.SearchResult> =>
+        params.type === 'news' ? newsResult : mainResult,
+    };
+
+    const merged = await executeParallelSearches({
+      searchAPI,
+      query: 'test query',
+      safeSearch: 1,
+      images: false,
+      videos: false,
+      news: true,
+      logger: silentLogger,
+    });
+
+    expect(merged.data?.topStories?.map((story) => story.link)).toEqual([
+      'https://n1.com',
+      'https://n2.com',
+      'https://n3.com',
+    ]);
+    expect(merged.data?.topStories?.[0].title).toBe('Story for https://n1.com');
+    expect(merged.data?.news).toBeUndefined();
+  });
+});

--- a/src/tools/search/source-processing.test.ts
+++ b/src/tools/search/source-processing.test.ts
@@ -258,6 +258,46 @@ describe('createSourceProcessor topStories capping', () => {
     expect(data.topStories?.[0].content).toBeDefined();
   });
 
+  test('caps topStories when organic results are missing', async () => {
+    const scrapedUrls: string[] = [];
+    const processor = createProcessorWithStories(scrapedUrls);
+
+    const data = await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: true,
+      numElements: 3,
+      result: {
+        success: true,
+        data: { topStories: storyLinks.map(makeStory) },
+      },
+    });
+
+    expect(data.topStories?.length).toBe(3);
+    expect(scrapedUrls).toEqual([]);
+  });
+
+  test('caps topStories on the empty-links early return with news disabled', async () => {
+    const scrapedUrls: string[] = [];
+    const processor = createProcessorWithStories(scrapedUrls);
+
+    const data = await processor.processSources({
+      query: 'test query',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: 3,
+      result: {
+        success: true,
+        data: { organic: [], topStories: storyLinks.map(makeStory) },
+      },
+    });
+
+    expect(data.topStories?.length).toBe(3);
+    expect(scrapedUrls).toEqual([]);
+  });
+
   test('caps topStories to numElements even when news is disabled', async () => {
     const scrapedUrls: string[] = [];
     const processor = createProcessorWithStories(scrapedUrls);

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -23,9 +23,10 @@ import { createReranker } from './rerankers';
 import { Constants } from '@/common';
 
 /**
- * Executes parallel searches and merges the results
+ * Executes parallel searches and merges the results,
+ * deduplicating top stories by link
  */
-async function executeParallelSearches({
+export async function executeParallelSearches({
   searchAPI,
   query,
   date,
@@ -172,6 +173,23 @@ async function executeParallelSearches({
       }
     }
   });
+
+  if (
+    mergedResults.topStories !== undefined &&
+    mergedResults.topStories.length > 1
+  ) {
+    /** The main search's own news results and the parallel news sub-search
+     * frequently return the same stories — keep the first occurrence of each
+     * link so duplicates aren't scraped, reranked, and formatted repeatedly */
+    const seenLinks = new Set<string>();
+    mergedResults.topStories = mergedResults.topStories.filter((story) => {
+      if (!story.link || seenLinks.has(story.link)) {
+        return false;
+      }
+      seenLinks.add(story.link);
+      return true;
+    });
+  }
 
   return { success: true, data: mergedResults };
 }
@@ -340,6 +358,7 @@ export const createSearchTool = (
     tavilySearchOptions,
     rerankerType = 'cohere',
     topResults = 5,
+    maxContentLength,
     strategies = ['no_extraction'],
     filterContent = true,
     safeSearch = 1,
@@ -444,6 +463,7 @@ export const createSearchTool = (
     {
       reranker: selectedReranker,
       topResults,
+      maxContentLength,
       strategies,
       filterContent,
       logger,

--- a/src/tools/search/types.ts
+++ b/src/tools/search/types.ts
@@ -133,6 +133,10 @@ export interface ScrapeResult {
 
 export interface ProcessSourcesConfig {
   topResults?: number;
+  /** Max chars of scraped content stored per source and passed to the
+   * chunker/reranker. Defaults to 50,000; also configurable via the
+   * `SEARCH_MAX_CONTENT_LENGTH` env var. */
+  maxContentLength?: number;
   strategies?: string[];
   filterContent?: boolean;
   reranker?: BaseReranker;


### PR DESCRIPTION
## Summary

Continues and supersedes #63 — full credit to @dan-and for the deep investigation that identified these issues. The original branch went stale, so I reimplemented the fixes on current `main`, with unit tests and fresh real-API verification.

Web search was leaking full raw scraped page content into the search artifact and letting merged news results balloon far past the requested source count, overflowing smaller context windows (see the detailed analysis in #63).

- Stripped `content`/`references` from sources without highlights in `expandHighlights` — the early-return path previously passed the entire scraped page (tens to hundreds of KB per source) downstream whenever the reranker returned no highlights, a scrape produced no usable text, or rerank fell back; the normal path already deleted these fields.
- Capped scraped content at 50,000 chars per source, applied at storage time after cleaning and again before chunking, bounding reranker request sizes against degenerate pages (minified content, dense tables, very long articles). Configurable via `maxContentLength` on `ProcessSourcesConfig`/`createSearchTool`, or the `SEARCH_MAX_CONTENT_LENGTH` env var.
- Deduplicated merged `topStories` by link in `executeParallelSearches` — the main search's own news results and the parallel news sub-search frequently return the same stories, which were then scraped, reranked, and formatted repeatedly (the "4-5x the same news" from #63).
- Capped `topStories` to the requested source count (`numElements`) in `processSources` after enrichment, mirroring how organic results are limited via `fetchContents`' `target`; previously 24-37 news entries could flow into the formatted LLM output. SearXNG was worst affected, but Serper's news sub-search is also uncapped at the source.
- Added `source-processing.test.ts` with 10 tests covering content stripping (no highlights, empty highlights, normal expansion path), both cap layers, the env var override, the 50k default, topStories capping with news on and off, and merge dedupe.

Real-API before/after on this branch vs. unmodified `main` (Serper + Firecrawl, identical query with `news: true`):

| Metric | Before (`main`) | After |
| --- | --- | --- |
| Raw content in artifact (sources without highlights) | 238,576 chars across 11 sources | 0 chars |
| Search artifact JSON | 250,236 chars | 6,481 chars |
| `topStories` entries | 10 | 5 |

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the new unit suite plus all existing search tests: `npx jest src/tools/search` — 69 tests pass.
- Ran the CI-equivalent full suite; the only failures are the 3 pre-existing API-key-dependent spec suites that fail identically on unmodified `main`.
- Verified end-to-end against real APIs with a measurement harness that invokes `createSearchTool` and inspects the LLM output string and the `web_search` artifact: ran it on unmodified `main` and on this branch with the same query, once with a working reranker pipeline and once with `rerankerType: 'none'` to force the no-highlights path. The numbers in the table above are from those runs. The reranker-error path was also exercised live (Jina returned 403), confirming the fallback ranking produces bounded output.
- `npx tsc --noEmit`, `npx eslint src/tools/search/`, and `npm run sort-imports:check` are clean.

### **Test Configuration**:

- Search: Serper; Scraper: Firecrawl (hosted v2 API); Rerankers: Jina (403 fallback path) and `none`
- Node v24.16.0, macOS

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes