### PR TITLE
📐 feat: AgentContext.projectContextUsage: pre-send context snapshot

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1339,11 +1339,20 @@ export class AgentContext {
    * invoking the model — the pre-send / page-load / window-switch counterpart to
    * the live `ON_CONTEXT_USAGE` snapshot. Runs the same pruner + budget math the
    * graph uses (`createPruneMessages` → `getTokenBudgetBreakdown` →
-   * `syncBudgetDerivedFields`) so projected numbers match a real call. Uses a
-   * local pruner and never mutates this context, so it is safe to call off the
-   * hot path. Returns null when the context lacks the tokenizer or window needed
-   * to prune. Omits the live post-format reconciliation (provider-specific,
-   * invoke-time) — a small, acceptable delta for a pre-send estimate.
+   * `syncBudgetDerivedFields`) so projected numbers match a real call. Returns
+   * null when the context lacks the tokenizer or window needed to prune. Omits
+   * the live post-format reconciliation (provider-specific, invoke-time) — a
+   * small, acceptable delta for a pre-send estimate.
+   *
+   * Safe to call off the hot path: the pruner replaces tool-result slots in
+   * place, so the supplied `messages` are passed as a shallow copy and never
+   * mutated; this context's own state is untouched. Token counts are recounted
+   * for the supplied messages (the context's `indexTokenCountMap` is keyed to
+   * the live run's branch and would missum an arbitrary branch) unless the
+   * caller passes a map it guarantees matches. Live usage is NOT pulled from this
+   * context — a fresh pruner would recalibrate the prior call's provider input
+   * against the whole projected branch; an uncalibrated estimate is the honest
+   * pre-send view. Callers wanting calibration pass `usageMetadata` explicitly.
    */
   projectContextUsage(
     messages: BaseMessage[],
@@ -1351,18 +1360,27 @@ export class AgentContext {
       runId?: string;
       agentId?: string;
       usageMetadata?: Partial<UsageMetadata>;
+      indexTokenCountMap?: Record<string, number | undefined>;
     }
   ): t.ContextUsageEvent | null {
-    if (this.tokenCounter == null || this.maxContextTokens == null) {
+    const tokenCounter = this.tokenCounter;
+    if (tokenCounter == null || this.maxContextTokens == null) {
       return null;
+    }
+    let indexTokenCountMap = opts?.indexTokenCountMap;
+    if (indexTokenCountMap == null) {
+      indexTokenCountMap = {};
+      for (let i = 0; i < messages.length; i++) {
+        indexTokenCountMap[String(i)] = tokenCounter(messages[i]);
+      }
     }
     const prune = createPruneMessages({
       startIndex: 0,
       provider: this.provider,
-      tokenCounter: this.tokenCounter,
+      tokenCounter,
       maxTokens: this.maxContextTokens,
       thinkingEnabled: isThinkingEnabled(this.provider, this.clientOptions),
-      indexTokenCountMap: this.indexTokenCountMap,
+      indexTokenCountMap,
       contextPruningConfig: this.contextPruningConfig,
       summarizationEnabled: this.summarizationEnabled,
       reserveRatio: this.summarizationConfig?.reserveRatio,
@@ -1377,10 +1395,10 @@ export class AgentContext {
       effectiveInstructionTokens,
       calibrationRatio,
     } = prune({
-      messages,
-      usageMetadata: opts?.usageMetadata ?? this.currentUsage,
-      lastCallUsage: this.lastCallUsage,
-      totalTokensFresh: this.totalTokensFresh,
+      messages: [...messages],
+      usageMetadata: opts?.usageMetadata,
+      lastCallUsage: undefined,
+      totalTokensFresh: false,
     });
     const breakdown = this.getTokenBudgetBreakdown(messages);
     breakdown.messageCount = context.length;

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -18,6 +18,7 @@ import {
 import {
   addCacheControl,
   addCacheControlToStablePrefixMessages,
+  cloneMessage,
 } from '@/messages/cache';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
@@ -1344,22 +1345,25 @@ export class AgentContext {
    * the live post-format reconciliation (provider-specific, invoke-time) — a
    * small, acceptable delta for a pre-send estimate.
    *
-   * Safe to call off the hot path: the pruner replaces tool-result slots in
-   * place, so the supplied `messages` are passed as a shallow copy and never
-   * mutated; this context's own state is untouched. Token counts are recounted
-   * for the supplied messages (the context's `indexTokenCountMap` is keyed to
-   * the live run's branch and would missum an arbitrary branch) unless the
-   * caller passes a map it guarantees matches. Live usage is NOT pulled from this
-   * context — a fresh pruner would recalibrate the prior call's provider input
-   * against the whole projected branch; an uncalibrated estimate is the honest
-   * pre-send view. Callers wanting calibration pass `usageMetadata` explicitly.
+   * Safe to call off the hot path: the supplied `messages` are never mutated
+   * (each is passed as a clone — the pruner both replaces tool-result slots and
+   * unshifts reasoning blocks into AI content arrays in place), and this
+   * context's own state is untouched apart from refreshing stale instruction
+   * counts (idempotent, exactly what a real call does). Token counts are
+   * recounted for the supplied messages (the context's `indexTokenCountMap` is
+   * keyed to the live run's branch and would missum an arbitrary branch) unless
+   * the caller passes a map it guarantees matches. Calibration is NOT re-derived
+   * from this context's live usage (a fresh pruner would compare the prior
+   * call's provider input against the whole projected branch); the learned
+   * `calibrationRatio` is applied as a static seed, and callers may override it
+   * with a persisted ratio via `opts.calibrationRatio`.
    */
   projectContextUsage(
     messages: BaseMessage[],
     opts?: {
       runId?: string;
       agentId?: string;
-      usageMetadata?: Partial<UsageMetadata>;
+      calibrationRatio?: number;
       indexTokenCountMap?: Record<string, number | undefined>;
     }
   ): t.ContextUsageEvent | null {
@@ -1367,6 +1371,17 @@ export class AgentContext {
     if (tokenCounter == null || this.maxContextTokens == null) {
       return null;
     }
+    /** Refresh stale system overhead (handoff/summary changes) so instruction
+     *  tokens match the prompt a real call would send. */
+    this.initializeSystemRunnable();
+    /** Clone array-content messages: the pruner unshifts reasoning blocks into
+     *  AI content arrays in place, which would otherwise corrupt the caller's
+     *  history. (Slot replacements land on the mapped array, not the caller's.) */
+    const projected = messages.map((message) =>
+      Array.isArray(message.content)
+        ? cloneMessage(message, [...message.content])
+        : message
+    );
     let indexTokenCountMap = opts?.indexTokenCountMap;
     if (indexTokenCountMap == null) {
       indexTokenCountMap = {};
@@ -1384,7 +1399,7 @@ export class AgentContext {
       contextPruningConfig: this.contextPruningConfig,
       summarizationEnabled: this.summarizationEnabled,
       reserveRatio: this.summarizationConfig?.reserveRatio,
-      calibrationRatio: this.calibrationRatio,
+      calibrationRatio: opts?.calibrationRatio ?? this.calibrationRatio,
       getInstructionTokens: () => this.instructionTokens,
     });
     const {
@@ -1395,8 +1410,8 @@ export class AgentContext {
       effectiveInstructionTokens,
       calibrationRatio,
     } = prune({
-      messages: [...messages],
-      usageMetadata: opts?.usageMetadata,
+      messages: projected,
+      usageMetadata: undefined,
       lastCallUsage: undefined,
       totalTokensFresh: false,
     });

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -7,7 +7,6 @@ import type {
   BaseMessageFields,
 } from '@langchain/core/messages';
 import type { RunnableConfig, Runnable } from '@langchain/core/runnables';
-import type { createPruneMessages } from '@/messages';
 import type * as t from '@/types';
 import {
   ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
@@ -22,7 +21,12 @@ import {
 } from '@/messages/cache';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { apportionTokenCounts } from '@/utils/tokens';
-import { DEFAULT_RESERVE_RATIO } from '@/messages';
+import {
+  DEFAULT_RESERVE_RATIO,
+  createPruneMessages,
+  syncBudgetDerivedFields,
+} from '@/messages';
+import { isThinkingEnabled } from '@/llm/request';
 import { toJsonSchema } from '@/utils/schema';
 
 type AgentSystemTextBlock = {
@@ -1328,6 +1332,70 @@ export class AgentContext {
       `  availableForMessages: ${b.availableForMessages}`,
     ];
     return lines.join('\n');
+  }
+
+  /**
+   * Projects the context-usage snapshot for an arbitrary message set WITHOUT
+   * invoking the model — the pre-send / page-load / window-switch counterpart to
+   * the live `ON_CONTEXT_USAGE` snapshot. Runs the same pruner + budget math the
+   * graph uses (`createPruneMessages` → `getTokenBudgetBreakdown` →
+   * `syncBudgetDerivedFields`) so projected numbers match a real call. Uses a
+   * local pruner and never mutates this context, so it is safe to call off the
+   * hot path. Returns null when the context lacks the tokenizer or window needed
+   * to prune. Omits the live post-format reconciliation (provider-specific,
+   * invoke-time) — a small, acceptable delta for a pre-send estimate.
+   */
+  projectContextUsage(
+    messages: BaseMessage[],
+    opts?: {
+      runId?: string;
+      agentId?: string;
+      usageMetadata?: Partial<UsageMetadata>;
+    }
+  ): t.ContextUsageEvent | null {
+    if (this.tokenCounter == null || this.maxContextTokens == null) {
+      return null;
+    }
+    const prune = createPruneMessages({
+      startIndex: 0,
+      provider: this.provider,
+      tokenCounter: this.tokenCounter,
+      maxTokens: this.maxContextTokens,
+      thinkingEnabled: isThinkingEnabled(this.provider, this.clientOptions),
+      indexTokenCountMap: this.indexTokenCountMap,
+      contextPruningConfig: this.contextPruningConfig,
+      summarizationEnabled: this.summarizationEnabled,
+      reserveRatio: this.summarizationConfig?.reserveRatio,
+      calibrationRatio: this.calibrationRatio,
+      getInstructionTokens: () => this.instructionTokens,
+    });
+    const {
+      context,
+      prePruneContextTokens,
+      remainingContextTokens,
+      contextBudget,
+      effectiveInstructionTokens,
+      calibrationRatio,
+    } = prune({
+      messages,
+      usageMetadata: opts?.usageMetadata ?? this.currentUsage,
+      lastCallUsage: this.lastCallUsage,
+      totalTokensFresh: this.totalTokensFresh,
+    });
+    const breakdown = this.getTokenBudgetBreakdown(messages);
+    breakdown.messageCount = context.length;
+    const usage: t.ContextUsageEvent = {
+      runId: opts?.runId,
+      agentId: opts?.agentId,
+      breakdown,
+      contextBudget,
+      effectiveInstructionTokens,
+      prePruneContextTokens,
+      remainingContextTokens,
+      calibrationRatio,
+    };
+    syncBudgetDerivedFields(usage);
+    return usage;
   }
 
   /**

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -2165,16 +2165,16 @@ describe('AgentContext', () => {
       const ctx = createBasicContext({ tokenCounter: countByChars });
       ctx.maxContextTokens = maxContextTokens;
       const messages: AIMessage[] = [];
-      const indexTokenCountMap: Record<string, number> = {};
       for (let i = 0; i < count; i++) {
+        // countByChars counts content length, and projectContextUsage recounts
+        // the supplied messages — so size content to the intended per-msg tokens.
+        const content = 'x'.repeat(perMessageTokens);
         messages.push(
           i % 2 === 0
-            ? (new HumanMessage(`m${i}`) as unknown as AIMessage)
-            : new AIMessage(`m${i}`),
+            ? (new HumanMessage(content) as unknown as AIMessage)
+            : new AIMessage(content),
         );
-        indexTokenCountMap[String(i)] = perMessageTokens;
       }
-      ctx.indexTokenCountMap = indexTokenCountMap;
       return { ctx, messages };
     };
 
@@ -2225,6 +2225,93 @@ describe('AgentContext', () => {
 
       expect(ctx.pruneMessages).toBeUndefined();
       expect(ctx.indexTokenCountMap).toEqual(mapBefore);
+    });
+
+    it('does not mutate the caller messages under context pressure', () => {
+      const ctx = createBasicContext({ tokenCounter: countByChars });
+      ctx.maxContextTokens = 400;
+      const consumed = new ToolMessage({
+        content: 'x'.repeat(20_000),
+        tool_call_id: 't1',
+        name: 'tool',
+      });
+      const messages: AIMessage[] = [
+        new HumanMessage('question') as unknown as AIMessage,
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 't1', name: 'tool', args: {} }],
+        }),
+        consumed as unknown as AIMessage,
+        new AIMessage('final answer'),
+      ];
+      const originalRef = messages[2];
+      const originalContent = (messages[2] as unknown as ToolMessage).content;
+
+      ctx.projectContextUsage(messages);
+
+      expect(messages[2]).toBe(originalRef);
+      expect((messages[2] as unknown as ToolMessage).content).toBe(
+        originalContent,
+      );
+    });
+
+    it('recounts the supplied branch, ignoring a stale context token map', () => {
+      const ctx = createBasicContext({ tokenCounter: countByChars });
+      ctx.maxContextTokens = 3_000;
+      // Empty/stale map — if it were reused, every message would count as 0 and
+      // nothing would prune. The fresh recount must drive pruning instead.
+      ctx.indexTokenCountMap = {};
+      const messages: AIMessage[] = [];
+      for (let i = 0; i < 6; i++) {
+        messages.push(new HumanMessage('x'.repeat(1_000)) as unknown as AIMessage);
+      }
+
+      const usage = ctx.projectContextUsage(messages);
+
+      expect(usage).not.toBeNull();
+      expect(usage!.breakdown.messageCount).toBeLessThan(6);
+    });
+
+    it('uses a caller-supplied token map when provided', () => {
+      const { ctx, messages } = buildBranch(3_000, 1, 6);
+      // Each message is ~1 char, so a recount would fit all 6. The supplied map
+      // claims 1000 each, forcing a prune — proving the map is honored.
+      const indexTokenCountMap: Record<string, number> = {};
+      for (let i = 0; i < messages.length; i++) {
+        indexTokenCountMap[String(i)] = 1_000;
+      }
+
+      const usage = ctx.projectContextUsage(messages, { indexTokenCountMap });
+
+      expect(usage!.breakdown.messageCount).toBeLessThan(6);
+    });
+
+    it('ignores this context live usage so projections are not recalibrated', () => {
+      const build = (): { ctx: AgentContext; messages: AIMessage[] } => {
+        const ctx = createBasicContext({ tokenCounter: countByChars });
+        ctx.maxContextTokens = 5_000;
+        const messages: AIMessage[] = [0, 1, 2].map(
+          () => new HumanMessage('x'.repeat(1_000)) as unknown as AIMessage,
+        );
+        return { ctx, messages };
+      };
+
+      const clean = build();
+      const cleanUsage = clean.ctx.projectContextUsage(clean.messages);
+
+      const dirty = build();
+      dirty.ctx.currentUsage = {
+        input_tokens: 4_000,
+        output_tokens: 50,
+        total_tokens: 4_050,
+      };
+      dirty.ctx.updateLastCallUsage({ input_tokens: 4_000, output_tokens: 50 });
+      const dirtyUsage = dirty.ctx.projectContextUsage(dirty.messages);
+
+      expect(dirtyUsage!.remainingContextTokens).toBe(
+        cleanUsage!.remainingContextTokens,
+      );
+      expect(dirtyUsage!.calibrationRatio).toBe(cleanUsage!.calibrationRatio);
     });
   });
 });

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -2313,5 +2313,67 @@ describe('AgentContext', () => {
       );
       expect(dirtyUsage!.calibrationRatio).toBe(cleanUsage!.calibrationRatio);
     });
+
+    it('does not mutate AI message content arrays during projection', () => {
+      const ctx = createBasicContext({
+        agentConfig: {
+          provider: Providers.ANTHROPIC,
+          clientOptions: {
+            model: 'claude-x',
+            thinking: { type: 'enabled', budget_tokens: 1024 },
+          } as never,
+        },
+        tokenCounter: countByChars,
+      });
+      ctx.maxContextTokens = 2_000;
+      const aiContent = [
+        { type: 'thinking', thinking: 'step by step', signature: 'sig' },
+        { type: 'text', text: 'the answer' },
+      ];
+      const ai = new AIMessage({ content: aiContent as never });
+      const messages: AIMessage[] = [
+        new HumanMessage('question') as unknown as AIMessage,
+        ai,
+        new HumanMessage('another') as unknown as AIMessage,
+      ];
+      const contentRef = ai.content;
+      const lenBefore = (ai.content as unknown[]).length;
+
+      ctx.projectContextUsage(messages);
+
+      expect(messages[1].content).toBe(contentRef);
+      expect((messages[1].content as unknown[]).length).toBe(lenBefore);
+    });
+
+    it('honors an explicit calibrationRatio seed', () => {
+      const base = buildBranch(100_000, 1_000, 4);
+      const baseUsage = base.ctx.projectContextUsage(base.messages);
+
+      const scaled = buildBranch(100_000, 1_000, 4);
+      const scaledUsage = scaled.ctx.projectContextUsage(scaled.messages, {
+        calibrationRatio: 3,
+      });
+
+      expect(scaledUsage!.calibrationRatio).toBe(3);
+      expect(scaledUsage!.remainingContextTokens).not.toBe(
+        baseUsage!.remainingContextTokens,
+      );
+    });
+
+    it('refreshes a stale system runnable before projecting', () => {
+      const ctx = createBasicContext({
+        agentConfig: { instructions: 'system prompt' },
+        tokenCounter: countByChars,
+      });
+      ctx.maxContextTokens = 5_000;
+      ctx.initializeSystemRunnable();
+      const systemBefore = ctx.systemMessageTokens;
+
+      // Adds a handoff preamble + marks stale, but defers the token recount.
+      ctx.setHandoffContext('PriorAgent', ['SiblingA', 'SiblingB']);
+      ctx.projectContextUsage([new HumanMessage('hi') as unknown as AIMessage]);
+
+      expect(ctx.systemMessageTokens).toBeGreaterThan(systemBefore);
+    });
   });
 });

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -2147,4 +2147,84 @@ describe('AgentContext', () => {
       expect(ctx.lastCallUsage!.inputTokens).toBe(8005);
     });
   });
+
+  describe('projectContextUsage', () => {
+    const countByChars = (msg: { content: unknown }): number => {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : JSON.stringify(msg.content);
+      return content.length;
+    };
+
+    const buildBranch = (
+      maxContextTokens: number,
+      perMessageTokens: number,
+      count: number,
+    ): { ctx: AgentContext; messages: AIMessage[] } => {
+      const ctx = createBasicContext({ tokenCounter: countByChars });
+      ctx.maxContextTokens = maxContextTokens;
+      const messages: AIMessage[] = [];
+      const indexTokenCountMap: Record<string, number> = {};
+      for (let i = 0; i < count; i++) {
+        messages.push(
+          i % 2 === 0
+            ? (new HumanMessage(`m${i}`) as unknown as AIMessage)
+            : new AIMessage(`m${i}`),
+        );
+        indexTokenCountMap[String(i)] = perMessageTokens;
+      }
+      ctx.indexTokenCountMap = indexTokenCountMap;
+      return { ctx, messages };
+    };
+
+    it('returns null without a tokenizer or a window', () => {
+      const noCounter = createBasicContext({});
+      noCounter.maxContextTokens = 1000;
+      expect(noCounter.projectContextUsage([new HumanMessage('hi')])).toBeNull();
+
+      const noWindow = createBasicContext({ tokenCounter: countByChars });
+      noWindow.maxContextTokens = undefined;
+      expect(noWindow.projectContextUsage([new HumanMessage('hi')])).toBeNull();
+    });
+
+    it('keeps the whole branch and reports headroom when it fits', () => {
+      const { ctx, messages } = buildBranch(100_000, 1_000, 4);
+      const usage = ctx.projectContextUsage(messages);
+
+      expect(usage).not.toBeNull();
+      expect(usage!.breakdown.messageCount).toBe(4);
+      expect(usage!.breakdown.maxContextTokens).toBe(100_000);
+      expect(usage!.remainingContextTokens).toBeGreaterThan(0);
+      expect(usage!.breakdown.messageTokens).toBeGreaterThan(0);
+
+      const max = usage!.contextBudget ?? usage!.breakdown.maxContextTokens;
+      const used = max - (usage!.remainingContextTokens ?? 0);
+      expect(used).toBeLessThanOrEqual(max);
+    });
+
+    it('prunes older messages when the branch exceeds the window', () => {
+      const { ctx, messages } = buildBranch(3_000, 1_000, 6);
+      const usage = ctx.projectContextUsage(messages);
+
+      expect(usage).not.toBeNull();
+      expect(usage!.breakdown.messageCount).toBeGreaterThan(0);
+      expect(usage!.breakdown.messageCount).toBeLessThan(6);
+      expect(usage!.remainingContextTokens).toBeGreaterThanOrEqual(0);
+
+      const max = usage!.contextBudget ?? usage!.breakdown.maxContextTokens;
+      expect(max - (usage!.remainingContextTokens ?? 0)).toBeLessThanOrEqual(max);
+    });
+
+    it('does not mutate the context (local pruner, no field writes)', () => {
+      const { ctx, messages } = buildBranch(3_000, 1_000, 6);
+      const mapBefore = { ...ctx.indexTokenCountMap };
+
+      expect(ctx.pruneMessages).toBeUndefined();
+      ctx.projectContextUsage(messages);
+
+      expect(ctx.pruneMessages).toBeUndefined();
+      expect(ctx.indexTokenCountMap).toEqual(mapBefore);
+    });
+  });
 });

--- a/src/agents/__tests__/projection.test.ts
+++ b/src/agents/__tests__/projection.test.ts
@@ -1,0 +1,73 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { Providers } from '@/common';
+import { projectAgentContextUsage } from '../projection';
+
+const countByChars = (msg: { content: unknown }): number => {
+  const content =
+    typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content);
+  return content.length;
+};
+
+const agent = (maxContextTokens: number): t.AgentInputs => ({
+  agentId: 'test-agent',
+  provider: Providers.OPENAI,
+  instructions: 'system prompt',
+  maxContextTokens,
+});
+
+const branch = (perMessageChars: number, count: number): AIMessage[] => {
+  const messages: AIMessage[] = [];
+  for (let i = 0; i < count; i++) {
+    const content = 'x'.repeat(perMessageChars);
+    messages.push(
+      i % 2 === 0
+        ? (new HumanMessage(content) as unknown as AIMessage)
+        : new AIMessage(content),
+    );
+  }
+  return messages;
+};
+
+describe('projectAgentContextUsage', () => {
+  it('returns a budget snapshot for a branch that fits', async () => {
+    const usage = await projectAgentContextUsage({
+      agent: agent(100_000),
+      messages: branch(1_000, 4),
+      tokenCounter: countByChars,
+    });
+
+    expect(usage).not.toBeNull();
+    expect(usage!.breakdown.maxContextTokens).toBe(100_000);
+    expect(usage!.breakdown.messageCount).toBe(4);
+    expect(usage!.remainingContextTokens).toBeGreaterThan(0);
+    expect(usage!.agentId).toBe('test-agent');
+  });
+
+  it('prunes when the branch exceeds the window', async () => {
+    const usage = await projectAgentContextUsage({
+      agent: agent(3_000),
+      messages: branch(1_000, 6),
+      tokenCounter: countByChars,
+    });
+
+    expect(usage).not.toBeNull();
+    expect(usage!.breakdown.messageCount).toBeGreaterThan(0);
+    expect(usage!.breakdown.messageCount).toBeLessThan(6);
+  });
+
+  it('returns null without a context window', async () => {
+    const noWindow: t.AgentInputs = {
+      agentId: 'test-agent',
+      provider: Providers.OPENAI,
+      instructions: 'sys',
+    };
+    const usage = await projectAgentContextUsage({
+      agent: noWindow,
+      messages: branch(100, 2),
+      tokenCounter: countByChars,
+    });
+
+    expect(usage).toBeNull();
+  });
+});

--- a/src/agents/projection.ts
+++ b/src/agents/projection.ts
@@ -1,0 +1,46 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { AgentContext } from './AgentContext';
+
+export interface ProjectAgentContextUsageParams {
+  /** Same `AgentInputs` a run is built from (instructions, tools, model, window). */
+  agent: t.AgentInputs;
+  /** Branch messages to project, in send order (no leading system message). */
+  messages: BaseMessage[];
+  tokenCounter: t.TokenCounter;
+  /** Per-message counts aligned to `messages` (e.g. from `formatAgentMessages`).
+   *  When omitted, counts are recounted via `tokenCounter`. */
+  indexTokenCountMap?: Record<string, number>;
+  /** Provider-calibrated ratio from a prior snapshot, applied as a static seed. */
+  calibrationRatio?: number;
+  runId?: string;
+  agentId?: string;
+}
+
+/**
+ * Projects a pre-send context-usage snapshot for a branch under an agent config
+ * WITHOUT invoking the model — the host-side (page-load / branch-switch /
+ * window-switch) counterpart to the live `ON_CONTEXT_USAGE` event. Builds a
+ * throwaway `AgentContext` from the same `AgentInputs` a run uses, awaits its
+ * instruction/tool token accounting, then runs the shared pruner + budget math
+ * via `AgentContext.projectContextUsage` (which never mutates the supplied
+ * messages). Returns null when the config has no tokenizer or context window.
+ */
+export async function projectAgentContextUsage({
+  agent,
+  messages,
+  tokenCounter,
+  indexTokenCountMap,
+  calibrationRatio,
+  runId,
+  agentId,
+}: ProjectAgentContextUsageParams): Promise<t.ContextUsageEvent | null> {
+  const context = AgentContext.fromConfig(agent, tokenCounter, indexTokenCountMap);
+  await context.tokenCalculationPromise;
+  return context.projectContextUsage(messages, {
+    runId,
+    agentId: agentId ?? agent.agentId,
+    calibrationRatio,
+    indexTokenCountMap,
+  });
+}

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -25,6 +25,7 @@ import {
   formatContentStrings,
   isLegacyConvertible,
   createPruneMessages,
+  syncBudgetDerivedFields,
   addCacheControl,
   getMessageId,
   makeIsDeferred,
@@ -109,35 +110,6 @@ function trailingMutationStart(messages: BaseMessage[]): number {
     index--;
   }
   return Math.max(0, Math.min(index, messages.length - 2));
-}
-
-/**
- * Re-derives the breakdown fields coupled to the calibrated budget math so
- * the snapshot stays internally consistent: the aggregate
- * `instructionTokens`/`availableForMessages` reflect the pruner's effective
- * (calibrated) overhead — component fields remain local estimates — and
- * `messageTokens` mirrors `contextBudget - instructions - remaining`.
- */
-function syncBudgetDerivedFields(usage: t.ContextUsageEvent): void {
-  const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
-  if (effectiveInstructionTokens == null) {
-    return;
-  }
-  breakdown.instructionTokens = effectiveInstructionTokens;
-  if (contextBudget == null) {
-    return;
-  }
-  breakdown.availableForMessages = Math.max(
-    0,
-    contextBudget - effectiveInstructionTokens
-  );
-  if (usage.remainingContextTokens == null) {
-    return;
-  }
-  breakdown.messageTokens = Math.max(
-    0,
-    contextBudget - effectiveInstructionTokens - usage.remainingContextTokens
-  );
 }
 
 type ReasoningKey = 'reasoning_content' | 'reasoning';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ export * from './messages';
 /* Graphs */
 export * from './graphs';
 
+/* Context-usage projection (host-side pre-send snapshot) */
+export * from './agents/projection';
+
 /* Summarization */
 export * from './summarization';
 

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -1,0 +1,32 @@
+import type * as t from '@/types';
+
+/**
+ * Reconciles a context-usage breakdown's instruction/available/message fields
+ * from the pruner's budget metrics. `messageTokens` and `availableForMessages`
+ * are DERIVED from `contextBudget` / `effectiveInstructionTokens` /
+ * `remainingContextTokens` rather than summed from the index map — that map is
+ * keyed by pre-prune indices, so summing it over the kept context would missum.
+ * Shared by the live snapshot path (`Graph.createCallModel`) and the pre-send
+ * projection (`AgentContext.projectContextUsage`) so both yield identical numbers.
+ */
+export function syncBudgetDerivedFields(usage: t.ContextUsageEvent): void {
+  const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
+  if (effectiveInstructionTokens == null) {
+    return;
+  }
+  breakdown.instructionTokens = effectiveInstructionTokens;
+  if (contextBudget == null) {
+    return;
+  }
+  breakdown.availableForMessages = Math.max(
+    0,
+    contextBudget - effectiveInstructionTokens
+  );
+  if (usage.remainingContextTokens == null) {
+    return;
+  }
+  breakdown.messageTokens = Math.max(
+    0,
+    contextBudget - effectiveInstructionTokens - usage.remainingContextTokens
+  );
+}

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -41,7 +41,7 @@ function deepCloneContent<T extends string | MessageContentComplex[]>(
  * in downstream code (e.g., ensureThinkingBlockInMessages).
  * For plain objects (AnthropicMessage), uses object spread.
  */
-function cloneMessage<T extends MessageWithContent>(
+export function cloneMessage<T extends MessageWithContent>(
   message: T,
   content: string | MessageContentComplex[]
 ): T {

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -1,6 +1,7 @@
 export * from './core';
 export * from './ids';
 export * from './prune';
+export * from './budget';
 export * from './format';
 export * from './cache';
 export * from './anthropicToolCache';


### PR DESCRIPTION
## Summary

Adds `AgentContext.projectContextUsage(messages, opts?)` — a pure, off-the-hot-path projection of the context-usage snapshot for an arbitrary message set, **without invoking the model**.

It runs the *same* pruner + budget math the live path uses (`createPruneMessages` → `getTokenBudgetBreakdown` → `syncBudgetDerivedFields`), so a "what would I send" projection produces numbers identical to a real call's `ON_CONTEXT_USAGE` snapshot. It returns `null` when the context has no tokenizer/window, uses a **local** pruner, and never mutates the context — safe to call repeatedly off the run loop.

## Why

A host-side context gauge (e.g. LibreChat) is accurate while streaming and on reload of a turn that emitted a live snapshot. But two states have no SDK data and currently fall back to a client-side estimate that sums the whole branch with no window/prune awareness:

- **Snapshot-less branches** — pre-feature history, foreign imports, long un-summarized branches.
- **Model/window switches** — a persisted snapshot's window is baked at generation time.

`projectContextUsage` lets the host ask the SDK "what would the context be for this branch under this config" so the gauge always reflects the SDK's authoritative pruning, not a re-derivation.

## Changes

- `AgentContext.projectContextUsage(...)` (new). Pre-send counterpart to the live snapshot; omits the live post-format reconciliation (provider-specific, invoke-time) — a small, acceptable delta for a pre-send estimate.
- `syncBudgetDerivedFields` moves from `Graph.ts` to a shared `src/messages/budget.ts` so the live and projected paths share one derivation (no drift). **Live snapshot behavior is unchanged** — the function body and its two call sites are identical; only the location moved.

## Tests

- New `projectContextUsage` cases in `AgentContext.test.ts`: null without tokenizer/window; keeps the whole branch + reports headroom when it fits; prunes older messages when the branch exceeds the window; does not mutate the context.
- Full `AgentContext` suite (89) and `messages` suite (349) green; the live `context-usage-event` emission spec (2) still passes, confirming the relocation didn't change the hot path. Typecheck + lint clean.

_(The two `src/llm/{anthropic,google}/llm.spec.ts` suites fail locally with "API key not found" — pre-existing, env-only, unrelated.)_

## Follow-up (separate, LibreChat)

A projection endpoint that builds the agent context for a branch + resolved config and calls this method, plus client wiring so the gauge prefers live snapshot → fresh persisted snapshot → projection → estimate.