### PR TITLE
🦭 feat: Mid-Stream Tool Call Seals for Bedrock Converse & Google

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -4411,6 +4411,127 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.eagerEventToolExecutions.size).toBe(0);
   });
 
+  it('does not prestart on-arrival sealed calls when batch-sensitive hooks are configured', async () => {
+    const graph = createGraph({
+      hookRegistry: {} as StandardGraph['hookRegistry'],
+    });
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+            },
+          ],
+          response_metadata: googleOnArrivalToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('does not prestart on-arrival sealed calls for programmatic tool calling batches', async () => {
+    const graph = createGraph();
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+            },
+          ],
+          response_metadata: googleOnArrivalToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      {
+        langgraph_node: 'agent',
+        [Constants.PROGRAMMATIC_TOOL_CALLING]: true,
+      },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('does not prestart on-arrival sealed calls when eager execution is disabled', async () => {
+    const graph = createGraph({
+      eagerEventToolExecution: { enabled: false },
+    } as Partial<StandardGraph>);
+    const dispatchSpy = jest.spyOn(events, 'safeDispatchCustomEvent');
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+            },
+          ],
+          response_metadata: googleOnArrivalToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      GraphEvents.ON_TOOL_EXECUTE,
+      expect.anything(),
+      expect.anything()
+    );
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
   it('does not prestart on-arrival sealed calls when direct tools may stream', async () => {
     const graph = createGraph({
       getAgentContext: jest.fn(

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -6,6 +6,8 @@ import {
   STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
 import {
   Constants,
@@ -138,6 +140,14 @@ const finalToolCallResponseMetadata = { finish_reason: 'tool_calls' };
 const openAIResponsesToolCallMetadata = {
   [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
     OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+};
+const bedrockConverseToolCallMetadata = {
+  [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+    BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+};
+const googleOnArrivalToolCallMetadata = {
+  [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]: GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+  [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
 };
 
 describe('ChatModelStreamHandler eager event tool execution', () => {
@@ -4022,5 +4032,434 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       turn: 1,
     });
     expect(graph.eagerEventToolUsageCount.get('weather')).toBe(2);
+  });
+
+  it('prestarts Bedrock Converse streamed tool calls on content block stop seals', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.BEDROCK,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              index: 1,
+            },
+          ],
+          response_metadata: bedrockConverseToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"city":"N',
+              index: 1,
+            },
+          ],
+          response_metadata: bedrockConverseToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: 'YC"}',
+              index: 1,
+            },
+          ],
+          response_metadata: bedrockConverseToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '',
+              index: 1,
+            },
+          ],
+          response_metadata: {
+            ...bedrockConverseToolCallMetadata,
+            [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+              kind: 'single',
+              index: 1,
+            },
+          },
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+    expect(
+      graph.eagerEventToolCallChunks.has(chunkStateKey('step-key', 1))
+    ).toBe(false);
+  });
+
+  it('prestarts each Bedrock tool call at its own stop seal in multi-call turns', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.BEDROCK,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const sendChunk = async (chunk: Record<string, unknown>): Promise<void> =>
+      handler.handle(
+        GraphEvents.CHAT_MODEL_STREAM,
+        { chunk: chunk as unknown as t.StreamChunk },
+        metadata,
+        graph
+      );
+
+    await sendChunk({
+      content: '',
+      tool_call_chunks: [{ id: 'call_weather', name: 'weather', index: 1 }],
+      response_metadata: bedrockConverseToolCallMetadata,
+    });
+    await sendChunk({
+      content: '',
+      tool_call_chunks: [{ args: '{"city":"NYC"}', index: 1 }],
+      response_metadata: bedrockConverseToolCallMetadata,
+    });
+    await sendChunk({
+      content: '',
+      tool_call_chunks: [{ args: '', index: 1 }],
+      response_metadata: {
+        ...bedrockConverseToolCallMetadata,
+        [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 1 },
+      },
+    });
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      args: { city: 'NYC' },
+    });
+
+    await sendChunk({
+      content: '',
+      tool_call_chunks: [{ id: 'call_stock', name: 'stock', index: 2 }],
+      response_metadata: bedrockConverseToolCallMetadata,
+    });
+    await sendChunk({
+      content: '',
+      tool_call_chunks: [{ args: '{"ticker":"CH"}', index: 2 }],
+      response_metadata: bedrockConverseToolCallMetadata,
+    });
+
+    expect(toolExecuteCalls).toHaveLength(1);
+
+    await sendChunk({
+      content: '',
+      tool_call_chunks: [{ args: '', index: 2 }],
+      response_metadata: {
+        ...bedrockConverseToolCallMetadata,
+        [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 2 },
+      },
+    });
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_stock',
+      args: { ticker: 'CH' },
+      turn: 0,
+    });
+  });
+
+  it('prestarts Google tool calls sealed on arrival without a final tool-call signal', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.GOOGLE,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+            },
+          ],
+          response_metadata: googleOnArrivalToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+
+    // A later chunk with another sealed call prestarts independently.
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: { ticker: 'CH' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: '{"ticker":"CH"}',
+            },
+          ],
+          response_metadata: googleOnArrivalToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_stock',
+      name: 'stock',
+      args: { ticker: 'CH' },
+      turn: 0,
+    });
+    expect(graph.eagerEventToolExecutions.has('call_weather')).toBe(true);
+    expect(graph.eagerEventToolExecutions.has('call_stock')).toBe(true);
+  });
+
+  it('keeps Google tool calls lazy without an on-arrival seal', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.GOOGLE,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [{ name: 'weather' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        toolExecuteCalls.push(data as t.ToolExecuteBatchRequest);
+      });
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+            },
+          ],
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('does not prestart on-arrival sealed calls when direct tools may stream', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.GOOGLE,
+          reasoningKey: 'reasoning',
+          toolDefinitions: [{ name: 'weather' }],
+          graphTools: [{ name: 'lookup' }],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        toolExecuteCalls.push(data as t.ToolExecuteBatchRequest);
+      });
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+          ],
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+            },
+          ],
+          response_metadata: googleOnArrivalToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(graph.eagerEventToolExecutions.size).toBe(0);
   });
 });

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -226,6 +226,14 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
 
     const seenBlockIndices = new Set<number>();
     const toolUseBlockIndices = new Set<number>();
+    /**
+     * Guardrails can reject an already-streamed toolUse block at
+     * `messageStop` (`guardrail_intervened`), after `contentBlockStop` has
+     * passed. Only emit eager-execution seals when no guardrails are
+     * configured, so a later intervention can't race an eagerly started tool.
+     */
+    const sealToolUseOnStop =
+      options.guardrailConfig == null && this.guardrailConfig == null;
 
     for await (const event of response.stream) {
       if (event.contentBlockStart != null) {
@@ -280,7 +288,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
         const stopIdx = event.contentBlockStop.contentBlockIndex;
         if (stopIdx != null) {
           seenBlockIndices.add(stopIdx);
-          if (toolUseBlockIndices.has(stopIdx)) {
+          if (sealToolUseOnStop && toolUseBlockIndices.has(stopIdx)) {
             // Converse guarantees the block's input is complete at stop, so
             // emit an explicit seal chunk for eager tool execution — through
             // the callback path too, for registered stream handlers.

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -241,6 +241,18 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
             }
           }
           yield this.enrichChunk(startChunk, seenBlockIndices);
+
+          // Registered stream handlers receive chunks through callback
+          // events, not the yielded generator — dispatch the start chunk so
+          // they see the tool call's id/name (eager chunk state needs both).
+          await runManager?.handleLLMNewToken(
+            startChunk.text,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { chunk: startChunk }
+          );
         }
       } else if (event.contentBlockDelta != null) {
         const deltaChunk = handleConverseStreamContentBlockDelta(
@@ -270,8 +282,18 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
           seenBlockIndices.add(stopIdx);
           if (toolUseBlockIndices.has(stopIdx)) {
             // Converse guarantees the block's input is complete at stop, so
-            // emit an explicit seal chunk for eager tool execution.
-            yield createConverseToolUseStopChunk(stopIdx);
+            // emit an explicit seal chunk for eager tool execution — through
+            // the callback path too, for registered stream handlers.
+            const sealChunk = createConverseToolUseStopChunk(stopIdx);
+            yield sealChunk;
+            await runManager?.handleLLMNewToken(
+              sealChunk.text,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              { chunk: sealChunk }
+            );
           }
         }
       } else {

--- a/src/llm/bedrock/index.ts
+++ b/src/llm/bedrock/index.ts
@@ -34,6 +34,7 @@ import type { BaseMessage, ResponseMetadata } from '@langchain/core/messages';
 import type { ChatBedrockConverseInput } from '@langchain/aws';
 import {
   convertToConverseMessages,
+  createConverseToolUseStopChunk,
   handleConverseStreamContentBlockStart,
   handleConverseStreamContentBlockDelta,
   handleConverseStreamMetadata,
@@ -224,6 +225,7 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
     }
 
     const seenBlockIndices = new Set<number>();
+    const toolUseBlockIndices = new Set<number>();
 
     for await (const event of response.stream) {
       if (event.contentBlockStart != null) {
@@ -234,6 +236,9 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
           const idx = event.contentBlockStart.contentBlockIndex;
           if (idx != null) {
             seenBlockIndices.add(idx);
+            if (event.contentBlockStart.start?.toolUse != null) {
+              toolUseBlockIndices.add(idx);
+            }
           }
           yield this.enrichChunk(startChunk, seenBlockIndices);
         }
@@ -263,6 +268,11 @@ export class CustomChatBedrockConverse extends ChatBedrockConverse {
         const stopIdx = event.contentBlockStop.contentBlockIndex;
         if (stopIdx != null) {
           seenBlockIndices.add(stopIdx);
+          if (toolUseBlockIndices.has(stopIdx)) {
+            // Converse guarantees the block's input is complete at stop, so
+            // emit an explicit seal chunk for eager tool execution.
+            yield createConverseToolUseStopChunk(stopIdx);
+          }
         }
       } else {
         yield new ChatGenerationChunk({

--- a/src/llm/bedrock/streamSealDispatch.test.ts
+++ b/src/llm/bedrock/streamSealDispatch.test.ts
@@ -1,0 +1,131 @@
+import { expect, test, describe, jest } from '@jest/globals';
+import { HumanMessage, AIMessageChunk } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import { CustomChatBedrockConverse } from './index';
+
+/**
+ * Registered stream handlers consume chunks through `handleLLMNewToken`
+ * callback events, not the yielded generator (`attemptInvoke` skips manual
+ * dispatch when a handler is registered). These tests drive the Converse
+ * stream loop with a stubbed client and assert that toolUse start and stop
+ * seal chunks reach BOTH paths.
+ */
+describe('Converse stream seal dispatch', () => {
+  async function runStream(events: Array<Record<string, unknown>>): Promise<{
+    yielded: AIMessageChunk[];
+    dispatched: AIMessageChunk[];
+  }> {
+    const model = new CustomChatBedrockConverse({
+      model: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+      region: 'us-east-1',
+      credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+    });
+
+    (model as unknown as { client: { send: unknown } }).client.send = jest.fn(
+      async () => ({
+        stream: (async function* () {
+          yield* events;
+        })(),
+      })
+    );
+
+    const dispatched: AIMessageChunk[] = [];
+    const runManager = {
+      handleLLMNewToken: jest.fn(
+        async (
+          _token: string,
+          _idx?: unknown,
+          _runId?: unknown,
+          _parentRunId?: unknown,
+          _tags?: unknown,
+          fields?: { chunk?: ChatGenerationChunk }
+        ) => {
+          const message = fields?.chunk?.message;
+          if (message instanceof AIMessageChunk) {
+            dispatched.push(message);
+          }
+        }
+      ),
+    } as unknown as CallbackManagerForLLMRun;
+
+    const yielded: AIMessageChunk[] = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage('hi')],
+      {} as Parameters<CustomChatBedrockConverse['_streamResponseChunks']>[1],
+      runManager
+    )) {
+      if (chunk.message instanceof AIMessageChunk) {
+        yielded.push(chunk.message);
+      }
+    }
+    return { yielded, dispatched };
+  }
+
+  const toolUseEvents = [
+    {
+      contentBlockStart: {
+        contentBlockIndex: 1,
+        start: { toolUse: { toolUseId: 'call_1', name: 'weather' } },
+      },
+    },
+    {
+      contentBlockDelta: {
+        contentBlockIndex: 1,
+        delta: { toolUse: { input: '{"city":"NYC"}' } },
+      },
+    },
+    { contentBlockStop: { contentBlockIndex: 1 } },
+  ];
+
+  test('dispatches toolUse start and stop seal chunks to callbacks', async () => {
+    const { yielded, dispatched } = await runStream(toolUseEvents);
+
+    const sealOf = (m: AIMessageChunk): unknown =>
+      (m.response_metadata as Record<string, unknown>)[
+        STREAMED_TOOL_CALL_SEAL_METADATA_KEY
+      ];
+
+    expect(yielded.some((m) => sealOf(m) != null)).toBe(true);
+
+    expect(dispatched).toHaveLength(3);
+    expect(dispatched[0].tool_call_chunks).toMatchObject([
+      { id: 'call_1', name: 'weather', index: 1 },
+    ]);
+    expect(dispatched[1].tool_call_chunks).toMatchObject([
+      { args: '{"city":"NYC"}', index: 1 },
+    ]);
+    expect(sealOf(dispatched[2])).toEqual({ kind: 'single', index: 1 });
+    expect(
+      (dispatched[2].response_metadata as Record<string, unknown>)[
+        STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY
+      ]
+    ).toBe(BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER);
+  });
+
+  test('does not emit seal chunks for non-toolUse block stops', async () => {
+    const { yielded, dispatched } = await runStream([
+      {
+        contentBlockDelta: {
+          contentBlockIndex: 0,
+          delta: { text: 'hello' },
+        },
+      },
+      { contentBlockStop: { contentBlockIndex: 0 } },
+    ]);
+
+    const hasSeal = (m: AIMessageChunk): boolean =>
+      (m.response_metadata as Record<string, unknown>)[
+        STREAMED_TOOL_CALL_SEAL_METADATA_KEY
+      ] != null;
+
+    expect(yielded.some(hasSeal)).toBe(false);
+    expect(dispatched.some(hasSeal)).toBe(false);
+    expect(dispatched).toHaveLength(1);
+  });
+});

--- a/src/llm/bedrock/streamSealDispatch.test.ts
+++ b/src/llm/bedrock/streamSealDispatch.test.ts
@@ -17,7 +17,10 @@ import { CustomChatBedrockConverse } from './index';
  * seal chunks reach BOTH paths.
  */
 describe('Converse stream seal dispatch', () => {
-  async function runStream(events: Array<Record<string, unknown>>): Promise<{
+  async function runStream(
+    events: Array<Record<string, unknown>>,
+    modelFields: Record<string, unknown> = {}
+  ): Promise<{
     yielded: AIMessageChunk[];
     dispatched: AIMessageChunk[];
   }> {
@@ -25,6 +28,7 @@ describe('Converse stream seal dispatch', () => {
       model: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
       region: 'us-east-1',
       credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
+      ...modelFields,
     });
 
     (model as unknown as { client: { send: unknown } }).client.send = jest.fn(
@@ -106,6 +110,29 @@ describe('Converse stream seal dispatch', () => {
         STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY
       ]
     ).toBe(BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER);
+  });
+
+  test('does not emit seal chunks when guardrails are configured', async () => {
+    const { yielded, dispatched } = await runStream(toolUseEvents, {
+      guardrailConfig: {
+        guardrailIdentifier: 'guardrail_1',
+        guardrailVersion: '1',
+      },
+    });
+
+    const hasSeal = (m: AIMessageChunk): boolean =>
+      (m.response_metadata as Record<string, unknown>)[
+        STREAMED_TOOL_CALL_SEAL_METADATA_KEY
+      ] != null;
+
+    // Guardrails can reject the turn at messageStop after contentBlockStop,
+    // so no eager seal may be emitted — but tool chunks still stream.
+    expect(yielded.some(hasSeal)).toBe(false);
+    expect(dispatched.some(hasSeal)).toBe(false);
+    expect(dispatched).toHaveLength(2);
+    expect(dispatched[0].tool_call_chunks).toMatchObject([
+      { id: 'call_1', name: 'weather', index: 1 },
+    ]);
   });
 
   test('does not emit seal chunks for non-toolUse block stops', async () => {

--- a/src/llm/bedrock/utils/index.ts
+++ b/src/llm/bedrock/utils/index.ts
@@ -10,6 +10,7 @@ export {
 
 export {
   convertConverseMessageToLangChainMessage,
+  createConverseToolUseStopChunk,
   handleConverseStreamContentBlockStart,
   handleConverseStreamContentBlockDelta,
   handleConverseStreamMetadata,

--- a/src/llm/bedrock/utils/message_outputs.test.ts
+++ b/src/llm/bedrock/utils/message_outputs.test.ts
@@ -1,0 +1,85 @@
+import { expect, test, describe } from '@jest/globals';
+import { AIMessageChunk } from '@langchain/core/messages';
+import type { ContentBlockDeltaEvent, ContentBlockStartEvent } from '../types';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import {
+  createConverseToolUseStopChunk,
+  handleConverseStreamContentBlockStart,
+  handleConverseStreamContentBlockDelta,
+} from './message_outputs';
+
+function asAIMessageChunk(message: unknown): AIMessageChunk {
+  expect(message).toBeInstanceOf(AIMessageChunk);
+  return message as AIMessageChunk;
+}
+
+describe('Converse streamed tool-call seal metadata', () => {
+  test('stamps the adapter on toolUse content block starts', () => {
+    const chunk = handleConverseStreamContentBlockStart({
+      contentBlockIndex: 1,
+      start: {
+        toolUse: { toolUseId: 'call_1', name: 'weather' },
+      },
+    } as ContentBlockStartEvent);
+
+    const message = asAIMessageChunk(chunk?.message);
+    expect(message.response_metadata).toMatchObject({
+      contentBlockIndex: 1,
+      [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+        BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+    });
+    expect(message.tool_call_chunks).toEqual([
+      {
+        id: 'call_1',
+        name: 'weather',
+        index: 1,
+        type: 'tool_call_chunk',
+      },
+    ]);
+  });
+
+  test('stamps the adapter on toolUse deltas but not text deltas', () => {
+    const toolChunk = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 1,
+      delta: { toolUse: { input: '{"city":' } },
+    } as ContentBlockDeltaEvent);
+    const toolMetadata = asAIMessageChunk(toolChunk.message)
+      .response_metadata as Record<string, unknown>;
+    expect(toolMetadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]).toBe(
+      BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER
+    );
+
+    const textChunk = handleConverseStreamContentBlockDelta({
+      contentBlockIndex: 0,
+      delta: { text: 'hello' },
+    } as ContentBlockDeltaEvent);
+    const textMetadata = asAIMessageChunk(textChunk.message)
+      .response_metadata as Record<string, unknown>;
+    expect(
+      textMetadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]
+    ).toBeUndefined();
+  });
+
+  test('builds an explicit single seal chunk for a stopped toolUse block', () => {
+    const chunk = createConverseToolUseStopChunk(2);
+
+    const message = asAIMessageChunk(chunk.message);
+    expect(message.response_metadata).toEqual({
+      [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+        BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+      [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'single', index: 2 },
+    });
+    expect(message.tool_call_chunks).toEqual([
+      {
+        args: '',
+        index: 2,
+        type: 'tool_call_chunk',
+      },
+    ]);
+    expect(message.content).toBe('');
+  });
+});

--- a/src/llm/bedrock/utils/message_outputs.ts
+++ b/src/llm/bedrock/utils/message_outputs.ts
@@ -17,6 +17,11 @@ import type {
   MessageContentReasoningBlockReasoningTextPartial,
   MessageContentReasoningBlockRedacted,
 } from '../types';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
 import { toLangChainContent } from '@/messages/langchain';
 
 /**
@@ -235,6 +240,8 @@ export function handleConverseStreamContentBlockDelta(
         ],
         response_metadata: {
           contentBlockIndex: contentBlockDelta.contentBlockIndex,
+          [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+            BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
         },
       }),
     });
@@ -292,6 +299,8 @@ export function handleConverseStreamContentBlockStart(
         ],
         response_metadata: {
           contentBlockIndex: index,
+          [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+            BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
         },
       }),
     });
@@ -299,6 +308,40 @@ export function handleConverseStreamContentBlockStart(
 
   // Return null for non-tool content block starts (text blocks don't need special handling)
   return null;
+}
+
+/**
+ * Build the chunk emitted when a Converse `contentBlockStop` event closes a
+ * toolUse block. The Converse protocol guarantees a block's input is complete
+ * at `contentBlockStop`, so this chunk carries an explicit streamed tool-call
+ * seal for that block index. The empty `args` delta merges as a no-op into the
+ * accumulated tool call; id/name are omitted so the chunk matches the existing
+ * entry purely by index.
+ */
+export function createConverseToolUseStopChunk(
+  contentBlockIndex: number
+): ChatGenerationChunk {
+  return new ChatGenerationChunk({
+    text: '',
+    message: new AIMessageChunk({
+      content: '',
+      tool_call_chunks: [
+        {
+          args: '',
+          index: contentBlockIndex,
+          type: 'tool_call_chunk',
+        },
+      ],
+      response_metadata: {
+        [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+          BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+        [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: {
+          kind: 'single',
+          index: contentBlockIndex,
+        },
+      },
+    }),
+  });
 }
 
 /**

--- a/src/llm/google/utils/common.test.ts
+++ b/src/llm/google/utils/common.test.ts
@@ -1,0 +1,64 @@
+import { expect, test, describe } from '@jest/globals';
+import { AIMessageChunk } from '@langchain/core/messages';
+import type { EnhancedGenerateContentResponse } from '@google/generative-ai';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import { convertResponseContentToChatGenerationChunk } from './common';
+
+function buildResponse(
+  parts: Array<Record<string, unknown>>
+): EnhancedGenerateContentResponse {
+  return {
+    candidates: [
+      {
+        content: { role: 'model', parts },
+        index: 0,
+      },
+    ],
+  } as unknown as EnhancedGenerateContentResponse;
+}
+
+function asAIMessageChunk(message: unknown): AIMessageChunk {
+  expect(message).toBeInstanceOf(AIMessageChunk);
+  return message as AIMessageChunk;
+}
+
+describe('convertResponseContentToChatGenerationChunk seal metadata', () => {
+  test('stamps an on-arrival seal on function call chunks', () => {
+    const chunk = convertResponseContentToChatGenerationChunk(
+      buildResponse([
+        {
+          functionCall: { name: 'weather', args: { city: 'NYC' } },
+        },
+      ]),
+      { usageMetadata: undefined, index: 0 }
+    );
+
+    const message = asAIMessageChunk(chunk?.message);
+    expect(message.response_metadata).toMatchObject({
+      [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+        GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+      [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+    });
+    expect(message.tool_call_chunks).toHaveLength(1);
+    expect(message.tool_calls?.[0]).toMatchObject({
+      name: 'weather',
+      args: { city: 'NYC' },
+    });
+  });
+
+  test('does not stamp seal metadata on text-only chunks', () => {
+    const chunk = convertResponseContentToChatGenerationChunk(
+      buildResponse([{ text: 'hello' }]),
+      { usageMetadata: undefined, index: 0 }
+    );
+
+    const metadata = asAIMessageChunk(chunk?.message)
+      .response_metadata as Record<string, unknown>;
+    expect(metadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]).toBeUndefined();
+    expect(metadata[STREAMED_TOOL_CALL_SEAL_METADATA_KEY]).toBeUndefined();
+  });
+});

--- a/src/llm/google/utils/common.ts
+++ b/src/llm/google/utils/common.ts
@@ -36,6 +36,11 @@ import {
 } from '@google/generative-ai';
 import type { ChatGeneration, ChatResult } from '@langchain/core/outputs';
 import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import {
   jsonSchemaToGeminiParameters,
   schemaToGenerativeAIParameters,
 } from './zod_to_genai_parameters';
@@ -770,6 +775,18 @@ export function convertResponseContentToChatGenerationChunk(
     response.candidates[0]?.finishReason === 'MAX_TOKENS' ||
     response.candidates[0]?.finishReason === 'SAFETY';
 
+  // The GenAI API delivers function calls as complete objects (never partial
+  // arg deltas), so every call on this chunk is sealed on arrival for eager
+  // tool execution.
+  const response_metadata: Record<string, unknown> | undefined =
+    toolCallChunks.length > 0
+      ? {
+        [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+            GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+        [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+      }
+      : undefined;
+
   return new ChatGenerationChunk({
     text,
     message: new AIMessageChunk({
@@ -779,6 +796,7 @@ export function convertResponseContentToChatGenerationChunk(
       // Each chunk can have unique "generationInfo", and merging strategy is unclear,
       // so leave blank for now.
       additional_kwargs,
+      response_metadata,
       usage_metadata: isFinalChunk ? extra.usageMetadata : undefined,
     }),
     generationInfo,

--- a/src/llm/vertexai/index.ts
+++ b/src/llm/vertexai/index.ts
@@ -11,6 +11,11 @@ import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager
 import type { BaseMessage, UsageMetadata } from '@langchain/core/messages';
 import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type { GoogleThinkingConfig, VertexAIClientOptions } from '@/types';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
 
 /**
  * `@langchain/google-common`'s `_streamResponseChunks` emits usage on TWO
@@ -46,6 +51,31 @@ export function repairStreamUsageMetadata(
   if (generationInfoUsage.output_tokens <= current.output_tokens)
     return current;
   return generationInfoUsage;
+}
+
+/**
+ * The Gemini API delivers function calls as complete objects — never as
+ * partial arg deltas. `@langchain/google-common` pre-parses each streamed
+ * functionCall part into `tool_calls` (invalid args land in
+ * `invalid_tool_calls` instead), so a chunk whose tool-call chunks all parsed
+ * cleanly is sealed on arrival for eager tool execution. Anything that fails
+ * the parse check is left unstamped and falls back to the lazy path.
+ */
+export function sealCompleteStreamedToolCalls(message: AIMessageChunk): void {
+  const chunkCount = message.tool_call_chunks?.length ?? 0;
+  if (
+    chunkCount === 0 ||
+    (message.invalid_tool_calls?.length ?? 0) > 0 ||
+    (message.tool_calls?.length ?? 0) !== chunkCount
+  ) {
+    return;
+  }
+  message.response_metadata = {
+    ...message.response_metadata,
+    [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+      GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+    [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+  };
 }
 
 type AdditionalKwargs =
@@ -503,6 +533,7 @@ export class ChatVertexAI extends ChatGoogle {
         if (repaired !== chunk.message.usage_metadata) {
           chunk.message.usage_metadata = repaired;
         }
+        sealCompleteStreamedToolCalls(chunk.message);
       }
       yield chunk;
     }

--- a/src/llm/vertexai/sealStreamedToolCalls.test.ts
+++ b/src/llm/vertexai/sealStreamedToolCalls.test.ts
@@ -1,0 +1,88 @@
+import { expect, test, describe } from '@jest/globals';
+import { AIMessageChunk } from '@langchain/core/messages';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import { sealCompleteStreamedToolCalls } from './index';
+
+describe('sealCompleteStreamedToolCalls', () => {
+  test('stamps an on-arrival seal when every tool-call chunk parsed cleanly', () => {
+    const message = new AIMessageChunk({
+      content: '',
+      tool_call_chunks: [
+        {
+          id: 'call_1',
+          name: 'weather',
+          args: '{"city":"NYC"}',
+          type: 'tool_call_chunk',
+        },
+      ],
+    });
+
+    sealCompleteStreamedToolCalls(message);
+
+    expect(message.response_metadata).toMatchObject({
+      [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+        GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+      [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+    });
+  });
+
+  test('stamps multi-call chunks when all calls are complete', () => {
+    const message = new AIMessageChunk({
+      content: '',
+      tool_call_chunks: [
+        {
+          id: 'call_1',
+          name: 'weather',
+          args: '{"city":"NYC"}',
+          type: 'tool_call_chunk',
+        },
+        {
+          id: 'call_2',
+          name: 'stock',
+          args: '{"ticker":"CH"}',
+          type: 'tool_call_chunk',
+        },
+      ],
+    });
+
+    sealCompleteStreamedToolCalls(message);
+
+    expect(
+      message.response_metadata[STREAMED_TOOL_CALL_SEAL_METADATA_KEY]
+    ).toEqual({ kind: 'all' });
+  });
+
+  test('leaves chunks without tool calls unstamped', () => {
+    const message = new AIMessageChunk({ content: 'hello' });
+
+    sealCompleteStreamedToolCalls(message);
+
+    expect(
+      message.response_metadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]
+    ).toBeUndefined();
+  });
+
+  test('leaves chunks with unparsable tool calls unstamped', () => {
+    // No id forces the parse into invalid_tool_calls.
+    const message = new AIMessageChunk({
+      content: '',
+      tool_call_chunks: [
+        {
+          name: 'weather',
+          args: '{"city":',
+          type: 'tool_call_chunk',
+        },
+      ],
+    });
+
+    sealCompleteStreamedToolCalls(message);
+
+    expect(
+      message.response_metadata[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]
+    ).toBeUndefined();
+  });
+});

--- a/src/llm/vertexai/streamSealDispatch.test.ts
+++ b/src/llm/vertexai/streamSealDispatch.test.ts
@@ -1,0 +1,148 @@
+import { expect, test, describe, jest } from '@jest/globals';
+import { HumanMessage, AIMessageChunk } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import {
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import { ChatVertexAI } from './index';
+
+/**
+ * Registered stream handlers consume chunks through `handleLLMNewToken`
+ * callback events. `@langchain/google-common` yields each chunk BEFORE
+ * dispatching that callback, and the generator only resumes (firing the
+ * callback) after this package's `_streamResponseChunks` override has
+ * stamped the seal on the same message object — so callback consumers must
+ * observe sealed chunks. This drives the real google-common stream loop and
+ * conversion with a stubbed connection to lock that ordering in.
+ */
+describe('Vertex stream seal dispatch', () => {
+  async function runStream(outputs: unknown[]): Promise<{
+    yielded: AIMessageChunk[];
+    dispatched: AIMessageChunk[];
+  }> {
+    const model = new ChatVertexAI({
+      model: 'gemini-2.5-flash',
+      authOptions: {
+        projectId: 'test-project',
+        credentials: { client_email: 'test@test', private_key: 'test' },
+      },
+    });
+
+    let index = 0;
+    const fakeStream = {
+      get streamDone(): boolean {
+        return index > outputs.length;
+      },
+      async nextChunk(): Promise<unknown> {
+        const output = index < outputs.length ? outputs[index] : null;
+        index += 1;
+        return output;
+      },
+    };
+    (
+      model as unknown as {
+        streamedConnection: { request: unknown };
+      }
+    ).streamedConnection.request = jest.fn(async () => ({ data: fakeStream }));
+
+    const dispatched: AIMessageChunk[] = [];
+    const runManager = {
+      handleCustomEvent: jest.fn(async () => undefined),
+      handleLLMNewToken: jest.fn(
+        async (
+          _token: string,
+          _idx?: unknown,
+          _runId?: unknown,
+          _parentRunId?: unknown,
+          _tags?: unknown,
+          fields?: { chunk?: ChatGenerationChunk }
+        ) => {
+          const message = fields?.chunk?.message;
+          if (message instanceof AIMessageChunk) {
+            dispatched.push(message);
+          }
+        }
+      ),
+    } as unknown as CallbackManagerForLLMRun;
+
+    const yielded: AIMessageChunk[] = [];
+    for await (const chunk of model._streamResponseChunks(
+      [new HumanMessage('hi')],
+      {} as Parameters<ChatVertexAI['_streamResponseChunks']>[1],
+      runManager
+    )) {
+      if (chunk.message instanceof AIMessageChunk) {
+        yielded.push(chunk.message);
+      }
+    }
+    return { yielded, dispatched };
+  }
+
+  test('callback consumers receive function-call chunks already sealed', async () => {
+    const { yielded, dispatched } = await runStream([
+      {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                { functionCall: { name: 'weather', args: { city: 'NYC' } } },
+              ],
+            },
+            index: 0,
+          },
+        ],
+      },
+    ]);
+
+    const metadataOf = (m: AIMessageChunk): Record<string, unknown> =>
+      m.response_metadata as Record<string, unknown>;
+
+    const yieldedCall = yielded.find(
+      (m) => (m.tool_call_chunks?.length ?? 0) > 0
+    );
+    expect(yieldedCall).toBeDefined();
+    expect(
+      metadataOf(yieldedCall!)[STREAMED_TOOL_CALL_SEAL_METADATA_KEY]
+    ).toEqual({ kind: 'all' });
+
+    const dispatchedCall = dispatched.find(
+      (m) => (m.tool_call_chunks?.length ?? 0) > 0
+    );
+    expect(dispatchedCall).toBeDefined();
+    expect(dispatchedCall!.tool_calls?.[0]).toMatchObject({
+      name: 'weather',
+      args: { city: 'NYC' },
+    });
+    expect(
+      metadataOf(dispatchedCall!)[STREAMED_TOOL_CALL_SEAL_METADATA_KEY]
+    ).toEqual({ kind: 'all' });
+    expect(
+      metadataOf(dispatchedCall!)[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]
+    ).toBe(GOOGLE_STREAMED_TOOL_CALL_ADAPTER);
+  });
+
+  test('text-only chunks are not sealed on either path', async () => {
+    const { yielded, dispatched } = await runStream([
+      {
+        candidates: [
+          {
+            content: { role: 'model', parts: [{ text: 'hello' }] },
+            index: 0,
+          },
+        ],
+      },
+    ]);
+
+    const hasSeal = (m: AIMessageChunk): boolean =>
+      (m.response_metadata as Record<string, unknown>)[
+        STREAMED_TOOL_CALL_SEAL_METADATA_KEY
+      ] != null;
+
+    expect(yielded.some(hasSeal)).toBe(false);
+    expect(dispatched.some(hasSeal)).toBe(false);
+  });
+});

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -265,6 +265,21 @@ function hasExplicitStreamedToolCallSeals(
   );
 }
 
+/**
+ * True when a provider adapter marked every tool call on this chunk as
+ * complete on arrival (seal kind `all`), e.g. Google GenAI / Vertex AI, whose
+ * protocol delivers function calls as whole objects rather than arg deltas.
+ */
+function hasOnArrivalToolCallSeal(chunk: Partial<AIMessageChunk>): boolean {
+  const metadata = chunk.response_metadata as
+    | Record<string, unknown>
+    | undefined;
+  return (
+    getStreamedToolCallAdapter(metadata) != null &&
+    getStreamedToolCallSeal(metadata)?.kind === 'all'
+  );
+}
+
 function hasDirectToolCallInBatch(args: {
   graph: StandardGraph;
   agentContext?: AgentContext;
@@ -1405,6 +1420,21 @@ export class ChatModelStreamHandler implements t.EventHandler {
         if (!hasToolCallChunks) {
           pruneEagerToolCallChunkStates({ graph, stepKey, clearStep: true });
         }
+      } else if (
+        hasOnArrivalToolCallSeal(chunk) &&
+        !hasPotentialDirectToolInStreamContext({ graph, agentContext })
+      ) {
+        // Providers like Google never signal `tool_calls`/`tool_use` as the
+        // finish reason, but their adapters seal calls on arrival — prestart
+        // these mid-stream under the same direct-tool guard as streamed
+        // chunk sealing.
+        startEagerToolExecutions({
+          graph,
+          metadata,
+          agentContext,
+          toolCalls: chunk.tool_calls,
+          skipExisting: true,
+        });
       }
     }
 

--- a/src/tools/streamedToolCallSeals.ts
+++ b/src/tools/streamedToolCallSeals.ts
@@ -3,9 +3,19 @@ export const STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY =
 export const STREAMED_TOOL_CALL_SEAL_METADATA_KEY =
   'lc_streamed_tool_call_seal';
 export const OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER = 'openai_responses';
+export const BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER = 'bedrock_converse';
+export const GOOGLE_STREAMED_TOOL_CALL_ADAPTER = 'google_genai';
 
 export type StreamedToolCallAdapter =
-  typeof OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER;
+  | typeof OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER
+  | typeof BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER
+  | typeof GOOGLE_STREAMED_TOOL_CALL_ADAPTER;
+
+const STREAMED_TOOL_CALL_ADAPTERS: ReadonlySet<string> = new Set([
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+]);
 
 export type StreamedToolCallSeal =
   | {
@@ -20,11 +30,9 @@ export type StreamedToolCallSeal =
 export function getStreamedToolCallAdapter(
   metadata: Record<string, unknown> | undefined
 ): StreamedToolCallAdapter | undefined {
-  if (
-    metadata?.[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY] ===
-    OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER
-  ) {
-    return OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER;
+  const adapter = metadata?.[STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY];
+  if (typeof adapter === 'string' && STREAMED_TOOL_CALL_ADAPTERS.has(adapter)) {
+    return adapter as StreamedToolCallAdapter;
   }
   return undefined;
 }
@@ -47,9 +55,7 @@ export function getStreamedToolCallSeal(
   }
   const id = 'id' in seal && typeof seal.id === 'string' ? seal.id : undefined;
   const index =
-    'index' in seal && typeof seal.index === 'number'
-      ? seal.index
-      : undefined;
+    'index' in seal && typeof seal.index === 'number' ? seal.index : undefined;
   if (id == null && index == null) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

I extended eager event tool execution's mid-stream prestart beyond Anthropic and OpenAI Responses to Bedrock Converse, Google GenAI, and Vertex AI, by emitting explicit streamed tool-call seals at the points where each provider's wire protocol guarantees a call's arguments are final. Until now, Bedrock and Google received no eager execution at all: Bedrock never maps `stopReason` onto `finish_reason`, and Gemini finishes function-call turns with `STOP`, so neither provider ever hit the final tool-call signal path — every tool call waited for ToolNode. Chat Completions-compatible providers are deliberately left on the final-signal path, since that protocol has no per-call completion event and index advancement is not a reliable seal (Kimi/Moonshot revise prior-index args after advancing).

- Stamped the `bedrock_converse` streamed tool-call adapter on Converse toolUse `contentBlockStart`/`contentBlockDelta` chunks so the stream handler records their chunk state for eager execution.
- Emitted an explicit `kind: single` seal chunk at Converse `contentBlockStop` for toolUse blocks, where the protocol guarantees the block's input is complete — each call in a multi-call turn now prestarts at its own stop event, including the last one, instead of waiting for the model turn to end. The seal chunk carries an empty `args` delta keyed by block index, which merges as a no-op into the accumulated tool call.
- Stamped a `google_genai` adapter with an on-arrival `kind: all` seal on Google GenAI function-call chunks in `convertResponseContentToChatGenerationChunk`, since the GenAI API delivers function calls as complete objects, never as partial arg deltas.
- Sealed complete streamed tool calls in the Vertex AI `_streamResponseChunks` wrapper, gated on `@langchain/google-common`'s parse results: chunks with any `invalid_tool_calls` or a `tool_calls`/`tool_call_chunks` count mismatch are left unstamped and fall back to the lazy path.
- Added an on-arrival prestart branch in `ChatModelStreamHandler` for chunks carrying complete `tool_calls` and a `kind: all` seal but no `tool_calls`/`tool_use` finish signal, guarded by the same potential-direct-tool check as streamed chunk sealing; all existing batch gates (eager config, event-driven execution, hooks/HITL, PTC, direct tools, output references) still apply through `createEagerToolExecutionPlan`.
- Generalized `getStreamedToolCallAdapter` to an adapter allowlist so seal consumers remain agnostic to which provider emitted the seal.
- Added handler-level tests covering Bedrock stop-seal prestarts (single and multi-call turns), Google on-arrival prestarts, the no-seal lazy fallback, and the direct-tool guard, plus unit tests for the Bedrock seal chunk factory, the Google conversion stamp, and the Vertex seal conditions.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npx jest src/__tests__/stream.eagerEventExecution.test.ts src/stream.test.ts src/llm/bedrock/utils/message_outputs.test.ts src/llm/google/utils/common.test.ts src/llm/vertexai/sealStreamedToolCalls.test.ts` — 74 tests pass, including the 9 new seal cases.
- `npx tsc --noEmit`, `eslint --fix`, and `sort-imports` all pass.
- Full `npx jest` run: the only failing suites are the live-API specs (`*.simple.test.ts`, `llm.spec.ts`) failing on missing API keys and `gemini-3-pro-preview` 404s in this environment; notably, the live Google/Vertex streaming tool-call round-trip specs that do run here pass with the seal stamping in place.

### **Test Configuration**:

- Node 24 / npm ci, no provider credentials required for the new tests (live specs excluded as above).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes