### PR TITLE
📮 feat: Sequential Tool Call Seals for Official OpenAI & Azure

### DIFF
--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -8,6 +8,7 @@ import {
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
   BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
   GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+  OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 } from '@/tools/streamedToolCallSeals';
 import {
   Constants,
@@ -148,6 +149,10 @@ const bedrockConverseToolCallMetadata = {
 const googleOnArrivalToolCallMetadata = {
   [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]: GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
   [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: { kind: 'all' },
+};
+const openAIChatSequentialToolCallMetadata = {
+  [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+    OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 };
 
 describe('ChatModelStreamHandler eager event tool execution', () => {
@@ -4530,6 +4535,144 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
       expect.anything()
     );
     expect(graph.eagerEventToolExecutions.size).toBe(0);
+  });
+
+  it('prestarts official OpenAI sequential streamed tool calls when a later index begins', async () => {
+    const graph = createGraph({
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.OPENAI,
+          reasoningKey: 'reasoning_content',
+          toolDefinitions: [{ name: 'weather' }, { name: 'stock' }],
+          graphTools: [],
+          agentId: 'agent_1',
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        toolExecuteCalls.push(batch);
+        batch.resolve(
+          batch.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            status: 'success',
+            content: `ok ${call.name}`,
+          }))
+        );
+      });
+
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: '{"city":"NYC"}',
+              index: 0,
+            },
+          ],
+          response_metadata: openAIChatSequentialToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(0);
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              id: 'call_stock',
+              name: 'stock',
+              index: 1,
+            },
+          ],
+          response_metadata: openAIChatSequentialToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0]).toMatchObject({
+      id: 'call_weather',
+      name: 'weather',
+      args: { city: 'NYC' },
+      stepId: expect.stringMatching(/^step_/),
+      turn: 0,
+    });
+
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_call_chunks: [
+            {
+              args: '{"ticker":"CH"}',
+              index: 1,
+            },
+          ],
+          response_metadata: openAIChatSequentialToolCallMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(1);
+
+    // The final cumulative tool_calls chunk dispatches only the unstarted call.
+    await handler.handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_weather',
+              name: 'weather',
+              args: { city: 'NYC' },
+            },
+            {
+              id: 'call_stock',
+              name: 'stock',
+              args: { ticker: 'CH' },
+            },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      metadata,
+      graph
+    );
+
+    expect(toolExecuteCalls).toHaveLength(2);
+    expect(toolExecuteCalls[1].toolCalls).toHaveLength(1);
+    expect(toolExecuteCalls[1].toolCalls[0]).toMatchObject({
+      id: 'call_stock',
+      name: 'stock',
+      args: { ticker: 'CH' },
+      turn: 0,
+    });
   });
 
   it('does not prestart on-arrival sealed calls when direct tools may stream', async () => {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -714,14 +714,15 @@ function isOfficialOpenAIBaseURL(baseURL: string | null | undefined): boolean {
 }
 
 const AZURE_FIRST_PARTY_BASE_PATH_PATTERN =
-  /^https:\/\/[^/]+\.(openai\.azure\.com|cognitiveservices\.azure\.com)(:\d+)?(\/|$)/;
+  /^https:\/\/[^/]+\.(openai\.azure\.com|cognitiveservices\.azure\.com|api\.cognitive\.microsoft\.com)(:\d+)?(\/|$)/;
 
 /**
  * Azure OpenAI is first-party when requests resolve to an instance-name
- * endpoint or an *.openai.azure.com / *.cognitiveservices.azure.com base
- * path. A custom `clientConfig.baseURL` or a non-Azure `azureOpenAIBasePath`
- * routes through a proxy or Azure-compatible endpoint whose stream contract
- * is unknown, so those are not stamped.
+ * endpoint or an *.openai.azure.com / *.cognitiveservices.azure.com /
+ * regional *.api.cognitive.microsoft.com base path. A custom
+ * `clientConfig.baseURL` or a non-Azure `azureOpenAIBasePath` routes through
+ * a proxy or Azure-compatible endpoint whose stream contract is unknown, so
+ * those are not stamped.
  */
 function isFirstPartyAzureEndpoint(args: {
   baseURL: string | null | undefined;

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -34,6 +34,10 @@ import type { ChatGeneration, ChatResult } from '@langchain/core/outputs';
 import type { ChatXAIInput } from '@langchain/xai';
 import type * as t from '@langchain/openai';
 import type { HeaderValue, HeadersLike } from './types';
+import {
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
 import { isReasoningModel, _convertMessagesToOpenAIParams } from './utils';
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -670,6 +674,40 @@ export class CustomAzureOpenAIClient extends AzureOpenAIClient {
   }
 }
 
+const OFFICIAL_OPENAI_BASE_URL_PATTERN = /^https:\/\/api\.openai\.com(\/|$)/;
+
+/**
+ * Official OpenAI (api.openai.com) and Azure OpenAI Chat Completions streams
+ * emit tool-call deltas strictly sequentially by index: once a delta for a
+ * later index appears, a prior index's arguments never change. Stamping this
+ * adapter lets the stream handler seal a prior call for eager execution the
+ * moment the next call begins. OpenAI-compatible endpoints (custom baseURL)
+ * must NOT be stamped — e.g. live Kimi/Moonshot streams revise prior-index
+ * args after advancing — so callers gate on the wire endpoint, not the class.
+ */
+function stampSequentialStreamedToolCallAdapter(
+  message: BaseMessageChunk
+): BaseMessageChunk {
+  if (
+    message instanceof AIMessageChunk &&
+    (message.tool_call_chunks?.length ?? 0) > 0
+  ) {
+    message.response_metadata = {
+      ...message.response_metadata,
+      [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]:
+        OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
+    };
+  }
+  return message;
+}
+
+function isOfficialOpenAIBaseURL(baseURL: string | null | undefined): boolean {
+  if (baseURL == null || baseURL === '') {
+    return true;
+  }
+  return OFFICIAL_OPENAI_BASE_URL_PATTERN.test(baseURL);
+}
+
 class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   private includeReasoningContent?: boolean;
   private includeReasoningDetails?: boolean;
@@ -721,7 +759,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     rawResponse: OpenAIClient.Chat.Completions.ChatCompletionChunk,
     defaultRole?: OpenAIClient.Chat.ChatCompletionRole
   ): BaseMessageChunk {
-    return attachLibreChatDeltaFields(
+    const message = attachLibreChatDeltaFields(
       super._convertCompletionsDeltaToBaseMessageChunk(
         delta,
         rawResponse,
@@ -729,6 +767,10 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
       ),
       delta
     );
+    if (isOfficialOpenAIBaseURL(this.clientConfig.baseURL)) {
+      return stampSequentialStreamedToolCallAdapter(message);
+    }
+    return message;
   }
 
   protected _convertCompletionsMessageToBaseMessage(
@@ -1088,6 +1130,22 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
     return getGatedReasoningParams(this.model, this.reasoning, options);
+  }
+
+  protected _convertCompletionsDeltaToBaseMessageChunk(
+    delta: Record<string, unknown>,
+    rawResponse: OpenAIClient.Chat.Completions.ChatCompletionChunk,
+    defaultRole?: OpenAIClient.Chat.ChatCompletionRole
+  ): BaseMessageChunk {
+    // Azure OpenAI is first-party: same sequential-by-index stream contract
+    // as api.openai.com, so its tool-call deltas are always stamped.
+    return stampSequentialStreamedToolCallAdapter(
+      super._convertCompletionsDeltaToBaseMessageChunk(
+        delta,
+        rawResponse,
+        defaultRole
+      )
+    );
   }
 
   _getClientOptions(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -702,10 +702,38 @@ function stampSequentialStreamedToolCallAdapter(
 }
 
 function isOfficialOpenAIBaseURL(baseURL: string | null | undefined): boolean {
-  if (baseURL == null || baseURL === '') {
+  // The OpenAI SDK falls back to OPENAI_BASE_URL when the client has no
+  // explicit baseURL, so an unset constructor value can still route to an
+  // OpenAI-compatible endpoint.
+  const effectiveBaseURL =
+    baseURL != null && baseURL !== '' ? baseURL : process.env.OPENAI_BASE_URL;
+  if (effectiveBaseURL == null || effectiveBaseURL === '') {
     return true;
   }
-  return OFFICIAL_OPENAI_BASE_URL_PATTERN.test(baseURL);
+  return OFFICIAL_OPENAI_BASE_URL_PATTERN.test(effectiveBaseURL);
+}
+
+const AZURE_FIRST_PARTY_BASE_PATH_PATTERN =
+  /^https:\/\/[^/]+\.(openai\.azure\.com|cognitiveservices\.azure\.com)(:\d+)?(\/|$)/;
+
+/**
+ * Azure OpenAI is first-party when requests resolve to an instance-name
+ * endpoint or an *.openai.azure.com / *.cognitiveservices.azure.com base
+ * path. A custom `clientConfig.baseURL` or a non-Azure `azureOpenAIBasePath`
+ * routes through a proxy or Azure-compatible endpoint whose stream contract
+ * is unknown, so those are not stamped.
+ */
+function isFirstPartyAzureEndpoint(args: {
+  baseURL: string | null | undefined;
+  azureOpenAIBasePath: string | undefined;
+}): boolean {
+  if (args.baseURL != null && args.baseURL !== '') {
+    return false;
+  }
+  if (args.azureOpenAIBasePath == null || args.azureOpenAIBasePath === '') {
+    return true;
+  }
+  return AZURE_FIRST_PARTY_BASE_PATH_PATTERN.test(args.azureOpenAIBasePath);
 }
 
 class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
@@ -1137,15 +1165,22 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     rawResponse: OpenAIClient.Chat.Completions.ChatCompletionChunk,
     defaultRole?: OpenAIClient.Chat.ChatCompletionRole
   ): BaseMessageChunk {
-    // Azure OpenAI is first-party: same sequential-by-index stream contract
-    // as api.openai.com, so its tool-call deltas are always stamped.
-    return stampSequentialStreamedToolCallAdapter(
-      super._convertCompletionsDeltaToBaseMessageChunk(
-        delta,
-        rawResponse,
-        defaultRole
-      )
+    const message = super._convertCompletionsDeltaToBaseMessageChunk(
+      delta,
+      rawResponse,
+      defaultRole
     );
+    if (
+      isFirstPartyAzureEndpoint({
+        baseURL: this.clientConfig.baseURL,
+        azureOpenAIBasePath: this.azureOpenAIBasePath,
+      })
+    ) {
+      // First-party Azure OpenAI: same sequential-by-index stream contract
+      // as api.openai.com.
+      return stampSequentialStreamedToolCallAdapter(message);
+    }
+    return message;
   }
 
   _getClientOptions(

--- a/src/llm/openai/sequentialToolCallSeals.test.ts
+++ b/src/llm/openai/sequentialToolCallSeals.test.ts
@@ -1,0 +1,108 @@
+import { expect, test, describe } from '@jest/globals';
+import { AIMessageChunk } from '@langchain/core/messages';
+import type { BaseMessageChunk } from '@langchain/core/messages';
+import {
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import { ChatOpenAI, AzureChatOpenAI } from './index';
+
+type DeltaConverter = {
+  _convertCompletionsDeltaToBaseMessageChunk(
+    delta: Record<string, unknown>,
+    rawResponse: Record<string, unknown>
+  ): BaseMessageChunk;
+};
+
+const rawResponse = {
+  id: 'chatcmpl-1',
+  object: 'chat.completion.chunk',
+  created: 1,
+  model: 'gpt-5.5',
+  choices: [],
+};
+
+const toolCallDelta = {
+  role: 'assistant',
+  tool_calls: [
+    {
+      index: 0,
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'weather', arguments: '{"ci' },
+    },
+  ],
+};
+
+function convertDelta(
+  model: unknown,
+  delta: Record<string, unknown>
+): AIMessageChunk {
+  const converter = (model as { completions: DeltaConverter }).completions;
+  const message = converter._convertCompletionsDeltaToBaseMessageChunk(
+    delta,
+    rawResponse
+  );
+  expect(message).toBeInstanceOf(AIMessageChunk);
+  return message as AIMessageChunk;
+}
+
+function adapterOf(message: AIMessageChunk): unknown {
+  return (message.response_metadata as Record<string, unknown>)[
+    STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY
+  ];
+}
+
+describe('Chat Completions sequential tool-call seal stamping', () => {
+  test('stamps tool-call deltas when no baseURL is configured (official)', () => {
+    const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
+  });
+
+  test('stamps tool-call deltas for an explicit api.openai.com baseURL', () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5.5',
+      apiKey: 'test',
+      configuration: { baseURL: 'https://api.openai.com/v1' },
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
+  });
+
+  test('does not stamp tool-call deltas for OpenAI-compatible endpoints', () => {
+    const model = new ChatOpenAI({
+      model: 'kimi-k2',
+      apiKey: 'test',
+      configuration: { baseURL: 'https://api.moonshot.ai/v1' },
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBeUndefined();
+  });
+
+  test('does not stamp text-only deltas', () => {
+    const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
+    const message = convertDelta(model, {
+      role: 'assistant',
+      content: 'hello',
+    });
+    expect(adapterOf(message)).toBeUndefined();
+  });
+
+  test('stamps Azure OpenAI tool-call deltas (first-party endpoint)', () => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiInstanceName: 'test-instance',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
+  });
+});

--- a/src/llm/openai/sequentialToolCallSeals.test.ts
+++ b/src/llm/openai/sequentialToolCallSeals.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, describe } from '@jest/globals';
 import { AIMessageChunk } from '@langchain/core/messages';
+import { expect, test, describe, beforeEach, afterAll } from '@jest/globals';
 import type { BaseMessageChunk } from '@langchain/core/messages';
 import {
   STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
@@ -54,6 +54,30 @@ function adapterOf(message: AIMessageChunk): unknown {
 }
 
 describe('Chat Completions sequential tool-call seal stamping', () => {
+  // Both the implementation (OPENAI_BASE_URL fallback) and the Azure
+  // constructor (AZURE_OPENAI_BASE_PATH fallback) read the environment, so
+  // isolate these vars to keep the suite deterministic across shells.
+  const ISOLATED_ENV_VARS = ['OPENAI_BASE_URL', 'AZURE_OPENAI_BASE_PATH'];
+  const originalEnv = new Map(
+    ISOLATED_ENV_VARS.map((name) => [name, process.env[name]])
+  );
+
+  beforeEach(() => {
+    for (const name of ISOLATED_ENV_VARS) {
+      delete process.env[name];
+    }
+  });
+
+  afterAll(() => {
+    for (const [name, value] of originalEnv) {
+      if (value == null) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  });
+
   test('stamps tool-call deltas when no baseURL is configured (official)', () => {
     const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
     const message = convertDelta(model, toolCallDelta);
@@ -94,37 +118,19 @@ describe('Chat Completions sequential tool-call seal stamping', () => {
   });
 
   test('does not stamp when OPENAI_BASE_URL routes to a compatible endpoint', () => {
-    const previous = process.env.OPENAI_BASE_URL;
     process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1';
-    try {
-      const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
-      const message = convertDelta(model, toolCallDelta);
-      expect(adapterOf(message)).toBeUndefined();
-    } finally {
-      if (previous == null) {
-        delete process.env.OPENAI_BASE_URL;
-      } else {
-        process.env.OPENAI_BASE_URL = previous;
-      }
-    }
+    const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBeUndefined();
   });
 
   test('stamps when OPENAI_BASE_URL points at api.openai.com', () => {
-    const previous = process.env.OPENAI_BASE_URL;
     process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1';
-    try {
-      const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
-      const message = convertDelta(model, toolCallDelta);
-      expect(adapterOf(message)).toBe(
-        OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
-      );
-    } finally {
-      if (previous == null) {
-        delete process.env.OPENAI_BASE_URL;
-      } else {
-        process.env.OPENAI_BASE_URL = previous;
-      }
-    }
+    const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
   });
 
   test('stamps Azure OpenAI tool-call deltas (first-party endpoint)', () => {
@@ -147,6 +153,20 @@ describe('Chat Completions sequential tool-call seal stamping', () => {
       azureOpenAIApiVersion: '2024-08-01-preview',
       azureOpenAIBasePath:
         'https://test-resource.openai.azure.com/openai/deployments',
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
+  });
+
+  test('stamps Azure deltas for a regional cognitive services base path', () => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+      azureOpenAIBasePath:
+        'https://westeurope.api.cognitive.microsoft.com/openai/deployments',
     });
     const message = convertDelta(model, toolCallDelta);
     expect(adapterOf(message)).toBe(

--- a/src/llm/openai/sequentialToolCallSeals.test.ts
+++ b/src/llm/openai/sequentialToolCallSeals.test.ts
@@ -93,6 +93,40 @@ describe('Chat Completions sequential tool-call seal stamping', () => {
     expect(adapterOf(message)).toBeUndefined();
   });
 
+  test('does not stamp when OPENAI_BASE_URL routes to a compatible endpoint', () => {
+    const previous = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1';
+    try {
+      const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
+      const message = convertDelta(model, toolCallDelta);
+      expect(adapterOf(message)).toBeUndefined();
+    } finally {
+      if (previous == null) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = previous;
+      }
+    }
+  });
+
+  test('stamps when OPENAI_BASE_URL points at api.openai.com', () => {
+    const previous = process.env.OPENAI_BASE_URL;
+    process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1';
+    try {
+      const model = new ChatOpenAI({ model: 'gpt-5.5', apiKey: 'test' });
+      const message = convertDelta(model, toolCallDelta);
+      expect(adapterOf(message)).toBe(
+        OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+      );
+    } finally {
+      if (previous == null) {
+        delete process.env.OPENAI_BASE_URL;
+      } else {
+        process.env.OPENAI_BASE_URL = previous;
+      }
+    }
+  });
+
   test('stamps Azure OpenAI tool-call deltas (first-party endpoint)', () => {
     const model = new AzureChatOpenAI({
       azureOpenAIApiKey: 'test',
@@ -104,5 +138,42 @@ describe('Chat Completions sequential tool-call seal stamping', () => {
     expect(adapterOf(message)).toBe(
       OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
     );
+  });
+
+  test('stamps Azure deltas for an *.openai.azure.com base path', () => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+      azureOpenAIBasePath:
+        'https://test-resource.openai.azure.com/openai/deployments',
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
+  });
+
+  test('does not stamp Azure deltas routed through a proxy base path', () => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+      azureOpenAIBasePath: 'https://proxy.example.com/openai/deployments',
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBeUndefined();
+  });
+
+  test('does not stamp Azure deltas with a custom client baseURL', () => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiInstanceName: 'test-instance',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+      configuration: { baseURL: 'https://gateway.example.com/azure' },
+    } as unknown as ConstructorParameters<typeof AzureChatOpenAI>[0]);
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBeUndefined();
   });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -6,6 +6,12 @@ import type { AgentContext } from '@/agents/AgentContext';
 import type { StandardGraph } from '@/graphs';
 import type * as t from '@/types';
 import {
+  getStreamedToolCallSeal,
+  getStreamedToolCallAdapter,
+  streamedToolCallAdapterAllowsSequentialSeal,
+  type StreamedToolCallSeal,
+} from '@/tools/streamedToolCallSeals';
+import {
   ToolCallTypes,
   ContentTypes,
   GraphEvents,
@@ -15,11 +21,6 @@ import {
   CODE_EXECUTION_TOOLS,
   LOCAL_CODING_BUNDLE_NAMES,
 } from '@/common';
-import {
-  getStreamedToolCallSeal,
-  getStreamedToolCallAdapter,
-  type StreamedToolCallSeal,
-} from '@/tools/streamedToolCallSeals';
 import {
   buildToolExecutionRequestPlan,
   coerceRecordArgs,
@@ -1465,7 +1466,10 @@ export class ChatModelStreamHandler implements t.EventHandler {
         chunk.response_metadata as Record<string, unknown> | undefined
       );
       const allowSequentialSeal =
-        canPrestartSequentialStreamedToolChunks(agentContext);
+        canPrestartSequentialStreamedToolChunks(agentContext) ||
+        streamedToolCallAdapterAllowsSequentialSeal(
+          chunk.response_metadata as Record<string, unknown> | undefined
+        );
       const canStreamEager =
         (allowSequentialSeal || hasExplicitStreamedToolCallSeals(chunk)) &&
         !hasPotentialDirectToolInStreamContext({ graph, agentContext }) &&

--- a/src/tools/streamedToolCallSeals.ts
+++ b/src/tools/streamedToolCallSeals.ts
@@ -5,17 +5,39 @@ export const STREAMED_TOOL_CALL_SEAL_METADATA_KEY =
 export const OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER = 'openai_responses';
 export const BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER = 'bedrock_converse';
 export const GOOGLE_STREAMED_TOOL_CALL_ADAPTER = 'google_genai';
+export const OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER =
+  'openai_chat_sequential';
 
 export type StreamedToolCallAdapter =
   | typeof OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER
   | typeof BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER
-  | typeof GOOGLE_STREAMED_TOOL_CALL_ADAPTER;
+  | typeof GOOGLE_STREAMED_TOOL_CALL_ADAPTER
+  | typeof OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER;
 
 const STREAMED_TOOL_CALL_ADAPTERS: ReadonlySet<string> = new Set([
   OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
   BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
   GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+  OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER,
 ]);
+
+/**
+ * Adapters whose wire protocol streams tool calls strictly sequentially by
+ * index, so a prior call is sealed the moment a later index begins. Used by
+ * the stream handler to extend next-index sealing beyond the provider-keyed
+ * Anthropic allowlist.
+ */
+const SEQUENTIAL_SEAL_STREAMED_TOOL_CALL_ADAPTERS: ReadonlySet<string> =
+  new Set([OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER]);
+
+export function streamedToolCallAdapterAllowsSequentialSeal(
+  metadata: Record<string, unknown> | undefined
+): boolean {
+  const adapter = getStreamedToolCallAdapter(metadata);
+  return (
+    adapter != null && SEQUENTIAL_SEAL_STREAMED_TOOL_CALL_ADAPTERS.has(adapter)
+  );
+}
 
 export type StreamedToolCallSeal =
   | {


### PR DESCRIPTION
## Summary

I extended mid-stream eager tool prestart (from #237) to official OpenAI and Azure OpenAI Chat Completions using next-index sequential sealing, gated on the wire endpoint rather than the provider class. Chat Completions has no per-call completion event, so a prior call is sealed the moment a delta for a later index appears — safe only when the backend is genuinely first-party, which is exactly what the baseURL gate guarantees: OpenAI-compatible endpoints (Kimi/Moonshot, OpenRouter, LiteLLM, custom endpoints) always carry a custom baseURL, are never stamped, and stay on the existing final-signal path. Notably, `ChatMoonshot` extends `ChatOpenAI` and shares the completions delegate, so gating on the endpoint instead of the class is what keeps it excluded by construction.

- Stamped a new `openai_chat_sequential` streamed tool-call adapter on Chat Completions tool-call deltas in `LibreChatOpenAICompletions` when the configured baseURL is `api.openai.com` or unset, and unconditionally in `LibreChatAzureOpenAICompletions` (Azure is first-party with the same stream contract).
- Allowed next-index sequential sealing in `ChatModelStreamHandler` when a chunk carries a sequential-capable adapter, alongside the existing Anthropic provider allowlist; recording, direct-tool guards, and all batch gates from #237 apply unchanged.
- Left the last call of each turn on the existing final-signal path, which dedups already-started calls via `skipExisting` — covered by a test asserting the final batch dispatches only the unstarted call.
- Added unit tests for the stamping matrix (no baseURL, explicit api.openai.com, custom/compatible endpoint, text-only deltas, Azure) and a handler-level test mirroring the Anthropic sequential flow.

## Empirical basis

Probed live streaming with parallel tool calls, inspecting every raw delta for prior-index revisions after a later index began:

- **api.openai.com, gpt-5.5**: 16/16 runs clean (12 standard, 4 long-args turns spanning ~165 deltas with a ~500-char argument string), strictly sequential by index, ids on first delta, `finish_reason: tool_calls`.
- **Azure OpenAI** (gpt-4.1-nano deployment): 6/6 runs clean, identical structure.

Residual wrong-seal exposure is bounded by the existing protections: unparsable args never prestart (strict-JSON guard), and ToolNode refuses to re-run on name/args drift.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `npx jest src/__tests__ src/stream.test.ts src/llm/openai src/tools` — 994 tests pass, including 5 new stamping tests and the new sequential handler test; the pre-existing "keeps OpenAI Chat Completions streamed chunks on the final tool_calls path" and "does not use next-index sealing for Moonshot" tests still pass, confirming un-stamped chunks keep today's behavior.
- `npx tsc --noEmit`, eslint, prettier, and sort-imports all clean.

### **Test Configuration**:

- Node 24 / npm ci; live probes used OPENAI_API_KEY and AZURE_OPENAI_* from .env (not required by the test suite).

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes