### PR TITLE
💸 feat: Report Subagent Child-Run Model Usage via Usage Sink

### DIFF
--- a/src/common/enum.ts
+++ b/src/common/enum.ts
@@ -185,6 +185,17 @@ export enum Constants {
   /** Anthropic server tool ID prefix (web_search, code_execution, etc.) */
   ANTHROPIC_SERVER_TOOL_PREFIX = 'srvtoolu_',
   SKILL_TOOL = 'skill',
+  /**
+   * Callback-metadata keys stamped by `attemptInvoke` /
+   * `tryFallbackProviders` carrying the provider (SDK `Providers` enum
+   * value) and configured model that actually served a model invocation.
+   * Unlike `ls_provider` — which derived providers inherit from their base
+   * class (e.g. DeepSeek/OpenRouter report `'openai'`) — these reflect the
+   * SDK's own routing, including fallback-provider calls. Consumed by the
+   * subagent usage-capture handler to tag billing events.
+   */
+  INVOKED_PROVIDER = '__invoked_provider',
+  INVOKED_MODEL = '__invoked_model',
   READ_FILE = 'read_file',
   BASH_TOOL = 'bash_tool',
   BASH_PROGRAMMATIC_TOOL_CALLING = 'run_tools_with_bash',

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -825,6 +825,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   agentContexts: Map<string, AgentContext> = new Map();
   /** Default agent ID to use */
   defaultAgentId: string;
+  /**
+   * Host sink for model usage emitted inside subagent child runs. Threaded
+   * into each `SubagentExecutor` this graph creates (and from there into
+   * child graphs, so nested subagents report too). See
+   * {@link t.StandardGraphInput.subagentUsageSink}.
+   */
+  subagentUsageSink?: t.SubagentUsageSink;
 
   constructor({
     runId,
@@ -834,11 +841,13 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     tokenCounter,
     indexTokenCountMap,
     calibrationRatio,
+    subagentUsageSink,
   }: t.StandardGraphInput) {
     super();
     this.runId = runId;
     this.signal = signal;
     this.langfuse = langfuse;
+    this.subagentUsageSink = subagentUsageSink;
 
     if (agents.length === 0) {
       throw new Error('At least one agent configuration is required');
@@ -2063,6 +2072,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           parentAgentId: agentContext.agentId,
           langfuse: this.langfuse,
           tokenCounter: agentContext.tokenCounter,
+          usageSink: this.subagentUsageSink,
           maxDepth: effectiveSubagentDepth,
           createChildGraph: (input): StandardGraph => {
             const childGraph = new StandardGraph(input);

--- a/src/llm/invoke.test.ts
+++ b/src/llm/invoke.test.ts
@@ -12,8 +12,8 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
+import { Constants, Providers } from '@/common';
 import { ToolNode } from '@/tools/ToolNode';
-import { Providers } from '@/common';
 
 /**
  * Minimal stub model shape `attemptInvoke` reads. Either `invoke` or
@@ -334,6 +334,84 @@ describe('tryFallbackProviders applies the same lazy annotation transform', () =
     expect(invokeMessages.length).toBeGreaterThanOrEqual(1);
     expect(invokeMessages[invokeMessages.length - 1][0].content).toBe(
       '[ref: tool0turn0]\noutput'
+    );
+
+    jest.dontMock('@/llm/init');
+    jest.resetModules();
+  });
+});
+
+describe('invocation attribution metadata', () => {
+  it('stamps INVOKED_PROVIDER on the config passed to the model', async () => {
+    const capturedConfigs: unknown[] = [];
+    const model: StubModel = {
+      invoke: jest.fn(
+        async (_m: BaseMessage[], config?: unknown): Promise<AIMessage> => {
+          capturedConfigs.push(config);
+          return new AIMessage({ content: 'ok' });
+        }
+      ),
+    };
+
+    await attemptInvoke(
+      {
+        model: model as t.ChatModel,
+        messages: [new HumanMessage('hi')],
+        /** A ChatOpenAI-derived provider — `ls_provider` would lie here. */
+        provider: Providers.DEEPSEEK,
+      },
+      { configurable: { run_id: 'run-attr' }, metadata: { existing: true } }
+    );
+
+    const config = capturedConfigs[0] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(config.metadata?.[Constants.INVOKED_PROVIDER]).toBe(
+      Providers.DEEPSEEK
+    );
+    /** Pre-existing metadata is preserved, not replaced. */
+    expect(config.metadata?.existing).toBe(true);
+  });
+
+  it('stamps INVOKED_MODEL from the fallback clientOptions in tryFallbackProviders', async () => {
+    const capturedConfigs: unknown[] = [];
+    const model: StubModel = {
+      invoke: jest.fn(
+        async (_m: BaseMessage[], config?: unknown): Promise<AIMessage> => {
+          capturedConfigs.push(config);
+          return new AIMessage({ content: 'ok' });
+        }
+      ),
+    };
+
+    jest.doMock('@/llm/init', () => ({
+      initializeModel: (): unknown => model,
+    }));
+    jest.resetModules();
+    const { tryFallbackProviders: freshTry } = (await import(
+      '@/llm/invoke'
+    )) as { tryFallbackProviders: typeof tryFallbackProviders };
+
+    await freshTry({
+      fallbacks: [
+        {
+          provider: Providers.ANTHROPIC,
+          clientOptions: { model: 'claude-fallback-1' },
+        },
+      ],
+      messages: [new HumanMessage('hi')],
+      primaryError: new Error('primary failed'),
+      config: { configurable: { run_id: 'run-attr-fb' } },
+    });
+
+    const config = capturedConfigs[0] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(config.metadata?.[Constants.INVOKED_MODEL]).toBe(
+      'claude-fallback-1'
+    );
+    expect(config.metadata?.[Constants.INVOKED_PROVIDER]).toBe(
+      Providers.ANTHROPIC
     );
 
     jest.dontMock('@/llm/init');

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -6,10 +6,10 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type * as t from '@/types';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
+import { Constants, GraphEvents, Providers } from '@/common';
 import { manualToolStreamProviders } from '@/llm/providers';
 import { modifyDeltaProperties } from '@/messages';
 import { ChatModelStreamHandler } from '@/stream';
-import { GraphEvents, Providers } from '@/common';
 import { initializeModel } from '@/llm/init';
 
 /**
@@ -208,6 +208,23 @@ export async function attemptInvoke(
   const runId = config?.configurable?.run_id as string | undefined;
   const messagesForProvider = annotateMessagesForLLM(messages, registry, runId);
 
+  /**
+   * Stamp the provider that is ACTUALLY serving this invocation onto the
+   * callback metadata. `attemptInvoke` is the single funnel for primary,
+   * fallback, and summarization model calls, so consumers that need
+   * provider attribution per call (the subagent usage-capture handler)
+   * read this key instead of trusting static agent config — which is
+   * wrong for fallback-served calls — or `ls_provider` — which derived
+   * providers inherit from their base class.
+   */
+  config = {
+    ...config,
+    metadata: {
+      ...(config?.metadata ?? {}),
+      [Constants.INVOKED_PROVIDER]: provider,
+    },
+  };
+
   if (model.stream) {
     const stream = await model.stream(messagesForProvider, config);
     let finalChunk: AIMessageChunk | undefined;
@@ -224,7 +241,7 @@ export async function attemptInvoke(
         });
       }
     } else if (registeredStreamHandler == null) {
-      const metadata = config?.metadata as Record<string, unknown> | undefined;
+      const metadata = config.metadata as Record<string, unknown> | undefined;
       const streamHandler = new ChatModelStreamHandler();
       for await (const chunk of stream) {
         const handlingChunk = getStreamHandlingChunk({
@@ -247,7 +264,7 @@ export async function attemptInvoke(
         });
       }
     } else {
-      const metadata = config?.metadata as Record<string, unknown> | undefined;
+      const metadata = config.metadata as Record<string, unknown> | undefined;
       for await (const chunk of stream) {
         const handlingChunk = getStreamHandlingChunk({
           current: finalChunk,
@@ -293,6 +310,25 @@ export async function attemptInvoke(
 }
 
 /**
+ * Best-effort read of the configured model name from client options.
+ * Providers disagree on the key (`model` vs `modelName`).
+ */
+function extractClientOptionsModel(
+  clientOptions: t.ClientOptions | undefined
+): string | undefined {
+  const options = clientOptions as
+    | { model?: unknown; modelName?: unknown }
+    | undefined;
+  if (typeof options?.model === 'string' && options.model !== '') {
+    return options.model;
+  }
+  if (typeof options?.modelName === 'string' && options.modelName !== '') {
+    return options.modelName;
+  }
+  return undefined;
+}
+
+/**
  * Attempts each fallback provider in order until one succeeds.
  * Throws the last error if all fallbacks fail.
  */
@@ -321,6 +357,24 @@ export async function tryFallbackProviders({
         clientOptions: fb.clientOptions,
         tools,
       });
+      /**
+       * Stamp the fallback's configured model onto callback metadata so
+       * per-call attribution (subagent usage capture) doesn't fall back to
+       * the PRIMARY config's model when the provider reports no
+       * `ls_model_name`. The serving provider is stamped uniformly by
+       * `attemptInvoke` (`INVOKED_PROVIDER`).
+       */
+      const fbModelName = extractClientOptionsModel(fb.clientOptions);
+      const fbConfig: RunnableConfig | undefined =
+        fbModelName == null
+          ? config
+          : {
+            ...config,
+            metadata: {
+              ...(config?.metadata ?? {}),
+              [Constants.INVOKED_MODEL]: fbModelName,
+            },
+          };
       const result = await attemptInvoke(
         {
           model: fbModel as t.ChatModel,
@@ -329,7 +383,7 @@ export async function tryFallbackProviders({
           context,
           onChunk,
         },
-        config
+        fbConfig
       );
       return result;
     } catch (e) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -129,6 +129,7 @@ export class Run<_T extends t.BaseGraphState> {
   private toolOutputReferences?: t.ToolOutputReferencesConfig;
   private eagerEventToolExecution?: t.EagerEventToolExecutionConfig;
   private toolExecution?: t.ToolExecutionConfig;
+  private subagentUsageSink?: t.SubagentUsageSink;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   graphRunnable?: t.CompiledStateWorkflow;
@@ -176,6 +177,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.toolOutputReferences = config.toolOutputReferences;
     this.eagerEventToolExecution = config.eagerEventToolExecution;
     this.toolExecution = config.toolExecution;
+    this.subagentUsageSink = config.subagentUsageSink;
 
     if (!config.graphConfig) {
       throw new Error('Graph config not provided');
@@ -249,6 +251,7 @@ export class Run<_T extends t.BaseGraphState> {
       tokenCounter: this.tokenCounter,
       indexTokenCountMap: this.indexTokenCountMap,
       calibrationRatio: this.calibrationRatio,
+      subagentUsageSink: this.subagentUsageSink,
     });
     /** Propagate compile options from graph config */
     standardGraph.compileOptions = this.applyHITLCheckpointerFallback(
@@ -276,6 +279,7 @@ export class Run<_T extends t.BaseGraphState> {
       tokenCounter: this.tokenCounter,
       indexTokenCountMap: this.indexTokenCountMap,
       calibrationRatio: this.calibrationRatio,
+      subagentUsageSink: this.subagentUsageSink,
     });
 
     multiAgentGraph.compileOptions =

--- a/src/scripts/subagent-usage-sink.ts
+++ b/src/scripts/subagent-usage-sink.ts
@@ -86,7 +86,9 @@ async function main(): Promise<void> {
       [GraphEvents.TOOL_END]: new ToolEndHandler(),
       [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
     },
-    subagentUsageSink: (event) => sunkEvents.push(event),
+    subagentUsageSink: (event) => {
+      sunkEvents.push(event);
+    },
   });
 
   const callerConfig = {

--- a/src/scripts/subagent-usage-sink.ts
+++ b/src/scripts/subagent-usage-sink.ts
@@ -1,0 +1,174 @@
+import { config } from 'dotenv';
+config();
+
+import { HumanMessage } from '@langchain/core/messages';
+import type { UsageMetadata } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { ToolEndHandler, ModelEndHandler } from '@/events';
+import { Providers, GraphEvents } from '@/common';
+import { Run } from '@/run';
+
+/**
+ * Live verification for `subagentUsageSink` (host billing of subagent
+ * child-run model usage).
+ *
+ * Runs a supervisor that MUST delegate to a "researcher" subagent, then
+ * asserts:
+ * 1. The host's CHAT_MODEL_END handler collected the PARENT's calls only.
+ * 2. The sink received one event per CHILD model call, tagged with the
+ *    subagent type, child run id, and the child's model/provider.
+ * 3. Child usage has real token counts (the previously-unbilled tokens).
+ *
+ * Usage:
+ *   OPENAI_API_KEY=... npx ts-node -r tsconfig-paths/register src/scripts/subagent-usage-sink.ts
+ *
+ * Or with Anthropic:
+ *   ANTHROPIC_API_KEY=... npx ts-node -r tsconfig-paths/register src/scripts/subagent-usage-sink.ts --provider anthropic
+ */
+
+const useAnthropic =
+  process.argv.includes('--provider') &&
+  process.argv[process.argv.indexOf('--provider') + 1] === 'anthropic';
+
+const provider = useAnthropic ? Providers.ANTHROPIC : Providers.OPENAI;
+const apiKey = useAnthropic
+  ? process.env.ANTHROPIC_API_KEY
+  : process.env.OPENAI_API_KEY;
+const modelName = useAnthropic ? 'claude-sonnet-4-20250514' : 'gpt-4o-mini';
+
+if (!apiKey) {
+  console.error(
+    `Missing ${useAnthropic ? 'ANTHROPIC_API_KEY' : 'OPENAI_API_KEY'} environment variable`
+  );
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  console.log('=== Subagent Usage Sink Live Verification ===\n');
+  console.log(`Provider: ${provider}`);
+  console.log(`Model: ${modelName}\n`);
+
+  const parentAgent: t.AgentInputs = {
+    agentId: 'supervisor',
+    provider,
+    clientOptions: { modelName, apiKey },
+    instructions: `You are a supervisor agent. For ANY user question, you MUST delegate to the "researcher" subagent via the subagent tool — never answer directly. After the subagent returns, give the user a one-sentence final answer.`,
+    maxContextTokens: 16000,
+    subagentConfigs: [
+      {
+        type: 'researcher',
+        name: 'Research Specialist',
+        description: 'Researches questions and returns concise answers.',
+        agentInputs: {
+          agentId: 'researcher',
+          provider,
+          clientOptions: { modelName, apiKey },
+          instructions:
+            'You are a research specialist. Answer the task in one or two sentences.',
+          maxContextTokens: 8000,
+        },
+      },
+    ],
+  };
+
+  const collectedUsage: UsageMetadata[] = [];
+  const sunkEvents: t.SubagentUsageEvent[] = [];
+
+  const runId = `usage-sink-live-${Date.now()}`;
+  const run = await Run.create<t.IState>({
+    runId,
+    graphConfig: {
+      type: 'standard',
+      agents: [parentAgent],
+    },
+    returnContent: true,
+    customHandlers: {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
+    },
+    subagentUsageSink: (event) => sunkEvents.push(event),
+  });
+
+  const callerConfig = {
+    configurable: { thread_id: `usage-sink-${Date.now()}` },
+    streamMode: 'values' as const,
+    version: 'v2' as const,
+  };
+
+  await run.processStream(
+    {
+      messages: [
+        new HumanMessage(
+          'In what year was the Eiffel Tower completed? Use the researcher subagent.'
+        ),
+      ],
+    },
+    callerConfig
+  );
+
+  console.log('\n--- Parent collectedUsage (CHAT_MODEL_END handler) ---');
+  console.dir(collectedUsage, { depth: null });
+
+  console.log('\n--- Subagent usage sink events ---');
+  console.dir(sunkEvents, { depth: null });
+
+  const failures: string[] = [];
+
+  if (collectedUsage.length < 2) {
+    failures.push(
+      `expected >= 2 parent model calls in collectedUsage, got ${collectedUsage.length}`
+    );
+  }
+  if (sunkEvents.length === 0) {
+    failures.push('sink received NO child usage events');
+  }
+  for (const event of sunkEvents) {
+    if (event.subagentType !== 'researcher') {
+      failures.push(`unexpected subagentType: ${event.subagentType}`);
+    }
+    if (event.runId !== runId) {
+      failures.push(`event.runId mismatch: ${event.runId}`);
+    }
+    if (!event.subagentRunId.startsWith(`${runId}_sub_`)) {
+      failures.push(`event.subagentRunId mismatch: ${event.subagentRunId}`);
+    }
+    if (event.provider !== provider) {
+      failures.push(`event.provider mismatch: ${event.provider}`);
+    }
+    if (event.model == null || event.model === '') {
+      failures.push('event.model missing');
+    }
+    const input = Number(event.usage.input_tokens) || 0;
+    const output = Number(event.usage.output_tokens) || 0;
+    if (input <= 0 || output <= 0) {
+      failures.push(
+        `child usage has non-positive tokens: input=${input} output=${output}`
+      );
+    }
+  }
+
+  const childTotal = sunkEvents.reduce(
+    (sum, e) =>
+      sum +
+      (Number(e.usage.input_tokens) || 0) +
+      (Number(e.usage.output_tokens) || 0),
+    0
+  );
+  console.log(
+    `\nChild tokens that were previously invisible to billing: ${childTotal}`
+  );
+
+  if (failures.length > 0) {
+    console.error('\nFAIL:');
+    for (const failure of failures) {
+      console.error(`  - ${failure}`);
+    }
+    process.exit(1);
+  }
+  console.log('\nPASS: subagent child usage reported through the sink.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -1,6 +1,12 @@
+import { ChatGenerationChunk } from '@langchain/core/outputs';
 import { FakeListChatModel } from '@langchain/core/utils/testing';
-import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+} from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { UsageMetadata } from '@langchain/core/messages';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type * as t from '@/types';
 import {
@@ -387,5 +393,120 @@ describe('Subagent Integration', () => {
     expect(contextWith!.toolSchemaTokens).toBeGreaterThan(
       contextWithout!.toolSchemaTokens
     );
+  });
+
+  it('reports child model usage through subagentUsageSink', async () => {
+    const CHILD_USAGE = {
+      input_tokens: 11,
+      output_tokens: 7,
+      total_tokens: 18,
+    };
+    /**
+     * The default mock (FakeListChatModel) reports no usage. Re-mock with a
+     * subclass that reports `usage_metadata` the way live providers do:
+     * stamped on the generation in the invoke path, and carried on a final
+     * zero-content chunk in the stream path (the graph's `attemptInvoke`
+     * prefers `model.stream()`, and chunk concatenation folds the usage
+     * into the aggregated message that `handleLLMEnd` receives).
+     */
+    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+      if (provider === Providers.OPENAI) {
+        return class extends FakeListChatModel {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          constructor(_options: any) {
+            super({ responses: [CHILD_RESPONSE] });
+          }
+          async _generate(
+            ...args: Parameters<FakeListChatModel['_generate']>
+          ): ReturnType<FakeListChatModel['_generate']> {
+            const result = await super._generate(...args);
+            for (const generation of result.generations) {
+              (generation.message as AIMessage).usage_metadata = {
+                ...CHILD_USAGE,
+              };
+            }
+            return result;
+          }
+          async *_streamResponseChunks(
+            ...args: Parameters<FakeListChatModel['_streamResponseChunks']>
+          ): ReturnType<FakeListChatModel['_streamResponseChunks']> {
+            yield* super._streamResponseChunks(...args);
+            yield new ChatGenerationChunk({
+              text: '',
+              message: new AIMessageChunk({
+                content: '',
+                usage_metadata: { ...CHILD_USAGE },
+              }),
+            });
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+      }
+      return originalGetChatModelClass(provider);
+    }) as typeof providers.getChatModelClass);
+
+    const collectedUsage: UsageMetadata[] = [];
+    const sunkEvents: t.SubagentUsageEvent[] = [];
+    const customHandlers: Record<string, t.EventHandler> = {
+      [GraphEvents.TOOL_END]: new ToolEndHandler(),
+      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(collectedUsage),
+    };
+
+    const runId = `subagent-usage-${Date.now()}`;
+    const run = await Run.create<t.IState>({
+      runId,
+      graphConfig: {
+        type: 'standard',
+        agents: [createParentAgent()],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers,
+      subagentUsageSink: (event) => sunkEvents.push(event),
+    });
+
+    const subagentToolCall: ToolCall = {
+      id: 'call_subagent_usage',
+      name: Constants.SUBAGENT,
+      args: {
+        description: 'What is the capital of France?',
+        subagent_type: 'researcher',
+      },
+      type: 'tool_call',
+    };
+
+    run.Graph?.overrideTestModel(
+      [
+        'Let me delegate this research task.',
+        `Based on the research: ${CHILD_RESPONSE}`,
+      ],
+      10,
+      [subagentToolCall]
+    );
+
+    await run.processStream(
+      { messages: [new HumanMessage('What is the capital of France?')] },
+      callerConfig
+    );
+
+    /** Child made exactly one model call; all events are child-tagged. */
+    expect(sunkEvents).toHaveLength(1);
+    const event = sunkEvents[0];
+    /** Chunk concat adds empty `*_token_details` — match on the counts. */
+    expect(event.usage).toMatchObject(CHILD_USAGE);
+    expect(event.subagentType).toBe('researcher');
+    expect(event.subagentAgentId).toBe('researcher');
+    expect(event.provider).toBe(Providers.OPENAI);
+    /** FakeListChatModel emits no ls_model_name → config fallback. */
+    expect(event.model).toBe('gpt-4o-mini');
+    expect(event.runId).toBe(runId);
+    expect(event.subagentRunId).toContain(`${runId}_sub_`);
+    /**
+     * The parent's own calls must NOT be routed through the sink — they
+     * flow through the registered CHAT_MODEL_END handler. (The fake
+     * override model reports no usage, so collectedUsage stays empty;
+     * the load-bearing assertion is that the sink saw no parent calls.)
+     */
+    expect(sunkEvents.every((e) => e.subagentType === 'researcher')).toBe(true);
   });
 });

--- a/src/specs/subagent.test.ts
+++ b/src/specs/subagent.test.ts
@@ -462,7 +462,9 @@ describe('Subagent Integration', () => {
       returnContent: true,
       skipCleanup: true,
       customHandlers,
-      subagentUsageSink: (event) => sunkEvents.push(event),
+      subagentUsageSink: (event) => {
+        sunkEvents.push(event);
+      },
     });
 
     const subagentToolCall: ToolCall = {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -6,8 +6,8 @@ import {
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
 } from '@/summarization/node';
+import { Constants, GraphEvents, Providers } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
-import { GraphEvents, Providers } from '@/common';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
 
@@ -214,6 +214,65 @@ describe('createSummarizeNode', () => {
     expect(
       (completeEvent?.data as t.SummarizeCompleteEvent).error
     ).toBeUndefined();
+  });
+
+  it('stamps INVOKED_MODEL/INVOKED_PROVIDER metadata for a dedicated summarizer model', async () => {
+    captureEvents();
+
+    const capturedConfigs: unknown[] = [];
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: jest
+              .fn()
+              .mockImplementation(
+                async (_messages: unknown, config?: unknown) => {
+                  capturedConfigs.push(config);
+                  return { content: 'Summary text' };
+                }
+              ),
+          };
+        }
+      } as never
+    );
+
+    const agentContext = createAgentContext({
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        model: 'gpt-4.1-mini',
+      },
+    });
+    const graph = mockGraph();
+    const node = createSummarizeNode({
+      agentContext,
+      graph,
+      generateStepId,
+    });
+
+    await node(
+      {
+        messages: [new HumanMessage('Hello'), new HumanMessage('World')],
+        summarizationRequest: {
+          remainingContextTokens: 1000,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    /**
+     * Usage consumers (the subagent usage-capture handler) attribute the
+     * call from these keys — without them, a summarizer model that differs
+     * from the agent's primary would be billed against the primary config.
+     */
+    const config = capturedConfigs[0] as {
+      metadata?: Record<string, unknown>;
+    };
+    expect(config.metadata?.[Constants.INVOKED_MODEL]).toBe('gpt-4.1-mini');
+    expect(config.metadata?.[Constants.INVOKED_PROVIDER]).toBe(
+      Providers.OPENAI
+    );
   });
 
   it('collects streamed text when model supports stream()', async () => {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -10,7 +10,13 @@ import type { AgentContext } from '@/agents/AgentContext';
 import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
-import { ContentTypes, GraphEvents, StepTypes, Providers } from '@/common';
+import {
+  Constants,
+  ContentTypes,
+  GraphEvents,
+  StepTypes,
+  Providers,
+} from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
@@ -938,6 +944,19 @@ export function createSummarizeNode({
           agent_id: request.agentId,
           summarization_provider: clientConfig.provider,
           summarization_model: clientConfig.modelName,
+          /**
+             * Per-call model attribution for usage consumers (the subagent
+             * usage-capture handler): the summarizer's model can differ from
+             * the agent's primary, and providers that emit no `ls_model_name`
+             * would otherwise be billed against the primary config's model.
+             * Omitted for self-summarize (no explicit model — the primary
+             * config fallback is then correct). `tryFallbackProviders`
+             * overrides this per fallback attempt; `INVOKED_PROVIDER` is
+             * stamped by `attemptInvoke` itself.
+             */
+          ...(clientConfig.modelName != null && clientConfig.modelName !== ''
+            ? { [Constants.INVOKED_MODEL]: clientConfig.modelName }
+            : {}),
         },
       }
       : undefined;

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -543,7 +543,9 @@ describe('SubagentExecutor', () => {
       const events: SubagentUsageEvent[] = [];
       const { factory, getInput } = makeCapturingGraphFactory();
       const executor = createExecutor({
-        usageSink: (event) => events.push(event),
+        usageSink: (event) => {
+          events.push(event);
+        },
         createChildGraph: factory,
       });
 
@@ -613,7 +615,9 @@ describe('SubagentExecutor', () => {
         },
       });
       const executor = createExecutor({
-        usageSink: (event) => events.push(event),
+        usageSink: (event) => {
+          events.push(event);
+        },
         createChildGraph: factory,
       });
 
@@ -652,7 +656,9 @@ describe('SubagentExecutor', () => {
         },
       });
       const executor = createExecutor({
-        usageSink: (event) => events.push(event),
+        usageSink: (event) => {
+          events.push(event);
+        },
         createChildGraph: factory,
       });
 
@@ -687,7 +693,9 @@ describe('SubagentExecutor', () => {
         },
       });
       const executor = createExecutor({
-        usageSink: (event) => events.push(event),
+        usageSink: (event) => {
+          events.push(event);
+        },
         createChildGraph: factory,
       });
 
@@ -731,7 +739,9 @@ describe('SubagentExecutor', () => {
         },
       });
       const executor = createExecutor({
-        usageSink: (event) => events.push(event),
+        usageSink: (event) => {
+          events.push(event);
+        },
         createChildGraph: factory,
       });
 
@@ -774,7 +784,9 @@ describe('SubagentExecutor', () => {
         },
       });
       const executor = createExecutor({
-        usageSink: (event) => events.push(event),
+        usageSink: (event) => {
+          events.push(event);
+        },
         createChildGraph: factory,
       });
 
@@ -794,7 +806,9 @@ describe('SubagentExecutor', () => {
         },
       });
       const executor = createExecutor({
-        usageSink: (event) => events.push(event),
+        usageSink: (event) => {
+          events.push(event);
+        },
         createChildGraph: factory,
       });
 
@@ -832,6 +846,55 @@ describe('SubagentExecutor', () => {
       });
 
       expect(result.content).toBe('child done');
+    });
+
+    it('awaits async sinks and swallows their rejections', async () => {
+      const settled: string[] = [];
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          await handler.handleLLMEnd?.(
+            makeLLMEndOutput({
+              input_tokens: 1,
+              output_tokens: 1,
+              total_tokens: 2,
+            }),
+            'call-1'
+          );
+          await handler.handleLLMEnd?.(
+            makeLLMEndOutput({
+              input_tokens: 2,
+              output_tokens: 2,
+              total_tokens: 4,
+            }),
+            'call-2'
+          );
+          /**
+           * Both sink dispatches must have settled by the time
+           * `handleLLMEnd` resolves — a dropped promise would leave
+           * `recorded` missing here and surface the second call's
+           * rejection as unhandled.
+           */
+          settled.push('drive-done');
+        },
+      });
+      const executor = createExecutor({
+        usageSink: async (event) => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          if (event.usage.input_tokens === 2) {
+            throw new Error('async host sink rejected');
+          }
+          settled.push('recorded');
+        },
+        createChildGraph: factory,
+      });
+
+      const result = await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(result.content).toBe('child done');
+      expect(settled).toEqual(['recorded', 'drive-done']);
     });
   });
 

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -19,7 +19,7 @@ import {
   summarizeEvent,
 } from '../subagent';
 import { sanitizeForwardedSubagentUpdateData } from '../subagent/SubagentExecutor';
-import { Providers, GraphEvents, StepTypes } from '@/common';
+import { Constants, Providers, GraphEvents, StepTypes } from '@/common';
 import { AgentContext } from '@/agents/AgentContext';
 import { HookRegistry } from '@/hooks/HookRegistry';
 import { HandlerRegistry } from '@/events';
@@ -519,32 +519,31 @@ describe('SubagentExecutor', () => {
       };
     }
 
+    const makeChoice = (
+      usage: Record<string, number> | undefined
+    ): unknown => ({
+      text: 'ok',
+      message: new AIMessage({
+        content: 'ok',
+        ...(usage
+          ? {
+            usage_metadata: usage as unknown as AIMessage['usage_metadata'],
+          }
+          : {}),
+      }),
+    });
+
     const makeLLMEndOutput = (
       usage: Record<string, number> | undefined
     ): unknown => ({
-      generations: [
-        [
-          {
-            text: 'ok',
-            message: new AIMessage({
-              content: 'ok',
-              ...(usage
-                ? {
-                  usage_metadata:
-                      usage as unknown as AIMessage['usage_metadata'],
-                }
-                : {}),
-            }),
-          },
-        ],
-      ],
+      generations: [[makeChoice(usage)]],
     });
 
-    it('forwards the sink into the child graph input (nested propagation)', async () => {
-      const sink = jest.fn();
+    it('forwards a wrapped sink into the child graph input that rewrites runId to the root run', async () => {
+      const events: SubagentUsageEvent[] = [];
       const { factory, getInput } = makeCapturingGraphFactory();
       const executor = createExecutor({
-        usageSink: sink,
+        usageSink: (event) => events.push(event),
         createChildGraph: factory,
       });
 
@@ -553,7 +552,29 @@ describe('SubagentExecutor', () => {
         subagentType: 'researcher',
       });
 
-      expect(getInput()?.subagentUsageSink).toBe(sink);
+      const forwarded = getInput()?.subagentUsageSink;
+      expect(typeof forwarded).toBe('function');
+      /**
+       * Simulate a NESTED child's emission: its executor stamps `runId`
+       * with its own parent (an intermediate `*_sub_*` id). The wrapper
+       * must rewrite it to THIS executor's parent run so the host always
+       * sees root-run attribution, while the emitting child's identity
+       * (`subagentRunId`) is preserved.
+       */
+      forwarded?.({
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        model: 'gpt-4o-mini',
+        provider: Providers.OPENAI,
+        subagentType: 'nested-grandchild',
+        subagentRunId: 'test-run_sub_a_sub_b',
+        subagentAgentId: 'grandchild',
+        runId: 'test-run_sub_a',
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].runId).toBe('test-run');
+      expect(events[0].subagentRunId).toBe('test-run_sub_a_sub_b');
+      expect(events[0].subagentType).toBe('nested-grandchild');
     });
 
     it('does not attach a capture callback when no sink is provided', async () => {
@@ -643,6 +664,126 @@ describe('SubagentExecutor', () => {
       expect(events).toHaveLength(1);
       /** `makeChildInputs` configures `clientOptions.modelName`. */
       expect(events[0].model).toBe('gpt-4o-mini');
+    });
+
+    it('emits one event per generation group when a call has multiple completions (n > 1)', async () => {
+      const usage = { input_tokens: 10, output_tokens: 4, total_tokens: 14 };
+      const events: SubagentUsageEvent[] = [];
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          /**
+           * One provider request with two choices — both carry the same
+           * request-level usage. Emitting per choice would double-bill.
+           */
+          await handler.handleLLMEnd?.(
+            { generations: [[makeChoice(usage), makeChoice(usage)]] },
+            'call-1'
+          );
+          /** Batched prompts: two groups = two requests = two events. */
+          await handler.handleLLMEnd?.(
+            { generations: [[makeChoice(usage)], [makeChoice(usage)]] },
+            'call-2'
+          );
+        },
+      });
+      const executor = createExecutor({
+        usageSink: (event) => events.push(event),
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(events).toHaveLength(3);
+    });
+
+    it('prefers INVOKED_PROVIDER/INVOKED_MODEL metadata for fallback-served calls', async () => {
+      const events: SubagentUsageEvent[] = [];
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          /**
+           * Mirror a fallback-served call: `attemptInvoke` stamps the
+           * serving provider, `tryFallbackProviders` stamps the fallback's
+           * configured model, and the provider reports no `ls_model_name`.
+           */
+          await handler.handleChatModelStart?.(
+            {},
+            [[]],
+            'call-1',
+            undefined,
+            undefined,
+            undefined,
+            {
+              [Constants.INVOKED_PROVIDER]: Providers.ANTHROPIC,
+              [Constants.INVOKED_MODEL]: 'claude-fallback-1',
+            }
+          );
+          await handler.handleLLMEnd?.(
+            makeLLMEndOutput({
+              input_tokens: 5,
+              output_tokens: 3,
+              total_tokens: 8,
+            }),
+            'call-1'
+          );
+        },
+      });
+      const executor = createExecutor({
+        usageSink: (event) => events.push(event),
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(events).toHaveLength(1);
+      /** Not the configured primary (openAI / gpt-4o-mini). */
+      expect(events[0].provider).toBe(Providers.ANTHROPIC);
+      expect(events[0].model).toBe('claude-fallback-1');
+    });
+
+    it('prefers provider-reported ls_model_name over INVOKED_MODEL', async () => {
+      const events: SubagentUsageEvent[] = [];
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          await handler.handleChatModelStart?.(
+            {},
+            [[]],
+            'call-1',
+            undefined,
+            undefined,
+            undefined,
+            {
+              ls_model_name: 'claude-fallback-1-20260101',
+              [Constants.INVOKED_PROVIDER]: Providers.ANTHROPIC,
+              [Constants.INVOKED_MODEL]: 'claude-fallback-1',
+            }
+          );
+          await handler.handleLLMEnd?.(
+            makeLLMEndOutput({
+              input_tokens: 5,
+              output_tokens: 3,
+              total_tokens: 8,
+            }),
+            'call-1'
+          );
+        },
+      });
+      const executor = createExecutor({
+        usageSink: (event) => events.push(event),
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(events[0].model).toBe('claude-fallback-1-20260101');
     });
 
     it('skips model calls that report no usage_metadata', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -4,7 +4,9 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type {
   AgentInputs,
   ResolvedSubagentConfig,
+  StandardGraphInput,
   SubagentUpdateEvent,
+  SubagentUsageEvent,
   ToolExecuteBatchRequest,
   ToolExecuteResult,
 } from '@/types';
@@ -454,6 +456,242 @@ describe('SubagentExecutor', () => {
     });
 
     expect(observedLangfuse).toBe(langfuse);
+  });
+
+  describe('usage sink', () => {
+    type CapturedCallbackHandler = {
+      handleChatModelStart?: (
+        llm: unknown,
+        messages: unknown,
+        runId: string,
+        parentRunId?: string,
+        extraParams?: Record<string, unknown>,
+        tags?: string[],
+        metadata?: Record<string, unknown>
+      ) => unknown;
+      handleLLMEnd?: (output: unknown, runId: string) => unknown;
+      handleLLMError?: (err: unknown, runId: string) => unknown;
+    };
+    type CapturedInvokeOptions = { callbacks?: CapturedCallbackHandler[] };
+
+    /**
+     * Stub factory that records the `StandardGraphInput` the executor
+     * builds and the options passed to `workflow.invoke`, so tests can
+     * drive the attached usage-capture callback directly (the stubbed
+     * invoke never makes real model calls, so callbacks would otherwise
+     * never fire).
+     */
+    function makeCapturingGraphFactory(driveDuringInvoke?: {
+      drive: (handler: CapturedCallbackHandler) => void | Promise<void>;
+    }): {
+      factory: (input: StandardGraphInput) => StandardGraph;
+      getInput: () => StandardGraphInput | undefined;
+      getInvokeOptions: () => CapturedInvokeOptions | undefined;
+    } {
+      let capturedInput: StandardGraphInput | undefined;
+      let capturedOptions: CapturedInvokeOptions | undefined;
+      const factory = (input: StandardGraphInput): StandardGraph => {
+        capturedInput = input;
+        return {
+          createWorkflow: (): { invoke: jest.Mock } => ({
+            invoke: jest
+              .fn()
+              .mockImplementation(
+                async (_input: unknown, options: CapturedInvokeOptions) => {
+                  capturedOptions = options;
+                  const usageHandler = options.callbacks?.find(
+                    (cb) => cb.handleLLMEnd != null
+                  );
+                  if (driveDuringInvoke && usageHandler) {
+                    await driveDuringInvoke.drive(usageHandler);
+                  }
+                  return { messages: [new AIMessage('child done')] };
+                }
+              ),
+          }),
+          clearHeavyState: jest.fn(),
+        } as unknown as StandardGraph;
+      };
+      return {
+        factory,
+        getInput: () => capturedInput,
+        getInvokeOptions: () => capturedOptions,
+      };
+    }
+
+    const makeLLMEndOutput = (
+      usage: Record<string, number> | undefined
+    ): unknown => ({
+      generations: [
+        [
+          {
+            text: 'ok',
+            message: new AIMessage({
+              content: 'ok',
+              ...(usage
+                ? {
+                  usage_metadata:
+                      usage as unknown as AIMessage['usage_metadata'],
+                }
+                : {}),
+            }),
+          },
+        ],
+      ],
+    });
+
+    it('forwards the sink into the child graph input (nested propagation)', async () => {
+      const sink = jest.fn();
+      const { factory, getInput } = makeCapturingGraphFactory();
+      const executor = createExecutor({
+        usageSink: sink,
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(getInput()?.subagentUsageSink).toBe(sink);
+    });
+
+    it('does not attach a capture callback when no sink is provided', async () => {
+      const { factory, getInvokeOptions } = makeCapturingGraphFactory();
+      const executor = createExecutor({ createChildGraph: factory });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(getInvokeOptions()?.callbacks).toEqual([]);
+    });
+
+    it('emits tagged usage events with per-call ls_model_name', async () => {
+      const events: SubagentUsageEvent[] = [];
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          await handler.handleChatModelStart?.(
+            {},
+            [[]],
+            'call-1',
+            undefined,
+            undefined,
+            undefined,
+            { ls_model_name: 'gpt-4o-mini-2024-07-18' }
+          );
+          await handler.handleLLMEnd?.(
+            makeLLMEndOutput({
+              input_tokens: 11,
+              output_tokens: 7,
+              total_tokens: 18,
+            }),
+            'call-1'
+          );
+        },
+      });
+      const executor = createExecutor({
+        usageSink: (event) => events.push(event),
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(events).toHaveLength(1);
+      const event = events[0];
+      expect(event.usage).toEqual({
+        input_tokens: 11,
+        output_tokens: 7,
+        total_tokens: 18,
+      });
+      expect(event.model).toBe('gpt-4o-mini-2024-07-18');
+      expect(event.provider).toBe(Providers.OPENAI);
+      expect(event.subagentType).toBe('researcher');
+      expect(event.subagentAgentId).toBe('child-agent');
+      expect(event.subagentRunId).toContain('test-run_sub_');
+      expect(event.runId).toBe('test-run');
+    });
+
+    it('falls back to the configured model when a call has no ls_model_name', async () => {
+      const events: SubagentUsageEvent[] = [];
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          await handler.handleLLMEnd?.(
+            makeLLMEndOutput({
+              input_tokens: 3,
+              output_tokens: 2,
+              total_tokens: 5,
+            }),
+            'call-1'
+          );
+        },
+      });
+      const executor = createExecutor({
+        usageSink: (event) => events.push(event),
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(events).toHaveLength(1);
+      /** `makeChildInputs` configures `clientOptions.modelName`. */
+      expect(events[0].model).toBe('gpt-4o-mini');
+    });
+
+    it('skips model calls that report no usage_metadata', async () => {
+      const events: SubagentUsageEvent[] = [];
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          await handler.handleLLMEnd?.(makeLLMEndOutput(undefined), 'call-1');
+        },
+      });
+      const executor = createExecutor({
+        usageSink: (event) => events.push(event),
+        createChildGraph: factory,
+      });
+
+      await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(events).toEqual([]);
+    });
+
+    it('swallows sink errors without breaking the child run', async () => {
+      const { factory } = makeCapturingGraphFactory({
+        drive: async (handler) => {
+          await handler.handleLLMEnd?.(
+            makeLLMEndOutput({
+              input_tokens: 1,
+              output_tokens: 1,
+              total_tokens: 2,
+            }),
+            'call-1'
+          );
+        },
+      });
+      const executor = createExecutor({
+        usageSink: () => {
+          throw new Error('host sink exploded');
+        },
+        createChildGraph: factory,
+      });
+
+      const result = await executor.execute({
+        description: 'Research this topic',
+        subagentType: 'researcher',
+      });
+
+      expect(result.content).toBe('child done');
+    });
   });
 
   it('returns error message when child graph throws', async () => {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -26,7 +26,7 @@ import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs/Graph';
 import type { HandlerRegistry } from '@/events';
-import { GraphEvents, Callback, StepTypes } from '@/common';
+import { Constants, GraphEvents, Callback, StepTypes } from '@/common';
 import { executeHooks } from '@/hooks';
 
 const DEFAULT_MAX_TURNS = 25;
@@ -364,6 +364,7 @@ export class SubagentExecutor {
     const childRunId = `${this.parentRunId}_sub_${nanoid(8)}`;
     const maxTurns = config.maxTurns ?? DEFAULT_MAX_TURNS;
 
+    const hostUsageSink = this.usageSink;
     const childGraph = this.createChildGraph({
       runId: childRunId,
       signal: this.parentSignal,
@@ -377,8 +378,20 @@ export class SubagentExecutor {
        * level attaches its own capture callback — `workflow.invoke` replaces
        * the inherited callback chain, so a single top-level handler would
        * never see grandchild model calls.
+       *
+       * The wrapper rewrites `runId` to THIS executor's parent run: nested
+       * executors emit with their own `parentRunId` (a `*_sub_*` child id),
+       * and each wrapper layer rewrites upward, so by the time an event
+       * reaches the host sink its `runId` is the ROOT run — hosts keying
+       * billing by run id never see intermediate child run ids there
+       * (`subagentRunId` still identifies the emitting child).
        */
-      subagentUsageSink: this.usageSink,
+      subagentUsageSink:
+        hostUsageSink == null
+          ? undefined
+          : (event): void => {
+            hostUsageSink({ ...event, runId: this.parentRunId });
+          },
     });
 
     let forwarding: ForwarderCallback | undefined;
@@ -784,9 +797,15 @@ function createUsageCaptureHandler(args: {
   subagentRunId: string;
   subagentAgentId: string;
   parentRunId: string;
-  /** Child config's provider enum — hosts key pricing/cache semantics off it. */
+  /**
+   * Child config's provider enum — the default tag when a call carries no
+   * `INVOKED_PROVIDER` metadata (hosts key pricing/cache semantics off it).
+   */
   provider?: string;
-  /** Child config's model, used when a call carries no `ls_model_name`. */
+  /**
+   * Child config's model, used when a call carries neither `ls_model_name`
+   * nor `INVOKED_MODEL` metadata.
+   */
   fallbackModel?: string;
 }): BaseCallbackHandler {
   const {
@@ -798,8 +817,19 @@ function createUsageCaptureHandler(args: {
     provider,
     fallbackModel,
   } = args;
-  /** Per-call `ls_model_name` keyed by LangChain callback runId. */
-  const modelNamesByCallId = new Map<string, string>();
+  /**
+   * Per-call attribution keyed by LangChain callback runId. `model` joins
+   * `ls_model_name` (provider-reported) with `INVOKED_MODEL` (stamped by
+   * `tryFallbackProviders` from the fallback's client options); `provider`
+   * is `INVOKED_PROVIDER`, stamped by `attemptInvoke` with the SDK enum of
+   * the provider that ACTUALLY served the call — correct for
+   * fallback-served calls, where the static config provider would mis-tag
+   * pricing/cache semantics.
+   */
+  const callInfoByCallId = new Map<
+    string,
+    { model?: string; provider?: string }
+  >();
   const handler = BaseCallbackHandler.fromMethods({
     handleChatModelStart: (
       _llm: unknown,
@@ -810,15 +840,32 @@ function createUsageCaptureHandler(args: {
       _tags?: string[],
       metadata?: Record<string, unknown>
     ): void => {
-      const lsModelName = metadata?.ls_model_name;
-      if (typeof lsModelName === 'string' && lsModelName.length > 0) {
-        modelNamesByCallId.set(runId, lsModelName);
+      const callModel =
+        asNonEmptyString(metadata?.ls_model_name) ??
+        asNonEmptyString(metadata?.[Constants.INVOKED_MODEL]);
+      const callProvider = asNonEmptyString(
+        metadata?.[Constants.INVOKED_PROVIDER]
+      );
+      if (callModel != null || callProvider != null) {
+        callInfoByCallId.set(runId, {
+          model: callModel,
+          provider: callProvider,
+        });
       }
     },
     handleLLMEnd: (output: LLMResult, runId: string): void => {
-      const model = modelNamesByCallId.get(runId) ?? fallbackModel;
-      modelNamesByCallId.delete(runId);
+      const callInfo = callInfoByCallId.get(runId);
+      callInfoByCallId.delete(runId);
+      const model = callInfo?.model ?? fallbackModel;
+      const callProvider = callInfo?.provider ?? provider;
       for (const generationGroup of output.generations) {
+        /**
+         * At most ONE event per generation group: each group is one
+         * provider request (the outer array is per-prompt for batched
+         * calls), and with multiple completions (`n > 1`) every choice in
+         * a group repeats the request-level `usage_metadata` — emitting
+         * per choice would multiply billed tokens.
+         */
         for (const generation of generationGroup) {
           const message = (generation as ChatGeneration | undefined)?.message;
           const usage = (
@@ -831,7 +878,7 @@ function createUsageCaptureHandler(args: {
             sink({
               usage,
               model,
-              provider,
+              provider: callProvider,
               subagentType,
               subagentRunId,
               subagentAgentId,
@@ -840,11 +887,12 @@ function createUsageCaptureHandler(args: {
           } catch {
             /* observational — a throwing host sink must not break the child run */
           }
+          break;
         }
       }
     },
     handleLLMError: (_err: unknown, runId: string): void => {
-      modelNamesByCallId.delete(runId);
+      callInfoByCallId.delete(runId);
     },
   });
   /**
@@ -854,6 +902,10 @@ function createUsageCaptureHandler(args: {
    */
   handler.awaitHandlers = true;
   return handler;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
 }
 
 /**

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1,8 +1,9 @@
 import { nanoid } from 'nanoid';
 import { HumanMessage } from '@langchain/core/messages';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
+import type { ChatGeneration, LLMResult } from '@langchain/core/outputs';
 import type { Callbacks } from '@langchain/core/callbacks/manager';
-import type { BaseMessage } from '@langchain/core/messages';
 import type {
   AgentInputs,
   MessageDeltaEvent,
@@ -16,6 +17,7 @@ import type {
   SubagentConfig,
   SubagentUpdateEvent,
   SubagentUpdatePhase,
+  SubagentUsageSink,
   ToolExecuteBatchRequest,
   ToolCallDelta,
   TokenCounter,
@@ -236,6 +238,15 @@ export type SubagentExecutorOptions = {
    * post-`createWorkflow`, so `createAgentNode` must capture lazily).
    */
   parentHandlerRegistry?: HandlerRegistry | (() => HandlerRegistry | undefined);
+  /**
+   * Receives a usage event for every model call the child run makes. The
+   * child workflow executes via `invoke()` with a detached callbacks array,
+   * so its `on_chat_model_end` events never reach the parent's handler
+   * registry — without this sink, child token usage is invisible to the
+   * host (unbilled model calls). Forwarded into the child graph's input so
+   * nested subagents report through the same sink.
+   */
+  usageSink?: SubagentUsageSink;
 };
 
 export class SubagentExecutor {
@@ -248,6 +259,7 @@ export class SubagentExecutor {
   private readonly tokenCounter?: TokenCounter;
   private readonly maxDepth: number;
   private readonly createChildGraph: ChildGraphFactory;
+  private readonly usageSink?: SubagentUsageSink;
   private readonly resolveParentHandlerRegistry?: () =>
     | HandlerRegistry
     | undefined;
@@ -262,6 +274,7 @@ export class SubagentExecutor {
     this.tokenCounter = options.tokenCounter;
     this.maxDepth = options.maxDepth ?? 1;
     this.createChildGraph = options.createChildGraph;
+    this.usageSink = options.usageSink;
     const rawRegistry = options.parentHandlerRegistry;
     if (typeof rawRegistry === 'function') {
       this.resolveParentHandlerRegistry = rawRegistry;
@@ -357,6 +370,15 @@ export class SubagentExecutor {
       agents: [childInputs],
       langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
+      /**
+       * Forwarded so the child graph's own `SubagentExecutor` (created in
+       * its `createAgentNode` when `allowNested` keeps subagentConfigs)
+       * reports nested-child usage through the same host sink. Each nesting
+       * level attaches its own capture callback — `workflow.invoke` replaces
+       * the inherited callback chain, so a single top-level handler would
+       * never see grandchild model calls.
+       */
+      subagentUsageSink: this.usageSink,
     });
 
     let forwarding: ForwarderCallback | undefined;
@@ -402,7 +424,31 @@ export class SubagentExecutor {
        * `runName` gives the child a distinct LangSmith trace root (avoids
        * nested trace pollution).
        */
-      const callbacks: Callbacks = forwarder ? [forwarder] : [];
+      const callbackHandlers: BaseCallbackHandler[] = [];
+      if (forwarder) {
+        callbackHandlers.push(forwarder);
+      }
+      /**
+       * Usage capture rides the same detached callbacks array. Because
+       * `callbacks` REPLACES the inherited chain (see above), the host's
+       * `CHAT_MODEL_END` handler never observes the child's model calls —
+       * this handler is the child-side equivalent of `ModelEndHandler`,
+       * reporting per-call usage to the host's sink for billing.
+       */
+      if (this.usageSink) {
+        callbackHandlers.push(
+          createUsageCaptureHandler({
+            sink: this.usageSink,
+            subagentType,
+            subagentRunId: childRunId,
+            subagentAgentId: childAgentId,
+            parentRunId: this.parentRunId,
+            provider: config.agentInputs.provider,
+            fallbackModel: extractConfiguredModel(config.agentInputs),
+          })
+        );
+      }
+      const callbacks: Callbacks = callbackHandlers;
       /**
        * Inherit the parent's host `configurable` — host-set fields
        * (`requestBody`, `user`, `userMCPAuthMap`, etc.) AND the run-
@@ -717,6 +763,118 @@ export class SubagentExecutor {
     handler.awaitHandlers = true;
     return { handler, drain };
   }
+}
+
+/**
+ * Builds the child-run equivalent of a host `CHAT_MODEL_END` handler: a
+ * callback that joins per-call model identity (captured from
+ * `ls_model_name` at chat-model start) with the usage metadata reported at
+ * LLM end, and emits a {@link SubagentUsageEvent} through the host's sink.
+ *
+ * Attached to the child `workflow.invoke` callbacks array, so it observes
+ * every model call inside the child graph — the agent loop and any
+ * auxiliary calls (e.g. child-side summarization). It does NOT observe
+ * deeper subagent levels: each nesting level replaces the callback chain
+ * and attaches its own capture handler via the forwarded
+ * `subagentUsageSink` on the child graph's input.
+ */
+function createUsageCaptureHandler(args: {
+  sink: SubagentUsageSink;
+  subagentType: string;
+  subagentRunId: string;
+  subagentAgentId: string;
+  parentRunId: string;
+  /** Child config's provider enum — hosts key pricing/cache semantics off it. */
+  provider?: string;
+  /** Child config's model, used when a call carries no `ls_model_name`. */
+  fallbackModel?: string;
+}): BaseCallbackHandler {
+  const {
+    sink,
+    subagentType,
+    subagentRunId,
+    subagentAgentId,
+    parentRunId,
+    provider,
+    fallbackModel,
+  } = args;
+  /** Per-call `ls_model_name` keyed by LangChain callback runId. */
+  const modelNamesByCallId = new Map<string, string>();
+  const handler = BaseCallbackHandler.fromMethods({
+    handleChatModelStart: (
+      _llm: unknown,
+      _messages: unknown,
+      runId: string,
+      _parentRunId?: string,
+      _extraParams?: Record<string, unknown>,
+      _tags?: string[],
+      metadata?: Record<string, unknown>
+    ): void => {
+      const lsModelName = metadata?.ls_model_name;
+      if (typeof lsModelName === 'string' && lsModelName.length > 0) {
+        modelNamesByCallId.set(runId, lsModelName);
+      }
+    },
+    handleLLMEnd: (output: LLMResult, runId: string): void => {
+      const model = modelNamesByCallId.get(runId) ?? fallbackModel;
+      modelNamesByCallId.delete(runId);
+      for (const generationGroup of output.generations) {
+        for (const generation of generationGroup) {
+          const message = (generation as ChatGeneration | undefined)?.message;
+          const usage = (
+            message as { usage_metadata?: UsageMetadata } | undefined
+          )?.usage_metadata;
+          if (usage == null) {
+            continue;
+          }
+          try {
+            sink({
+              usage,
+              model,
+              provider,
+              subagentType,
+              subagentRunId,
+              subagentAgentId,
+              runId: parentRunId,
+            });
+          } catch {
+            /* observational — a throwing host sink must not break the child run */
+          }
+        }
+      }
+    },
+    handleLLMError: (_err: unknown, runId: string): void => {
+      modelNamesByCallId.delete(runId);
+    },
+  });
+  /**
+   * Dispatch usage synchronously with each model call so all entries are
+   * sunk before `workflow.invoke` resolves — hosts read their accumulator
+   * right after the parent run completes.
+   */
+  handler.awaitHandlers = true;
+  return handler;
+}
+
+/**
+ * Best-effort read of the configured model from a subagent's client
+ * options. Providers disagree on the key (`model` vs `modelName`), and the
+ * value is only a fallback for calls that carry no `ls_model_name`.
+ */
+function extractConfiguredModel(agentInputs: AgentInputs): string | undefined {
+  const clientOptions = agentInputs.clientOptions as
+    | { model?: unknown; modelName?: unknown }
+    | undefined;
+  if (typeof clientOptions?.model === 'string' && clientOptions.model !== '') {
+    return clientOptions.model;
+  }
+  if (
+    typeof clientOptions?.modelName === 'string' &&
+    clientOptions.modelName !== ''
+  ) {
+    return clientOptions.modelName;
+  }
+  return undefined;
 }
 
 function sanitizeChildConfigurable(

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -389,9 +389,10 @@ export class SubagentExecutor {
       subagentUsageSink:
         hostUsageSink == null
           ? undefined
-          : (event): void => {
-            hostUsageSink({ ...event, runId: this.parentRunId });
-          },
+          : /** Returns the host sink's result so async sinks stay awaited
+             *  through every wrapper layer. */
+          (event): void | Promise<void> =>
+            hostUsageSink({ ...event, runId: this.parentRunId }),
     });
 
     let forwarding: ForwarderCallback | undefined;
@@ -853,7 +854,7 @@ function createUsageCaptureHandler(args: {
         });
       }
     },
-    handleLLMEnd: (output: LLMResult, runId: string): void => {
+    handleLLMEnd: async (output: LLMResult, runId: string): Promise<void> => {
       const callInfo = callInfoByCallId.get(runId);
       callInfoByCallId.delete(runId);
       const model = callInfo?.model ?? fallbackModel;
@@ -874,8 +875,15 @@ function createUsageCaptureHandler(args: {
           if (usage == null) {
             continue;
           }
+          /**
+           * Awaited so async host sinks (billing/persistence) complete
+           * before the model call resolves — `awaitHandlers` only waits on
+           * `handleLLMEnd` itself, so a dropped promise here would let the
+           * parent run finish before usage is recorded and would turn sink
+           * rejections into unhandled rejections.
+           */
           try {
-            sink({
+            await sink({
               usage,
               model,
               provider: callProvider,
@@ -885,7 +893,7 @@ function createUsageCaptureHandler(args: {
               runId: parentRunId,
             });
           } catch {
-            /* observational — a throwing host sink must not break the child run */
+            /* observational — a throwing/rejecting host sink must not break the child run */
           }
           break;
         }

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -3,6 +3,7 @@ import type {
   BaseMessage,
   AIMessageChunk,
   SystemMessage,
+  UsageMetadata,
 } from '@langchain/core/messages';
 import type { BindToolsInput } from '@langchain/core/language_models/chat_models';
 import type { START, StateGraph, StateGraphArgs } from '@langchain/langgraph';
@@ -299,6 +300,17 @@ export type StandardGraphInput = {
   tokenCounter?: TokenCounter;
   indexTokenCountMap?: Record<string, number>;
   calibrationRatio?: number;
+  /**
+   * Receives a {@link SubagentUsageEvent} for every model call made inside
+   * a subagent child run spawned from this graph (including nested
+   * subagents and child-side summarization calls). Child graphs run via
+   * `invoke()` outside the host's `streamEvents` loop, so their
+   * `on_chat_model_end` events never reach the run's handler registry —
+   * this sink is the only way hosts can observe child token usage for
+   * billing/accounting. Parent-graph model calls are NOT reported here;
+   * they already flow through the registry's `CHAT_MODEL_END` handler.
+   */
+  subagentUsageSink?: SubagentUsageSink;
 };
 
 export type GraphEdge = {
@@ -408,6 +420,46 @@ export interface SubagentUpdateEvent {
   /** ISO timestamp for ordering / display. */
   timestamp: string;
 }
+
+/**
+ * Token usage for a single model call made inside a subagent child run.
+ * Emitted through {@link SubagentUsageSink} as each call completes, so
+ * hosts can bill child-run model usage that never reaches the parent
+ * run's `CHAT_MODEL_END` handler (child graphs execute via `invoke()`
+ * outside the host's `streamEvents` loop).
+ */
+export interface SubagentUsageEvent {
+  /** Usage metadata reported by the child's model call. */
+  usage: UsageMetadata;
+  /**
+   * Model that produced this usage. Per-call `ls_model_name` from the
+   * model's callback metadata when available (covers child-side
+   * summarization or any call that differs from the configured model),
+   * falling back to the subagent config's `clientOptions` model.
+   */
+  model?: string;
+  /**
+   * Provider of the subagent's configured agent (the SDK `Providers`
+   * enum value from its `AgentInputs`, not LangSmith's `ls_provider`
+   * string — hosts key pricing/cache semantics off the enum).
+   */
+  provider?: string;
+  /** Subagent `type` identifier from the SubagentConfig. */
+  subagentType: string;
+  /** Child run ID (unique per subagent execution). */
+  subagentRunId: string;
+  /** Child agent ID assigned to this subagent execution. */
+  subagentAgentId: string;
+  /** Parent run ID under which the subagent was spawned. */
+  runId: string;
+}
+
+/**
+ * Host-provided callback receiving {@link SubagentUsageEvent}s. Invoked
+ * synchronously as each child model call completes; implementations should
+ * be cheap and non-throwing (errors are swallowed by the executor).
+ */
+export type SubagentUsageSink = (event: SubagentUsageEvent) => void;
 
 export type LangfuseToolOutputTracingConfig = {
   /**

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -435,13 +435,18 @@ export interface SubagentUsageEvent {
    * Model that produced this usage. Per-call `ls_model_name` from the
    * model's callback metadata when available (covers child-side
    * summarization or any call that differs from the configured model),
-   * falling back to the subagent config's `clientOptions` model.
+   * then the fallback-invocation's configured model (`INVOKED_MODEL`
+   * metadata), then the subagent config's `clientOptions` model.
    */
   model?: string;
   /**
-   * Provider of the subagent's configured agent (the SDK `Providers`
-   * enum value from its `AgentInputs`, not LangSmith's `ls_provider`
-   * string — hosts key pricing/cache semantics off the enum).
+   * Provider that actually served this call — the SDK `Providers` enum
+   * value stamped per-invocation by `attemptInvoke` (`INVOKED_PROVIDER`
+   * metadata), so fallback-served calls are attributed to the fallback
+   * provider, not the configured primary. Falls back to the subagent
+   * config's provider. Never LangSmith's `ls_provider` string — derived
+   * providers inherit that from their base class, and hosts key
+   * pricing/cache semantics off the enum.
    */
   provider?: string;
   /** Subagent `type` identifier from the SubagentConfig. */
@@ -450,7 +455,13 @@ export interface SubagentUsageEvent {
   subagentRunId: string;
   /** Child agent ID assigned to this subagent execution. */
   subagentAgentId: string;
-  /** Parent run ID under which the subagent was spawned. */
+  /**
+   * ROOT run ID of the host run that owns billing. For nested subagents
+   * each forwarding layer rewrites this upward, so events from any depth
+   * surface with the outermost run's ID — never an intermediate
+   * `*_sub_*` child id (use {@link subagentRunId} to identify the
+   * emitting child).
+   */
   runId: string;
 }
 

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -466,11 +466,16 @@ export interface SubagentUsageEvent {
 }
 
 /**
- * Host-provided callback receiving {@link SubagentUsageEvent}s. Invoked
- * synchronously as each child model call completes; implementations should
- * be cheap and non-throwing (errors are swallowed by the executor).
+ * Host-provided callback receiving {@link SubagentUsageEvent}s. Invoked as
+ * each child model call completes. May return a promise — the executor
+ * awaits each dispatch (so all usage is recorded before the child's result
+ * resolves to the parent) and swallows both synchronous throws and
+ * rejections; implementations should still be cheap, as they sit on the
+ * child's model-call path.
  */
-export type SubagentUsageSink = (event: SubagentUsageEvent) => void;
+export type SubagentUsageSink = (
+  event: SubagentUsageEvent
+) => void | Promise<void>;
 
 export type LangfuseToolOutputTracingConfig = {
   /**

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -126,6 +126,15 @@ export type RunConfig = {
   langfuse?: g.LangfuseConfig;
   customHandlers?: Record<string, g.EventHandler>;
   /**
+   * Receives token usage for every model call made inside subagent child
+   * runs (including nested subagents). Child graphs execute via `invoke()`
+   * outside this run's `streamEvents` loop, so their model-end events never
+   * reach `customHandlers` — without this sink, child usage is invisible to
+   * the host. Parent-graph calls are not reported here; they flow through
+   * the registered `CHAT_MODEL_END` handler as usual.
+   */
+  subagentUsageSink?: g.SubagentUsageSink;
+  /**
    * Pre-constructed hook registry for this run. Hooks fire at lifecycle
    * points in `processStream` (RunStart, UserPromptSubmit, Stop,
    * StopFailure) and around tool calls (PreToolUse, PostToolUse,


### PR DESCRIPTION
## Summary

Subagent child runs spawned by the `subagent` tool execute via `workflow.invoke()` with a detached callbacks array — the forwarder only relays custom UI events, so the child's `on_chat_model_end` events never reach the host's `CHAT_MODEL_END` handler registered on the parent `Run`. Hosts (e.g. LibreChat) therefore never see child token usage: those model calls go unbilled and balance enforcement is blind to them. Nested children detach again at every level.

This adds an opt-in **usage sink** so hosts can observe every model call made inside subagent child runs:

- Adds `SubagentUsageEvent` / `SubagentUsageSink` types: per-call usage tagged with the subagent `type`, child run ID, child agent ID, parent run ID, model, and provider.
- Plumbs `RunConfig.subagentUsageSink` → `StandardGraph` / `MultiAgentGraph` → `SubagentExecutor` (`createAgentNode`).
- `SubagentExecutor.execute()` attaches a usage-capture callback to the child invoke — the child-side equivalent of `ModelEndHandler`: `handleChatModelStart` records per-call `ls_model_name` keyed by callback runId; `handleLLMEnd` joins it with `usage_metadata` from the generations and emits through the sink. Captures the agent loop plus auxiliary calls (e.g. child-side summarization).
- `model` prefers per-call `ls_model_name` with fallback to the subagent config's `clientOptions` model; `provider` is the config's `Providers` enum value (not LangSmith's `ls_provider` string), since hosts key pricing/cache semantics off the enum (`'openAI'` vs `'openai'`, `'vertexai'` vs `'google_vertexai'`).
- Forwards the sink into the child graph's `StandardGraphInput`, so each nesting level attaches its own capture handler — grandchild usage reports through the same sink (a single top-level handler can never see it, as each `invoke` replaces the callback chain).
- Sink dispatch is awaited per model call (`awaitHandlers`) so all entries are sunk before the parent's tool result resolves; host sink errors are swallowed.
- Parent-graph calls are NOT reported through the sink — they continue to flow through the registered `CHAT_MODEL_END` handler, so there is no double-counting.

No behavior change when the sink is omitted.

## Testing

- 6 new `SubagentExecutor` unit tests: sink forwarding into child graph input, tagged event emission with `ls_model_name`, configured-model fallback, no-usage skip, no-callback-when-no-sink, sink-error swallowing.
- New integration spec in `src/specs/subagent.test.ts`: full `Run.processStream` with a fake child model that reports `usage_metadata` on a final stream chunk (mirroring live providers); asserts exactly the child's call reaches the sink, tagged correctly, while the parent's calls stay on the `CHAT_MODEL_END` path.
- Full suite green (only pre-existing keyless live-provider specs fail without credentials).
- **Live-verified** with real Anthropic and OpenAI credentials via the new `src/scripts/subagent-usage-sink.ts` script: parent calls landed in `collectedUsage`, the child's call arrived through the sink with correct model/provider/run tagging and real token counts on both providers.

```
node -r dotenv/config --loader ./tsconfig-paths-bootstrap.mjs --experimental-specifier-resolution=node ./src/scripts/subagent-usage-sink.ts [--provider anthropic]
```

Downstream: LibreChat consumes this via `createSubagentUsageSink` (companion PR) — requires a release > 3.2.33.