### PR TITLE
📬 feat: Per-Call Tool Completion Emission via onResult Channel

### DIFF
--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -2476,6 +2476,49 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
       }
 
+      /**
+       * Per-call completion fast-path: when the host reports a result
+       * through `onResult` before the batch resolves, emit that call's
+       * completed run step immediately instead of waiting for the slowest
+       * call in the batch. Safe only when nothing can change the result
+       * after execution — post-tool hooks may rewrite output and HITL may
+       * deny a call, so those configurations keep batch-time emission.
+       * Ids are claimed synchronously before the async dispatch and
+       * released if the dispatch fails, letting the batch path re-emit.
+       */
+      const canEmitEarlyCompletions =
+        this.hookRegistry == null && this.humanInTheLoop?.enabled !== true;
+      const earlyCompletionDispatchedIds = new Set<string>();
+      const earlyCompletionDispatches: Array<Promise<void>> = [];
+      const dispatchRequestById = new Map(
+        dispatchRequests.map((request) => [request.id, request])
+      );
+      const onResult = (result: t.ToolExecuteResult): void => {
+        const request =
+          result.toolCallId != null
+            ? dispatchRequestById.get(result.toolCallId)
+            : undefined;
+        if (
+          request == null ||
+          earlyCompletionDispatchedIds.has(result.toolCallId)
+        ) {
+          return;
+        }
+        earlyCompletionDispatchedIds.add(result.toolCallId);
+        earlyCompletionDispatches.push(
+          this.dispatchEarlyToolCompletion(result, request, config).then(
+            (dispatched) => {
+              if (!dispatched) {
+                earlyCompletionDispatchedIds.delete(result.toolCallId);
+              }
+            },
+            () => {
+              earlyCompletionDispatchedIds.delete(result.toolCallId);
+            }
+          )
+        );
+      };
+
       const dispatchPromise =
         dispatchRequests.length === 0
           ? Promise.resolve([] as t.ToolExecuteResult[])
@@ -2506,6 +2549,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 maybeResolve();
               },
               reject,
+              ...(canEmitEarlyCompletions && { onResult }),
             };
 
             void safeDispatchCustomEvent(
@@ -2540,6 +2584,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         eagerResultsPromise,
         dispatchPromise,
       ]);
+      // Settle in-flight early completion dispatches before the batch loop
+      // below decides which completions still need emitting.
+      await Promise.allSettled(earlyCompletionDispatches);
       const eagerCompletionDispatchedIds = new Set(
         eagerResults
           .filter((result) => result.completionDispatched)
@@ -2728,7 +2775,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           });
         }
 
-        if (!eagerCompletionDispatchedIds.has(result.toolCallId)) {
+        if (
+          !eagerCompletionDispatchedIds.has(result.toolCallId) &&
+          !earlyCompletionDispatchedIds.has(result.toolCallId)
+        ) {
           await this.dispatchStepCompleted(
             result.toolCallId,
             toolName,
@@ -2946,7 +2996,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     output: string,
     config: RunnableConfig,
     turn?: number
-  ): Promise<void> {
+  ): Promise<boolean> {
     const stepId = this.toolCallStepIds?.get(toolCallId) ?? '';
     if (!stepId) {
       // eslint-disable-next-line no-console
@@ -2957,7 +3007,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       );
     }
 
-    await safeDispatchCustomEvent(
+    const dispatched = await safeDispatchCustomEvent(
       GraphEvents.ON_RUN_STEP_COMPLETED,
       {
         result: {
@@ -2974,6 +3024,38 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         },
       },
       config
+    );
+    return dispatched !== false;
+  }
+
+  /**
+   * Emits the completed run step for a single host-reported result before
+   * the batch resolves. Mirrors the batch loop's output formatting exactly;
+   * callers gate on the no-hooks/no-HITL configuration, so the raw result
+   * content here is also the final content. Returns whether the event was
+   * actually dispatched so the caller can fall back to batch-time emission.
+   */
+  private async dispatchEarlyToolCompletion(
+    result: t.ToolExecuteResult,
+    request: t.ToolCallRequest,
+    config: RunnableConfig
+  ): Promise<boolean> {
+    const output =
+      result.status === 'error'
+        ? `Error: ${result.errorMessage ?? 'Unknown error'}\n Please fix your mistakes.`
+        : truncateToolResultContent(
+          typeof result.content === 'string'
+            ? result.content
+            : JSON.stringify(result.content),
+          this.maxToolResultChars
+        );
+    return this.dispatchStepCompleted(
+      result.toolCallId,
+      request.name,
+      request.args,
+      output,
+      config,
+      request.turn
     );
   }
 

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -1,0 +1,368 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import type { StructuredToolInterface } from '@langchain/core/tools';
+import type * as t from '@/types';
+import * as events from '@/utils/events';
+import { GraphEvents } from '@/common';
+import { HookRegistry } from '@/hooks';
+import { ToolNode } from '../ToolNode';
+
+function createDummyTool(name: string): StructuredToolInterface {
+  return tool(async () => 'direct should not run', {
+    name,
+    description: 'dummy',
+    schema: z.object({}).passthrough(),
+  }) as unknown as StructuredToolInterface;
+}
+
+function createAIMessageWithToolCalls(
+  toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>
+): AIMessage {
+  return new AIMessage({
+    content: '',
+    tool_calls: toolCalls,
+  });
+}
+
+type CompletionEvent = {
+  result: {
+    id: string;
+    tool_call: { id: string; output: string };
+  };
+};
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('ToolNode per-call onResult completion emission', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('emits a completion as the host reports each result, before the batch resolves', async () => {
+    const timeline: string[] = [];
+    const completions: CompletionEvent[] = [];
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          const completion = data as CompletionEvent;
+          completions.push(completion);
+          timeline.push(`completed:${completion.result.tool_call.id}`);
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        expect(batch.onResult).toBeDefined();
+
+        // Host finishes the fast call first and reports it immediately.
+        timeline.push('onResult:call_weather');
+        batch.onResult?.({
+          toolCallId: 'call_weather',
+          status: 'success',
+          content: 'sunny',
+        });
+
+        await flushAsync();
+        timeline.push('resolving-batch');
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+          {
+            toolCallId: 'call_stock',
+            status: 'success',
+            content: '42',
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather'), createDummyTool('stock')],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([
+        ['call_weather', 'step_weather'],
+        ['call_stock', 'step_stock'],
+      ]),
+    });
+
+    const result = (await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+          { id: 'call_stock', name: 'stock', args: { ticker: 'CH' } },
+        ]),
+      ],
+    })) as { messages: ToolMessage[] };
+
+    // The fast call's completion was emitted before the batch resolved.
+    expect(timeline.indexOf('completed:call_weather')).toBeGreaterThan(
+      timeline.indexOf('onResult:call_weather')
+    );
+    expect(timeline.indexOf('completed:call_weather')).toBeLessThan(
+      timeline.indexOf('resolving-batch')
+    );
+
+    // Exactly one completion per call: early for weather, batch for stock.
+    const byId = completions.map((c) => c.result.tool_call.id);
+    expect(byId.filter((id) => id === 'call_weather')).toHaveLength(1);
+    expect(byId.filter((id) => id === 'call_stock')).toHaveLength(1);
+    expect(
+      completions.find((c) => c.result.tool_call.id === 'call_weather')?.result
+        .tool_call.output
+    ).toBe('sunny');
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.map((m) => m.content)).toEqual(['sunny', '42']);
+  });
+
+  it('ignores duplicate and unknown onResult reports', async () => {
+    const completions: CompletionEvent[] = [];
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(data as CompletionEvent);
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.onResult?.({
+          toolCallId: 'call_weather',
+          status: 'success',
+          content: 'sunny',
+        });
+        batch.onResult?.({
+          toolCallId: 'call_weather',
+          status: 'success',
+          content: 'sunny again',
+        });
+        batch.onResult?.({
+          toolCallId: 'call_unknown',
+          status: 'success',
+          content: 'never requested',
+        });
+        await flushAsync();
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+        ]),
+      ],
+    });
+
+    const byId = completions.map((c) => c.result.tool_call.id);
+    expect(byId.filter((id) => id === 'call_weather')).toHaveLength(1);
+    expect(byId.filter((id) => id === 'call_unknown')).toHaveLength(0);
+  });
+
+  it('does not offer onResult when batch-sensitive hooks are configured', async () => {
+    let observedBatch: t.ToolExecuteBatchRequest | undefined;
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        observedBatch = batch;
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      hookRegistry: new HookRegistry(),
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+        ]),
+      ],
+    });
+
+    expect(observedBatch).toBeDefined();
+    expect(observedBatch?.onResult).toBeUndefined();
+  });
+
+  it('does not offer onResult when human-in-the-loop is enabled', async () => {
+    let observedBatch: t.ToolExecuteBatchRequest | undefined;
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        observedBatch = batch;
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      humanInTheLoop: { enabled: true },
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+        ]),
+      ],
+    });
+
+    expect(observedBatch).toBeDefined();
+    expect(observedBatch?.onResult).toBeUndefined();
+  });
+
+  it('falls back to batch emission when the early dispatch is not delivered', async () => {
+    const completionAttempts: CompletionEvent[] = [];
+    let failNextCompletion = true;
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<boolean | void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completionAttempts.push(data as CompletionEvent);
+          if (failNextCompletion) {
+            failNextCompletion = false;
+            return false;
+          }
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.onResult?.({
+          toolCallId: 'call_weather',
+          status: 'success',
+          content: 'sunny',
+        });
+        await flushAsync();
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'success',
+            content: 'sunny',
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+        ]),
+      ],
+    });
+
+    // First attempt (early) was rejected by the dispatcher; the batch path
+    // re-emitted it.
+    expect(completionAttempts).toHaveLength(2);
+    expect(completionAttempts[0].result.tool_call.id).toBe('call_weather');
+    expect(completionAttempts[1].result.tool_call.id).toBe('call_weather');
+  });
+
+  it('emits error-status results with the standard error formatting', async () => {
+    const completions: CompletionEvent[] = [];
+
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          completions.push(data as CompletionEvent);
+          return;
+        }
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) {
+          return;
+        }
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.onResult?.({
+          toolCallId: 'call_weather',
+          status: 'error',
+          content: '',
+          errorMessage: 'city not found',
+        });
+        await flushAsync();
+        batch.resolve([
+          {
+            toolCallId: 'call_weather',
+            status: 'error',
+            content: '',
+            errorMessage: 'city not found',
+          },
+        ]);
+      });
+
+    const toolNode = new ToolNode({
+      tools: [createDummyTool('weather')],
+      eventDrivenMode: true,
+      toolCallStepIds: new Map([['call_weather', 'step_weather']]),
+    });
+
+    await toolNode.invoke({
+      messages: [
+        createAIMessageWithToolCalls([
+          { id: 'call_weather', name: 'weather', args: { city: 'NYC' } },
+        ]),
+      ],
+    });
+
+    expect(completions).toHaveLength(1);
+    expect(completions[0].result.tool_call.output).toBe(
+      'Error: city not found\n Please fix your mistakes.'
+    );
+  });
+});

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -415,6 +415,16 @@ export type ToolExecuteBatchRequest = {
   resolve: (results: ToolExecuteResult[]) => void;
   /** Promise rejector - handler calls this on fatal error */
   reject: (error: Error) => void;
+  /**
+   * Optional per-call result channel. When present, the handler MAY invoke
+   * this as each tool call settles (before the final `resolve`) so the
+   * graph can emit that call's completion event without waiting for the
+   * slowest call in the batch. Purely an emission fast-path: the handler
+   * must still pass every result to `resolve`, which remains the
+   * authoritative batch outcome. Only provided when no post-tool hooks or
+   * human-in-the-loop flows could change a result after execution.
+   */
+  onResult?: (result: ToolExecuteResult) => void;
 };
 
 /**


### PR DESCRIPTION
## Summary

I decoupled tool-completion UI latency from the slowest call in a batch. The host already executes tool batches in parallel (LibreChat's `createToolExecuteHandler` runs `Promise.all` over the calls), but the `ON_TOOL_EXECUTE` contract only exposed a single `resolve(results[])` channel — so a 1-second tool's completion event waited for the 30-second tool next to it. This adds an optional per-call channel: the host may report each result through `onResult` the moment it settles, and ToolNode emits that call's completed run step immediately. It is purely an emission fast-path — `resolve` remains the authoritative batch outcome, the graph state still transitions once per batch (the next model turn inherently needs every ToolMessage), and handlers that never call `onResult` behave exactly as today. This composes with the eager-execution seals from #237/#238 rather than overlapping them: sealing moves when execution starts; `onResult` moves when results appear, including on the fully lazy path.

- Added `onResult?: (result: ToolExecuteResult) => void` to `ToolExecuteBatchRequest`, documented as optional and non-authoritative.
- Offered the callback only in no-hooks/no-HITL configurations — `PostToolUse` hooks can rewrite output (`updatedOutput`) and HITL can deny a call after execution, so those configurations keep batch-time emission; this mirrors the existing batch-sensitivity gate for eager execution.
- Claimed ids synchronously on first report to dedupe duplicate `onResult` calls; ignored unknown ids; released the claim when a dispatch fails or is not delivered so the batch path re-emits.
- Awaited in-flight early dispatches after the batch settles, before the batch loop decides which completions still need emitting — closing the double-emit race.
- Mirrored the batch loop's output formatting exactly (truncation for success, standard error string for failures) and changed `dispatchStepCompleted` to report whether the event was delivered.
- The companion LibreChat change is a near-one-liner: call `data.onResult?.(result)` inside the existing `Promise.all` mapper; safe to land before this releases since the callback is optional.

## Change Type

- [x] New feature (non-breaking change which adds functionality)

## Testing

- New suite `src/tools/__tests__/ToolNode.onResultCompletion.test.ts` (6 tests): per-call emission lands before the batch resolves with no double emission; duplicate/unknown reports ignored; `onResult` withheld when hooks or HITL are configured; undelivered early dispatch falls back to batch emission; error results use the standard error formatting.
- `npx jest src/tools src/__tests__ src/stream.test.ts` — 956 tests pass; `npx tsc --noEmit`, eslint, prettier, sort-imports clean.

### **Test Configuration**:

- Node 24 / npm ci; no provider credentials required.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes