### PR TITLE
📊 feat: Emit ON_CONTEXT_USAGE Token Budget Snapshots

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1014,6 +1014,7 @@ export class AgentContext {
     let toolTokens = 0;
     const countedToolNames = new Set<string>();
     const rawToolTokenCounts: Record<string, number> = {};
+    const deferredCountedNames = new Set<string>();
 
     /**
      * Iterate both `tools` (user-provided instance tools) and `graphTools`
@@ -1080,6 +1081,9 @@ export class AgentContext {
       countedToolNames.add(def.name);
       rawToolTokenCounts[def.name] =
         (rawToolTokenCounts[def.name] ?? 0) + schemaTokens;
+      if (def.defer_loading === true) {
+        deferredCountedNames.add(def.name);
+      }
     }
 
     const isAnthropic =
@@ -1099,7 +1103,10 @@ export class AgentContext {
     const deferredToolNames: string[] = [];
     for (const [name, rawCount] of Object.entries(rawToolTokenCounts)) {
       toolTokenCounts[name] = Math.ceil(rawCount * toolTokenMultiplier);
-      if (this.toolRegistry?.get(name)?.defer_loading === true) {
+      if (
+        deferredCountedNames.has(name) ||
+        this.toolRegistry?.get(name)?.defer_loading === true
+      ) {
         deferredToolNames.push(name);
       }
     }

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -191,8 +191,9 @@ export class AgentContext {
   dynamicInstructionTokens: number = 0;
   /** Token count for tool schemas only. */
   toolSchemaTokens: number = 0;
-  /** Per-tool schema token counts (post-multiplier), keyed by tool name. */
-  toolTokenCounts: Record<string, number> = {};
+  /** Per-tool schema token counts (post-multiplier), keyed by tool name.
+   *  `undefined` when not calculated (e.g. cached aggregate schema tokens). */
+  toolTokenCounts?: Record<string, number>;
   /** Names of counted tools that are deferred (`defer_loading`) and discovered. */
   deferredToolNames: string[] = [];
   /** Running calibration ratio from the pruner — persisted across runs via contextMeta. */
@@ -898,7 +899,7 @@ export class AgentContext {
     this.systemMessageTokens = 0;
     this.dynamicInstructionTokens = 0;
     this.toolSchemaTokens = 0;
-    this.toolTokenCounts = {};
+    this.toolTokenCounts = undefined;
     this.deferredToolNames = [];
     this.cachedSystemRunnable = undefined;
     this.systemRunnableStale = true;
@@ -1282,7 +1283,8 @@ export class AgentContext {
       messageCount,
       messageTokens,
       availableForMessages,
-      toolTokenCounts: { ...this.toolTokenCounts },
+      toolTokenCounts:
+        this.toolTokenCounts != null ? { ...this.toolTokenCounts } : undefined,
       deferredToolNames:
         this.deferredToolNames.length > 0
           ? [...this.deferredToolNames]

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1247,9 +1247,8 @@ export class AgentContext {
    * Returns a structured breakdown of how the context token budget is consumed.
    * Useful for diagnostics when context overflow or pruning issues occur.
    *
-   * Note: `toolCount` reflects discoveries immediately, but `toolSchemaTokens`
-   * is a snapshot taken during `calculateInstructionTokens` and is not
-   * recomputed when `markToolsAsDiscovered` is called mid-run.
+   * Note: `markToolsAsDiscovered` re-triggers `calculateInstructionTokens`,
+   * so `toolSchemaTokens`/`toolTokenCounts` refresh before the next call.
    */
   getTokenBudgetBreakdown(messages?: BaseMessage[]): t.TokenBudgetBreakdown {
     const maxContextTokens = this.maxContextTokens ?? 0;
@@ -1273,7 +1272,14 @@ export class AgentContext {
       }
     }
 
-    const reserveTokens = Math.round(maxContextTokens * DEFAULT_RESERVE_RATIO);
+    /** Mirror the pruner's reserve math so availableForMessages agrees
+     *  with the contextBudget computed during pruning */
+    const reserveRatio =
+      this.summarizationConfig?.reserveRatio ?? DEFAULT_RESERVE_RATIO;
+    const reserveTokens =
+      reserveRatio > 0 && reserveRatio < 1
+        ? Math.round(maxContextTokens * reserveRatio)
+        : 0;
     const availableForMessages = Math.max(
       0,
       maxContextTokens - reserveTokens - this.instructionTokens
@@ -1365,6 +1371,14 @@ export class AgentContext {
     }
     if (hasNewDiscoveries) {
       this.systemRunnableStale = true;
+      /** Refresh schema token accounting so the next call's budget and
+       *  per-tool breakdown include the newly discovered tools; awaited
+       *  via tokenCalculationPromise before the next model call */
+      if (this.tokenCounter) {
+        this.tokenCalculationPromise = this.calculateInstructionTokens(
+          this.tokenCounter
+        );
+      }
     }
     return hasNewDiscoveries;
   }

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -21,6 +21,7 @@ import {
   addCacheControlToStablePrefixMessages,
 } from '@/messages/cache';
 import { createSchemaOnlyTools } from '@/tools/schema';
+import { apportionTokenCounts } from '@/utils/tokens';
 import { DEFAULT_RESERVE_RATIO } from '@/messages';
 import { toJsonSchema } from '@/utils/schema';
 
@@ -1101,10 +1102,15 @@ export class AgentContext {
       : DEFAULT_TOOL_TOKEN_MULTIPLIER;
     this.toolSchemaTokens = Math.ceil(toolTokens * toolTokenMultiplier);
 
-    const toolTokenCounts: Record<string, number> = Object.create(null);
+    /** Largest-remainder apportionment keeps the per-tool counts summing
+     *  exactly to the aggregate despite per-entry rounding */
+    const toolTokenCounts = apportionTokenCounts(
+      rawToolTokenCounts,
+      toolTokenMultiplier,
+      this.toolSchemaTokens
+    );
     const deferredToolNames: string[] = [];
-    for (const [name, rawCount] of Object.entries(rawToolTokenCounts)) {
-      toolTokenCounts[name] = Math.ceil(rawCount * toolTokenMultiplier);
+    for (const name of Object.keys(rawToolTokenCounts)) {
       if (
         deferredCountedNames.has(name) ||
         this.toolRegistry?.get(name)?.defer_loading === true

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -191,6 +191,10 @@ export class AgentContext {
   dynamicInstructionTokens: number = 0;
   /** Token count for tool schemas only. */
   toolSchemaTokens: number = 0;
+  /** Per-tool schema token counts (post-multiplier), keyed by tool name. */
+  toolTokenCounts: Record<string, number> = {};
+  /** Names of counted tools that are deferred (`defer_loading`) and discovered. */
+  deferredToolNames: string[] = [];
   /** Running calibration ratio from the pruner — persisted across runs via contextMeta. */
   calibrationRatio: number = 1;
   /** Provider-observed instruction overhead from the pruner's best-variance turn. */
@@ -894,6 +898,8 @@ export class AgentContext {
     this.systemMessageTokens = 0;
     this.dynamicInstructionTokens = 0;
     this.toolSchemaTokens = 0;
+    this.toolTokenCounts = {};
+    this.deferredToolNames = [];
     this.cachedSystemRunnable = undefined;
     this.systemRunnableStale = true;
     this.lastToken = undefined;
@@ -1006,6 +1012,7 @@ export class AgentContext {
   ): Promise<void> {
     let toolTokens = 0;
     const countedToolNames = new Set<string>();
+    const rawToolTokenCounts: Record<string, number> = {};
 
     /**
      * Iterate both `tools` (user-provided instance tools) and `graphTools`
@@ -1040,11 +1047,14 @@ export class AgentContext {
             toolName,
             (genericTool.description as string | undefined) ?? ''
           );
-          toolTokens += tokenCounter(
+          const schemaTokens = tokenCounter(
             new SystemMessage(JSON.stringify(jsonSchema))
           );
+          toolTokens += schemaTokens;
           if (toolName) {
             countedToolNames.add(toolName);
+            rawToolTokenCounts[toolName] =
+              (rawToolTokenCounts[toolName] ?? 0) + schemaTokens;
           }
         }
       }
@@ -1062,7 +1072,13 @@ export class AgentContext {
           parameters: def.parameters ?? {},
         },
       };
-      toolTokens += tokenCounter(new SystemMessage(JSON.stringify(schema)));
+      const schemaTokens = tokenCounter(
+        new SystemMessage(JSON.stringify(schema))
+      );
+      toolTokens += schemaTokens;
+      countedToolNames.add(def.name);
+      rawToolTokenCounts[def.name] =
+        (rawToolTokenCounts[def.name] ?? 0) + schemaTokens;
     }
 
     const isAnthropic =
@@ -1077,6 +1093,17 @@ export class AgentContext {
       ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER
       : DEFAULT_TOOL_TOKEN_MULTIPLIER;
     this.toolSchemaTokens = Math.ceil(toolTokens * toolTokenMultiplier);
+
+    const toolTokenCounts: Record<string, number> = {};
+    const deferredToolNames: string[] = [];
+    for (const [name, rawCount] of Object.entries(rawToolTokenCounts)) {
+      toolTokenCounts[name] = Math.ceil(rawCount * toolTokenMultiplier);
+      if (this.toolRegistry?.get(name)?.defer_loading === true) {
+        deferredToolNames.push(name);
+      }
+    }
+    this.toolTokenCounts = toolTokenCounts;
+    this.deferredToolNames = deferredToolNames;
   }
 
   /**
@@ -1255,6 +1282,11 @@ export class AgentContext {
       messageCount,
       messageTokens,
       availableForMessages,
+      toolTokenCounts: { ...this.toolTokenCounts },
+      deferredToolNames:
+        this.deferredToolNames.length > 0
+          ? [...this.deferredToolNames]
+          : undefined,
     };
   }
 

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1013,7 +1013,9 @@ export class AgentContext {
   ): Promise<void> {
     let toolTokens = 0;
     const countedToolNames = new Set<string>();
-    const rawToolTokenCounts: Record<string, number> = {};
+    /** Prototype-free: external tool names like `toString` must not hit
+     *  inherited properties during accumulation */
+    const rawToolTokenCounts: Record<string, number> = Object.create(null);
     const deferredCountedNames = new Set<string>();
 
     /**
@@ -1099,7 +1101,7 @@ export class AgentContext {
       : DEFAULT_TOOL_TOKEN_MULTIPLIER;
     this.toolSchemaTokens = Math.ceil(toolTokens * toolTokenMultiplier);
 
-    const toolTokenCounts: Record<string, number> = {};
+    const toolTokenCounts: Record<string, number> = Object.create(null);
     const deferredToolNames: string[] = [];
     for (const [name, rawCount] of Object.entries(rawToolTokenCounts)) {
       toolTokenCounts[name] = Math.ceil(rawCount * toolTokenMultiplier);

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -1414,7 +1414,7 @@ describe('AgentContext', () => {
       expect(ctx.getTokenBudgetBreakdown().toolCount).toBe(2);
     });
 
-    it('toolSchemaTokens snapshot does not auto-update after markToolsAsDiscovered', async () => {
+    it('refreshes toolSchemaTokens and per-tool counts after markToolsAsDiscovered', async () => {
       const toolDefinitions: t.LCTool[] = [
         {
           name: 'deferred',
@@ -1431,9 +1431,13 @@ describe('AgentContext', () => {
 
       await ctx.tokenCalculationPromise;
       expect(ctx.toolSchemaTokens).toBe(0);
+      expect(ctx.toolTokenCounts).toEqual({});
 
       ctx.markToolsAsDiscovered(['deferred']);
-      expect(ctx.toolSchemaTokens).toBe(0);
+      await ctx.tokenCalculationPromise;
+      expect(ctx.toolSchemaTokens).toBeGreaterThan(0);
+      expect(ctx.toolTokenCounts?.deferred).toBeGreaterThan(0);
+      expect(ctx.deferredToolNames).toContain('deferred');
     });
   });
 

--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -31,6 +31,8 @@ export enum GraphEvents {
   ON_SUBAGENT_UPDATE = 'on_subagent_update',
   /** [Custom] Diagnostic logging event for context management observability */
   ON_AGENT_LOG = 'on_agent_log',
+  /** [Custom] Per-model-call context window usage snapshot (post-prune token budget) */
+  ON_CONTEXT_USAGE = 'on_context_usage',
 
   /* Official Events */
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -89,6 +89,26 @@ const { AGENT, TOOLS, SUMMARIZE } = GraphNodeKeys;
 /** Minimum relative variance before calibrated toolSchemaTokens overrides current value. */
 const CALIBRATION_VARIANCE_THRESHOLD = 0.15;
 
+/**
+ * Start index of the span post-prune formatters can mutate in place: the
+ * trailing tool batch plus its owning AI message (artifact formatting touches
+ * every tool result after the last AI tool call; Bedrock rewrites the AI
+ * message before a trailing tool result). Capped so the usage-snapshot
+ * recount stays constant-cost.
+ */
+function trailingMutationStart(messages: BaseMessage[]): number {
+  const MAX_SPAN = 16;
+  let index = messages.length - 1;
+  while (
+    index >= 0 &&
+    messages[index]?.getType() === 'tool' &&
+    messages.length - index < MAX_SPAN
+  ) {
+    index--;
+  }
+  return Math.max(0, Math.min(index, messages.length - 2));
+}
+
 type ReasoningKey = 'reasoning_content' | 'reasoning';
 type ReasoningSummary = { summary?: Array<{ text?: string }> };
 type ReasoningDetail = { type?: string; text?: string };
@@ -1508,11 +1528,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
         /** Dispatched right before the model invoke — a summarization
          *  detour returns from this node without an LLM call, and the
-         *  post-summary retry produces its own snapshot */
+         *  post-summary retry produces its own snapshot.
+         *
+         *  The breakdown describes the post-prune prompt: counts from the
+         *  kept context, message tokens derived from the same calibrated
+         *  budget math as `remainingContextTokens` (the index map is keyed
+         *  by pre-prune state indices, so summing it over `context` would
+         *  missum); `prePruneContextTokens` carries the pre-prune metric. */
+        const usageBreakdown = agentContext.getTokenBudgetBreakdown(messages);
+        usageBreakdown.messageCount = context.length;
+        if (
+          contextBudget != null &&
+          effectiveInstructionTokens != null &&
+          remainingContextTokens != null
+        ) {
+          usageBreakdown.messageTokens = Math.max(
+            0,
+            contextBudget - effectiveInstructionTokens - remainingContextTokens
+          );
+        }
         contextUsage = {
           runId: this.runId,
           agentId,
-          breakdown: agentContext.getTokenBudgetBreakdown(messages),
+          breakdown: usageBreakdown,
           contextBudget,
           effectiveInstructionTokens,
           prePruneContextTokens,
@@ -1627,12 +1665,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       let finalMessages = messagesToUse;
       /** Tail snapshot for the dispatch-time usage delta: in-place
        *  formatters (artifact appends, Bedrock content rewrites, legacy
-       *  string conversion) only mutate trailing messages and are invisible
-       *  to both length and identity checks — capture before they run */
+       *  string conversion) only mutate the trailing tool batch and are
+       *  invisible to both length and identity checks — capture before
+       *  they run */
+      const tailStart = trailingMutationStart(messagesToUse);
       let preFormatTailTokens: number | null = null;
       if (contextUsage != null && agentContext.tokenCounter != null) {
         preFormatTailTokens = 0;
-        for (const message of messagesToUse.slice(-2)) {
+        for (const message of messagesToUse.slice(tailStart)) {
           preFormatTailTokens += agentContext.tokenCounter(message);
         }
       }
@@ -1860,10 +1900,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.tokenCounter != null &&
           contextUsage.remainingContextTokens != null
         ) {
-          /** Same-length formatting can still grow trailing messages in
-           *  place — adjust remaining by the tail's calibrated delta */
+          /** Same-length formatting can still grow the trailing tool batch
+           *  in place — adjust remaining by its calibrated delta */
           let postFormatTailTokens = 0;
-          for (const message of finalMessages.slice(-2)) {
+          for (const message of finalMessages.slice(tailStart)) {
             postFormatTailTokens += agentContext.tokenCounter(message);
           }
           const tailDelta = postFormatTailTokens - preFormatTailTokens;
@@ -1878,7 +1918,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             );
           }
         }
-        void safeDispatchCustomEvent(
+        /** Awaited so async host handlers receive the pre-invoke snapshot
+         *  before any model deltas are emitted */
+        await safeDispatchCustomEvent(
           GraphEvents.ON_CONTEXT_USAGE,
           contextUsage,
           config

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1625,6 +1625,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       let finalMessages = messagesToUse;
+      /** Tail snapshot for the dispatch-time usage delta: in-place
+       *  formatters (artifact appends, Bedrock content rewrites, legacy
+       *  string conversion) only mutate trailing messages and are invisible
+       *  to both length and identity checks — capture before they run */
+      let preFormatTailTokens: number | null = null;
+      if (contextUsage != null && agentContext.tokenCounter != null) {
+        preFormatTailTokens = 0;
+        for (const message of messagesToUse.slice(-2)) {
+          preFormatTailTokens += agentContext.tokenCounter(message);
+        }
+      }
       if (agentContext.useLegacyContent) {
         finalMessages = formatContentStrings(finalMessages);
       }
@@ -1817,6 +1828,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
       /** Past the empty-prompt guard — a model call is now guaranteed */
       if (contextUsage != null) {
+        const usageRatio =
+          contextUsage.calibrationRatio != null &&
+          contextUsage.calibrationRatio > 0
+            ? contextUsage.calibrationRatio
+            : 1;
         if (
           agentContext.tokenCounter != null &&
           finalMessages.length !== messagesToUse.length
@@ -1828,11 +1844,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           for (const message of finalMessages) {
             rawTokens += agentContext.tokenCounter(message);
           }
-          const ratio =
-            contextUsage.calibrationRatio != null &&
-            contextUsage.calibrationRatio > 0
-              ? contextUsage.calibrationRatio
-              : 1;
           if (
             contextUsage.contextBudget != null &&
             contextUsage.effectiveInstructionTokens != null
@@ -1841,7 +1852,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               0,
               contextUsage.contextBudget -
                 contextUsage.effectiveInstructionTokens -
-                Math.round(rawTokens * ratio)
+                Math.round(rawTokens * usageRatio)
+            );
+          }
+        } else if (
+          preFormatTailTokens != null &&
+          agentContext.tokenCounter != null &&
+          contextUsage.remainingContextTokens != null
+        ) {
+          /** Same-length formatting can still grow trailing messages in
+           *  place — adjust remaining by the tail's calibrated delta */
+          let postFormatTailTokens = 0;
+          for (const message of finalMessages.slice(-2)) {
+            postFormatTailTokens += agentContext.tokenCounter(message);
+          }
+          const tailDelta = postFormatTailTokens - preFormatTailTokens;
+          if (tailDelta !== 0) {
+            contextUsage.remainingContextTokens = Math.max(
+              0,
+              Math.min(
+                contextUsage.contextBudget ?? Number.MAX_SAFE_INTEGER,
+                contextUsage.remainingContextTokens -
+                  Math.round(tailDelta * usageRatio)
+              )
             );
           }
         }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -109,6 +109,35 @@ function trailingMutationStart(messages: BaseMessage[]): number {
   return Math.max(0, Math.min(index, messages.length - 2));
 }
 
+/**
+ * Re-derives the breakdown fields coupled to the calibrated budget math so
+ * the snapshot stays internally consistent: the aggregate
+ * `instructionTokens`/`availableForMessages` reflect the pruner's effective
+ * (calibrated) overhead — component fields remain local estimates — and
+ * `messageTokens` mirrors `contextBudget - instructions - remaining`.
+ */
+function syncBudgetDerivedFields(usage: t.ContextUsageEvent): void {
+  const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
+  if (effectiveInstructionTokens == null) {
+    return;
+  }
+  breakdown.instructionTokens = effectiveInstructionTokens;
+  if (contextBudget == null) {
+    return;
+  }
+  breakdown.availableForMessages = Math.max(
+    0,
+    contextBudget - effectiveInstructionTokens
+  );
+  if (usage.remainingContextTokens == null) {
+    return;
+  }
+  breakdown.messageTokens = Math.max(
+    0,
+    contextBudget - effectiveInstructionTokens - usage.remainingContextTokens
+  );
+}
+
 type ReasoningKey = 'reasoning_content' | 'reasoning';
 type ReasoningSummary = { summary?: Array<{ text?: string }> };
 type ReasoningDetail = { type?: string; text?: string };
@@ -1537,16 +1566,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          *  missum); `prePruneContextTokens` carries the pre-prune metric. */
         const usageBreakdown = agentContext.getTokenBudgetBreakdown(messages);
         usageBreakdown.messageCount = context.length;
-        if (
-          contextBudget != null &&
-          effectiveInstructionTokens != null &&
-          remainingContextTokens != null
-        ) {
-          usageBreakdown.messageTokens = Math.max(
-            0,
-            contextBudget - effectiveInstructionTokens - remainingContextTokens
-          );
-        }
         contextUsage = {
           runId: this.runId,
           agentId,
@@ -1557,6 +1576,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           remainingContextTokens,
           calibrationRatio: agentContext.calibrationRatio,
         };
+        syncBudgetDerivedFields(contextUsage);
 
         const hasPrunedMessages =
           agentContext.summarizationEnabled === true &&
@@ -1884,6 +1904,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           for (const message of finalMessages) {
             rawTokens += agentContext.tokenCounter(message);
           }
+          contextUsage.breakdown.messageCount = finalMessages.length;
           if (
             contextUsage.contextBudget != null &&
             contextUsage.effectiveInstructionTokens != null
@@ -1918,6 +1939,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             );
           }
         }
+        syncBudgetDerivedFields(contextUsage);
         /** Awaited so async host handlers receive the pre-invoke snapshot
          *  before any model deltas are emitted */
         await safeDispatchCustomEvent(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1462,6 +1462,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           originalToolContent,
           calibrationRatio,
           resolvedInstructionOverhead,
+          contextBudget,
+          effectiveInstructionTokens,
         } = agentContext.pruneMessages({
           messages,
           usageMetadata: agentContext.currentUsage,
@@ -1492,6 +1494,21 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           }
         }
         messagesToUse = context;
+
+        void safeDispatchCustomEvent(
+          GraphEvents.ON_CONTEXT_USAGE,
+          {
+            runId: this.runId,
+            agentId,
+            breakdown: agentContext.getTokenBudgetBreakdown(messages),
+            contextBudget,
+            effectiveInstructionTokens,
+            prePruneContextTokens,
+            remainingContextTokens,
+            calibrationRatio: agentContext.calibrationRatio,
+          } satisfies t.ContextUsageEvent,
+          config
+        );
 
         const hasPrunedMessages =
           agentContext.summarizationEnabled === true &&

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -23,6 +23,7 @@ import {
   formatArtifactPayload,
   enforceOriginalContentCap,
   formatContentStrings,
+  isLegacyConvertible,
   createPruneMessages,
   addCacheControl,
   getMessageId,
@@ -45,6 +46,7 @@ import {
   isAnthropicLike,
   isOpenAILike,
   isGoogleLike,
+  apportionTokenCounts,
   joinKeys,
   sleep,
 } from '@/utils';
@@ -1541,15 +1543,14 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               : 1;
           if (variance > CALIBRATION_VARIANCE_THRESHOLD) {
             agentContext.toolSchemaTokens = calibratedToolTokens;
-            /** Keep the per-tool breakdown summing to the calibrated
-             *  aggregate by scaling each entry proportionally */
+            /** Largest-remainder apportionment keeps the per-tool breakdown
+             *  summing exactly to the calibrated aggregate */
             if (agentContext.toolTokenCounts != null && currentToolTokens > 0) {
-              const factor = calibratedToolTokens / currentToolTokens;
-              for (const name of Object.keys(agentContext.toolTokenCounts)) {
-                agentContext.toolTokenCounts[name] = Math.round(
-                  agentContext.toolTokenCounts[name] * factor
-                );
-              }
+              agentContext.toolTokenCounts = apportionTokenCounts(
+                agentContext.toolTokenCounts,
+                calibratedToolTokens / currentToolTokens,
+                calibratedToolTokens
+              );
             }
           }
         }
@@ -1685,15 +1686,29 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       let finalMessages = messagesToUse;
       /** Tail snapshot for the dispatch-time usage delta: in-place
        *  formatters (artifact appends, Bedrock content rewrites, legacy
-       *  string conversion) only mutate the trailing tool batch and are
-       *  invisible to both length and identity checks — capture before
-       *  they run */
+       *  string conversion) mutate without changing length or identity —
+       *  capture before they run. Legacy string conversion can also touch
+       *  messages before the tail, so those convertible indices are
+       *  tracked separately (none exist in the common case). */
       const tailStart = trailingMutationStart(messagesToUse);
       let preFormatTailTokens: number | null = null;
+      let legacyIndices: number[] | null = null;
+      let preFormatLegacyTokens = 0;
       if (contextUsage != null && agentContext.tokenCounter != null) {
         preFormatTailTokens = 0;
         for (const message of messagesToUse.slice(tailStart)) {
           preFormatTailTokens += agentContext.tokenCounter(message);
+        }
+        if (agentContext.useLegacyContent) {
+          legacyIndices = [];
+          for (let i = 0; i < tailStart; i++) {
+            if (isLegacyConvertible(messagesToUse[i])) {
+              legacyIndices.push(i);
+              preFormatLegacyTokens += agentContext.tokenCounter(
+                messagesToUse[i]
+              );
+            }
+          }
         }
       }
       if (agentContext.useLegacyContent) {
@@ -1921,20 +1936,30 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentContext.tokenCounter != null &&
           contextUsage.remainingContextTokens != null
         ) {
-          /** Same-length formatting can still grow the trailing tool batch
-           *  in place — adjust remaining by its calibrated delta */
+          /** Same-length formatting can still mutate in place — the trailing
+           *  tool batch (artifacts, Bedrock rewrites) and any legacy-converted
+           *  messages before it — adjust remaining by the calibrated delta */
           let postFormatTailTokens = 0;
           for (const message of finalMessages.slice(tailStart)) {
             postFormatTailTokens += agentContext.tokenCounter(message);
           }
-          const tailDelta = postFormatTailTokens - preFormatTailTokens;
-          if (tailDelta !== 0) {
+          let formatDelta = postFormatTailTokens - preFormatTailTokens;
+          if (legacyIndices != null && legacyIndices.length > 0) {
+            let postFormatLegacyTokens = 0;
+            for (const index of legacyIndices) {
+              postFormatLegacyTokens += agentContext.tokenCounter(
+                finalMessages[index]
+              );
+            }
+            formatDelta += postFormatLegacyTokens - preFormatLegacyTokens;
+          }
+          if (formatDelta !== 0) {
             contextUsage.remainingContextTokens = Math.max(
               0,
               Math.min(
                 contextUsage.contextBudget ?? Number.MAX_SAFE_INTEGER,
                 contextUsage.remainingContextTokens -
-                  Math.round(tailDelta * usageRatio)
+                  Math.round(formatDelta * usageRatio)
               )
             );
           }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1732,42 +1732,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }
       }
 
-      if (contextUsage != null) {
-        if (
-          agentContext.tokenCounter != null &&
-          finalMessages.length !== messagesToUse.length
-        ) {
-          /** Post-prune formatting restructured the payload (e.g. thinking
-           *  placeholder collapse, orphan drops) — recount so the gauge
-           *  reflects what is actually sent */
-          let rawTokens = 0;
-          for (const message of finalMessages) {
-            rawTokens += agentContext.tokenCounter(message);
-          }
-          const ratio =
-            contextUsage.calibrationRatio != null &&
-            contextUsage.calibrationRatio > 0
-              ? contextUsage.calibrationRatio
-              : 1;
-          if (
-            contextUsage.contextBudget != null &&
-            contextUsage.effectiveInstructionTokens != null
-          ) {
-            contextUsage.remainingContextTokens = Math.max(
-              0,
-              contextUsage.contextBudget -
-                contextUsage.effectiveInstructionTokens -
-                Math.round(rawTokens * ratio)
-            );
-          }
-        }
-        void safeDispatchCustomEvent(
-          GraphEvents.ON_CONTEXT_USAGE,
-          contextUsage,
-          config
-        );
-      }
-
       if (
         agentContext.lastStreamCall != null &&
         agentContext.streamBuffer != null
@@ -1838,6 +1802,43 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             type: 'empty_messages',
             info: `Message pruning removed all messages as none fit in the context window. ${guidance}\n${breakdown}`,
           })
+        );
+      }
+
+      /** Past the empty-prompt guard — a model call is now guaranteed */
+      if (contextUsage != null) {
+        if (
+          agentContext.tokenCounter != null &&
+          finalMessages.length !== messagesToUse.length
+        ) {
+          /** Post-prune formatting restructured the payload (e.g. thinking
+           *  placeholder collapse, orphan drops) — recount so the gauge
+           *  reflects what is actually sent */
+          let rawTokens = 0;
+          for (const message of finalMessages) {
+            rawTokens += agentContext.tokenCounter(message);
+          }
+          const ratio =
+            contextUsage.calibrationRatio != null &&
+            contextUsage.calibrationRatio > 0
+              ? contextUsage.calibrationRatio
+              : 1;
+          if (
+            contextUsage.contextBudget != null &&
+            contextUsage.effectiveInstructionTokens != null
+          ) {
+            contextUsage.remainingContextTokens = Math.max(
+              0,
+              contextUsage.contextBudget -
+                contextUsage.effectiveInstructionTokens -
+                Math.round(rawTokens * ratio)
+            );
+          }
+        }
+        void safeDispatchCustomEvent(
+          GraphEvents.ON_CONTEXT_USAGE,
+          contextUsage,
+          config
         );
       }
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1492,6 +1492,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               : 1;
           if (variance > CALIBRATION_VARIANCE_THRESHOLD) {
             agentContext.toolSchemaTokens = calibratedToolTokens;
+            /** Keep the per-tool breakdown summing to the calibrated
+             *  aggregate by scaling each entry proportionally */
+            if (agentContext.toolTokenCounts != null && currentToolTokens > 0) {
+              const factor = calibratedToolTokens / currentToolTokens;
+              for (const name of Object.keys(agentContext.toolTokenCounts)) {
+                agentContext.toolTokenCounts[name] = Math.round(
+                  agentContext.toolTokenCounts[name] * factor
+                );
+              }
+            }
           }
         }
         messagesToUse = context;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1423,6 +1423,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       this.config = config;
 
       let messagesToUse = messages;
+      let contextUsage: t.ContextUsageEvent | null = null;
       if (
         !agentContext.pruneMessages &&
         agentContext.tokenCounter &&
@@ -1495,20 +1496,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         }
         messagesToUse = context;
 
-        void safeDispatchCustomEvent(
-          GraphEvents.ON_CONTEXT_USAGE,
-          {
-            runId: this.runId,
-            agentId,
-            breakdown: agentContext.getTokenBudgetBreakdown(messages),
-            contextBudget,
-            effectiveInstructionTokens,
-            prePruneContextTokens,
-            remainingContextTokens,
-            calibrationRatio: agentContext.calibrationRatio,
-          } satisfies t.ContextUsageEvent,
-          config
-        );
+        /** Dispatched right before the model invoke — a summarization
+         *  detour returns from this node without an LLM call, and the
+         *  post-summary retry produces its own snapshot */
+        contextUsage = {
+          runId: this.runId,
+          agentId,
+          breakdown: agentContext.getTokenBudgetBreakdown(messages),
+          contextBudget,
+          effectiveInstructionTokens,
+          prePruneContextTokens,
+          remainingContextTokens,
+          calibrationRatio: agentContext.calibrationRatio,
+        };
 
         const hasPrunedMessages =
           agentContext.summarizationEnabled === true &&
@@ -1730,6 +1730,42 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             { runId: this.runId, agentId }
           );
         }
+      }
+
+      if (contextUsage != null) {
+        if (
+          agentContext.tokenCounter != null &&
+          finalMessages.length !== messagesToUse.length
+        ) {
+          /** Post-prune formatting restructured the payload (e.g. thinking
+           *  placeholder collapse, orphan drops) — recount so the gauge
+           *  reflects what is actually sent */
+          let rawTokens = 0;
+          for (const message of finalMessages) {
+            rawTokens += agentContext.tokenCounter(message);
+          }
+          const ratio =
+            contextUsage.calibrationRatio != null &&
+            contextUsage.calibrationRatio > 0
+              ? contextUsage.calibrationRatio
+              : 1;
+          if (
+            contextUsage.contextBudget != null &&
+            contextUsage.effectiveInstructionTokens != null
+          ) {
+            contextUsage.remainingContextTokens = Math.max(
+              0,
+              contextUsage.contextBudget -
+                contextUsage.effectiveInstructionTokens -
+                Math.round(rawTokens * ratio)
+            );
+          }
+        }
+        void safeDispatchCustomEvent(
+          GraphEvents.ON_CONTEXT_USAGE,
+          contextUsage,
+          config
+        );
       }
 
       if (

--- a/src/messages/content.ts
+++ b/src/messages/content.ts
@@ -1,5 +1,25 @@
-import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  BaseMessage,
+  MessageContentComplex,
+} from '@langchain/core/messages';
 import { ContentTypes } from '@/common';
+
+/**
+ * Whether {@link formatContentStrings} will flatten this message's content:
+ * a human/ai/system message whose content is an array of text-only blocks.
+ */
+export const isLegacyConvertible = (message: BaseMessage): boolean => {
+  const messageType = message.getType();
+  const isValidMessage =
+    messageType === 'human' || messageType === 'ai' || messageType === 'system';
+  if (!isValidMessage) {
+    return false;
+  }
+  if (!Array.isArray(message.content)) {
+    return false;
+  }
+  return message.content.every((block) => block.type === ContentTypes.TEXT);
+};
 
 /**
  * Formats an array of messages for LangChain, making sure all content fields are strings
@@ -13,42 +33,14 @@ export const formatContentStrings = (
   const result: Array<BaseMessage> = [];
 
   for (const message of payload) {
-    const messageType = message.getType();
-    const isValidMessage =
-      messageType === 'human' ||
-      messageType === 'ai' ||
-      messageType === 'system';
-
-    if (!isValidMessage) {
-      result.push(message);
-      continue;
-    }
-
-    // If content is already a string, add as-is
-    if (typeof message.content === 'string') {
-      result.push(message);
-      continue;
-    }
-
-    // If content is not an array, add as-is
-    if (!Array.isArray(message.content)) {
-      result.push(message);
-      continue;
-    }
-
-    // Check if all content blocks are text type
-    const allTextBlocks = message.content.every(
-      (block) => block.type === ContentTypes.TEXT
-    );
-
-    // Only convert to string if all blocks are text type
-    if (!allTextBlocks) {
+    if (!isLegacyConvertible(message)) {
       result.push(message);
       continue;
     }
 
     // Reduce text types to a single string
-    const content = message.content.reduce((acc, curr) => {
+    const blocks = message.content as MessageContentComplex[];
+    const content = blocks.reduce((acc, curr) => {
       if (curr.type === ContentTypes.TEXT) {
         return `${acc}${curr[ContentTypes.TEXT] || ''}\n`;
       }

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1312,6 +1312,10 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     originalToolContent?: Map<number, string>;
     calibrationRatio?: number;
     resolvedInstructionOverhead?: number;
+    /** Usable budget this call: maxTokens minus output reserve */
+    contextBudget?: number;
+    /** Calibrated instruction overhead actually applied this call */
+    effectiveInstructionTokens?: number;
   } {
     if (params.messages.length === 0) {
       return {
@@ -1549,6 +1553,8 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           pruningBudget > 0 ? calibratedTotalTokens / pruningBudget : 0,
         calibrationRatio,
         resolvedInstructionOverhead: bestInstructionOverhead,
+        contextBudget: pruningBudget,
+        effectiveInstructionTokens: currentInstructionTokens,
       };
     }
 
@@ -1752,6 +1758,8 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
           originalToolContent.size > 0 ? originalToolContent : undefined,
         calibrationRatio,
         resolvedInstructionOverhead: bestInstructionOverhead,
+        contextBudget: pruningBudget,
+        effectiveInstructionTokens: currentInstructionTokens,
       };
     }
 
@@ -2123,6 +2131,8 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
         originalToolContent.size > 0 ? originalToolContent : undefined,
       calibrationRatio,
       resolvedInstructionOverhead: bestInstructionOverhead,
+      contextBudget: pruningBudget,
+      effectiveInstructionTokens: currentInstructionTokens,
     };
   };
 }

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -1318,14 +1318,30 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
     effectiveInstructionTokens?: number;
   } {
     if (params.messages.length === 0) {
+      /** Post-compaction calls still invoke the model — report the same
+       *  reserve-adjusted budget fields as the populated paths */
+      const emptyInstructionTokens =
+        factoryParams.getInstructionTokens?.() ?? 0;
+      const emptyReserveRatio =
+        factoryParams.reserveRatio ?? DEFAULT_RESERVE_RATIO;
+      const emptyBudget =
+        factoryParams.maxTokens -
+        (emptyReserveRatio > 0 && emptyReserveRatio < 1
+          ? Math.round(factoryParams.maxTokens * emptyReserveRatio)
+          : 0);
       return {
         context: [],
         indexTokenCountMap,
         messagesToRefine: [],
         prePruneContextTokens: 0,
-        remainingContextTokens: factoryParams.maxTokens,
+        remainingContextTokens: Math.max(
+          0,
+          emptyBudget - emptyInstructionTokens
+        ),
         calibrationRatio,
         resolvedInstructionOverhead: bestInstructionOverhead,
+        contextBudget: emptyBudget,
+        effectiveInstructionTokens: emptyInstructionTokens,
       };
     }
 

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2107,9 +2107,20 @@ export function createPruneMessages(factoryParams: PruneMessagesFactoryParams) {
       }
     }
 
+    /** Scale raw-space remaining back to calibrated/provider units so it is
+     *  directly comparable with pruningBudget and prePruneContextTokens */
+    const rawRemaining = Math.max(
+      0,
+      initialRemainingContextTokens + reclaimedTokens
+    );
     const remainingContextTokens = Math.max(
       0,
-      Math.min(pruningBudget, initialRemainingContextTokens + reclaimedTokens)
+      Math.min(
+        pruningBudget,
+        calibrationRatio > 0
+          ? Math.round(rawRemaining * calibrationRatio)
+          : rawRemaining
+      )
     );
 
     runThinkingStartIndex = thinkingStartIndex ?? -1;

--- a/src/run.ts
+++ b/src/run.ts
@@ -78,6 +78,7 @@ const CUSTOM_GRAPH_EVENTS = new Set<string>([
   GraphEvents.ON_SUMMARIZE_COMPLETE,
   GraphEvents.ON_SUBAGENT_UPDATE,
   GraphEvents.ON_AGENT_LOG,
+  GraphEvents.ON_CONTEXT_USAGE,
   GraphEvents.ON_CUSTOM_EVENT,
 ]);
 

--- a/src/specs/context-accuracy.live.test.ts
+++ b/src/specs/context-accuracy.live.test.ts
@@ -1,0 +1,285 @@
+// src/specs/context-accuracy.live.test.ts
+/**
+ * Live ACCURACY verification for ON_CONTEXT_USAGE against real provider
+ * counts in the hard scenarios: tool loops (where calibration engages),
+ * prompt caching (cache fields for cost math), and pruning under context
+ * pressure (calibrated remaining-units math). Logs measured ratios.
+ *
+ * Run with:
+ * RUN_CONTEXT_USAGE_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- context-accuracy.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { createTokenCounter, TokenEncoderManager } from '@/utils/tokens';
+import { GraphEvents, Providers } from '@/common';
+import { ModelEndHandler } from '@/events';
+import { Run } from '@/run';
+
+const shouldRunLive =
+  process.env.RUN_CONTEXT_USAGE_LIVE_TESTS === '1' &&
+  process.env.ANTHROPIC_API_KEY != null &&
+  process.env.ANTHROPIC_API_KEY !== '';
+
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+const modelName =
+  process.env.ANTHROPIC_CONTEXT_LIVE_MODEL ?? 'claude-haiku-4-5';
+
+function createStreamConfig(threadId: string): Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+} {
+  return {
+    configurable: { thread_id: threadId },
+    streamMode: 'values',
+    version: 'v2',
+  };
+}
+
+interface Captured {
+  contextEvents: t.ContextUsageEvent[];
+  collectedUsage: Array<{
+    input_tokens?: number;
+    output_tokens?: number;
+    input_token_details?: { cache_creation?: number; cache_read?: number };
+  }>;
+  handlers: Record<string, t.EventHandler>;
+}
+
+function createCapture(): Captured {
+  const contextEvents: t.ContextUsageEvent[] = [];
+  const collectedUsage: Captured['collectedUsage'] = [];
+  const handlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage as never),
+    [GraphEvents.ON_CONTEXT_USAGE]: {
+      handle: (_event, data): void => {
+        contextEvents.push(data as unknown as t.ContextUsageEvent);
+      },
+    },
+  };
+  return { contextEvents, collectedUsage, handlers };
+}
+
+function estimatedUsed(event: t.ContextUsageEvent): number {
+  return (event.contextBudget ?? 0) - (event.remainingContextTokens ?? 0);
+}
+
+const addTool = tool(
+  async ({ a, b }: { a: number; b: number }) => String(a + b),
+  {
+    name: 'add',
+    description: 'Add two numbers and return the sum',
+    schema: z.object({ a: z.number(), b: z.number() }),
+  }
+);
+
+/** ~5K tokens so the system prompt clears the haiku prompt-cache minimum;
+ *  salted per run so the first call always writes a cold cache entry */
+function buildLongInstructions(salt: string): string {
+  return [
+    `Session ${salt}: you are a precise assistant. Use the add tool for any arithmetic, then reply with only the number.`,
+    ...Array.from(
+      { length: 200 },
+      (_, i) =>
+        `Rule ${i}: always answer precisely, verify arithmetic results twice, and keep every response to a single line without commentary.`
+    ),
+  ].join(' ');
+}
+
+describeIfLive('Context accuracy live integration', () => {
+  jest.setTimeout(240_000);
+
+  let tokenCounter: t.TokenCounter;
+
+  beforeAll(async () => {
+    tokenCounter = await createTokenCounter();
+  });
+
+  afterAll(() => {
+    TokenEncoderManager.reset();
+  });
+
+  it('tracks provider counts through a cached tool loop and tightens with calibration', async () => {
+    const capture = createCapture();
+    const run = await Run.create<t.IState>({
+      runId: `ctx-acc-loop-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          modelName,
+          apiKey: process.env.ANTHROPIC_API_KEY,
+          temperature: 0,
+          maxTokens: 128,
+          streaming: true,
+          streamUsage: true,
+          promptCache: true,
+        },
+        instructions: buildLongInstructions(`${Date.now()}`),
+        maxContextTokens: 16000,
+        tools: [addTool],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: capture.handlers,
+      tokenCounter,
+      indexTokenCountMap: {},
+    });
+
+    await run.processStream(
+      {
+        messages: [
+          new HumanMessage(
+            'Use the add tool to compute 1742 + 2581, then reply with only the number.'
+          ),
+        ],
+      },
+      createStreamConfig(`ctx-acc-loop-${Date.now()}`)
+    );
+
+    expect(capture.contextEvents.length).toBeGreaterThanOrEqual(2);
+    expect(capture.collectedUsage.length).toBe(capture.contextEvents.length);
+
+    const ratios = capture.contextEvents.map((event, index) => {
+      const usage = capture.collectedUsage[index];
+      /** LangChain-normalized Anthropic usage reports cache fields as
+       *  subsets of input_tokens; only add them when genuinely additive
+       *  (same heuristic as calculateTotalTokens) */
+      const baseInput = usage.input_tokens ?? 0;
+      const cacheSum =
+        (usage.input_token_details?.cache_creation ?? 0) +
+        (usage.input_token_details?.cache_read ?? 0);
+      const providerInput = baseInput + (cacheSum > baseInput ? cacheSum : 0);
+      console.log(`[ctx-accuracy] call ${index + 1}:`, {
+        estimated: estimatedUsed(event),
+        providerInput,
+        providerParts: {
+          input: usage.input_tokens,
+          cacheWrite: usage.input_token_details?.cache_creation,
+          cacheRead: usage.input_token_details?.cache_read,
+        },
+        effectiveInstructionTokens: event.effectiveInstructionTokens,
+        systemMessageTokens: event.breakdown.systemMessageTokens,
+        toolSchemaTokens: event.breakdown.toolSchemaTokens,
+        messageTokens: event.breakdown.messageTokens,
+        remaining: event.remainingContextTokens,
+        budget: event.contextBudget,
+        calibrationRatio: event.calibrationRatio,
+      });
+      return estimatedUsed(event) / providerInput;
+    });
+    console.log('[ctx-accuracy] tool-loop estimate/provider ratios:', ratios);
+
+    /** Call 1: uncalibrated local estimate must be in the right ballpark */
+    expect(ratios[0]).toBeGreaterThan(0.5);
+    expect(ratios[0]).toBeLessThan(2);
+
+    /** Call 2+: calibration has real provider counts — tighter band, and
+     *  no further from truth than the uncalibrated call (noise epsilon) */
+    const last = ratios[ratios.length - 1];
+    expect(last).toBeGreaterThan(0.6);
+    expect(last).toBeLessThan(1.7);
+    expect(Math.abs(last - 1)).toBeLessThanOrEqual(
+      Math.abs(ratios[0] - 1) + 0.15
+    );
+
+    /** Prompt caching engaged: write on the first call, read on the next */
+    const cacheWrites = capture.collectedUsage.map(
+      (u) => u.input_token_details?.cache_creation ?? 0
+    );
+    const cacheReads = capture.collectedUsage.map(
+      (u) => u.input_token_details?.cache_read ?? 0
+    );
+    expect(Math.max(...cacheWrites)).toBeGreaterThan(0);
+    expect(Math.max(...cacheReads)).toBeGreaterThan(0);
+
+    const text = (run.getRunMessages() ?? [])
+      .filter((message) => message.getType() === 'ai')
+      .map((message) =>
+        typeof message.content === 'string'
+          ? message.content
+          : JSON.stringify(message.content)
+      )
+      .join(' ');
+    expect(text).toContain('4323');
+  });
+
+  it('stays accurate when pruning drops history under a small budget', async () => {
+    const capture = createCapture();
+    const history: BaseMessage[] = [];
+    for (let i = 0; i < 8; i++) {
+      history.push(
+        new HumanMessage(
+          `Question ${i}: please summarize the following filler passage. ` +
+            `${'The quick brown fox jumps over the lazy dog while counting tokens carefully. '.repeat(12)}`
+        ),
+        new AIMessage(
+          `Answer ${i}: the passage repeats a pangram about a fox and a dog while counting tokens. `.repeat(
+            4
+          )
+        )
+      );
+    }
+    history.push(new HumanMessage('Reply with exactly one word: pruned'));
+
+    const indexTokenCountMap: Record<string, number> = {};
+    for (let i = 0; i < history.length; i++) {
+      indexTokenCountMap[i] = tokenCounter(history[i]);
+    }
+
+    const run = await Run.create<t.IState>({
+      runId: `ctx-acc-prune-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: Providers.ANTHROPIC,
+          modelName,
+          apiKey: process.env.ANTHROPIC_API_KEY,
+          temperature: 0,
+          maxTokens: 64,
+          streaming: true,
+          streamUsage: true,
+        },
+        instructions: 'You follow instructions exactly.',
+        maxContextTokens: 1500,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: capture.handlers,
+      tokenCounter,
+      indexTokenCountMap,
+    });
+
+    await run.processStream(
+      { messages: history },
+      createStreamConfig(`ctx-acc-prune-${Date.now()}`)
+    );
+
+    expect(capture.contextEvents).toHaveLength(1);
+    const event = capture.contextEvents[0];
+    const usage = capture.collectedUsage[0];
+
+    /** Pruning engaged: the full history exceeds what was sent */
+    expect(event.prePruneContextTokens).toBeGreaterThan(estimatedUsed(event));
+    expect(event.remainingContextTokens).toBeGreaterThanOrEqual(0);
+    expect(event.remainingContextTokens).toBeLessThan(event.contextBudget ?? 0);
+
+    const providerInput = usage.input_tokens ?? 0;
+    const ratio = estimatedUsed(event) / providerInput;
+    console.log('[ctx-accuracy] pruned-run estimate/provider ratio:', ratio, {
+      estimated: estimatedUsed(event),
+      providerInput,
+      prePrune: event.prePruneContextTokens,
+      budget: event.contextBudget,
+    });
+    expect(ratio).toBeGreaterThan(0.4);
+    expect(ratio).toBeLessThan(2.5);
+  });
+});

--- a/src/specs/context-accuracy.live.test.ts
+++ b/src/specs/context-accuracy.live.test.ts
@@ -7,6 +7,10 @@
  *
  * Run with:
  * RUN_CONTEXT_USAGE_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- context-accuracy.live.test.ts --runInBand
+ *
+ * The google/bedrock matrix entries skip without GOOGLE_API_KEY /
+ * BEDROCK_AWS_* creds; Bedrock's AWS SDK needs
+ * NODE_OPTIONS='--experimental-vm-modules' under jest.
  */
 import { config as dotenvConfig } from 'dotenv';
 dotenvConfig();
@@ -92,6 +96,50 @@ function buildLongInstructions(salt: string): string {
     ),
   ].join(' ');
 }
+
+/** Cross-provider accuracy matrix: different tokenizers and usage shapes */
+const providerMatrix: Array<{
+  name: string;
+  enabled: boolean;
+  llmConfig: Record<string, unknown>;
+}> = [
+  {
+    name: 'google',
+    enabled: !!process.env.GOOGLE_API_KEY,
+    llmConfig: {
+      provider: Providers.GOOGLE,
+      model: process.env.GOOGLE_CONTEXT_LIVE_MODEL ?? 'gemini-2.5-flash',
+      apiKey: process.env.GOOGLE_API_KEY,
+      temperature: 0,
+      streaming: true,
+      streamUsage: true,
+    },
+  },
+  {
+    name: 'bedrock',
+    enabled:
+      !!process.env.BEDROCK_AWS_ACCESS_KEY_ID &&
+      !!process.env.BEDROCK_AWS_SECRET_ACCESS_KEY,
+    llmConfig: {
+      provider: Providers.BEDROCK,
+      model:
+        process.env.BEDROCK_CONTEXT_LIVE_MODEL ??
+        'us.anthropic.claude-sonnet-4-6',
+      region:
+        process.env.BEDROCK_AWS_REGION ??
+        process.env.AWS_DEFAULT_REGION ??
+        'us-east-1',
+      credentials: {
+        accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID,
+        secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY,
+      },
+      temperature: 0,
+      maxTokens: 128,
+      streaming: true,
+      streamUsage: true,
+    },
+  },
+];
 
 describeIfLive('Context accuracy live integration', () => {
   jest.setTimeout(240_000);
@@ -210,6 +258,82 @@ describeIfLive('Context accuracy live integration', () => {
       .join(' ');
     expect(text).toContain('4323');
   });
+
+  for (const entry of providerMatrix) {
+    const itIfProvider = entry.enabled ? it : it.skip;
+    itIfProvider(
+      `${entry.name}: tool-loop estimates track provider counts across tokenizers`,
+      async () => {
+        const capture = createCapture();
+        const run = await Run.create<t.IState>({
+          runId: `ctx-acc-${entry.name}-${Date.now()}`,
+          graphConfig: {
+            type: 'standard',
+            llmConfig: entry.llmConfig as t.LLMConfig,
+            instructions:
+              'You are a precise assistant. Use the add tool for any arithmetic, then reply with only the number. ' +
+              Array.from(
+                { length: 40 },
+                (_, i) =>
+                  `Rule ${i}: answer precisely and keep responses to a single line.`
+              ).join(' '),
+            maxContextTokens: 16000,
+            tools: [addTool],
+          },
+          returnContent: true,
+          skipCleanup: true,
+          customHandlers: capture.handlers,
+          tokenCounter,
+          indexTokenCountMap: {},
+        });
+
+        await run.processStream(
+          {
+            messages: [
+              new HumanMessage(
+                'Use the add tool to compute 1742 + 2581, then reply with only the number.'
+              ),
+            ],
+          },
+          createStreamConfig(`ctx-acc-${entry.name}-${Date.now()}`)
+        );
+
+        expect(capture.contextEvents.length).toBeGreaterThanOrEqual(2);
+        expect(capture.collectedUsage.length).toBe(
+          capture.contextEvents.length
+        );
+
+        const ratios = capture.contextEvents.map((event, index) => {
+          const usage = capture.collectedUsage[index];
+          const baseInput = usage.input_tokens ?? 0;
+          const cacheSum =
+            (usage.input_token_details?.cache_creation ?? 0) +
+            (usage.input_token_details?.cache_read ?? 0);
+          const providerInput =
+            baseInput + (cacheSum > baseInput ? cacheSum : 0);
+          return estimatedUsed(event) / providerInput;
+        });
+        console.log(`[ctx-accuracy] ${entry.name} ratios:`, ratios, {
+          provider: capture.collectedUsage.map((u) => ({
+            input: u.input_tokens,
+            details: u.input_token_details,
+          })),
+        });
+
+        /** Foreign tokenizers diverge most on the uncalibrated first call */
+        expect(ratios[0]).toBeGreaterThan(0.3);
+        expect(ratios[0]).toBeLessThan(3);
+
+        /** Calibration has real counts from call 1 — tighter band */
+        const last = ratios[ratios.length - 1];
+        expect(last).toBeGreaterThan(0.5);
+        expect(last).toBeLessThan(2);
+        expect(Math.abs(last - 1)).toBeLessThanOrEqual(
+          Math.abs(ratios[0] - 1) + 0.2
+        );
+      }
+    );
+  }
 
   it('stays accurate when pruning drops history under a small budget', async () => {
     const capture = createCapture();

--- a/src/specs/context-usage-event.test.ts
+++ b/src/specs/context-usage-event.test.ts
@@ -1,0 +1,104 @@
+import { HumanMessage, BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { GraphEvents, Providers } from '@/common';
+import { Run } from '@/run';
+
+const charCounter: t.TokenCounter = (msg: BaseMessage): number => {
+  const content = msg.content;
+  if (typeof content === 'string') {
+    return content.length + 3;
+  }
+  return 3;
+};
+
+const llmConfig: t.LLMConfig = {
+  provider: Providers.OPENAI,
+  streaming: true,
+  streamUsage: false,
+};
+
+const streamConfig = {
+  configurable: { thread_id: 'context-usage-event' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+describe('ON_CONTEXT_USAGE event', () => {
+  jest.setTimeout(15000);
+
+  it('dispatches a post-prune context snapshot per model call', async () => {
+    const received: t.ContextUsageEvent[] = [];
+    const maxContextTokens = 4000;
+
+    const run = await Run.create<t.IState>({
+      runId: 'test-context-usage-event',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        instructions: 'You are a helpful assistant.',
+        maxContextTokens,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.ON_CONTEXT_USAGE]: {
+          handle: (_event: string, data: t.StreamEventData): void => {
+            received.push(data as unknown as t.ContextUsageEvent);
+          },
+        },
+      },
+      tokenCounter: charCounter,
+      indexTokenCountMap: {},
+    });
+
+    run.Graph?.overrideTestModel(['Hello there!'], 1);
+    await run.processStream(
+      { messages: [new HumanMessage('hello')] },
+      streamConfig
+    );
+
+    expect(received).toHaveLength(1);
+    const event = received[0];
+    expect(event.runId).toBe('test-context-usage-event');
+    expect(event.agentId).toBeDefined();
+    expect(event.breakdown.maxContextTokens).toBe(maxContextTokens);
+    expect(event.breakdown.instructionTokens).toBeGreaterThan(0);
+    expect(event.contextBudget).toBeGreaterThan(0);
+    expect(event.contextBudget).toBeLessThanOrEqual(maxContextTokens);
+    expect(event.effectiveInstructionTokens).toBeGreaterThan(0);
+    expect(event.prePruneContextTokens).toBeGreaterThan(0);
+    expect(event.remainingContextTokens).toBeGreaterThan(0);
+    expect(event.remainingContextTokens).toBeLessThan(
+      event.contextBudget as number
+    );
+  });
+
+  it('does not dispatch when no tokenCounter is configured', async () => {
+    const received: t.ContextUsageEvent[] = [];
+
+    const run = await Run.create<t.IState>({
+      runId: 'test-context-usage-event-no-counter',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.ON_CONTEXT_USAGE]: {
+          handle: (_event: string, data: t.StreamEventData): void => {
+            received.push(data as unknown as t.ContextUsageEvent);
+          },
+        },
+      },
+    });
+
+    run.Graph?.overrideTestModel(['Hello there!'], 1);
+    await run.processStream(
+      { messages: [new HumanMessage('hello')] },
+      streamConfig
+    );
+
+    expect(received).toHaveLength(0);
+  });
+});

--- a/src/specs/context-usage-event.test.ts
+++ b/src/specs/context-usage-event.test.ts
@@ -72,6 +72,18 @@ describe('ON_CONTEXT_USAGE event', () => {
     expect(event.remainingContextTokens).toBeLessThan(
       event.contextBudget as number
     );
+    expect(event.breakdown.instructionTokens).toBe(
+      event.effectiveInstructionTokens
+    );
+    expect(event.breakdown.availableForMessages).toBe(
+      (event.contextBudget as number) -
+        (event.effectiveInstructionTokens as number)
+    );
+    expect(event.breakdown.messageTokens).toBe(
+      (event.contextBudget as number) -
+        (event.effectiveInstructionTokens as number) -
+        (event.remainingContextTokens as number)
+    );
   });
 
   it('does not dispatch when no tokenCounter is configured', async () => {

--- a/src/specs/context-usage-event.test.ts
+++ b/src/specs/context-usage-event.test.ts
@@ -63,6 +63,7 @@ describe('ON_CONTEXT_USAGE event', () => {
     expect(event.agentId).toBeDefined();
     expect(event.breakdown.maxContextTokens).toBe(maxContextTokens);
     expect(event.breakdown.instructionTokens).toBeGreaterThan(0);
+    expect(event.breakdown.toolTokenCounts).toEqual({});
     expect(event.contextBudget).toBeGreaterThan(0);
     expect(event.contextBudget).toBeLessThanOrEqual(maxContextTokens);
     expect(event.effectiveInstructionTokens).toBeGreaterThan(0);

--- a/src/specs/context-usage.live.test.ts
+++ b/src/specs/context-usage.live.test.ts
@@ -1,0 +1,297 @@
+// src/specs/context-usage.live.test.ts
+/**
+ * Live ON_CONTEXT_USAGE / usage accounting verification with real Anthropic
+ * calls — single agent, multi-agent handoff, and subagent isolation.
+ *
+ * Run with:
+ * RUN_CONTEXT_USAGE_LIVE_TESTS=1 ANTHROPIC_API_KEY=... npm test -- context-usage.live.test.ts --runInBand
+ */
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig();
+
+import { HumanMessage } from '@langchain/core/messages';
+import { describe, expect, it, jest } from '@jest/globals';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type * as t from '@/types';
+import { createTokenCounter, TokenEncoderManager } from '@/utils/tokens';
+import { Constants, GraphEvents, Providers } from '@/common';
+import { ModelEndHandler } from '@/events';
+import { Run } from '@/run';
+
+const shouldRunLive =
+  process.env.RUN_CONTEXT_USAGE_LIVE_TESTS === '1' &&
+  process.env.ANTHROPIC_API_KEY != null &&
+  process.env.ANTHROPIC_API_KEY !== '';
+
+const describeIfLive = shouldRunLive ? describe : describe.skip;
+const modelName =
+  process.env.ANTHROPIC_CONTEXT_LIVE_MODEL ?? 'claude-haiku-4-5';
+
+const MAX_CONTEXT_TOKENS = 8000;
+
+function createAnthropicAgent(
+  agentId: string,
+  instructions: string,
+  extras: Partial<t.AgentInputs> = {}
+): t.AgentInputs {
+  return {
+    agentId,
+    provider: Providers.ANTHROPIC,
+    clientOptions: {
+      modelName,
+      apiKey: process.env.ANTHROPIC_API_KEY,
+      temperature: 0,
+      maxTokens: 128,
+      streaming: true,
+      streamUsage: true,
+    },
+    instructions,
+    maxContextTokens: MAX_CONTEXT_TOKENS,
+    ...extras,
+  };
+}
+
+function createStreamConfig(threadId: string): Partial<RunnableConfig> & {
+  version: 'v1' | 'v2';
+  streamMode: string;
+} {
+  return {
+    configurable: { thread_id: threadId },
+    streamMode: 'values',
+    version: 'v2',
+  };
+}
+
+interface CapturedEvents {
+  contextEvents: t.ContextUsageEvent[];
+  subagentUpdates: unknown[];
+  collectedUsage: Array<Record<string, number | undefined>>;
+  handlers: Record<string, t.EventHandler>;
+}
+
+function createCapture(): CapturedEvents {
+  const contextEvents: t.ContextUsageEvent[] = [];
+  const subagentUpdates: unknown[] = [];
+  const collectedUsage: Array<Record<string, number | undefined>> = [];
+  const handlers: Record<string, t.EventHandler> = {
+    [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage as never),
+    [GraphEvents.ON_CONTEXT_USAGE]: {
+      handle: (_event, data): void => {
+        contextEvents.push(data as unknown as t.ContextUsageEvent);
+      },
+    },
+    [GraphEvents.ON_SUBAGENT_UPDATE]: {
+      handle: (_event, data): void => {
+        subagentUpdates.push(data);
+      },
+    },
+  };
+  return { contextEvents, subagentUpdates, collectedUsage, handlers };
+}
+
+describeIfLive('Context usage live integration', () => {
+  jest.setTimeout(180_000);
+
+  let tokenCounter: t.TokenCounter;
+
+  beforeAll(async () => {
+    tokenCounter = await createTokenCounter();
+  });
+
+  afterAll(() => {
+    TokenEncoderManager.reset();
+  });
+
+  it('emits a snapshot whose estimate tracks real provider input tokens', async () => {
+    const capture = createCapture();
+    const run = await Run.create<t.IState>({
+      runId: `ctx-live-single-${Date.now()}`,
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          createAnthropicAgent(
+            'solo',
+            'You are concise. Reply with one short sentence.'
+          ),
+        ],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: capture.handlers,
+      tokenCounter,
+      indexTokenCountMap: {},
+    });
+
+    await run.processStream(
+      { messages: [new HumanMessage('Say hello in five words or fewer.')] },
+      createStreamConfig(`ctx-live-single-${Date.now()}`)
+    );
+
+    expect(capture.contextEvents).toHaveLength(1);
+    const event = capture.contextEvents[0];
+    expect(event.agentId).toBe('solo');
+    expect(event.breakdown.maxContextTokens).toBe(MAX_CONTEXT_TOKENS);
+    expect(event.contextBudget).toBeLessThanOrEqual(MAX_CONTEXT_TOKENS);
+
+    expect(capture.collectedUsage).toHaveLength(1);
+    const usage = capture.collectedUsage[0];
+    expect(usage.input_tokens ?? 0).toBeGreaterThan(0);
+    expect(usage.output_tokens ?? 0).toBeGreaterThan(0);
+
+    /** The gauge shows `contextBudget - remaining` as occupancy; with a real
+     *  tokenizer it should land in the same ballpark as the provider count */
+    const estimatedUsed =
+      (event.contextBudget ?? 0) - (event.remainingContextTokens ?? 0);
+    const providerInput = usage.input_tokens ?? 0;
+    expect(estimatedUsed).toBeGreaterThan(0);
+    expect(estimatedUsed / providerInput).toBeGreaterThan(0.3);
+    expect(estimatedUsed / providerInput).toBeLessThan(3);
+  });
+
+  it('emits per-agent snapshots and usage across a real handoff', async () => {
+    const capture = createCapture();
+    const nonce = `ctx-live-handoff-${Date.now()}`;
+    const expectedReply = `${nonce}-confirmed`;
+    const handoffToolName = `${Constants.LC_TRANSFER_TO_}specialist`;
+
+    const run = await Run.create<t.IState>({
+      runId: `${nonce}-run`,
+      graphConfig: {
+        type: 'multi-agent',
+        agents: [
+          createAnthropicAgent(
+            'router',
+            `You are a routing agent. For every user request, your only valid action is to call the handoff tool named ${handoffToolName}. Do not answer directly.
+
+When you call the handoff tool, include instructions telling the specialist to reply exactly with this marker and no extra words: ${expectedReply}`
+          ),
+          createAnthropicAgent(
+            'specialist',
+            'You are the specialist. When you receive handoff instructions with a marker, reply exactly with that marker and no extra words.'
+          ),
+        ],
+        edges: [
+          {
+            from: 'router',
+            to: 'specialist',
+            edgeType: 'handoff',
+            description: 'Transfer to the specialist for the final response',
+            prompt:
+              'Instructions for the specialist. Include any exact marker that must be returned.',
+            promptKey: 'instructions',
+          },
+        ],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: capture.handlers,
+      tokenCounter,
+      indexTokenCountMap: {},
+    });
+
+    await run.processStream(
+      {
+        messages: [
+          new HumanMessage(
+            `Please delegate this to the specialist. The final answer must be exactly: ${expectedReply}`
+          ),
+        ],
+      },
+      createStreamConfig(`${nonce}-thread`)
+    );
+
+    const agentIds = new Set(
+      capture.contextEvents.map((event) => event.agentId)
+    );
+    expect(agentIds.has('router')).toBe(true);
+    expect(agentIds.has('specialist')).toBe(true);
+
+    for (const event of capture.contextEvents) {
+      expect(event.breakdown.maxContextTokens).toBe(MAX_CONTEXT_TOKENS);
+      expect(event.contextBudget).toBeLessThanOrEqual(MAX_CONTEXT_TOKENS);
+      expect(event.remainingContextTokens).toBeGreaterThan(0);
+    }
+
+    /** One snapshot per real model call — no ghost snapshots */
+    expect(capture.collectedUsage.length).toBe(capture.contextEvents.length);
+    expect(capture.collectedUsage.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('keeps subagent runs isolated from parent context/usage events', async () => {
+    const capture = createCapture();
+    const parent = createAnthropicAgent(
+      'parent',
+      'You are a supervisor. Delegate research tasks using the subagent tool.',
+      {
+        subagentConfigs: [
+          {
+            type: 'researcher',
+            name: 'Research Agent',
+            description: 'Researches and summarizes information',
+            agentInputs: createAnthropicAgent(
+              'researcher',
+              'You are a research agent. Answer in one short sentence.'
+            ),
+          },
+        ],
+      }
+    );
+
+    const run = await Run.create<t.IState>({
+      runId: `ctx-live-subagent-${Date.now()}`,
+      graphConfig: { type: 'standard', agents: [parent] },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: capture.handlers,
+      tokenCounter,
+      indexTokenCountMap: {},
+    });
+
+    /** Parent is a fake forced to call the subagent tool — the child run
+     *  executes on the real provider, exercising real isolation */
+    const subagentToolCall: ToolCall = {
+      id: 'call_subagent_live',
+      name: Constants.SUBAGENT,
+      args: {
+        description: 'What is the capital of France? One short sentence.',
+        subagent_type: 'researcher',
+      },
+      type: 'tool_call',
+    };
+    run.Graph?.overrideTestModel(
+      ['Delegating to the researcher.', 'The researcher confirmed the answer.'],
+      10,
+      [subagentToolCall]
+    );
+
+    await run.processStream(
+      { messages: [new HumanMessage('What is the capital of France?')] },
+      createStreamConfig(`ctx-live-subagent-${Date.now()}`)
+    );
+
+    /** Child progress arrives only as wrapped subagent updates */
+    expect(capture.subagentUpdates.length).toBeGreaterThan(0);
+
+    /** No raw child snapshots leak into the parent handler registry */
+    const childContextEvents = capture.contextEvents.filter(
+      (event) => event.agentId !== 'parent'
+    );
+    expect(childContextEvents).toHaveLength(0);
+    for (const event of capture.contextEvents) {
+      expect(event.agentId).toBe('parent');
+    }
+
+    /** Documented isolation: child model-call usage does not reach the
+     *  parent's collected usage (fake parent emits no usage_metadata) */
+    expect(capture.collectedUsage).toHaveLength(0);
+
+    const toolMessage = (run.getRunMessages() ?? []).find(
+      (message) =>
+        message.getType() === 'tool' &&
+        (message as { name?: string }).name === Constants.SUBAGENT
+    );
+    expect(toolMessage).toBeDefined();
+    expect(String(toolMessage?.content ?? '').toLowerCase()).toContain('paris');
+  });
+});

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -1444,7 +1444,10 @@ describe('Prune Messages Tests', () => {
       expect(result.context).toEqual([]);
       expect(result.messagesToRefine).toEqual([]);
       expect(result.prePruneContextTokens).toBe(0);
-      expect(result.remainingContextTokens).toBe(8000);
+      /** Reserve-adjusted budget (8000 − 5%) minus instruction overhead */
+      expect(result.contextBudget).toBe(7600);
+      expect(result.effectiveInstructionTokens).toBe(4000);
+      expect(result.remainingContextTokens).toBe(3600);
     });
   });
 

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -472,6 +472,53 @@ describe('Prune Messages Tests', () => {
       expect(typeof result.remainingContextTokens).toBe('number');
     });
 
+    it('should return remaining tokens in calibrated units when pruning with calibration', () => {
+      const tokenCounter = createTestTokenCounter();
+      const messages = [
+        new SystemMessage('System instruction'),
+        new HumanMessage('Message 1'),
+        new AIMessage('Response 1'),
+        new HumanMessage('Message 2'),
+        new AIMessage('Response 2'),
+      ];
+
+      const indexTokenCountMap = {
+        0: tokenCounter(messages[0]),
+        1: tokenCounter(messages[1]),
+        2: tokenCounter(messages[2]),
+        3: tokenCounter(messages[3]),
+        4: tokenCounter(messages[4]),
+      };
+
+      const calibrationRatio = 2;
+      const maxTokens = 80;
+      const pruneMessages = createPruneMessages({
+        maxTokens,
+        startIndex: 0,
+        tokenCounter,
+        indexTokenCountMap,
+        reserveRatio: 0,
+        calibrationRatio,
+      });
+
+      const result = pruneMessages({ messages });
+
+      expect(result.messagesToRefine?.length).toBeGreaterThan(0);
+
+      /** Pruning selects within rawSpaceBudget = maxTokens / ratio (raw units,
+       *  minus the 3-token assistant label); the returned remaining must be
+       *  scaled back so `budget - remaining` reflects provider-space usage */
+      const keptRaw = result.context.reduce(
+        (sum, msg) => sum + tokenCounter(msg),
+        0
+      );
+      const rawSpaceBudget = Math.round(maxTokens / calibrationRatio);
+      const expectedRemaining =
+        (rawSpaceBudget - keptRaw - 3) * calibrationRatio;
+      expect(result.remainingContextTokens).toBe(expectedRemaining);
+      expect(result.contextBudget).toBe(maxTokens);
+    });
+
     it('should respect startType parameter', () => {
       const tokenCounter = createTestTokenCounter();
       const messages = [

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -89,7 +89,13 @@ export interface AgentLogEvent {
   agentId?: string;
 }
 
-/** Per-model-call context window usage snapshot, dispatched after pruning */
+/**
+ * Per-model-call context window usage snapshot, dispatched after pruning and
+ * before the model invocation. Dispatched once per `callModel` invocation:
+ * fallback retries reuse the snapshot since the prompt is identical — budget
+ * numbers reflect the primary provider's tokenizer, and the calibration
+ * ratio self-corrects from whichever provider reports usage.
+ */
 export interface ContextUsageEvent {
   runId?: string;
   agentId?: string;

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -29,10 +29,10 @@ import type {
   MessageDeltaEvent,
   ReasoningDeltaEvent,
 } from '@/types/stream';
+import type { TokenCounter, TokenBudgetBreakdown } from '@/types/run';
 import type { Providers, Callback, GraphNodeKeys } from '@/common';
 import type { StandardGraph, MultiAgentGraph } from '@/graphs';
 import type { ClientOptions } from '@/types/llm';
-import type { TokenCounter } from '@/types/run';
 
 /** Interface for bound model with stream and invoke methods */
 export interface ChatModel {
@@ -89,6 +89,24 @@ export interface AgentLogEvent {
   agentId?: string;
 }
 
+/** Per-model-call context window usage snapshot, dispatched after pruning */
+export interface ContextUsageEvent {
+  runId?: string;
+  agentId?: string;
+  /** Structural token budget snapshot from AgentContext.getTokenBudgetBreakdown */
+  breakdown: TokenBudgetBreakdown;
+  /** Usable budget this call: maxContextTokens minus output reserve */
+  contextBudget?: number;
+  /** Calibrated instruction overhead actually applied this call */
+  effectiveInstructionTokens?: number;
+  /** Calibrated message tokens before pruning (excluding instructions) */
+  prePruneContextTokens?: number;
+  /** Tokens still free after instructions + pruned messages */
+  remainingContextTokens?: number;
+  /** EMA ratio of provider-reported vs locally estimated token counts */
+  calibrationRatio?: number;
+}
+
 export interface EventHandler {
   handle(
     event: string,
@@ -104,6 +122,7 @@ export interface EventHandler {
       | SummarizeCompleteEvent
       | SubagentUpdateEvent
       | AgentLogEvent
+      | ContextUsageEvent
       | ToolExecuteBatchRequest
       | { result: ToolEndEvent },
     metadata?: Record<string, unknown>,

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -242,6 +242,10 @@ export type TokenBudgetBreakdown = {
   messageTokens: number;
   /** Tokens available for messages after instructions. */
   availableForMessages: number;
+  /** Per-tool schema token counts (post-multiplier), keyed by tool name. */
+  toolTokenCounts?: Record<string, number>;
+  /** Names of counted tools that are deferred (`defer_loading`) and discovered. */
+  deferredToolNames?: string[];
 };
 
 export type EventStreamOptions = {

--- a/src/utils/__tests__/apportion.test.ts
+++ b/src/utils/__tests__/apportion.test.ts
@@ -1,0 +1,32 @@
+import { apportionTokenCounts } from '@/utils/tokens';
+
+describe('apportionTokenCounts', () => {
+  it('sums exactly to a ceil-of-sum aggregate despite per-entry fractions', () => {
+    const raw = { add: 33, search: 33, fetch: 33 };
+    const multiplier = 1.4;
+    const target = Math.ceil((33 + 33 + 33) * multiplier);
+    const result = apportionTokenCounts(raw, multiplier, target);
+    const sum = Object.values(result).reduce((acc, count) => acc + count, 0);
+    expect(sum).toBe(target);
+    expect(Object.keys(result).sort()).toEqual(['add', 'fetch', 'search']);
+  });
+
+  it('gives larger remainders priority when distributing leftovers', () => {
+    const result = apportionTokenCounts({ a: 10, b: 19 }, 1.05, 31);
+    expect(result.a + result.b).toBe(31);
+    expect(result.b).toBe(20);
+    expect(result.a).toBe(11);
+  });
+
+  it('handles calibration-style rescaling to an arbitrary target', () => {
+    const counts = { a: 100, b: 200, c: 300 };
+    const target = 451;
+    const result = apportionTokenCounts(counts, target / 600, target);
+    const sum = Object.values(result).reduce((acc, count) => acc + count, 0);
+    expect(sum).toBe(target);
+  });
+
+  it('returns an empty map for no entries', () => {
+    expect(apportionTokenCounts({}, 1.4, 10)).toEqual({});
+  });
+});

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -396,6 +396,39 @@ export function getTokenCountForMessage(
 }
 
 /**
+ * Largest-remainder apportionment: scales each count by `multiplier` and
+ * distributes the rounding remainder so the results sum exactly to
+ * `targetTotal`. Keeps per-item breakdowns reconciled with an aggregate
+ * computed as a single rounded product of the summed raw counts.
+ */
+export function apportionTokenCounts(
+  rawCounts: Record<string, number>,
+  multiplier: number,
+  targetTotal: number
+): Record<string, number> {
+  const result: Record<string, number> = Object.create(null);
+  const remainders: Array<{ name: string; remainder: number }> = [];
+  let floorSum = 0;
+  for (const [name, rawCount] of Object.entries(rawCounts)) {
+    const scaled = rawCount * multiplier;
+    const floored = Math.floor(scaled);
+    result[name] = floored;
+    floorSum += floored;
+    remainders.push({ name, remainder: scaled - floored });
+  }
+  let leftover = targetTotal - floorSum;
+  if (leftover <= 0 || remainders.length === 0) {
+    return result;
+  }
+  remainders.sort((a, b) => b.remainder - a.remainder);
+  for (let i = 0; leftover > 0; i = (i + 1) % remainders.length) {
+    result[remainders[i].name] += 1;
+    leftover--;
+  }
+  return result;
+}
+
+/**
  * Anthropic's API consistently reports ~10% more tokens than the local
  * claude tokenizer due to internal message framing and content encoding.
  * Verified empirically across content types via the count_tokens endpoint.


### PR DESCRIPTION
## Summary

I added a first-class `ON_CONTEXT_USAGE` event so hosts can stream per-model-call context window accounting to their UIs (LibreChat consumes this for its context usage gauge in danny-avila/LibreChat#13670).

- Dispatch `ON_CONTEXT_USAGE` from `createCallModel` immediately after pruning, via `safeDispatchCustomEvent` (same fire-and-forget mechanism as `ON_AGENT_LOG`); fires on every model call, including tool-loop iterations, and only when a `tokenCounter`/`maxContextTokens` pruner exists.
- Carry the structural `TokenBudgetBreakdown` from `AgentContext.getTokenBudgetBreakdown` plus two fields the pruner already knows but did not return: `contextBudget` (maxTokens minus the output reserve) and `effectiveInstructionTokens` (the calibrated instruction overhead actually applied this call) — so consumers derive post-prune occupancy as `contextBudget − remainingContextTokens` with zero duplicated math. The breakdown's index-keyed `messageTokens` is pre-prune by design; the payload documents this.
- Export a `ContextUsageEvent` type and register the event in `CUSTOM_GRAPH_EVENTS` so the run loop routes it to host handler registries.
- Bumped to 3.3.0 (additive, minor).

## Testing

- New `src/specs/context-usage-event.test.ts`: asserts one snapshot per model call with budget invariants through a real `Run.create` + `processStream`, and that no event fires without a `tokenCounter`.
- `prune`, `token-accounting` (pipeline + e2e), `thinking-prune`, and `summarize-prune` suites pass (111 tests) alongside the new spec; `tsc --noEmit` clean; `npm run build` clean.
